### PR TITLE
Instance

### DIFF
--- a/examples/base/example-base.h
+++ b/examples/base/example-base.h
@@ -88,8 +88,12 @@ Result ExampleBase::createDevice(DeviceType deviceType)
 Result ExampleBase::createWindow(uint32_t width, uint32_t height)
 {
     const auto& deviceInfo = device->getDeviceInfo();
-    std::string title =
-        string::format("%s | %s (%s)", getName(), deviceInfo.adapterName, rhiGetDeviceTypeName(deviceInfo.deviceType));
+    std::string title = string::format(
+        "%s | %s (%s)",
+        getName(),
+        deviceInfo.adapterName,
+        getRHI()->getDeviceTypeName(deviceInfo.deviceType)
+    );
 
     window = glfwCreateWindow(width, height, title.c_str(), nullptr, nullptr);
     if (!window)

--- a/examples/base/example-base.h
+++ b/examples/base/example-base.h
@@ -79,7 +79,7 @@ void ExampleBase::onResize(int width, int height)
 
 Result ExampleBase::createDevice(DeviceType deviceType)
 {
-    IDevice::Desc deviceDesc = {};
+    DeviceDesc deviceDesc = {};
     deviceDesc.deviceType = deviceType;
     SLANG_RETURN_ON_FAIL(rhiCreateDevice(&deviceDesc, device.writeRef()));
     return SLANG_OK;

--- a/examples/base/example-base.h
+++ b/examples/base/example-base.h
@@ -105,7 +105,7 @@ Result ExampleBase::createDevice(DeviceType deviceType)
     deviceDesc.enableBackendValidation = true;
     deviceDesc.debugCallback = DebugPrinter::getInstance();
 #endif
-    SLANG_RETURN_ON_FAIL(rhiCreateDevice(&deviceDesc, device.writeRef()));
+    SLANG_RETURN_ON_FAIL(getRHI()->createDevice(deviceDesc, device.writeRef()));
     return SLANG_OK;
 }
 

--- a/include/slang-rhi.h
+++ b/include/slang-rhi.h
@@ -2545,6 +2545,10 @@ public:
     //     SLANG_RETURN_NULL_ON_FAIL(createDevice(desc, device.writeRef()));
     //     return device;
     // }
+
+    /// Reports current set of live objects.
+    /// Currently this just calls D3D's ReportLiveObjects.
+    virtual SLANG_NO_THROW Result SLANG_MCALL reportLiveObjects() = 0;
 };
 
 // Global public functions
@@ -2558,10 +2562,6 @@ extern "C"
 
     /// Given a type returns a function that can construct it, or nullptr if there isn't one
     SLANG_RHI_API SlangResult SLANG_MCALL rhiCreateDevice(const DeviceDesc* desc, IDevice** outDevice);
-
-    /// Reports current set of live objects in rhi.
-    /// Currently this only calls D3D's ReportLiveObjects.
-    SLANG_RHI_API SlangResult SLANG_MCALL rhiReportLiveObjects();
 }
 
 inline const FormatInfo& getFormatInfo(Format format)

--- a/include/slang-rhi.h
+++ b/include/slang-rhi.h
@@ -2192,6 +2192,13 @@ struct DeviceDesc
 
     GfxCount extendedDescCount = 0;
     void** extendedDescs = nullptr;
+
+    /// Enable RHI validation layer.
+    bool enableValidation = false;
+    /// Enable backend API validation layer.
+    bool enableBackendValidation = false;
+    /// Debug callback. If not null, this will be called for each debug message.
+    IDebugCallback* debugCallback = nullptr;
 };
 
 class IDevice : public ISlangUnknown
@@ -2555,14 +2562,6 @@ extern "C"
     /// Reports current set of live objects in rhi.
     /// Currently this only calls D3D's ReportLiveObjects.
     SLANG_RHI_API SlangResult SLANG_MCALL rhiReportLiveObjects();
-
-    /// Sets a callback for receiving debug messages.
-    /// The layer does not hold a strong reference to the callback object.
-    /// The user is responsible for holding the callback object alive.
-    SLANG_RHI_API SlangResult SLANG_MCALL rhiSetDebugCallback(IDebugCallback* callback);
-
-    /// Enables debug layer. The debug layer will check all `rhi` calls and verify that uses are valid.
-    SLANG_RHI_API void SLANG_MCALL rhiEnableDebugLayer();
 }
 
 inline const FormatInfo& getFormatInfo(Format format)

--- a/include/slang-rhi.h
+++ b/include/slang-rhi.h
@@ -283,6 +283,9 @@ struct FormatInfo
     GfxCount blockWidth;
     /// The height of a block in pixels.
     GfxCount blockHeight;
+
+    bool isTypeless : 1;
+    bool isCompressed : 1;
 };
 
 enum class FormatSupport
@@ -2543,15 +2546,6 @@ extern "C"
 {
     SLANG_RHI_API IRHI* SLANG_MCALL getRHI();
 
-    /// Checks if format is compressed
-    SLANG_RHI_API bool SLANG_MCALL rhiIsCompressedFormat(Format format);
-
-    /// Checks if format is typeless
-    SLANG_RHI_API bool SLANG_MCALL rhiIsTypelessFormat(Format format);
-
-    /// Gets information about the format
-    SLANG_RHI_API SlangResult SLANG_MCALL rhiGetFormatInfo(Format format, FormatInfo* outInfo);
-
     /// Gets a list of available adapters for a given device type
     SLANG_RHI_API SlangResult SLANG_MCALL rhiGetAdapters(DeviceType type, ISlangBlob** outAdaptersBlob);
 
@@ -2569,10 +2563,11 @@ extern "C"
 
     /// Enables debug layer. The debug layer will check all `rhi` calls and verify that uses are valid.
     SLANG_RHI_API void SLANG_MCALL rhiEnableDebugLayer();
+}
 
-    SLANG_RHI_API const char* SLANG_MCALL rhiGetDeviceTypeName(DeviceType type);
-
-    SLANG_RHI_API bool rhiIsDeviceTypeSupported(DeviceType type);
+inline const FormatInfo& getFormatInfo(Format format)
+{
+    return getRHI()->getFormatInfo(format);
 }
 
 /// Gets a list of available adapters for a given device type

--- a/include/slang-rhi.h
+++ b/include/slang-rhi.h
@@ -2135,15 +2135,10 @@ public:
     handleMessage(DebugMessageType type, DebugMessageSource source, const char* message) = 0;
 };
 
-class IDevice : public ISlangUnknown
-{
-    SLANG_COM_INTERFACE(0x311ee28b, 0xdb5a, 0x4a3c, {0x89, 0xda, 0xf0, 0x03, 0x0f, 0xd5, 0x70, 0x4b});
-
-public:
     struct SlangDesc
     {
-        slang::IGlobalSession* slangGlobalSession = nullptr; // (optional) A slang global session object. If null will
-                                                             // create automatically.
+    /// (optional) A slang global session object, if null a new one will be created.
+    slang::IGlobalSession* slangGlobalSession = nullptr;
 
         SlangMatrixLayoutMode defaultMatrixLayoutMode = SLANG_MATRIX_LAYOUT_ROW_MAJOR;
 
@@ -2153,20 +2148,21 @@ public:
         slang::PreprocessorMacroDesc const* preprocessorMacros = nullptr;
         GfxCount preprocessorMacroCount = 0;
 
-        const char* targetProfile = nullptr; // (optional) Target shader profile. If null this will be set to platform
-                                             // dependent default.
+    /// (optional) Target shader profile. If null this will be set to platform dependent default.
+    const char* targetProfile = nullptr;
+
         SlangFloatingPointMode floatingPointMode = SLANG_FLOATING_POINT_MODE_DEFAULT;
         SlangOptimizationLevel optimizationLevel = SLANG_OPTIMIZATION_LEVEL_DEFAULT;
         SlangTargetFlags targetFlags = kDefaultTargetFlags;
         SlangLineDirectiveMode lineDirectiveMode = SLANG_LINE_DIRECTIVE_MODE_DEFAULT;
     };
 
-    struct NativeHandles
+struct DeviceNativeHandles
     {
         NativeHandle handles[3] = {};
     };
 
-    struct Desc
+struct DeviceDesc
     {
         // The underlying API/Platform of the device.
         DeviceType deviceType = DeviceType::Default;
@@ -2174,7 +2170,7 @@ public:
         // NativeHandle for the ID3D12Device. For Vulkan, the first NativeHandle is the VkInstance, the second is the
         // VkPhysicalDevice, and the third is the VkDevice. For CUDA, this only contains a single value for the
         // CUDADevice.
-        NativeHandles existingDeviceHandles;
+    DeviceNativeHandles existingDeviceHandles;
         // LUID of the adapter to use. Use getGfxAdapters() to get a list of available adapters.
         const AdapterLUID* adapterLUID = nullptr;
         // Number of required features.
@@ -2195,7 +2191,12 @@ public:
         void** extendedDescs = nullptr;
     };
 
-    virtual SLANG_NO_THROW Result SLANG_MCALL getNativeDeviceHandles(NativeHandles* outHandles) = 0;
+class IDevice : public ISlangUnknown
+{
+    SLANG_COM_INTERFACE(0x311ee28b, 0xdb5a, 0x4a3c, {0x89, 0xda, 0xf0, 0x03, 0x0f, 0xd5, 0x70, 0x4b});
+
+public:
+    virtual SLANG_NO_THROW Result SLANG_MCALL getNativeDeviceHandles(DeviceNativeHandles* outHandles) = 0;
 
     virtual SLANG_NO_THROW bool SLANG_MCALL hasFeature(const char* feature) = 0;
 
@@ -2532,7 +2533,7 @@ extern "C"
     SLANG_RHI_API SlangResult SLANG_MCALL rhiGetAdapters(DeviceType type, ISlangBlob** outAdaptersBlob);
 
     /// Given a type returns a function that can construct it, or nullptr if there isn't one
-    SLANG_RHI_API SlangResult SLANG_MCALL rhiCreateDevice(const IDevice::Desc* desc, IDevice** outDevice);
+    SLANG_RHI_API SlangResult SLANG_MCALL rhiCreateDevice(const DeviceDesc* desc, IDevice** outDevice);
 
     /// Reports current set of live objects in rhi.
     /// Currently this only calls D3D's ReportLiveObjects.

--- a/include/slang-rhi.h
+++ b/include/slang-rhi.h
@@ -2533,18 +2533,27 @@ public:
 
     virtual SLANG_NO_THROW const char* SLANG_MCALL getDeviceTypeName(DeviceType type) = 0;
 
-    virtual SLANG_NO_THROW bool SLANG_MCALL isDeviceTypeSupported(DeviceType deviceType) = 0;
+    virtual SLANG_NO_THROW bool SLANG_MCALL isDeviceTypeSupported(DeviceType type) = 0;
 
-    // virtual SLANG_NO_THROW Result SLANG_MCALL getAdapter(DeviceType deviceType, ISlangBlob** outAdaptersBlob);
+    /// Gets a list of available adapters for a given device type.
+    virtual SLANG_NO_THROW Result SLANG_MCALL getAdapters(DeviceType type, ISlangBlob** outAdaptersBlob) = 0;
 
-    // virtual SLANG_NO_THROW Result SLANG_MCALL createDevice(const DeviceDesc& desc, IDevice** outDevice);
+    inline AdapterList getAdapters(DeviceType type)
+    {
+        ComPtr<ISlangBlob> blob;
+        SLANG_RETURN_NULL_ON_FAIL(getAdapters(type, blob.writeRef()));
+        return AdapterList(blob);
+    }
 
-    // ComPtr<IDevice> createDevice(const DeviceDesc& desc)
-    // {
-    //     ComPtr<IDevice> device;
-    //     SLANG_RETURN_NULL_ON_FAIL(createDevice(desc, device.writeRef()));
-    //     return device;
-    // }
+    /// Creates a device.
+    virtual SLANG_NO_THROW Result SLANG_MCALL createDevice(const DeviceDesc& desc, IDevice** outDevice) = 0;
+
+    ComPtr<IDevice> createDevice(const DeviceDesc& desc)
+    {
+        ComPtr<IDevice> device;
+        SLANG_RETURN_NULL_ON_FAIL(createDevice(desc, device.writeRef()));
+        return device;
+    }
 
     /// Reports current set of live objects.
     /// Currently this just calls D3D's ReportLiveObjects.
@@ -2555,26 +2564,13 @@ public:
 
 extern "C"
 {
+    /// Get the global interface to the RHI.
     SLANG_RHI_API IRHI* SLANG_MCALL getRHI();
-
-    /// Gets a list of available adapters for a given device type
-    SLANG_RHI_API SlangResult SLANG_MCALL rhiGetAdapters(DeviceType type, ISlangBlob** outAdaptersBlob);
-
-    /// Given a type returns a function that can construct it, or nullptr if there isn't one
-    SLANG_RHI_API SlangResult SLANG_MCALL rhiCreateDevice(const DeviceDesc* desc, IDevice** outDevice);
 }
 
 inline const FormatInfo& getFormatInfo(Format format)
 {
     return getRHI()->getFormatInfo(format);
-}
-
-/// Gets a list of available adapters for a given device type
-inline AdapterList rhiGetAdapters(DeviceType type)
-{
-    ComPtr<ISlangBlob> blob;
-    rhiGetAdapters(type, blob.writeRef());
-    return AdapterList(blob);
 }
 
 // Extended descs.

--- a/include/slang-rhi.h
+++ b/include/slang-rhi.h
@@ -2135,61 +2135,61 @@ public:
     handleMessage(DebugMessageType type, DebugMessageSource source, const char* message) = 0;
 };
 
-    struct SlangDesc
-    {
+struct SlangDesc
+{
     /// (optional) A slang global session object, if null a new one will be created.
     slang::IGlobalSession* slangGlobalSession = nullptr;
 
-        SlangMatrixLayoutMode defaultMatrixLayoutMode = SLANG_MATRIX_LAYOUT_ROW_MAJOR;
+    SlangMatrixLayoutMode defaultMatrixLayoutMode = SLANG_MATRIX_LAYOUT_ROW_MAJOR;
 
-        char const* const* searchPaths = nullptr;
-        GfxCount searchPathCount = 0;
+    char const* const* searchPaths = nullptr;
+    GfxCount searchPathCount = 0;
 
-        slang::PreprocessorMacroDesc const* preprocessorMacros = nullptr;
-        GfxCount preprocessorMacroCount = 0;
+    slang::PreprocessorMacroDesc const* preprocessorMacros = nullptr;
+    GfxCount preprocessorMacroCount = 0;
 
     /// (optional) Target shader profile. If null this will be set to platform dependent default.
     const char* targetProfile = nullptr;
 
-        SlangFloatingPointMode floatingPointMode = SLANG_FLOATING_POINT_MODE_DEFAULT;
-        SlangOptimizationLevel optimizationLevel = SLANG_OPTIMIZATION_LEVEL_DEFAULT;
-        SlangTargetFlags targetFlags = kDefaultTargetFlags;
-        SlangLineDirectiveMode lineDirectiveMode = SLANG_LINE_DIRECTIVE_MODE_DEFAULT;
-    };
+    SlangFloatingPointMode floatingPointMode = SLANG_FLOATING_POINT_MODE_DEFAULT;
+    SlangOptimizationLevel optimizationLevel = SLANG_OPTIMIZATION_LEVEL_DEFAULT;
+    SlangTargetFlags targetFlags = kDefaultTargetFlags;
+    SlangLineDirectiveMode lineDirectiveMode = SLANG_LINE_DIRECTIVE_MODE_DEFAULT;
+};
 
 struct DeviceNativeHandles
-    {
-        NativeHandle handles[3] = {};
-    };
+{
+    NativeHandle handles[3] = {};
+};
 
 struct DeviceDesc
-    {
-        // The underlying API/Platform of the device.
-        DeviceType deviceType = DeviceType::Default;
-        // The device's handles (if they exist) and their associated API. For D3D12, this contains a single
-        // NativeHandle for the ID3D12Device. For Vulkan, the first NativeHandle is the VkInstance, the second is the
-        // VkPhysicalDevice, and the third is the VkDevice. For CUDA, this only contains a single value for the
-        // CUDADevice.
+{
+    // The underlying API/Platform of the device.
+    DeviceType deviceType = DeviceType::Default;
+    // The device's handles (if they exist) and their associated API. For D3D12, this contains a single
+    // NativeHandle for the ID3D12Device. For Vulkan, the first NativeHandle is the VkInstance, the second is the
+    // VkPhysicalDevice, and the third is the VkDevice. For CUDA, this only contains a single value for the
+    // CUDADevice.
     DeviceNativeHandles existingDeviceHandles;
-        // LUID of the adapter to use. Use getGfxAdapters() to get a list of available adapters.
-        const AdapterLUID* adapterLUID = nullptr;
-        // Number of required features.
-        GfxCount requiredFeatureCount = 0;
-        // Array of required feature names, whose size is `requiredFeatureCount`.
-        const char** requiredFeatures = nullptr;
-        // A command dispatcher object that intercepts and handles actual low-level API call.
-        ISlangUnknown* apiCommandDispatcher = nullptr;
-        // The slot (typically UAV) used to identify NVAPI intrinsics. If >=0 NVAPI is required.
-        GfxIndex nvapiExtnSlot = -1;
-        // Configurations for Slang compiler.
-        SlangDesc slang = {};
+    // LUID of the adapter to use. Use getGfxAdapters() to get a list of available adapters.
+    const AdapterLUID* adapterLUID = nullptr;
+    // Number of required features.
+    GfxCount requiredFeatureCount = 0;
+    // Array of required feature names, whose size is `requiredFeatureCount`.
+    const char** requiredFeatures = nullptr;
+    // A command dispatcher object that intercepts and handles actual low-level API call.
+    ISlangUnknown* apiCommandDispatcher = nullptr;
+    // The slot (typically UAV) used to identify NVAPI intrinsics. If >=0 NVAPI is required.
+    GfxIndex nvapiExtnSlot = -1;
+    // Configurations for Slang compiler.
+    SlangDesc slang = {};
 
-        // Interface to persistent shader cache.
-        IPersistentShaderCache* persistentShaderCache = nullptr;
+    // Interface to persistent shader cache.
+    IPersistentShaderCache* persistentShaderCache = nullptr;
 
-        GfxCount extendedDescCount = 0;
-        void** extendedDescs = nullptr;
-    };
+    GfxCount extendedDescCount = 0;
+    void** extendedDescs = nullptr;
+};
 
 class IDevice : public ISlangUnknown
 {
@@ -2516,10 +2516,33 @@ public:
     afterCreateRayTracingState(IDevice* device, slang::IComponentType* program) = 0;
 };
 
+class IRHI
+{
+public:
+    virtual SLANG_NO_THROW const FormatInfo& SLANG_MCALL getFormatInfo(Format format) = 0;
+
+    virtual SLANG_NO_THROW const char* SLANG_MCALL getDeviceTypeName(DeviceType type) = 0;
+
+    virtual SLANG_NO_THROW bool SLANG_MCALL isDeviceTypeSupported(DeviceType deviceType) = 0;
+
+    // virtual SLANG_NO_THROW Result SLANG_MCALL getAdapter(DeviceType deviceType, ISlangBlob** outAdaptersBlob);
+
+    // virtual SLANG_NO_THROW Result SLANG_MCALL createDevice(const DeviceDesc& desc, IDevice** outDevice);
+
+    // ComPtr<IDevice> createDevice(const DeviceDesc& desc)
+    // {
+    //     ComPtr<IDevice> device;
+    //     SLANG_RETURN_NULL_ON_FAIL(createDevice(desc, device.writeRef()));
+    //     return device;
+    // }
+};
+
 // Global public functions
 
 extern "C"
 {
+    SLANG_RHI_API IRHI* SLANG_MCALL getRHI();
+
     /// Checks if format is compressed
     SLANG_RHI_API bool SLANG_MCALL rhiIsCompressedFormat(Format format);
 

--- a/src/cpu/cpu-device.cpp
+++ b/src/cpu/cpu-device.cpp
@@ -235,7 +235,7 @@ void DeviceImpl::dispatchCompute(int x, int y, int z)
             ->getEntryPointHostCallable(entryPointIndex, targetIndex, sharedLibrary.writeRef(), diagnostics.writeRef());
     if (diagnostics)
     {
-        getDebugCallback()->handleMessage(
+        handleMessage(
             compileResult == SLANG_OK ? DebugMessageType::Warning : DebugMessageType::Error,
             DebugMessageSource::Slang,
             (char*)diagnostics->getBufferPointer()

--- a/src/cpu/cpu-device.cpp
+++ b/src/cpu/cpu-device.cpp
@@ -18,7 +18,7 @@ DeviceImpl::~DeviceImpl()
     m_currentRootObject = nullptr;
 }
 
-Result DeviceImpl::initialize(const Desc& desc)
+Result DeviceImpl::initialize(const DeviceDesc& desc)
 {
     SLANG_RETURN_ON_FAIL(slangContext.initialize(
         desc.slang,
@@ -270,7 +270,7 @@ void DeviceImpl::copyBuffer(IBuffer* dst, size_t dstOffset, IBuffer* src, size_t
 
 namespace rhi {
 
-Result createCPUDevice(const IDevice::Desc* desc, IDevice** outDevice)
+Result createCPUDevice(const DeviceDesc* desc, IDevice** outDevice)
 {
     RefPtr<cpu::DeviceImpl> result = new cpu::DeviceImpl();
     SLANG_RETURN_ON_FAIL(result->initialize(*desc));

--- a/src/cpu/cpu-device.h
+++ b/src/cpu/cpu-device.h
@@ -11,7 +11,7 @@ class DeviceImpl : public ImmediateComputeDeviceBase
 public:
     ~DeviceImpl();
 
-    virtual SLANG_NO_THROW Result SLANG_MCALL initialize(const Desc& desc) override;
+    virtual SLANG_NO_THROW Result SLANG_MCALL initialize(const DeviceDesc& desc) override;
 
     virtual SLANG_NO_THROW Result SLANG_MCALL
     createTexture(const TextureDesc& desc, const SubresourceData* initData, ITexture** outTexture) override;
@@ -74,6 +74,6 @@ private:
 
 namespace rhi {
 
-Result SLANG_MCALL createCPUDevice(const IDevice::Desc* desc, IDevice** outDevice);
+Result SLANG_MCALL createCPUDevice(const DeviceDesc* desc, IDevice** outDevice);
 
 } // namespace rhi

--- a/src/cpu/cpu-texture.cpp
+++ b/src/cpu/cpu-texture.cpp
@@ -106,8 +106,7 @@ Result TextureImpl::init(SubresourceData const* initData)
     // the block extents would be 1 along each axis.
     //
     auto format = desc.format;
-    FormatInfo texelInfo;
-    rhiGetFormatInfo(format, &texelInfo);
+    const FormatInfo& texelInfo = getFormatInfo(format);
     uint32_t texelSize = uint32_t(texelInfo.blockSizeInBytes / texelInfo.pixelsPerBlock);
     m_texelSize = texelSize;
 

--- a/src/cuda/cuda-acceleration-structure.h
+++ b/src/cuda/cuda-acceleration-structure.h
@@ -39,10 +39,7 @@ public:
     std::vector<OptixBuildInput> buildInputs;
     OptixAccelBuildOptions buildOptions;
 
-    Result build(
-        const AccelerationStructureBuildDesc& buildDesc,
-        IDebugCallback* debugCallback
-    );
+    Result build(const AccelerationStructureBuildDesc& buildDesc, IDebugCallback* debugCallback);
 
 private:
     unsigned int translateBuildFlags(AccelerationStructureBuildFlags flags) const;

--- a/src/cuda/cuda-command-encoder.cpp
+++ b/src/cuda/cuda-command-encoder.cpp
@@ -213,7 +213,7 @@ void RayTracingPassEncoderImpl::buildAccelerationStructure(
 )
 {
     AccelerationStructureBuildInputBuilder builder;
-    SLANG_RETURN_VOID_ON_FAIL(builder.build(desc, getDebugCallback()));
+    SLANG_RETURN_VOID_ON_FAIL(builder.build(desc, m_commandBuffer->m_device->m_debugCallback));
 
     AccelerationStructureImpl* dstImpl = static_cast<AccelerationStructureImpl*>(dst);
 

--- a/src/cuda/cuda-device.cpp
+++ b/src/cuda/cuda-device.cpp
@@ -145,7 +145,7 @@ DeviceImpl::~DeviceImpl()
     }
 }
 
-Result DeviceImpl::getNativeDeviceHandles(NativeHandles* outHandles)
+Result DeviceImpl::getNativeDeviceHandles(DeviceNativeHandles* outHandles)
 {
     outHandles->handles[0].type = NativeHandleType::CUdevice;
     outHandles->handles[0].value = m_ctx.device;
@@ -159,7 +159,7 @@ Result DeviceImpl::getNativeDeviceHandles(NativeHandles* outHandles)
     return SLANG_OK;
 }
 
-Result DeviceImpl::initialize(const Desc& desc)
+Result DeviceImpl::initialize(const DeviceDesc& desc)
 {
     SLANG_RETURN_ON_FAIL(slangContext.initialize(
         desc.slang,

--- a/src/cuda/cuda-device.cpp
+++ b/src/cuda/cuda-device.cpp
@@ -1029,7 +1029,7 @@ Result DeviceImpl::createShaderProgram(
     );
     if (diagnostics)
     {
-        getDebugCallback()->handleMessage(
+        handleMessage(
             compileResult == SLANG_OK ? DebugMessageType::Warning : DebugMessageType::Error,
             DebugMessageSource::Slang,
             (char*)diagnostics->getBufferPointer()
@@ -1181,7 +1181,7 @@ Result DeviceImpl::getAccelerationStructureSizes(
 {
 #if SLANG_RHI_HAS_OPTIX
     AccelerationStructureBuildInputBuilder builder;
-    builder.build(desc, getDebugCallback());
+    builder.build(desc, m_debugCallback);
     OptixAccelBufferSizes sizes;
     SLANG_OPTIX_RETURN_ON_FAIL(optixAccelComputeMemoryUsage(
         m_ctx.optixContext,

--- a/src/cuda/cuda-device.cpp
+++ b/src/cuda/cuda-device.cpp
@@ -408,8 +408,7 @@ Result DeviceImpl::createTexture(const TextureDesc& desc, const SubresourceData*
         int numChannels = 0;
 
         SLANG_RETURN_ON_FAIL(getCUDAFormat(desc.format, &format));
-        FormatInfo info;
-        rhiGetFormatInfo(desc.format, &info);
+        const FormatInfo& info = getFormatInfo(desc.format);
         numChannels = info.channelCount;
 
         switch (format)
@@ -879,8 +878,7 @@ Result DeviceImpl::createTextureFromSharedHandle(
     SLANG_CUDA_RETURN_ON_FAIL(cuImportExternalMemory(&externalMemory, &externalMemoryHandleDesc));
     texture->m_cudaExternalMemory = externalMemory;
 
-    FormatInfo formatInfo;
-    SLANG_RETURN_ON_FAIL(rhiGetFormatInfo(desc.format, &formatInfo));
+    const FormatInfo formatInfo = getFormatInfo(desc.format);
     CUDA_ARRAY3D_DESCRIPTOR arrayDesc;
     arrayDesc.Depth = desc.size.depth;
     arrayDesc.Height = desc.size.height;
@@ -1138,9 +1136,8 @@ Result DeviceImpl::readTexture(ITexture* texture, ISlangBlob** outBlob, size_t* 
     const TextureDesc& desc = textureImpl->m_desc;
     auto width = desc.size.width;
     auto height = desc.size.height;
-    FormatInfo sizeInfo;
-    SLANG_RETURN_ON_FAIL(rhiGetFormatInfo(desc.format, &sizeInfo));
-    size_t pixelSize = sizeInfo.blockSizeInBytes / sizeInfo.pixelsPerBlock;
+    const FormatInfo& formatInfo = getFormatInfo(desc.format);
+    size_t pixelSize = formatInfo.blockSizeInBytes / formatInfo.pixelsPerBlock;
     size_t rowPitch = width * pixelSize;
     size_t size = height * rowPitch;
 

--- a/src/cuda/cuda-device.h
+++ b/src/cuda/cuda-device.h
@@ -35,9 +35,9 @@ public:
 public:
     ~DeviceImpl();
 
-    virtual SLANG_NO_THROW Result SLANG_MCALL getNativeDeviceHandles(NativeHandles* outHandles) override;
+    virtual SLANG_NO_THROW Result SLANG_MCALL getNativeDeviceHandles(DeviceNativeHandles* outHandles) override;
 
-    virtual SLANG_NO_THROW Result SLANG_MCALL initialize(const Desc& desc) override;
+    virtual SLANG_NO_THROW Result SLANG_MCALL initialize(const DeviceDesc& desc) override;
 
     Result getCUDAFormat(Format format, CUarray_format* outFormat);
 

--- a/src/cuda/cuda-helper-functions.cpp
+++ b/src/cuda/cuda-helper-functions.cpp
@@ -5,25 +5,7 @@ namespace rhi::cuda {
 
 Result CUDAErrorInfo::handle() const
 {
-    std::string str;
-    str += "Error: ";
-    str += m_filePath;
-    str += " (";
-    str += std::to_string(m_lineNo);
-    str += ")";
-    if (m_errorName)
-    {
-        str += " : ";
-        str += m_errorName;
-    }
-    if (m_errorString)
-    {
-        str += " : ";
-        str += m_errorString;
-    }
-
-    getDebugCallback()->handleMessage(DebugMessageType::Error, DebugMessageSource::Driver, str.data());
-
+    fprintf(stderr, "%s(%d): CUDA: %s (%s)\n", m_filePath, m_lineNo, m_errorString, m_errorName);
     return SLANG_FAIL;
 }
 

--- a/src/cuda/cuda-helper-functions.cpp
+++ b/src/cuda/cuda-helper-functions.cpp
@@ -93,7 +93,7 @@ Result SLANG_MCALL getCUDAAdapters(std::vector<AdapterInfo>& outAdapters)
     return cuda::getAdapters(outAdapters);
 }
 
-Result SLANG_MCALL createCUDADevice(const IDevice::Desc* desc, IDevice** outDevice)
+Result SLANG_MCALL createCUDADevice(const DeviceDesc* desc, IDevice** outDevice)
 {
     RefPtr<cuda::DeviceImpl> result = new cuda::DeviceImpl();
     SLANG_RETURN_ON_FAIL(result->initialize(*desc));

--- a/src/cuda/cuda-helper-functions.h
+++ b/src/cuda/cuda-helper-functions.h
@@ -97,6 +97,6 @@ namespace rhi {
 
 Result SLANG_MCALL getCUDAAdapters(std::vector<AdapterInfo>& outAdapters);
 
-Result SLANG_MCALL createCUDADevice(const IDevice::Desc* desc, IDevice** outDevice);
+Result SLANG_MCALL createCUDADevice(const DeviceDesc* desc, IDevice** outDevice);
 
 } // namespace rhi

--- a/src/d3d11/d3d11-buffer.cpp
+++ b/src/d3d11/d3d11-buffer.cpp
@@ -51,10 +51,10 @@ ID3D11ShaderResourceView* BufferImpl::getSRV(Format format, const BufferRange& r
     }
     else
     {
-        FormatInfo sizeInfo;
-        rhiGetFormatInfo(format, &sizeInfo);
-        srvDesc.Buffer.FirstElement = UINT(range.offset / (sizeInfo.blockSizeInBytes / sizeInfo.pixelsPerBlock));
-        srvDesc.Buffer.NumElements = UINT(range.size / (sizeInfo.blockSizeInBytes / sizeInfo.pixelsPerBlock));
+        const FormatInfo& formatInfo = getFormatInfo(format);
+        ;
+        srvDesc.Buffer.FirstElement = UINT(range.offset / (formatInfo.blockSizeInBytes / formatInfo.pixelsPerBlock));
+        srvDesc.Buffer.NumElements = UINT(range.size / (formatInfo.blockSizeInBytes / formatInfo.pixelsPerBlock));
     }
 
     SLANG_RETURN_NULL_ON_FAIL(m_device->m_device->CreateShaderResourceView(m_buffer, &srvDesc, srv.writeRef()));
@@ -87,10 +87,9 @@ ID3D11UnorderedAccessView* BufferImpl::getUAV(Format format, const BufferRange& 
     }
     else
     {
-        FormatInfo sizeInfo;
-        rhiGetFormatInfo(format, &sizeInfo);
-        uavDesc.Buffer.FirstElement = UINT(range.offset / (sizeInfo.blockSizeInBytes / sizeInfo.pixelsPerBlock));
-        uavDesc.Buffer.NumElements = UINT(range.size / (sizeInfo.blockSizeInBytes / sizeInfo.pixelsPerBlock));
+        const FormatInfo& formatInfo = getFormatInfo(format);
+        uavDesc.Buffer.FirstElement = UINT(range.offset / (formatInfo.blockSizeInBytes / formatInfo.pixelsPerBlock));
+        uavDesc.Buffer.NumElements = UINT(range.size / (formatInfo.blockSizeInBytes / formatInfo.pixelsPerBlock));
     }
 
     SLANG_RETURN_NULL_ON_FAIL(m_device->m_device->CreateUnorderedAccessView(m_buffer, &uavDesc, uav.writeRef()));

--- a/src/d3d11/d3d11-buffer.cpp
+++ b/src/d3d11/d3d11-buffer.cpp
@@ -52,7 +52,6 @@ ID3D11ShaderResourceView* BufferImpl::getSRV(Format format, const BufferRange& r
     else
     {
         const FormatInfo& formatInfo = getFormatInfo(format);
-        ;
         srvDesc.Buffer.FirstElement = UINT(range.offset / (formatInfo.blockSizeInBytes / formatInfo.pixelsPerBlock));
         srvDesc.Buffer.NumElements = UINT(range.size / (formatInfo.blockSizeInBytes / formatInfo.pixelsPerBlock));
     }

--- a/src/d3d11/d3d11-device.cpp
+++ b/src/d3d11/d3d11-device.cpp
@@ -23,7 +23,7 @@
 
 namespace rhi::d3d11 {
 
-Result DeviceImpl::initialize(const Desc& desc)
+Result DeviceImpl::initialize(const DeviceDesc& desc)
 {
     SLANG_RETURN_ON_FAIL(slangContext.initialize(
         desc.slang,

--- a/src/d3d11/d3d11-device.cpp
+++ b/src/d3d11/d3d11-device.cpp
@@ -418,9 +418,8 @@ Result DeviceImpl::readTexture(ITexture* texture, ISlangBlob** outBlob, size_t* 
         return E_INVALIDARG;
     }
 
-    FormatInfo sizeInfo;
-    rhiGetFormatInfo(textureImpl->m_desc.format, &sizeInfo);
-    size_t bytesPerPixel = sizeInfo.blockSizeInBytes / sizeInfo.pixelsPerBlock;
+    const FormatInfo& formatInfo = getFormatInfo(textureImpl->m_desc.format);
+    size_t bytesPerPixel = formatInfo.blockSizeInBytes / formatInfo.pixelsPerBlock;
     size_t rowPitch = int(textureImpl->m_desc.size.width) * bytesPerPixel;
     size_t bufferSize = rowPitch * int(textureImpl->m_desc.size.height);
     if (outRowPitch)

--- a/src/d3d11/d3d11-device.cpp
+++ b/src/d3d11/d3d11-device.cpp
@@ -1184,8 +1184,7 @@ Result DeviceImpl::createShaderProgram(
             DebugMessageType msgType = DebugMessageType::Warning;
             if (compileResult != SLANG_OK)
                 msgType = DebugMessageType::Error;
-            getDebugCallback()
-                ->handleMessage(msgType, DebugMessageSource::Slang, (char*)diagnostics->getBufferPointer());
+            handleMessage(msgType, DebugMessageSource::Slang, (char*)diagnostics->getBufferPointer());
             if (outDiagnosticBlob)
                 returnComPtr(outDiagnosticBlob, diagnostics);
         }

--- a/src/d3d11/d3d11-device.h
+++ b/src/d3d11/d3d11-device.h
@@ -10,7 +10,7 @@ class DeviceImpl : public ImmediateDevice
 public:
     ~DeviceImpl() {}
 
-    virtual SLANG_NO_THROW Result SLANG_MCALL initialize(const Desc& desc) override;
+    virtual SLANG_NO_THROW Result SLANG_MCALL initialize(const DeviceDesc& desc) override;
     virtual SLANG_NO_THROW Result SLANG_MCALL createSurface(WindowHandle windowHandle, ISurface** outSurface) override;
     virtual void beginRenderPass(const RenderPassDesc& desc) override;
     virtual void endRenderPass() override;
@@ -112,7 +112,7 @@ public:
     uint32_t m_stencilRef = 0;
     bool m_depthStencilStateDirty = true;
 
-    Desc m_desc;
+    DeviceDesc m_desc;
 
     float m_clearColor[4] = {0, 0, 0, 0};
 

--- a/src/d3d11/d3d11-helper-functions.cpp
+++ b/src/d3d11/d3d11-helper-functions.cpp
@@ -374,7 +374,7 @@ Result SLANG_MCALL getD3D11Adapters(std::vector<AdapterInfo>& outAdapters)
     return SLANG_OK;
 }
 
-Result SLANG_MCALL createD3D11Device(const IDevice::Desc* desc, IDevice** outDevice)
+Result SLANG_MCALL createD3D11Device(const DeviceDesc* desc, IDevice** outDevice)
 {
     RefPtr<d3d11::DeviceImpl> result = new d3d11::DeviceImpl();
     SLANG_RETURN_ON_FAIL(result->initialize(*desc));

--- a/src/d3d11/d3d11-helper-functions.h
+++ b/src/d3d11/d3d11-helper-functions.h
@@ -268,6 +268,6 @@ namespace rhi {
 
 Result SLANG_MCALL getD3D11Adapters(std::vector<AdapterInfo>& outAdapters);
 
-Result SLANG_MCALL createD3D11Device(const IDevice::Desc* desc, IDevice** outDevice);
+Result SLANG_MCALL createD3D11Device(const DeviceDesc* desc, IDevice** outDevice);
 
 } // namespace rhi

--- a/src/d3d12/d3d12-buffer.cpp
+++ b/src/d3d12/d3d12-buffer.cpp
@@ -120,11 +120,10 @@ D3D12Descriptor BufferImpl::getSRV(Format format, uint32_t stride, const BufferR
     }
     else
     {
-        FormatInfo sizeInfo;
-        rhiGetFormatInfo(format, &sizeInfo);
-        SLANG_RHI_ASSERT(sizeInfo.pixelsPerBlock == 1);
-        viewDesc.Buffer.FirstElement = range.offset / sizeInfo.blockSizeInBytes;
-        viewDesc.Buffer.NumElements = UINT(range.size / sizeInfo.blockSizeInBytes);
+        const FormatInfo& formatInfo = getFormatInfo(format);
+        SLANG_RHI_ASSERT(formatInfo.pixelsPerBlock == 1);
+        viewDesc.Buffer.FirstElement = range.offset / formatInfo.blockSizeInBytes;
+        viewDesc.Buffer.NumElements = UINT(range.size / formatInfo.blockSizeInBytes);
     }
 
     m_device->m_cpuViewHeap->allocate(&descriptor);
@@ -158,11 +157,10 @@ D3D12Descriptor BufferImpl::getUAV(Format format, uint32_t stride, const BufferR
     }
     else
     {
-        FormatInfo sizeInfo;
-        rhiGetFormatInfo(format, &sizeInfo);
-        SLANG_RHI_ASSERT(sizeInfo.pixelsPerBlock == 1);
-        viewDesc.Buffer.FirstElement = range.offset / sizeInfo.blockSizeInBytes;
-        viewDesc.Buffer.NumElements = UINT(range.size / sizeInfo.blockSizeInBytes);
+        const FormatInfo& formatInfo = getFormatInfo(format);
+        SLANG_RHI_ASSERT(formatInfo.pixelsPerBlock == 1);
+        viewDesc.Buffer.FirstElement = range.offset / formatInfo.blockSizeInBytes;
+        viewDesc.Buffer.NumElements = UINT(range.size / formatInfo.blockSizeInBytes);
     }
 
     m_device->m_cpuViewHeap->allocate(&descriptor);

--- a/src/d3d12/d3d12-command-encoder.cpp
+++ b/src/d3d12/d3d12-command-encoder.cpp
@@ -1167,7 +1167,7 @@ void RayTracingPassEncoderImpl::buildAccelerationStructure(
 {
     if (!m_commandBuffer->m_cmdList4)
     {
-        getDebugCallback()->handleMessage(
+        m_device->handleMessage(
             DebugMessageType::Error,
             DebugMessageSource::Layer,
             "Ray-tracing is not supported on current system."
@@ -1182,7 +1182,7 @@ void RayTracingPassEncoderImpl::buildAccelerationStructure(
     buildDesc.SourceAccelerationStructureData = srcImpl ? srcImpl->getDeviceAddress() : 0;
     buildDesc.ScratchAccelerationStructureData = scratchBuffer.buffer->getDeviceAddress() + scratchBuffer.offset;
     D3DAccelerationStructureInputsBuilder builder;
-    builder.build(desc, getDebugCallback());
+    builder.build(desc, m_device->m_debugCallback);
     buildDesc.Inputs = builder.desc;
 
     std::vector<D3D12_RAYTRACING_ACCELERATION_STRUCTURE_POSTBUILD_INFO_DESC> postBuildInfoDescs;
@@ -1209,7 +1209,7 @@ void RayTracingPassEncoderImpl::copyAccelerationStructure(
         copyMode = D3D12_RAYTRACING_ACCELERATION_STRUCTURE_COPY_MODE_COMPACT;
         break;
     default:
-        getDebugCallback()->handleMessage(
+        m_device->handleMessage(
             DebugMessageType::Error,
             DebugMessageSource::Layer,
             "Unsupported AccelerationStructureCopyMode."

--- a/src/d3d12/d3d12-command-encoder.cpp
+++ b/src/d3d12/d3d12-command-encoder.cpp
@@ -276,8 +276,7 @@ void ResourcePassEncoderImpl::uploadTextureData(
         dstTexture->m_desc.arrayLength
     );
     auto textureSize = dstTexture->m_desc.size;
-    FormatInfo formatInfo = {};
-    rhiGetFormatInfo(dstTexture->m_desc.format, &formatInfo);
+    const FormatInfo& formatInfo = getFormatInfo(dstTexture->m_desc.format);
     for (GfxCount i = 0; i < subresourceDataCount; i++)
     {
         auto subresourceIndex = baseSubresourceIndex + i;
@@ -557,8 +556,7 @@ void ResourcePassEncoderImpl::copyTextureToBuffer(
         srcTexture->m_desc.arrayLength
     );
     auto textureSize = srcTexture->m_desc.size;
-    FormatInfo formatInfo = {};
-    rhiGetFormatInfo(srcTexture->m_desc.format, &formatInfo);
+    const FormatInfo& formatInfo = getFormatInfo(srcTexture->m_desc.format);
     if (srcSubresource.mipLevelCount == 0)
         srcSubresource.mipLevelCount = srcTexture->m_desc.mipLevelCount;
     if (srcSubresource.layerCount == 0)

--- a/src/d3d12/d3d12-device.cpp
+++ b/src/d3d12/d3d12-device.cpp
@@ -165,7 +165,7 @@ Result DeviceImpl::createBuffer(
     return SLANG_OK;
 }
 
-Result DeviceImpl::getNativeDeviceHandles(NativeHandles* outHandles)
+Result DeviceImpl::getNativeDeviceHandles(DeviceNativeHandles* outHandles)
 {
     outHandles->handles[0].type = NativeHandleType::D3D12Device;
     outHandles->handles[0].value = (uint64_t)m_device;
@@ -324,7 +324,7 @@ Result DeviceImpl::_createDevice(
     return SLANG_OK;
 }
 
-Result DeviceImpl::initialize(const Desc& desc)
+Result DeviceImpl::initialize(const DeviceDesc& desc)
 {
     SLANG_RETURN_ON_FAIL(Device::initialize(desc));
 

--- a/src/d3d12/d3d12-device.h
+++ b/src/d3d12/d3d12-device.h
@@ -44,7 +44,7 @@ struct D3D12DeviceInfo
 class DeviceImpl : public Device
 {
 public:
-    Desc m_desc;
+    DeviceDesc m_desc;
     D3D12DeviceExtendedDesc m_extendedDesc;
 
     DeviceInfo m_info;
@@ -95,7 +95,7 @@ public:
     ComPtr<ID3D12CommandSignature> dispatchIndirectCmdSignature;
 
 public:
-    virtual SLANG_NO_THROW Result SLANG_MCALL initialize(const Desc& desc) override;
+    virtual SLANG_NO_THROW Result SLANG_MCALL initialize(const DeviceDesc& desc) override;
     virtual SLANG_NO_THROW Result SLANG_MCALL getFormatSupport(Format format, FormatSupport* outFormatSupport) override;
 
     virtual SLANG_NO_THROW Result SLANG_MCALL getQueue(QueueType type, ICommandQueue** outQueue) override;
@@ -161,7 +161,7 @@ public:
 
     virtual SLANG_NO_THROW const DeviceInfo& SLANG_MCALL getDeviceInfo() const override;
 
-    virtual SLANG_NO_THROW Result SLANG_MCALL getNativeDeviceHandles(NativeHandles* outHandles) override;
+    virtual SLANG_NO_THROW Result SLANG_MCALL getNativeDeviceHandles(DeviceNativeHandles* outHandles) override;
 
     ~DeviceImpl();
 

--- a/src/d3d12/d3d12-helper-functions.cpp
+++ b/src/d3d12/d3d12-helper-functions.cpp
@@ -504,7 +504,7 @@ Result SLANG_MCALL getD3D12Adapters(std::vector<AdapterInfo>& outAdapters)
     return SLANG_OK;
 }
 
-Result SLANG_MCALL createD3D12Device(const IDevice::Desc* desc, IDevice** outDevice)
+Result SLANG_MCALL createD3D12Device(const DeviceDesc* desc, IDevice** outDevice)
 {
     RefPtr<d3d12::DeviceImpl> result = new d3d12::DeviceImpl();
     SLANG_RETURN_ON_FAIL(result->initialize(*desc));

--- a/src/d3d12/d3d12-helper-functions.h
+++ b/src/d3d12/d3d12-helper-functions.h
@@ -81,6 +81,6 @@ namespace rhi {
 
 Result SLANG_MCALL getD3D12Adapters(std::vector<AdapterInfo>& outAdapters);
 
-Result SLANG_MCALL createD3D12Device(const IDevice::Desc* desc, IDevice** outDevice);
+Result SLANG_MCALL createD3D12Device(const DeviceDesc* desc, IDevice** outDevice);
 
 } // namespace rhi

--- a/src/d3d12/d3d12-pipeline.cpp
+++ b/src/d3d12/d3d12-pipeline.cpp
@@ -179,7 +179,7 @@ Result PipelineImpl::ensureAPIPipelineCreated()
                     meshDesc.MS = {shaderBin.code.data(), SIZE_T(shaderBin.code.size())};
                     break;
                 default:
-                    getDebugCallback()->handleMessage(
+                    m_device->handleMessage(
                         DebugMessageType::Error,
                         DebugMessageSource::Layer,
                         "Unsupported shader stage."
@@ -230,7 +230,7 @@ Result PipelineImpl::ensureAPIPipelineCreated()
                     graphicsDesc.GS = {shaderBin.code.data(), SIZE_T(shaderBin.code.size())};
                     break;
                 default:
-                    getDebugCallback()->handleMessage(
+                    m_device->handleMessage(
                         DebugMessageType::Error,
                         DebugMessageSource::Layer,
                         "Unsupported shader stage."
@@ -410,7 +410,7 @@ Result RayTracingPipelineImpl::ensureAPIPipelineCreated()
         );
         if (diagnostics.get())
         {
-            getDebugCallback()->handleMessage(
+            m_device->handleMessage(
                 compileResult == SLANG_OK ? DebugMessageType::Warning : DebugMessageType::Error,
                 DebugMessageSource::Slang,
                 (char*)diagnostics->getBufferPointer()

--- a/src/d3d12/d3d12-shader-object-layout.cpp
+++ b/src/d3d12/d3d12-shader-object-layout.cpp
@@ -511,7 +511,7 @@ Result RootShaderObjectLayoutImpl::RootSignatureDescBuilder::addDescriptorRange(
             rootParam.ParameterType = D3D12_ROOT_PARAMETER_TYPE_UAV;
             break;
         default:
-            getDebugCallback()->handleMessage(
+            m_device->handleMessage(
                 DebugMessageType::Error,
                 DebugMessageSource::Layer,
                 "A shader parameter marked as root parameter is neither SRV nor UAV."
@@ -941,14 +941,14 @@ Result RootShaderObjectLayoutImpl::createRootSignatureFromSlang(
             device->m_D3D12SerializeVersionedRootSignature(&versionedDesc, signature.writeRef(), error.writeRef())
         ))
     {
-        getDebugCallback()->handleMessage(
+        m_device->handleMessage(
             DebugMessageType::Error,
             DebugMessageSource::Layer,
             "error: D3D12SerializeRootSignature failed"
         );
         if (error)
         {
-            getDebugCallback()->handleMessage(
+            m_device->handleMessage(
                 DebugMessageType::Error,
                 DebugMessageSource::Driver,
                 (const char*)error->GetBufferPointer()

--- a/src/d3d12/d3d12-shader-object-layout.cpp
+++ b/src/d3d12/d3d12-shader-object-layout.cpp
@@ -941,14 +941,14 @@ Result RootShaderObjectLayoutImpl::createRootSignatureFromSlang(
             device->m_D3D12SerializeVersionedRootSignature(&versionedDesc, signature.writeRef(), error.writeRef())
         ))
     {
-        getDevice()->handleMessage(
+        device->handleMessage(
             DebugMessageType::Error,
             DebugMessageSource::Layer,
             "error: D3D12SerializeRootSignature failed"
         );
         if (error)
         {
-            getDevice()->handleMessage(
+            device->handleMessage(
                 DebugMessageType::Error,
                 DebugMessageSource::Driver,
                 (const char*)error->GetBufferPointer()

--- a/src/d3d12/d3d12-shader-object-layout.cpp
+++ b/src/d3d12/d3d12-shader-object-layout.cpp
@@ -941,14 +941,14 @@ Result RootShaderObjectLayoutImpl::createRootSignatureFromSlang(
             device->m_D3D12SerializeVersionedRootSignature(&versionedDesc, signature.writeRef(), error.writeRef())
         ))
     {
-        m_device->handleMessage(
+        getDevice()->handleMessage(
             DebugMessageType::Error,
             DebugMessageSource::Layer,
             "error: D3D12SerializeRootSignature failed"
         );
         if (error)
         {
-            m_device->handleMessage(
+            getDevice()->handleMessage(
                 DebugMessageType::Error,
                 DebugMessageSource::Driver,
                 (const char*)error->GetBufferPointer()

--- a/src/d3d12/d3d12-shader-object.cpp
+++ b/src/d3d12/d3d12-shader-object.cpp
@@ -1121,7 +1121,7 @@ Result RootShaderObjectImpl::_createSpecializedLayout(ShaderObjectLayoutImpl** o
 
     if (diagnosticBlob && diagnosticBlob->getBufferSize())
     {
-        getDebugCallback()->handleMessage(
+        m_device->handleMessage(
             SLANG_FAILED(result) ? DebugMessageType::Error : DebugMessageType::Info,
             DebugMessageSource::Layer,
             (const char*)diagnosticBlob->getBufferPointer()

--- a/src/d3d12/d3d12-texture-view.cpp
+++ b/src/d3d12/d3d12-texture-view.cpp
@@ -92,11 +92,10 @@ Result createD3D12BufferDescriptor(
         }
         else
         {
-            FormatInfo sizeInfo;
-            rhiGetFormatInfo(desc.format, &sizeInfo);
-            SLANG_RHI_ASSERT(sizeInfo.pixelsPerBlock == 1);
-            uavDesc.Buffer.FirstElement = offset / sizeInfo.blockSizeInBytes;
-            uavDesc.Buffer.NumElements = UINT(size / sizeInfo.blockSizeInBytes);
+            const FormatInfo& formatInfo = getFormatInfo(desc.format);
+            SLANG_RHI_ASSERT(formatInfo.pixelsPerBlock == 1);
+            uavDesc.Buffer.FirstElement = offset / formatInfo.blockSizeInBytes;
+            uavDesc.Buffer.NumElements = UINT(size / formatInfo.blockSizeInBytes);
         }
 
         if (size >= (1ull << 32) - 8)
@@ -141,11 +140,10 @@ Result createD3D12BufferDescriptor(
         }
         else
         {
-            FormatInfo sizeInfo;
-            rhiGetFormatInfo(desc.format, &sizeInfo);
-            SLANG_RHI_ASSERT(sizeInfo.pixelsPerBlock == 1);
-            srvDesc.Buffer.FirstElement = offset / sizeInfo.blockSizeInBytes;
-            srvDesc.Buffer.NumElements = UINT(size / sizeInfo.blockSizeInBytes);
+            const FormatInfo& formatInfo = getFormatInfo(desc.format);
+            SLANG_RHI_ASSERT(formatInfo.pixelsPerBlock == 1);
+            srvDesc.Buffer.FirstElement = offset / formatInfo.blockSizeInBytes;
+            srvDesc.Buffer.NumElements = UINT(size / formatInfo.blockSizeInBytes);
         }
 
         if (size >= (1ull << 32) - 8)

--- a/src/d3d12/d3d12-texture.cpp
+++ b/src/d3d12/d3d12-texture.cpp
@@ -194,7 +194,7 @@ D3D12Descriptor TextureImpl::getUAV(
     bool isMultiSample = m_desc.sampleCount > 1;
     D3D12_UNORDERED_ACCESS_VIEW_DESC viewDesc = {};
     viewDesc.Format =
-        rhiIsTypelessFormat(m_desc.format) ? D3DUtil::getMapFormat(m_desc.format) : D3DUtil::getMapFormat(format);
+        getFormatInfo(m_desc.format).isTypeless ? D3DUtil::getMapFormat(m_desc.format) : D3DUtil::getMapFormat(format);
     switch (type)
     {
     case TextureType::Texture1D:

--- a/src/debug-layer/debug-base.h
+++ b/src/debug-layer/debug-base.h
@@ -10,11 +10,19 @@
 
 namespace rhi::debug {
 
+struct DebugContext
+{
+    IDebugCallback* debugCallback = nullptr;
+};
+
 class DebugObjectBase : public ComObject
 {
 public:
     uint64_t uid;
-    DebugObjectBase()
+    DebugContext* ctx;
+
+    DebugObjectBase(DebugContext* ctx)
+        : ctx(ctx)
     {
         static uint64_t uidCounter = 0;
         uid = ++uidCounter;
@@ -26,14 +34,36 @@ class DebugObject : public TInterface, public DebugObjectBase
 {
 public:
     ComPtr<TInterface> baseObject;
+
+    DebugObject(DebugContext* ctx)
+        : DebugObjectBase(ctx)
+    {
+    }
 };
+
+#define SLANG_RHI_DEBUG_OBJECT_CONSTRUCTOR(name)                                                                       \
+    name(DebugContext* ctx)                                                                                            \
+        : DebugObject(ctx)                                                                                             \
+    {                                                                                                                  \
+    }
 
 template<typename TInterface>
 class UnownedDebugObject : public TInterface, public DebugObjectBase
 {
 public:
     TInterface* baseObject = nullptr;
+
+    UnownedDebugObject(DebugContext* ctx)
+        : DebugObjectBase(ctx)
+    {
+    }
 };
+
+#define SLANG_RHI_UNOWNED_DEBUG_OBJECT_CONSTRUCTOR(name)                                                               \
+    name(DebugContext* ctx)                                                                                            \
+        : UnownedDebugObject(ctx)                                                                                      \
+    {                                                                                                                  \
+    }
 
 class DebugDevice;
 class DebugShaderTable;

--- a/src/debug-layer/debug-buffer.h
+++ b/src/debug-layer/debug-buffer.h
@@ -9,6 +9,8 @@ class DebugBuffer : public DebugObject<IBuffer>
 public:
     SLANG_COM_OBJECT_IUNKNOWN_ALL;
 
+    SLANG_RHI_DEBUG_OBJECT_CONSTRUCTOR(DebugBuffer);
+
 public:
     IBuffer* getInterface(const Guid& guid);
     virtual SLANG_NO_THROW const BufferDesc& SLANG_MCALL getDesc() override;

--- a/src/debug-layer/debug-command-buffer.cpp
+++ b/src/debug-layer/debug-command-buffer.cpp
@@ -3,7 +3,13 @@
 
 namespace rhi::debug {
 
-DebugCommandBuffer::DebugCommandBuffer()
+DebugCommandBuffer::DebugCommandBuffer(DebugContext* ctx)
+    : DebugObject(ctx)
+    , m_renderPassEncoder(ctx)
+    , m_computePassEncoder(ctx)
+    , m_resourcePassEncoder(ctx)
+    , m_rayTracingPassEncoder(ctx)
+    , rootObject(ctx)
 {
     SLANG_RHI_API_FUNC;
     m_renderPassEncoder.commandBuffer = this;

--- a/src/debug-layer/debug-command-buffer.h
+++ b/src/debug-layer/debug-command-buffer.h
@@ -21,7 +21,7 @@ private:
     DebugRayTracingPassEncoder m_rayTracingPassEncoder;
 
 public:
-    DebugCommandBuffer();
+    DebugCommandBuffer(DebugContext* ctx);
     ICommandBuffer* getInterface(const Guid& guid);
     virtual SLANG_NO_THROW Result SLANG_MCALL beginResourcePass(IResourcePassEncoder** outEncoder) override;
     virtual SLANG_NO_THROW Result SLANG_MCALL

--- a/src/debug-layer/debug-command-encoder.cpp
+++ b/src/debug-layer/debug-command-encoder.cpp
@@ -406,7 +406,7 @@ void DebugRayTracingPassEncoder::buildAccelerationStructure(
     {
         innerQueryDesc.queryPool = getInnerObj(innerQueryDesc.queryPool);
     }
-    validateAccelerationStructureBuildDesc(desc);
+    validateAccelerationStructureBuildDesc(ctx, desc);
     baseObject->buildAccelerationStructure(
         innerDesc,
         getInnerObj(dst),

--- a/src/debug-layer/debug-command-encoder.h
+++ b/src/debug-layer/debug-command-encoder.h
@@ -43,6 +43,8 @@ public:
 class DebugResourcePassEncoder : public UnownedDebugObject<IResourcePassEncoder>, public DebugPassEncoder
 {
 public:
+    SLANG_RHI_UNOWNED_DEBUG_OBJECT_CONSTRUCTOR(DebugResourcePassEncoder);
+
     SLANG_RHI_FORWARD_PASS_ENCODER_IMPL(DebugPassEncoder)
 
     virtual IPassEncoder* getBaseObject() override { return baseObject; }
@@ -113,6 +115,8 @@ public:
 class DebugRenderPassEncoder : public UnownedDebugObject<IRenderPassEncoder>, public DebugPassEncoder
 {
 public:
+    SLANG_RHI_UNOWNED_DEBUG_OBJECT_CONSTRUCTOR(DebugRenderPassEncoder);
+
     SLANG_RHI_FORWARD_PASS_ENCODER_IMPL(DebugPassEncoder)
 
     virtual IPassEncoder* getBaseObject() override { return baseObject; }
@@ -174,6 +178,8 @@ public:
 class DebugComputePassEncoder : public UnownedDebugObject<IComputePassEncoder>, public DebugPassEncoder
 {
 public:
+    SLANG_RHI_UNOWNED_DEBUG_OBJECT_CONSTRUCTOR(DebugComputePassEncoder);
+
     SLANG_RHI_FORWARD_PASS_ENCODER_IMPL(DebugPassEncoder)
 
     virtual IPassEncoder* getBaseObject() override { return baseObject; }
@@ -201,6 +207,8 @@ public:
 class DebugRayTracingPassEncoder : public UnownedDebugObject<IRayTracingPassEncoder>, public DebugPassEncoder
 {
 public:
+    SLANG_RHI_UNOWNED_DEBUG_OBJECT_CONSTRUCTOR(DebugRayTracingPassEncoder);
+
     SLANG_RHI_FORWARD_PASS_ENCODER_IMPL(DebugPassEncoder)
 
     virtual IPassEncoder* getBaseObject() override { return baseObject; }

--- a/src/debug-layer/debug-command-queue.h
+++ b/src/debug-layer/debug-command-queue.h
@@ -9,6 +9,8 @@ class DebugCommandQueue : public DebugObject<ICommandQueue>
 public:
     SLANG_COM_OBJECT_IUNKNOWN_ALL;
 
+    SLANG_RHI_DEBUG_OBJECT_CONSTRUCTOR(DebugCommandQueue);
+
 public:
     ICommandQueue* getInterface(const Guid& guid);
     virtual SLANG_NO_THROW QueueType SLANG_MCALL getType() override;

--- a/src/debug-layer/debug-device.cpp
+++ b/src/debug-layer/debug-device.cpp
@@ -52,9 +52,10 @@ Result DebugDevice::getFormatSupport(Format format, FormatSupport* outFormatSupp
     return baseObject->getFormatSupport(format, outFormatSupport);
 }
 
-DebugDevice::DebugDevice()
+DebugDevice::DebugDevice(IDebugCallback* debugCallback)
     : DebugObject(&m_ctx)
 {
+    ctx->debugCallback = debugCallback;
     SLANG_RHI_API_FUNC_NAME("CreateDevice");
     RHI_VALIDATION_INFO("Debug layer is enabled.");
 }

--- a/src/debug-layer/debug-device.cpp
+++ b/src/debug-layer/debug-device.cpp
@@ -53,6 +53,7 @@ Result DebugDevice::getFormatSupport(Format format, FormatSupport* outFormatSupp
 }
 
 DebugDevice::DebugDevice()
+    : DebugObject(&m_ctx)
 {
     SLANG_RHI_API_FUNC_NAME("CreateDevice");
     RHI_VALIDATION_INFO("Debug layer is enabled.");
@@ -79,7 +80,7 @@ Result DebugDevice::createTransientResourceHeap(
 {
     SLANG_RHI_API_FUNC;
 
-    RefPtr<DebugTransientResourceHeap> outObject = new DebugTransientResourceHeap();
+    RefPtr<DebugTransientResourceHeap> outObject = new DebugTransientResourceHeap(ctx);
     auto result = baseObject->createTransientResourceHeap(desc, outObject->baseObject.writeRef());
     if (SLANG_FAILED(result))
         return result;
@@ -99,7 +100,7 @@ Result DebugDevice::createTexture(const TextureDesc& desc, const SubresourceData
         patchedDesc.label = label.c_str();
     }
 
-    RefPtr<DebugTexture> outObject = new DebugTexture();
+    RefPtr<DebugTexture> outObject = new DebugTexture(ctx);
     auto result = baseObject->createTexture(patchedDesc, initData, outObject->baseObject.writeRef());
     if (SLANG_FAILED(result))
         return result;
@@ -115,7 +116,7 @@ Result DebugDevice::createTextureFromNativeHandle(
 {
     SLANG_RHI_API_FUNC;
 
-    RefPtr<DebugTexture> outObject = new DebugTexture();
+    RefPtr<DebugTexture> outObject = new DebugTexture(ctx);
     auto result = baseObject->createTextureFromNativeHandle(handle, srcDesc, outObject->baseObject.writeRef());
     if (SLANG_FAILED(result))
         return result;
@@ -132,7 +133,7 @@ Result DebugDevice::createTextureFromSharedHandle(
 {
     SLANG_RHI_API_FUNC;
 
-    RefPtr<DebugTexture> outObject = new DebugTexture();
+    RefPtr<DebugTexture> outObject = new DebugTexture(ctx);
     auto result = baseObject->createTextureFromSharedHandle(handle, srcDesc, size, outObject->baseObject.writeRef());
     if (SLANG_FAILED(result))
         return result;
@@ -152,7 +153,7 @@ Result DebugDevice::createBuffer(const BufferDesc& desc, const void* initData, I
         patchedDesc.label = label.c_str();
     }
 
-    RefPtr<DebugBuffer> outObject = new DebugBuffer();
+    RefPtr<DebugBuffer> outObject = new DebugBuffer(ctx);
     auto result = baseObject->createBuffer(patchedDesc, initData, outObject->baseObject.writeRef());
     if (SLANG_FAILED(result))
         return result;
@@ -164,7 +165,7 @@ Result DebugDevice::createBufferFromNativeHandle(NativeHandle handle, const Buff
 {
     SLANG_RHI_API_FUNC;
 
-    RefPtr<DebugBuffer> outObject = new DebugBuffer();
+    RefPtr<DebugBuffer> outObject = new DebugBuffer(ctx);
     auto result = baseObject->createBufferFromNativeHandle(handle, srcDesc, outObject->baseObject.writeRef());
     if (SLANG_FAILED(result))
         return result;
@@ -176,7 +177,7 @@ Result DebugDevice::createBufferFromSharedHandle(NativeHandle handle, const Buff
 {
     SLANG_RHI_API_FUNC;
 
-    RefPtr<DebugBuffer> outObject = new DebugBuffer();
+    RefPtr<DebugBuffer> outObject = new DebugBuffer(ctx);
     auto result = baseObject->createBufferFromSharedHandle(handle, srcDesc, outObject->baseObject.writeRef());
     if (SLANG_FAILED(result))
         return result;
@@ -196,7 +197,7 @@ Result DebugDevice::createSampler(SamplerDesc const& desc, ISampler** outSampler
         patchedDesc.label = label.c_str();
     }
 
-    RefPtr<DebugSampler> outObject = new DebugSampler();
+    RefPtr<DebugSampler> outObject = new DebugSampler(ctx);
     auto result = baseObject->createSampler(patchedDesc, outObject->baseObject.writeRef());
     if (SLANG_FAILED(result))
         return result;
@@ -208,7 +209,7 @@ Result DebugDevice::createTextureView(ITexture* texture, const TextureViewDesc& 
 {
     SLANG_RHI_API_FUNC;
 
-    RefPtr<DebugTextureView> outObject = new DebugTextureView();
+    RefPtr<DebugTextureView> outObject = new DebugTextureView(ctx);
     auto result = baseObject->createTextureView(getInnerObj(texture), desc, outObject->baseObject.writeRef());
     if (SLANG_FAILED(result))
         return result;
@@ -222,7 +223,7 @@ Result DebugDevice::getAccelerationStructureSizes(
 )
 {
     SLANG_RHI_API_FUNC;
-    validateAccelerationStructureBuildDesc(desc);
+    validateAccelerationStructureBuildDesc(ctx, desc);
     return baseObject->getAccelerationStructureSizes(desc, outSizes);
 }
 
@@ -232,7 +233,7 @@ Result DebugDevice::createAccelerationStructure(
 )
 {
     SLANG_RHI_API_FUNC;
-    RefPtr<DebugAccelerationStructure> outObject = new DebugAccelerationStructure();
+    RefPtr<DebugAccelerationStructure> outObject = new DebugAccelerationStructure(ctx);
     auto result = baseObject->createAccelerationStructure(desc, outObject->baseObject.writeRef());
     if (SLANG_FAILED(result))
         return result;
@@ -244,7 +245,7 @@ Result DebugDevice::createSurface(WindowHandle windowHandle, ISurface** outSurfa
 {
     SLANG_RHI_API_FUNC;
 
-    RefPtr<DebugSurface> outObject = new DebugSurface();
+    RefPtr<DebugSurface> outObject = new DebugSurface(ctx);
     SLANG_RETURN_ON_FAIL(baseObject->createSurface(windowHandle, outObject->baseObject.writeRef()));
     returnComPtr(outSurface, outObject);
     return SLANG_OK;
@@ -254,7 +255,7 @@ Result DebugDevice::createInputLayout(InputLayoutDesc const& desc, IInputLayout*
 {
     SLANG_RHI_API_FUNC;
 
-    RefPtr<DebugInputLayout> outObject = new DebugInputLayout();
+    RefPtr<DebugInputLayout> outObject = new DebugInputLayout(ctx);
     auto result = baseObject->createInputLayout(desc, outObject->baseObject.writeRef());
     if (SLANG_FAILED(result))
         return result;
@@ -266,7 +267,7 @@ Result DebugDevice::getQueue(QueueType type, ICommandQueue** outQueue)
 {
     SLANG_RHI_API_FUNC;
 
-    RefPtr<DebugCommandQueue> outObject = new DebugCommandQueue();
+    RefPtr<DebugCommandQueue> outObject = new DebugCommandQueue(ctx);
     auto result = baseObject->getQueue(type, outObject->baseObject.writeRef());
     if (SLANG_FAILED(result))
         return result;
@@ -282,7 +283,7 @@ Result DebugDevice::createShaderObject(
 {
     SLANG_RHI_API_FUNC;
 
-    RefPtr<DebugShaderObject> outObject = new DebugShaderObject();
+    RefPtr<DebugShaderObject> outObject = new DebugShaderObject(ctx);
     auto result = baseObject->createShaderObject(type, containerType, outObject->baseObject.writeRef());
     outObject->m_typeName = string::from_cstr(type->getName());
     outObject->m_device = this;
@@ -302,7 +303,7 @@ Result DebugDevice::createShaderObject2(
 {
     SLANG_RHI_API_FUNC;
 
-    RefPtr<DebugShaderObject> outObject = new DebugShaderObject();
+    RefPtr<DebugShaderObject> outObject = new DebugShaderObject(ctx);
     auto result = baseObject->createShaderObject2(session, type, containerType, outObject->baseObject.writeRef());
     outObject->m_typeName = string::from_cstr(type->getName());
     outObject->m_device = this;
@@ -321,7 +322,7 @@ Result DebugDevice::createMutableShaderObject(
 {
     SLANG_RHI_API_FUNC;
 
-    RefPtr<DebugShaderObject> outObject = new DebugShaderObject();
+    RefPtr<DebugShaderObject> outObject = new DebugShaderObject(ctx);
     auto result = baseObject->createMutableShaderObject(type, containerType, outObject->baseObject.writeRef());
     outObject->m_typeName = string::from_cstr(type->getName());
     outObject->m_device = this;
@@ -341,7 +342,7 @@ Result DebugDevice::createMutableShaderObject2(
 {
     SLANG_RHI_API_FUNC;
 
-    RefPtr<DebugShaderObject> outObject = new DebugShaderObject();
+    RefPtr<DebugShaderObject> outObject = new DebugShaderObject(ctx);
     auto result =
         baseObject->createMutableShaderObject2(session, type, containerType, outObject->baseObject.writeRef());
     outObject->m_typeName = string::from_cstr(type->getName());
@@ -356,7 +357,7 @@ Result DebugDevice::createMutableShaderObject2(
 Result DebugDevice::createMutableRootShaderObject(IShaderProgram* program, IShaderObject** outRootObject)
 {
     SLANG_RHI_API_FUNC;
-    RefPtr<DebugShaderObject> outObject = new DebugShaderObject();
+    RefPtr<DebugShaderObject> outObject = new DebugShaderObject(ctx);
     auto result = baseObject->createMutableRootShaderObject(getInnerObj(program), outObject->baseObject.writeRef());
     if (SLANG_FAILED(result))
         return result;
@@ -374,7 +375,7 @@ Result DebugDevice::createShaderObjectFromTypeLayout(
 {
     SLANG_RHI_API_FUNC;
 
-    RefPtr<DebugShaderObject> outObject = new DebugShaderObject();
+    RefPtr<DebugShaderObject> outObject = new DebugShaderObject(ctx);
     auto result = baseObject->createShaderObjectFromTypeLayout(typeLayout, outObject->baseObject.writeRef());
     auto type = typeLayout->getType();
     outObject->m_typeName = string::from_cstr(type->getName());
@@ -392,7 +393,7 @@ Result DebugDevice::createMutableShaderObjectFromTypeLayout(
 )
 {
     SLANG_RHI_API_FUNC;
-    RefPtr<DebugShaderObject> outObject = new DebugShaderObject();
+    RefPtr<DebugShaderObject> outObject = new DebugShaderObject(ctx);
     auto result = baseObject->createMutableShaderObjectFromTypeLayout(typeLayout, outObject->baseObject.writeRef());
     if (SLANG_FAILED(result))
         return result;
@@ -412,7 +413,7 @@ Result DebugDevice::createShaderProgram(
 {
     SLANG_RHI_API_FUNC;
 
-    RefPtr<DebugShaderProgram> outObject = new DebugShaderProgram();
+    RefPtr<DebugShaderProgram> outObject = new DebugShaderProgram(ctx);
     auto result = baseObject->createShaderProgram(desc, outObject->baseObject.writeRef(), outDiagnostics);
     if (SLANG_FAILED(result))
         return result;
@@ -428,7 +429,7 @@ Result DebugDevice::createRenderPipeline(const RenderPipelineDesc& desc, IPipeli
     RenderPipelineDesc innerDesc = desc;
     innerDesc.program = getInnerObj(desc.program);
     innerDesc.inputLayout = getInnerObj(desc.inputLayout);
-    RefPtr<DebugPipeline> outObject = new DebugPipeline();
+    RefPtr<DebugPipeline> outObject = new DebugPipeline(ctx);
     auto result = baseObject->createRenderPipeline(innerDesc, outObject->baseObject.writeRef());
     if (SLANG_FAILED(result))
         return result;
@@ -443,7 +444,7 @@ Result DebugDevice::createComputePipeline(const ComputePipelineDesc& desc, IPipe
     ComputePipelineDesc innerDesc = desc;
     innerDesc.program = getInnerObj(desc.program);
 
-    RefPtr<DebugPipeline> outObject = new DebugPipeline();
+    RefPtr<DebugPipeline> outObject = new DebugPipeline(ctx);
     auto result = baseObject->createComputePipeline(innerDesc, outObject->baseObject.writeRef());
     if (SLANG_FAILED(result))
         return result;
@@ -458,7 +459,7 @@ Result DebugDevice::createRayTracingPipeline(const RayTracingPipelineDesc& desc,
     RayTracingPipelineDesc innerDesc = desc;
     innerDesc.program = getInnerObj(desc.program);
 
-    RefPtr<DebugPipeline> outObject = new DebugPipeline();
+    RefPtr<DebugPipeline> outObject = new DebugPipeline(ctx);
     auto result = baseObject->createRayTracingPipeline(innerDesc, outObject->baseObject.writeRef());
     if (SLANG_FAILED(result))
         return result;
@@ -487,7 +488,7 @@ const DeviceInfo& DebugDevice::getDeviceInfo() const
 Result DebugDevice::createQueryPool(const QueryPoolDesc& desc, IQueryPool** outPool)
 {
     SLANG_RHI_API_FUNC;
-    RefPtr<DebugQueryPool> result = new DebugQueryPool();
+    RefPtr<DebugQueryPool> result = new DebugQueryPool(ctx);
     result->desc = desc;
     SLANG_RETURN_ON_FAIL(baseObject->createQueryPool(desc, result->baseObject.writeRef()));
     returnComPtr(outPool, result);
@@ -497,7 +498,7 @@ Result DebugDevice::createQueryPool(const QueryPoolDesc& desc, IQueryPool** outP
 Result DebugDevice::createFence(const FenceDesc& desc, IFence** outFence)
 {
     SLANG_RHI_API_FUNC;
-    RefPtr<DebugFence> result = new DebugFence();
+    RefPtr<DebugFence> result = new DebugFence(ctx);
     SLANG_RETURN_ON_FAIL(baseObject->createFence(desc, result->baseObject.writeRef()));
     returnComPtr(outFence, result);
     return SLANG_OK;
@@ -535,7 +536,7 @@ Result DebugDevice::getTextureRowAlignment(size_t* outAlignment)
 Result DebugDevice::createShaderTable(const IShaderTable::Desc& desc, IShaderTable** outTable)
 {
     SLANG_RHI_API_FUNC;
-    RefPtr<DebugShaderTable> result = new DebugShaderTable();
+    RefPtr<DebugShaderTable> result = new DebugShaderTable(ctx);
     SLANG_RETURN_ON_FAIL(baseObject->createShaderTable(desc, result->baseObject.writeRef()));
     returnComPtr(outTable, result);
     return SLANG_OK;

--- a/src/debug-layer/debug-device.cpp
+++ b/src/debug-layer/debug-device.cpp
@@ -34,7 +34,7 @@ Result DebugDevice::queryInterface(SlangUUID const& uuid, void** outObject) noex
     return baseObject->queryInterface(uuid, outObject);
 }
 
-Result DebugDevice::getNativeDeviceHandles(NativeHandles* outHandles)
+Result DebugDevice::getNativeDeviceHandles(DeviceNativeHandles* outHandles)
 {
     return baseObject->getNativeDeviceHandles(outHandles);
 }

--- a/src/debug-layer/debug-device.h
+++ b/src/debug-layer/debug-device.h
@@ -12,7 +12,7 @@ public:
     SLANG_COM_OBJECT_IUNKNOWN_RELEASE;
 
 public:
-    DebugDevice();
+    DebugDevice(IDebugCallback* debugCallback);
     IDevice* getInterface(const Guid& guid);
     virtual SLANG_NO_THROW Result SLANG_MCALL getNativeDeviceHandles(DeviceNativeHandles* outHandles) override;
     virtual SLANG_NO_THROW bool SLANG_MCALL hasFeature(const char* feature) override;

--- a/src/debug-layer/debug-device.h
+++ b/src/debug-layer/debug-device.h
@@ -14,7 +14,7 @@ public:
 public:
     DebugDevice();
     IDevice* getInterface(const Guid& guid);
-    virtual SLANG_NO_THROW Result SLANG_MCALL getNativeDeviceHandles(NativeHandles* outHandles) override;
+    virtual SLANG_NO_THROW Result SLANG_MCALL getNativeDeviceHandles(DeviceNativeHandles* outHandles) override;
     virtual SLANG_NO_THROW bool SLANG_MCALL hasFeature(const char* feature) override;
     virtual SLANG_NO_THROW Result SLANG_MCALL
     getFeatures(const char** outFeatures, Size bufferSize, GfxCount* outFeatureCount) override;

--- a/src/debug-layer/debug-device.h
+++ b/src/debug-layer/debug-device.h
@@ -109,6 +109,9 @@ public:
     virtual SLANG_NO_THROW Result SLANG_MCALL getTextureRowAlignment(size_t* outAlignment) override;
     virtual SLANG_NO_THROW Result SLANG_MCALL
     createShaderTable(const IShaderTable::Desc& desc, IShaderTable** outTable) override;
+
+private:
+    DebugContext m_ctx;
 };
 
 } // namespace rhi::debug

--- a/src/debug-layer/debug-fence.h
+++ b/src/debug-layer/debug-fence.h
@@ -8,6 +8,10 @@ class DebugFence : public DebugObject<IFence>
 {
 public:
     SLANG_COM_OBJECT_IUNKNOWN_ALL;
+
+    SLANG_RHI_DEBUG_OBJECT_CONSTRUCTOR(DebugFence);
+
+public:
     IFence* getInterface(const Guid& guid);
     virtual SLANG_NO_THROW Result SLANG_MCALL getCurrentValue(uint64_t* outValue) override;
     virtual SLANG_NO_THROW Result SLANG_MCALL setCurrentValue(uint64_t value) override;

--- a/src/debug-layer/debug-helper-functions.cpp
+++ b/src/debug-layer/debug-helper-functions.cpp
@@ -95,7 +95,7 @@ std::string createSamplerLabel(const SamplerDesc& desc)
     );
 }
 
-void validateAccelerationStructureBuildDesc(const AccelerationStructureBuildDesc& buildDesc)
+void validateAccelerationStructureBuildDesc(DebugContext* ctx, const AccelerationStructureBuildDesc& buildDesc)
 {
     if (buildDesc.inputCount < 1)
     {

--- a/src/debug-layer/debug-helper-functions.h
+++ b/src/debug-layer/debug-helper-functions.h
@@ -65,16 +65,17 @@ char* _rhiDiagnoseFormat(
 }
 
 template<typename... TArgs>
-void _rhiDiagnoseImpl(DebugMessageType type, const char* format, TArgs... args)
+void _rhiDiagnoseImpl(DebugContext* ctx, DebugMessageType type, const char* format, TArgs... args)
 {
     char shortBuffer[256];
     std::vector<char> bufferArray;
     auto buffer = _rhiDiagnoseFormat(shortBuffer, sizeof(shortBuffer), bufferArray, format, args...);
-    getDebugCallback()->handleMessage(type, DebugMessageSource::Layer, buffer);
+    ctx->debugCallback->handleMessage(type, DebugMessageSource::Layer, buffer);
 }
 
 #define RHI_VALIDATION_ERROR(message)                                                                                  \
     _rhiDiagnoseImpl(                                                                                                  \
+        ctx,                                                                                                           \
         DebugMessageType::Error,                                                                                       \
         "%s: %s",                                                                                                      \
         _rhiGetFuncName(_currentFunctionName ? _currentFunctionName : SLANG_FUNC_SIG).c_str(),                         \
@@ -82,6 +83,7 @@ void _rhiDiagnoseImpl(DebugMessageType type, const char* format, TArgs... args)
     )
 #define RHI_VALIDATION_WARNING(message)                                                                                \
     _rhiDiagnoseImpl(                                                                                                  \
+        ctx,                                                                                                           \
         DebugMessageType::Warning,                                                                                     \
         "%s: %s",                                                                                                      \
         _rhiGetFuncName(_currentFunctionName ? _currentFunctionName : SLANG_FUNC_SIG).c_str(),                         \
@@ -89,6 +91,7 @@ void _rhiDiagnoseImpl(DebugMessageType type, const char* format, TArgs... args)
     )
 #define RHI_VALIDATION_INFO(message)                                                                                   \
     _rhiDiagnoseImpl(                                                                                                  \
+        ctx,                                                                                                           \
         DebugMessageType::Info,                                                                                        \
         "%s: %s",                                                                                                      \
         _rhiGetFuncName(_currentFunctionName ? _currentFunctionName : SLANG_FUNC_SIG).c_str(),                         \
@@ -100,6 +103,7 @@ void _rhiDiagnoseImpl(DebugMessageType type, const char* format, TArgs... args)
         std::vector<char> bufferArray;                                                                                 \
         auto message = _rhiDiagnoseFormat(shortBuffer, sizeof(shortBuffer), bufferArray, format, __VA_ARGS__);         \
         _rhiDiagnoseImpl(                                                                                              \
+            ctx,                                                                                                       \
             type,                                                                                                      \
             "%s: %s",                                                                                                  \
             _rhiGetFuncName(_currentFunctionName ? _currentFunctionName : SLANG_FUNC_SIG).c_str(),                     \
@@ -181,6 +185,6 @@ std::string createBufferLabel(const BufferDesc& desc);
 std::string createTextureLabel(const TextureDesc& desc);
 std::string createSamplerLabel(const SamplerDesc& desc);
 
-void validateAccelerationStructureBuildDesc(const AccelerationStructureBuildDesc& buildDesc);
+void validateAccelerationStructureBuildDesc(DebugContext* ctx, const AccelerationStructureBuildDesc& buildDesc);
 
 } // namespace rhi::debug

--- a/src/debug-layer/debug-pipeline.h
+++ b/src/debug-layer/debug-pipeline.h
@@ -9,6 +9,8 @@ class DebugPipeline : public DebugObject<IPipeline>
 public:
     SLANG_COM_OBJECT_IUNKNOWN_ALL;
 
+    SLANG_RHI_DEBUG_OBJECT_CONSTRUCTOR(DebugPipeline);
+
 public:
     IPipeline* getInterface(const Guid& guid);
     virtual SLANG_NO_THROW Result SLANG_MCALL getNativeHandle(NativeHandle* outHandle) override;

--- a/src/debug-layer/debug-query.h
+++ b/src/debug-layer/debug-query.h
@@ -9,6 +9,8 @@ class DebugQueryPool : public DebugObject<IQueryPool>
 public:
     SLANG_COM_OBJECT_IUNKNOWN_ALL;
 
+    SLANG_RHI_DEBUG_OBJECT_CONSTRUCTOR(DebugQueryPool);
+
     QueryPoolDesc desc;
 
 public:

--- a/src/debug-layer/debug-sampler.h
+++ b/src/debug-layer/debug-sampler.h
@@ -9,6 +9,8 @@ class DebugSampler : public DebugObject<ISampler>
 public:
     SLANG_COM_OBJECT_IUNKNOWN_ALL;
 
+    SLANG_RHI_DEBUG_OBJECT_CONSTRUCTOR(DebugSampler);
+
 public:
     ISampler* getInterface(const Guid& guid);
 

--- a/src/debug-layer/debug-shader-object.cpp
+++ b/src/debug-layer/debug-shader-object.cpp
@@ -50,7 +50,7 @@ Result DebugShaderObject::getEntryPoint(GfxIndex index, IShaderObject** entryPoi
     {
         for (GfxIndex i = 0; i < getEntryPointCount(); i++)
         {
-            RefPtr<DebugShaderObject> entryPointObj = new DebugShaderObject();
+            RefPtr<DebugShaderObject> entryPointObj = new DebugShaderObject(ctx);
             SLANG_RETURN_ON_FAIL(baseObject->getEntryPoint(i, entryPointObj->baseObject.writeRef()));
             m_entryPoints.push_back(entryPointObj);
         }
@@ -88,7 +88,7 @@ Result DebugShaderObject::getObject(ShaderOffset const& offset, IShaderObject** 
             return resultCode;
         }
     }
-    debugShaderObject = new DebugShaderObject();
+    debugShaderObject = new DebugShaderObject(ctx);
     debugShaderObject->baseObject = innerObject;
     debugShaderObject->m_typeName = string::from_cstr(innerObject->getElementTypeLayout()->getName());
     m_objects.emplace(ShaderOffsetKey{offset}, debugShaderObject);
@@ -159,7 +159,7 @@ Result DebugShaderObject::getCurrentVersion(ITransientResourceHeap* transientHea
     SLANG_RHI_API_FUNC;
     ComPtr<IShaderObject> innerObject;
     SLANG_RETURN_ON_FAIL(baseObject->getCurrentVersion(getInnerObj(transientHeap), innerObject.writeRef()));
-    RefPtr<DebugShaderObject> debugShaderObject = new DebugShaderObject();
+    RefPtr<DebugShaderObject> debugShaderObject = new DebugShaderObject(ctx);
     debugShaderObject->baseObject = innerObject;
     debugShaderObject->m_typeName = string::from_cstr(innerObject->getElementTypeLayout()->getName());
     returnComPtr(outObject, debugShaderObject);

--- a/src/debug-layer/debug-shader-object.h
+++ b/src/debug-layer/debug-shader-object.h
@@ -34,6 +34,9 @@ class DebugShaderObject : public DebugObject<IShaderObject>
 {
 public:
     SLANG_COM_OBJECT_IUNKNOWN_ALL;
+
+    SLANG_RHI_DEBUG_OBJECT_CONSTRUCTOR(DebugShaderObject);
+
     void checkCompleteness();
 
 public:
@@ -82,6 +85,11 @@ public:
 class DebugRootShaderObject : public DebugShaderObject
 {
 public:
+    DebugRootShaderObject(DebugContext* ctx)
+        : DebugShaderObject(ctx)
+    {
+    }
+
     virtual SLANG_NO_THROW uint32_t SLANG_MCALL addRef() override { return 1; }
     virtual SLANG_NO_THROW uint32_t SLANG_MCALL release() override { return 1; }
     virtual SLANG_NO_THROW Result SLANG_MCALL

--- a/src/debug-layer/debug-shader-program.h
+++ b/src/debug-layer/debug-shader-program.h
@@ -9,6 +9,8 @@ class DebugShaderProgram : public DebugObject<IShaderProgram>
 public:
     SLANG_COM_OBJECT_IUNKNOWN_ALL;
 
+    SLANG_RHI_DEBUG_OBJECT_CONSTRUCTOR(DebugShaderProgram);
+
 public:
     IShaderProgram* getInterface(const Guid& guid);
     virtual SLANG_NO_THROW slang::TypeReflection* SLANG_MCALL findTypeByName(const char* name) override;

--- a/src/debug-layer/debug-shader-table.h
+++ b/src/debug-layer/debug-shader-table.h
@@ -8,6 +8,10 @@ class DebugShaderTable : public DebugObject<IShaderTable>
 {
 public:
     SLANG_COM_OBJECT_IUNKNOWN_ALL;
+
+    SLANG_RHI_DEBUG_OBJECT_CONSTRUCTOR(DebugShaderTable);
+
+public:
     IShaderTable* getInterface(const Guid& guid);
 };
 

--- a/src/debug-layer/debug-surface.cpp
+++ b/src/debug-layer/debug-surface.cpp
@@ -21,7 +21,7 @@ Result DebugSurface::configure(const SurfaceConfig& config)
 
 Result DebugSurface::getCurrentTexture(ITexture** outTexture)
 {
-    RefPtr<DebugTexture> texture = new DebugTexture();
+    RefPtr<DebugTexture> texture = new DebugTexture(ctx);
     SLANG_RETURN_ON_FAIL(baseObject->getCurrentTexture(texture->baseObject.writeRef()));
     returnComPtr(outTexture, texture);
     return SLANG_OK;

--- a/src/debug-layer/debug-surface.h
+++ b/src/debug-layer/debug-surface.h
@@ -9,6 +9,8 @@ class DebugSurface : public DebugObject<ISurface>
 public:
     SLANG_COM_OBJECT_IUNKNOWN_ALL;
 
+    SLANG_RHI_DEBUG_OBJECT_CONSTRUCTOR(DebugSurface);
+
     ISurface* getInterface(const Guid& guid);
 
 public:

--- a/src/debug-layer/debug-texture-view.h
+++ b/src/debug-layer/debug-texture-view.h
@@ -10,6 +10,8 @@ class DebugTextureView : public DebugObject<ITextureView>
 public:
     SLANG_COM_OBJECT_IUNKNOWN_ALL;
 
+    SLANG_RHI_DEBUG_OBJECT_CONSTRUCTOR(DebugTextureView);
+
 public:
     ITextureView* getInterface(const Guid& guid);
     virtual SLANG_NO_THROW Result SLANG_MCALL getNativeHandle(NativeHandle* outHandle) override;
@@ -19,6 +21,8 @@ class DebugAccelerationStructure : public DebugObject<IAccelerationStructure>
 {
 public:
     SLANG_COM_OBJECT_IUNKNOWN_ALL;
+
+    SLANG_RHI_DEBUG_OBJECT_CONSTRUCTOR(DebugAccelerationStructure);
 
 public:
     IAccelerationStructure* getInterface(const Guid& guid);

--- a/src/debug-layer/debug-texture.h
+++ b/src/debug-layer/debug-texture.h
@@ -9,6 +9,8 @@ class DebugTexture : public DebugObject<ITexture>
 public:
     SLANG_COM_OBJECT_IUNKNOWN_ALL;
 
+    SLANG_RHI_DEBUG_OBJECT_CONSTRUCTOR(DebugTexture);
+
 public:
     ITexture* getInterface(const Guid& guid);
     virtual SLANG_NO_THROW const TextureDesc& SLANG_MCALL getDesc() override;

--- a/src/debug-layer/debug-transient-heap.cpp
+++ b/src/debug-layer/debug-transient-heap.cpp
@@ -10,7 +10,7 @@ Result DebugTransientResourceHeap::queryInterface(SlangUUID const& uuid, void** 
         *outObject = static_cast<ITransientResourceHeap*>(this);
     if (uuid == GUID::IID_ITransientResourceHeapD3D12)
     {
-        RefPtr<DebugTransientResourceHeapD3D12> result = new DebugTransientResourceHeapD3D12();
+        RefPtr<DebugTransientResourceHeapD3D12> result = new DebugTransientResourceHeapD3D12(ctx);
         baseObject->queryInterface(uuid, (void**)result->baseObject.writeRef());
         returnComPtr((ITransientResourceHeapD3D12**)outObject, result);
         return SLANG_OK;
@@ -36,7 +36,7 @@ Result DebugTransientResourceHeap::finish()
 Result DebugTransientResourceHeap::createCommandBuffer(ICommandBuffer** outCommandBuffer)
 {
     SLANG_RHI_API_FUNC;
-    RefPtr<DebugCommandBuffer> outObject = new DebugCommandBuffer();
+    RefPtr<DebugCommandBuffer> outObject = new DebugCommandBuffer(ctx);
     outObject->m_transientHeap = this;
     auto result = baseObject->createCommandBuffer(outObject->baseObject.writeRef());
     if (SLANG_FAILED(result))
@@ -51,7 +51,7 @@ Result DebugTransientResourceHeapD3D12::queryInterface(SlangUUID const& uuid, vo
         *outObject = static_cast<ITransientResourceHeapD3D12*>(this);
     if (uuid == GUID::IID_ITransientResourceHeap)
     {
-        RefPtr<DebugTransientResourceHeap> result = new DebugTransientResourceHeap();
+        RefPtr<DebugTransientResourceHeap> result = new DebugTransientResourceHeap(ctx);
         baseObject->queryInterface(uuid, (void**)result->baseObject.writeRef());
         returnComPtr((ITransientResourceHeap**)outObject, result);
         return SLANG_OK;

--- a/src/debug-layer/debug-transient-heap.h
+++ b/src/debug-layer/debug-transient-heap.h
@@ -10,6 +10,8 @@ public:
     SLANG_COM_OBJECT_IUNKNOWN_ADD_REF;
     SLANG_COM_OBJECT_IUNKNOWN_RELEASE;
 
+    SLANG_RHI_DEBUG_OBJECT_CONSTRUCTOR(DebugTransientResourceHeap);
+
 public:
     virtual SLANG_NO_THROW Result SLANG_MCALL queryInterface(SlangUUID const& uuid, void** outObject) override;
 
@@ -23,6 +25,8 @@ class DebugTransientResourceHeapD3D12 : public DebugObject<ITransientResourceHea
 public:
     SLANG_COM_OBJECT_IUNKNOWN_ADD_REF;
     SLANG_COM_OBJECT_IUNKNOWN_RELEASE;
+
+    SLANG_RHI_DEBUG_OBJECT_CONSTRUCTOR(DebugTransientResourceHeapD3D12);
 
 public:
     virtual SLANG_NO_THROW Result SLANG_MCALL queryInterface(SlangUUID const& uuid, void** outObject) override;

--- a/src/debug-layer/debug-vertex-layout.h
+++ b/src/debug-layer/debug-vertex-layout.h
@@ -9,6 +9,8 @@ class DebugInputLayout : public DebugObject<IInputLayout>
 public:
     SLANG_COM_OBJECT_IUNKNOWN_ALL;
 
+    SLANG_RHI_DEBUG_OBJECT_CONSTRUCTOR(DebugInputLayout);
+
 public:
     IInputLayout* getInterface(const Guid& guid);
 };

--- a/src/enum-strings.cpp
+++ b/src/enum-strings.cpp
@@ -44,10 +44,9 @@ const char* enumToString(DeviceType value)
 
 const char* enumToString(Format value)
 {
-    FormatInfo info;
-    if (rhiGetFormatInfo(value, &info) == SLANG_OK)
+    if (int(value) >= 0 && int(value) < int(Format::_Count))
     {
-        return info.name;
+        return getFormatInfo(value).name;
     }
     else
     {

--- a/src/metal/metal-command-encoder.cpp
+++ b/src/metal/metal-command-encoder.cpp
@@ -592,7 +592,11 @@ void RayTracingPassEncoderImpl::buildAccelerationStructure(
     MTL::AccelerationStructureCommandEncoder* encoder = m_commandBuffer->getMetalAccelerationStructureCommandEncoder();
 
     AccelerationStructureDescBuilder builder;
-    builder.build(desc, m_commandBuffer->m_device->getAccelerationStructureArray(), getDebugCallback());
+    builder.build(
+        desc,
+        m_commandBuffer->m_device->getAccelerationStructureArray(),
+        m_commandBuffer->m_device->m_debugCallback
+    );
 
     switch (desc.mode)
     {

--- a/src/metal/metal-device.cpp
+++ b/src/metal/metal-device.cpp
@@ -158,8 +158,7 @@ Result DeviceImpl::readTexture(ITexture* texture, ISlangBlob** outBlob, Size* ou
     GfxCount width = std::max(desc.size.width, 1);
     GfxCount height = std::max(desc.size.height, 1);
     GfxCount depth = std::max(desc.size.depth, 1);
-    FormatInfo formatInfo;
-    rhiGetFormatInfo(desc.format, &formatInfo);
+    const FormatInfo& formatInfo = getFormatInfo(desc.format);
     Size bytesPerPixel = formatInfo.blockSizeInBytes / formatInfo.pixelsPerBlock;
     Size bytesPerRow = Size(width) * bytesPerPixel;
     Size bytesPerSlice = Size(height) * bytesPerRow;
@@ -291,8 +290,7 @@ Result DeviceImpl::getTextureAllocationInfo(const TextureDesc& descIn, Size* out
     auto alignTo = [&](Size size, Size alignment) -> Size { return ((size + alignment - 1) / alignment) * alignment; };
 
     TextureDesc desc = fixupTextureDesc(descIn);
-    FormatInfo formatInfo;
-    rhiGetFormatInfo(desc.format, &formatInfo);
+    const FormatInfo& formatInfo = getFormatInfo(desc.format);
     MTL::PixelFormat pixelFormat = MetalUtil::translatePixelFormat(desc.format);
     Size alignment = m_device->minimumLinearTextureAlignmentForPixelFormat(pixelFormat);
     Size size = 0;

--- a/src/metal/metal-device.cpp
+++ b/src/metal/metal-device.cpp
@@ -232,7 +232,7 @@ Result DeviceImpl::getAccelerationStructureSizes(
     AUTORELEASEPOOL
 
     AccelerationStructureDescBuilder builder;
-    builder.build(desc, nullptr, getDebugCallback());
+    builder.build(desc, nullptr, m_debugCallback);
     MTL::AccelerationStructureSizes sizes = m_device->accelerationStructureSizes(builder.descriptor.get());
     outSizes->accelerationStructureSize = sizes.accelerationStructureSize;
     outSizes->scratchSize = sizes.buildScratchBufferSize;

--- a/src/metal/metal-device.cpp
+++ b/src/metal/metal-device.cpp
@@ -29,7 +29,7 @@ DeviceImpl::~DeviceImpl()
     m_queue.setNull();
 }
 
-Result DeviceImpl::getNativeDeviceHandles(NativeHandles* outHandles)
+Result DeviceImpl::getNativeDeviceHandles(DeviceNativeHandles* outHandles)
 {
     outHandles->handles[0].type = NativeHandleType::MTLDevice;
     outHandles->handles[0].value = (uint64_t)m_device.get();
@@ -38,7 +38,7 @@ Result DeviceImpl::getNativeDeviceHandles(NativeHandles* outHandles)
     return SLANG_OK;
 }
 
-Result DeviceImpl::initialize(const Desc& desc)
+Result DeviceImpl::initialize(const DeviceDesc& desc)
 {
     AUTORELEASEPOOL
 

--- a/src/metal/metal-device.h
+++ b/src/metal/metal-device.h
@@ -14,7 +14,7 @@ namespace rhi::metal {
 class DeviceImpl : public Device
 {
 public:
-    virtual SLANG_NO_THROW Result SLANG_MCALL initialize(const Desc& desc) override;
+    virtual SLANG_NO_THROW Result SLANG_MCALL initialize(const DeviceDesc& desc) override;
     virtual SLANG_NO_THROW Result SLANG_MCALL getFormatSupport(Format format, FormatSupport* outFormatSupport) override;
     virtual SLANG_NO_THROW Result SLANG_MCALL
     createTransientResourceHeap(const ITransientResourceHeap::Desc& desc, ITransientResourceHeap** outHeap) override;
@@ -88,7 +88,7 @@ public:
 
     // void waitForGpu();
     virtual SLANG_NO_THROW const DeviceInfo& SLANG_MCALL getDeviceInfo() const override;
-    virtual SLANG_NO_THROW Result SLANG_MCALL getNativeDeviceHandles(NativeHandles* outHandles) override;
+    virtual SLANG_NO_THROW Result SLANG_MCALL getNativeDeviceHandles(DeviceNativeHandles* outHandles) override;
     ~DeviceImpl();
 
 public:
@@ -97,7 +97,7 @@ public:
 
     bool captureEnabled() const { return std::getenv("MTL_CAPTURE") != nullptr; }
 
-    Desc m_desc;
+    DeviceDesc m_desc;
     NS::SharedPtr<MTL::Device> m_device;
     RefPtr<CommandQueueImpl> m_queue;
     NS::SharedPtr<MTL::CommandQueue> m_commandQueue;

--- a/src/metal/metal-helper-functions.cpp
+++ b/src/metal/metal-helper-functions.cpp
@@ -36,7 +36,7 @@ Result SLANG_MCALL getMetalAdapters(std::vector<AdapterInfo>& outAdapters)
     return SLANG_OK;
 }
 
-Result SLANG_MCALL createMetalDevice(const IDevice::Desc* desc, IDevice** outRenderer)
+Result SLANG_MCALL createMetalDevice(const DeviceDesc* desc, IDevice** outRenderer)
 {
     RefPtr<metal::DeviceImpl> result = new metal::DeviceImpl();
     SLANG_RETURN_ON_FAIL(result->initialize(*desc));

--- a/src/metal/metal-helper-functions.h
+++ b/src/metal/metal-helper-functions.h
@@ -112,6 +112,6 @@ struct RenderBindingContext : public BindingContext
 namespace rhi {
 
 Result SLANG_MCALL getMetalAdapters(std::vector<AdapterInfo>& outAdapters);
-Result SLANG_MCALL createMetalDevice(const IDevice::Desc* desc, IDevice** outRenderer);
+Result SLANG_MCALL createMetalDevice(const DeviceDesc* desc, IDevice** outRenderer);
 
 } // namespace rhi

--- a/src/rhi-shared.cpp
+++ b/src/rhi-shared.cpp
@@ -45,6 +45,23 @@ const Guid GUID::IID_IShaderTable = IShaderTable::getTypeGuid();
 const Guid GUID::IID_IPipelineCreationAPIDispatcher = IPipelineCreationAPIDispatcher::getTypeGuid();
 const Guid GUID::IID_ITransientResourceHeapD3D12 = ITransientResourceHeapD3D12::getTypeGuid();
 
+class NullDebugCallback : public IDebugCallback
+{
+public:
+    virtual void handleMessage(DebugMessageType type, DebugMessageSource source, const char* message) override
+    {
+        SLANG_UNUSED(type);
+        SLANG_UNUSED(source);
+        SLANG_UNUSED(message);
+    }
+
+    static IDebugCallback* getInstance()
+    {
+        static NullDebugCallback instance;
+        return &instance;
+    }
+};
+
 IFence* Fence::getInterface(const Guid& guid)
 {
     if (guid == GUID::IID_ISlangUnknown || guid == GUID::IID_IFence)
@@ -351,6 +368,8 @@ IDevice* Device::getInterface(const Guid& guid)
 
 Result Device::initialize(const DeviceDesc& desc)
 {
+    m_debugCallback = desc.debugCallback ? desc.debugCallback : NullDebugCallback::getInstance();
+
     persistentShaderCache = desc.persistentShaderCache;
 
     if (desc.apiCommandDispatcher)
@@ -887,8 +906,7 @@ Result ShaderProgram::compileShaders(Device* device)
             DebugMessageType msgType = DebugMessageType::Warning;
             if (compileResult != SLANG_OK)
                 msgType = DebugMessageType::Error;
-            getDebugCallback()
-                ->handleMessage(msgType, DebugMessageSource::Slang, (char*)diagnostics->getBufferPointer());
+            device->handleMessage(msgType, DebugMessageSource::Slang, (char*)diagnostics->getBufferPointer());
         }
         SLANG_RETURN_ON_FAIL(compileResult);
         SLANG_RETURN_ON_FAIL(createShaderModule(entryPointInfo, kernelCode));
@@ -990,7 +1008,7 @@ Result Device::maybeSpecializePipeline(
             );
             if (diagnosticBlob)
             {
-                getDebugCallback()->handleMessage(
+                handleMessage(
                     compileRs == SLANG_OK ? DebugMessageType::Warning : DebugMessageType::Error,
                     DebugMessageSource::Slang,
                     (char*)diagnosticBlob->getBufferPointer()
@@ -1048,28 +1066,6 @@ Result Device::maybeSpecializePipeline(
         outNewPipeline = specializedPipelineBase;
     }
     return SLANG_OK;
-}
-
-IDebugCallback*& _getDebugCallback()
-{
-    static IDebugCallback* callback = nullptr;
-    return callback;
-}
-
-class NullDebugCallback : public IDebugCallback
-{
-public:
-    virtual void handleMessage(DebugMessageType type, DebugMessageSource source, const char* message) override
-    {
-        SLANG_UNUSED(type);
-        SLANG_UNUSED(source);
-        SLANG_UNUSED(message);
-    }
-};
-IDebugCallback* _getNullDebugCallback()
-{
-    static NullDebugCallback result = {};
-    return &result;
 }
 
 Result ShaderObjectBase::copyFrom(IShaderObject* object, ITransientResourceHeap* transientHeap)

--- a/src/rhi-shared.cpp
+++ b/src/rhi-shared.cpp
@@ -349,7 +349,7 @@ IDevice* Device::getInterface(const Guid& guid)
     return (guid == GUID::IID_ISlangUnknown || guid == GUID::IID_IDevice) ? static_cast<IDevice*>(this) : nullptr;
 }
 
-Result Device::initialize(const Desc& desc)
+Result Device::initialize(const DeviceDesc& desc)
 {
     persistentShaderCache = desc.persistentShaderCache;
 
@@ -363,7 +363,7 @@ Result Device::initialize(const Desc& desc)
     return SLANG_OK;
 }
 
-Result Device::getNativeDeviceHandles(NativeHandles* outHandles)
+Result Device::getNativeDeviceHandles(DeviceNativeHandles* outHandles)
 {
     return SLANG_OK;
 }

--- a/src/rhi-shared.h
+++ b/src/rhi-shared.h
@@ -53,8 +53,6 @@ struct GUID
 
 class Device;
 
-bool isRhiDebugLayerEnabled();
-
 // We use a `BreakableReference` to avoid the cyclic reference situation in rhi implementation.
 // It is a common scenario where objects created from an `IDevice` implementation needs to hold
 // a strong reference to the device object that creates them. For example, a `Buffer` or a
@@ -1259,6 +1257,11 @@ public:
     );
 
 public:
+    inline void handleMessage(DebugMessageType type, DebugMessageSource source, const char* message)
+    {
+        m_debugCallback->handleMessage(type, source, message);
+    }
+
     ExtendedShaderObjectTypeList specializationArgs;
     // Given current pipeline and root shader object binding, generate and bind a specialized pipeline if necessary.
     // The newly specialized pipeline is held alive by the pipeline cache so users of `outNewPipeline` do not
@@ -1293,24 +1296,11 @@ public:
 
     std::map<slang::TypeLayoutReflection*, RefPtr<ShaderObjectLayout>> m_shaderObjectLayoutCache;
     ComPtr<IPipelineCreationAPIDispatcher> m_pipelineCreationAPIDispatcher;
+
+    IDebugCallback* m_debugCallback = nullptr;
 };
 
 bool isDepthFormat(Format format);
-
-IDebugCallback*& _getDebugCallback();
-IDebugCallback* _getNullDebugCallback();
-inline IDebugCallback* getDebugCallback()
-{
-    auto rs = _getDebugCallback();
-    if (rs)
-    {
-        return rs;
-    }
-    else
-    {
-        return _getNullDebugCallback();
-    }
-}
 
 // Implementations that have to come after Device
 

--- a/src/rhi-shared.h
+++ b/src/rhi-shared.h
@@ -1133,7 +1133,7 @@ public:
     SLANG_COM_OBJECT_IUNKNOWN_ADD_REF
     SLANG_COM_OBJECT_IUNKNOWN_RELEASE
 
-    virtual SLANG_NO_THROW Result SLANG_MCALL getNativeDeviceHandles(NativeHandles* outHandles) SLANG_OVERRIDE;
+    virtual SLANG_NO_THROW Result SLANG_MCALL getNativeDeviceHandles(DeviceNativeHandles* outHandles) SLANG_OVERRIDE;
     virtual SLANG_NO_THROW Result SLANG_MCALL
     getFeatures(const char** outFeatures, Size bufferSize, GfxCount* outFeatureCount) SLANG_OVERRIDE;
     virtual SLANG_NO_THROW bool SLANG_MCALL hasFeature(const char* featureName) SLANG_OVERRIDE;
@@ -1280,7 +1280,7 @@ public:
     virtual Result createMutableShaderObject(ShaderObjectLayout* layout, IShaderObject** outObject) = 0;
 
 protected:
-    virtual SLANG_NO_THROW Result SLANG_MCALL initialize(const Desc& desc);
+    virtual SLANG_NO_THROW Result SLANG_MCALL initialize(const DeviceDesc& desc);
 
 protected:
     std::vector<std::string> m_features;

--- a/src/rhi.cpp
+++ b/src/rhi.cpp
@@ -29,12 +29,6 @@ Result SLANG_MCALL getCUDAAdapters(std::vector<AdapterInfo>& outAdapters);
 
 Result SLANG_MCALL reportD3DLiveObjects();
 
-static bool debugLayerEnabled = false;
-bool isRhiDebugLayerEnabled()
-{
-    return debugLayerEnabled;
-}
-
 /* !!!!!!!!!!!!!!!!!!!!!!!!!!!!!! Global Functions !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! */
 
 struct FormatInfoMap
@@ -415,12 +409,13 @@ extern "C"
         auto resultCode = _createDevice(desc, innerDevice.writeRef());
         if (SLANG_FAILED(resultCode))
             return resultCode;
-        if (!debugLayerEnabled)
+        if (!desc->enableValidation)
         {
             returnComPtr(outDevice, innerDevice);
             return resultCode;
         }
         RefPtr<debug::DebugDevice> debugDevice = new debug::DebugDevice();
+        debugDevice->ctx->debugCallback = static_cast<Device*>(innerDevice.get())->m_debugCallback;
         debugDevice->baseObject = innerDevice;
         returnComPtr(outDevice, debugDevice);
         return resultCode;
@@ -432,17 +427,6 @@ extern "C"
         SLANG_RETURN_ON_FAIL(reportD3DLiveObjects());
 #endif
         return SLANG_OK;
-    }
-
-    SLANG_RHI_API Result SLANG_MCALL rhiSetDebugCallback(IDebugCallback* callback)
-    {
-        _getDebugCallback() = callback;
-        return SLANG_OK;
-    }
-
-    SLANG_RHI_API void SLANG_MCALL rhiEnableDebugLayer()
-    {
-        debugLayerEnabled = true;
     }
 }
 

--- a/src/rhi.cpp
+++ b/src/rhi.cpp
@@ -13,13 +13,13 @@
 
 namespace rhi {
 
-Result SLANG_MCALL createD3D11Device(const IDevice::Desc* desc, IDevice** outDevice);
-Result SLANG_MCALL createD3D12Device(const IDevice::Desc* desc, IDevice** outDevice);
-Result SLANG_MCALL createVKDevice(const IDevice::Desc* desc, IDevice** outDevice);
-Result SLANG_MCALL createMetalDevice(const IDevice::Desc* desc, IDevice** outDevice);
-Result SLANG_MCALL createCUDADevice(const IDevice::Desc* desc, IDevice** outDevice);
-Result SLANG_MCALL createCPUDevice(const IDevice::Desc* desc, IDevice** outDevice);
-Result SLANG_MCALL createWGPUDevice(const IDevice::Desc* desc, IDevice** outDevice);
+Result SLANG_MCALL createD3D11Device(const DeviceDesc* desc, IDevice** outDevice);
+Result SLANG_MCALL createD3D12Device(const DeviceDesc* desc, IDevice** outDevice);
+Result SLANG_MCALL createVKDevice(const DeviceDesc* desc, IDevice** outDevice);
+Result SLANG_MCALL createMetalDevice(const DeviceDesc* desc, IDevice** outDevice);
+Result SLANG_MCALL createCUDADevice(const DeviceDesc* desc, IDevice** outDevice);
+Result SLANG_MCALL createCPUDevice(const DeviceDesc* desc, IDevice** outDevice);
+Result SLANG_MCALL createWGPUDevice(const DeviceDesc* desc, IDevice** outDevice);
 
 Result SLANG_MCALL getD3D11Adapters(std::vector<AdapterInfo>& outAdapters);
 Result SLANG_MCALL getD3D12Adapters(std::vector<AdapterInfo>& outAdapters);
@@ -282,13 +282,13 @@ extern "C"
         return SLANG_OK;
     }
 
-    Result _createDevice(const IDevice::Desc* desc, IDevice** outDevice)
+    Result _createDevice(const DeviceDesc* desc, IDevice** outDevice)
     {
         switch (desc->deviceType)
         {
         case DeviceType::Default:
         {
-            IDevice::Desc newDesc = *desc;
+            DeviceDesc newDesc = *desc;
             newDesc.deviceType = DeviceType::D3D12;
             if (_createDevice(&newDesc, outDevice) == SLANG_OK)
                 return SLANG_OK;
@@ -344,7 +344,7 @@ extern "C"
         }
     }
 
-    SLANG_RHI_API Result SLANG_MCALL rhiCreateDevice(const IDevice::Desc* desc, IDevice** outDevice)
+    SLANG_RHI_API Result SLANG_MCALL rhiCreateDevice(const DeviceDesc* desc, IDevice** outDevice)
     {
         ComPtr<IDevice> innerDevice;
         auto resultCode = _createDevice(desc, innerDevice.writeRef());

--- a/src/rhi.cpp
+++ b/src/rhi.cpp
@@ -283,6 +283,14 @@ public:
         }
     }
 
+    Result reportLiveObjects() override
+    {
+#if SLANG_RHI_ENABLE_D3D12
+        SLANG_RETURN_ON_FAIL(reportD3DLiveObjects());
+#endif
+        return SLANG_OK;
+    }
+
     static RHI* getInstance()
     {
         static RHI instance;
@@ -419,14 +427,6 @@ extern "C"
         debugDevice->baseObject = innerDevice;
         returnComPtr(outDevice, debugDevice);
         return resultCode;
-    }
-
-    SLANG_RHI_API Result SLANG_MCALL rhiReportLiveObjects()
-    {
-#if SLANG_RHI_ENABLE_D3D12
-        SLANG_RETURN_ON_FAIL(reportD3DLiveObjects());
-#endif
-        return SLANG_OK;
     }
 }
 

--- a/src/rhi.cpp
+++ b/src/rhi.cpp
@@ -155,6 +155,52 @@ struct FormatInfoMap
         set(Format::BC7_UNORM_SRGB, "BC7_UNORM_SRGB", SLANG_SCALAR_TYPE_FLOAT32, 4, 16, 16, 4, 4);
     }
 
+    bool isTypless(Format format)
+    {
+        switch (format)
+        {
+        case Format::R32G32B32A32_TYPELESS:
+        case Format::R32G32B32_TYPELESS:
+        case Format::R32G32_TYPELESS:
+        case Format::R32_TYPELESS:
+        case Format::R16G16B16A16_TYPELESS:
+        case Format::R16G16_TYPELESS:
+        case Format::R16_TYPELESS:
+        case Format::R8G8B8A8_TYPELESS:
+        case Format::R8G8_TYPELESS:
+        case Format::R8_TYPELESS:
+        case Format::B8G8R8A8_TYPELESS:
+        case Format::R10G10B10A2_TYPELESS:
+            return true;
+        default:
+            return false;
+        }
+    }
+
+    bool isCompressed(Format format)
+    {
+        switch (format)
+        {
+        case Format::BC1_UNORM:
+        case Format::BC1_UNORM_SRGB:
+        case Format::BC2_UNORM:
+        case Format::BC2_UNORM_SRGB:
+        case Format::BC3_UNORM:
+        case Format::BC3_UNORM_SRGB:
+        case Format::BC4_UNORM:
+        case Format::BC4_SNORM:
+        case Format::BC5_UNORM:
+        case Format::BC5_SNORM:
+        case Format::BC6H_UF16:
+        case Format::BC6H_SF16:
+        case Format::BC7_UNORM:
+        case Format::BC7_UNORM_SRGB:
+            return true;
+        default:
+            return false;
+        }
+    }
+
     void set(
         Format format,
         const char* name,
@@ -175,6 +221,9 @@ struct FormatInfoMap
         info.pixelsPerBlock = pixelsPerBlock;
         info.blockWidth = blockWidth;
         info.blockHeight = blockHeight;
+
+        info.isTypeless = isTypless(format);
+        info.isCompressed = isCompressed(format);
     }
 
     const FormatInfo& get(Format format) const { return m_infos[Index(format)]; }
@@ -252,58 +301,6 @@ extern "C"
     IRHI* getRHI()
     {
         return RHI::getInstance();
-    }
-
-    SLANG_RHI_API bool SLANG_MCALL rhiIsCompressedFormat(Format format)
-    {
-        switch (format)
-        {
-        case Format::BC1_UNORM:
-        case Format::BC1_UNORM_SRGB:
-        case Format::BC2_UNORM:
-        case Format::BC2_UNORM_SRGB:
-        case Format::BC3_UNORM:
-        case Format::BC3_UNORM_SRGB:
-        case Format::BC4_UNORM:
-        case Format::BC4_SNORM:
-        case Format::BC5_UNORM:
-        case Format::BC5_SNORM:
-        case Format::BC6H_UF16:
-        case Format::BC6H_SF16:
-        case Format::BC7_UNORM:
-        case Format::BC7_UNORM_SRGB:
-            return true;
-        default:
-            return false;
-        }
-    }
-
-    SLANG_RHI_API bool SLANG_MCALL rhiIsTypelessFormat(Format format)
-    {
-        switch (format)
-        {
-        case Format::R32G32B32A32_TYPELESS:
-        case Format::R32G32B32_TYPELESS:
-        case Format::R32G32_TYPELESS:
-        case Format::R32_TYPELESS:
-        case Format::R16G16B16A16_TYPELESS:
-        case Format::R16G16_TYPELESS:
-        case Format::R16_TYPELESS:
-        case Format::R8G8B8A8_TYPELESS:
-        case Format::R8G8_TYPELESS:
-        case Format::R8_TYPELESS:
-        case Format::B8G8R8A8_TYPELESS:
-        case Format::R10G10B10A2_TYPELESS:
-            return true;
-        default:
-            return false;
-        }
-    }
-
-    SLANG_RHI_API Result SLANG_MCALL rhiGetFormatInfo(Format format, FormatInfo* outInfo)
-    {
-        *outInfo = s_formatInfoMap.get(format);
-        return SLANG_OK;
     }
 
     SLANG_RHI_API Result SLANG_MCALL rhiGetAdapters(DeviceType type, ISlangBlob** outAdaptersBlob)
@@ -446,16 +443,6 @@ extern "C"
     SLANG_RHI_API void SLANG_MCALL rhiEnableDebugLayer()
     {
         debugLayerEnabled = true;
-    }
-
-    const char* rhiGetDeviceTypeName(DeviceType type)
-    {
-        return RHI::getInstance()->getDeviceTypeName(type);
-    }
-
-    bool rhiIsDeviceTypeSupported(DeviceType type)
-    {
-        return RHI::getInstance()->isDeviceTypeSupported(type);
     }
 }
 

--- a/src/rhi.cpp
+++ b/src/rhi.cpp
@@ -412,8 +412,8 @@ Result RHI::createDevice(const DeviceDesc& desc, IDevice** outDevice)
         returnComPtr(outDevice, innerDevice);
         return resultCode;
     }
-    RefPtr<debug::DebugDevice> debugDevice = new debug::DebugDevice();
-    debugDevice->ctx->debugCallback = static_cast<Device*>(innerDevice.get())->m_debugCallback;
+    IDebugCallback* debugCallback = static_cast<Device*>(innerDevice.get())->m_debugCallback;
+    RefPtr<debug::DebugDevice> debugDevice = new debug::DebugDevice(debugCallback);
     debugDevice->baseObject = innerDevice;
     returnComPtr(outDevice, debugDevice);
     return resultCode;

--- a/src/slang-context.h
+++ b/src/slang-context.h
@@ -14,7 +14,7 @@ public:
     ComPtr<slang::IGlobalSession> globalSession;
     ComPtr<slang::ISession> session;
     Result initialize(
-        const IDevice::SlangDesc& desc,
+        const SlangDesc& desc,
         uint32_t extendedDescCount,
         void** extendedDescs,
         SlangCompileTarget compileTarget,

--- a/src/vulkan/vk-command-encoder.cpp
+++ b/src/vulkan/vk-command-encoder.cpp
@@ -1319,7 +1319,7 @@ void RayTracingPassEncoderImpl::_queryAccelerationStructureProperties(
         case QueryType::AccelerationStructureCurrentSize:
             continue;
         default:
-            getDebugCallback()->handleMessage(
+            m_device->handleMessage(
                 DebugMessageType::Error,
                 DebugMessageSource::Layer,
                 "Invalid query type for use in queryAccelerationStructureProperties."
@@ -1354,7 +1354,7 @@ void RayTracingPassEncoderImpl::buildAccelerationStructure(
 )
 {
     AccelerationStructureBuildGeometryInfoBuilder geomInfoBuilder;
-    if (geomInfoBuilder.build(desc, getDebugCallback()) != SLANG_OK)
+    if (geomInfoBuilder.build(desc, m_device->m_debugCallback) != SLANG_OK)
         return;
 
     geomInfoBuilder.buildInfo.dstAccelerationStructure = static_cast<AccelerationStructureImpl*>(dst)->m_vkHandle;
@@ -1408,7 +1408,7 @@ void RayTracingPassEncoderImpl::copyAccelerationStructure(
         copyInfo.mode = VK_COPY_ACCELERATION_STRUCTURE_MODE_COMPACT_KHR;
         break;
     default:
-        getDebugCallback()->handleMessage(
+        m_device->handleMessage(
             DebugMessageType::Error,
             DebugMessageSource::Layer,
             "Unsupported AccelerationStructureCopyMode."

--- a/src/vulkan/vk-device.cpp
+++ b/src/vulkan/vk-device.cpp
@@ -1023,10 +1023,8 @@ Result DeviceImpl::initialize(const DeviceDesc& desc)
         if (initDeviceResult != SLANG_OK)
             continue;
         descriptorSetAllocator.m_api = &m_api;
-        initDeviceResult = initVulkanInstanceAndDevice(
-            desc.existingDeviceHandles.handles,
-            ENABLE_VALIDATION_LAYER || desc.enableBackendValidation
-        );
+        initDeviceResult =
+            initVulkanInstanceAndDevice(desc.existingDeviceHandles.handles, desc.enableBackendValidation);
         if (initDeviceResult == SLANG_OK)
             break;
     }

--- a/src/vulkan/vk-device.cpp
+++ b/src/vulkan/vk-device.cpp
@@ -117,7 +117,7 @@ VKAPI_ATTR VkBool32 VKAPI_CALL DeviceImpl::debugMessageCallback(
     return ((DeviceImpl*)pUserData)->handleDebugMessage(messageSeverity, messageTypes, pCallbackData);
 }
 
-Result DeviceImpl::getNativeDeviceHandles(NativeHandles* outHandles)
+Result DeviceImpl::getNativeDeviceHandles(DeviceNativeHandles* outHandles)
 {
     outHandles->handles[0].type = NativeHandleType::VkInstance;
     outHandles->handles[0].value = (uint64_t)m_api.m_instance;
@@ -999,7 +999,7 @@ Result DeviceImpl::initVulkanInstanceAndDevice(const NativeHandle* handles, bool
     return SLANG_OK;
 }
 
-Result DeviceImpl::initialize(const Desc& desc)
+Result DeviceImpl::initialize(const DeviceDesc& desc)
 {
     // Initialize device info.
     {

--- a/src/vulkan/vk-device.cpp
+++ b/src/vulkan/vk-device.cpp
@@ -1110,9 +1110,8 @@ Result DeviceImpl::readTexture(ITexture* texture, ISlangBlob** outBlob, Size* ou
     const TextureDesc& desc = textureImpl->m_desc;
     auto width = desc.size.width;
     auto height = desc.size.height;
-    FormatInfo sizeInfo;
-    SLANG_RETURN_ON_FAIL(rhiGetFormatInfo(desc.format, &sizeInfo));
-    Size pixelSize = sizeInfo.blockSizeInBytes / sizeInfo.pixelsPerBlock;
+    const FormatInfo& formatInfo = getFormatInfo(desc.format);
+    Size pixelSize = formatInfo.blockSizeInBytes / formatInfo.pixelsPerBlock;
     Size rowPitch = width * pixelSize;
     int arrayLayerCount = desc.arrayLength * (desc.type == TextureType::TextureCube ? 6 : 1);
 
@@ -1742,8 +1741,7 @@ Result DeviceImpl::createTexture(const TextureDesc& descIn, const SubresourceDat
             // Handle senario where texture is sampled. We cannot use
             // a simple buffer copy for sampled textures. ClearColorImage
             // is not data accurate but it is fine for testing & works.
-            FormatInfo formatInfo;
-            rhiGetFormatInfo(desc.format, &formatInfo);
+            const FormatInfo& formatInfo = getFormatInfo(desc.format);
             uint32_t data = 0;
             VkClearColorValue clearColor;
             switch (formatInfo.channelType)

--- a/src/vulkan/vk-device.h
+++ b/src/vulkan/vk-device.h
@@ -13,7 +13,7 @@ class DeviceImpl : public Device
 {
 public:
     Result initVulkanInstanceAndDevice(const NativeHandle* handles, bool useValidationLayer);
-    virtual SLANG_NO_THROW Result SLANG_MCALL initialize(const Desc& desc) override;
+    virtual SLANG_NO_THROW Result SLANG_MCALL initialize(const DeviceDesc& desc) override;
     virtual SLANG_NO_THROW Result SLANG_MCALL getFormatSupport(Format format, FormatSupport* outFormatSupport) override;
     virtual SLANG_NO_THROW Result SLANG_MCALL
     createTransientResourceHeap(const ITransientResourceHeap::Desc& desc, ITransientResourceHeap** outHeap) override;
@@ -89,7 +89,7 @@ public:
 
     virtual SLANG_NO_THROW const DeviceInfo& SLANG_MCALL getDeviceInfo() const override;
 
-    virtual SLANG_NO_THROW Result SLANG_MCALL getNativeDeviceHandles(NativeHandles* outHandles) override;
+    virtual SLANG_NO_THROW Result SLANG_MCALL getNativeDeviceHandles(DeviceNativeHandles* outHandles) override;
 
     ~DeviceImpl();
 
@@ -145,7 +145,7 @@ public:
     uint32_t m_queueFamilyIndex;
     RefPtr<CommandQueueImpl> m_queue;
 
-    Desc m_desc;
+    DeviceDesc m_desc;
 
     DescriptorSetAllocator descriptorSetAllocator;
 

--- a/src/vulkan/vk-device.h
+++ b/src/vulkan/vk-device.h
@@ -12,7 +12,7 @@ namespace rhi::vk {
 class DeviceImpl : public Device
 {
 public:
-    Result initVulkanInstanceAndDevice(const NativeHandle* handles, bool useValidationLayer);
+    Result initVulkanInstanceAndDevice(const NativeHandle* handles, bool enableValidationLayer);
     virtual SLANG_NO_THROW Result SLANG_MCALL initialize(const DeviceDesc& desc) override;
     virtual SLANG_NO_THROW Result SLANG_MCALL getFormatSupport(Format format, FormatSupport* outFormatSupport) override;
     virtual SLANG_NO_THROW Result SLANG_MCALL

--- a/src/vulkan/vk-helper-functions.cpp
+++ b/src/vulkan/vk-helper-functions.cpp
@@ -8,16 +8,14 @@ namespace rhi::vk {
 
 Size calcRowSize(Format format, int width)
 {
-    FormatInfo sizeInfo;
-    rhiGetFormatInfo(format, &sizeInfo);
-    return Size((width + sizeInfo.blockWidth - 1) / sizeInfo.blockWidth * sizeInfo.blockSizeInBytes);
+    const FormatInfo& info = getFormatInfo(format);
+    return Size((width + info.blockWidth - 1) / info.blockWidth * info.blockSizeInBytes);
 }
 
 GfxCount calcNumRows(Format format, int height)
 {
-    FormatInfo sizeInfo;
-    rhiGetFormatInfo(format, &sizeInfo);
-    return (GfxCount)(height + sizeInfo.blockHeight - 1) / sizeInfo.blockHeight;
+    const FormatInfo& info = getFormatInfo(format);
+    return (GfxCount)(height + info.blockHeight - 1) / info.blockHeight;
 }
 
 VkAttachmentLoadOp translateLoadOp(LoadOp loadOp)

--- a/src/vulkan/vk-helper-functions.cpp
+++ b/src/vulkan/vk-helper-functions.cpp
@@ -508,7 +508,7 @@ Result SLANG_MCALL getVKAdapters(std::vector<AdapterInfo>& outAdapters)
     return SLANG_OK;
 }
 
-Result SLANG_MCALL createVKDevice(const IDevice::Desc* desc, IDevice** outRenderer)
+Result SLANG_MCALL createVKDevice(const DeviceDesc* desc, IDevice** outRenderer)
 {
     RefPtr<vk::DeviceImpl> result = new vk::DeviceImpl();
     SLANG_RETURN_ON_FAIL(result->initialize(*desc));

--- a/src/vulkan/vk-helper-functions.h
+++ b/src/vulkan/vk-helper-functions.h
@@ -174,6 +174,6 @@ namespace rhi {
 
 Result SLANG_MCALL getVKAdapters(std::vector<AdapterInfo>& outAdapters);
 
-Result SLANG_MCALL createVKDevice(const IDevice::Desc* desc, IDevice** outRenderer);
+Result SLANG_MCALL createVKDevice(const DeviceDesc* desc, IDevice** outRenderer);
 
 } // namespace rhi

--- a/src/vulkan/vk-helper-functions.h
+++ b/src/vulkan/vk-helper-functions.h
@@ -7,16 +7,6 @@
 
 #include <vector>
 
-// Vulkan has a different coordinate system to ogl
-// http://anki3d.org/vulkan-coordinate-system/
-#ifndef ENABLE_VALIDATION_LAYER
-#if _DEBUG
-#define ENABLE_VALIDATION_LAYER 1
-#else
-#define ENABLE_VALIDATION_LAYER 0
-#endif
-#endif
-
 #ifdef _MSC_VER
 #include <stddef.h>
 #pragma warning(disable : 4996)

--- a/src/vulkan/vk-texture.cpp
+++ b/src/vulkan/vk-texture.cpp
@@ -96,7 +96,7 @@ TextureSubresourceView TextureImpl::getView(Format format, TextureAspect aspect,
     VkImageViewCreateInfo createInfo = {};
     createInfo.sType = VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO;
     createInfo.flags = 0;
-    createInfo.format = rhiIsTypelessFormat(format) ? VulkanUtil::getVkFormat(format) : m_vkformat;
+    createInfo.format = getFormatInfo(format).isTypeless ? VulkanUtil::getVkFormat(format) : m_vkformat;
     createInfo.image = m_image;
     createInfo.components = VkComponentMapping{
         VK_COMPONENT_SWIZZLE_R,

--- a/src/wgpu/wgpu-device.cpp
+++ b/src/wgpu/wgpu-device.cpp
@@ -162,8 +162,7 @@ Result DeviceImpl::readTexture(ITexture* texture, ISlangBlob** outBlob, Size* ou
     GfxCount width = std::max(desc.size.width, 1);
     GfxCount height = std::max(desc.size.height, 1);
     GfxCount depth = std::max(desc.size.depth, 1);
-    FormatInfo formatInfo;
-    rhiGetFormatInfo(desc.format, &formatInfo);
+    const FormatInfo& formatInfo = getFormatInfo(desc.format);
     Size bytesPerPixel = formatInfo.blockSizeInBytes / formatInfo.pixelsPerBlock;
     Size bytesPerRow = Size(width) * bytesPerPixel;
     Size bytesPerSlice = Size(height) * bytesPerRow;

--- a/src/wgpu/wgpu-device.cpp
+++ b/src/wgpu/wgpu-device.cpp
@@ -35,7 +35,7 @@ Context::~Context()
 
 DeviceImpl::~DeviceImpl() {}
 
-Result DeviceImpl::getNativeDeviceHandles(NativeHandles* outHandles)
+Result DeviceImpl::getNativeDeviceHandles(DeviceNativeHandles* outHandles)
 {
     return SLANG_E_NOT_IMPLEMENTED;
 }
@@ -45,7 +45,7 @@ void DeviceImpl::handleError(WGPUErrorType type, char const* message)
     fprintf(stderr, "WGPU error: %s\n", message);
 }
 
-Result DeviceImpl::initialize(const Desc& desc)
+Result DeviceImpl::initialize(const DeviceDesc& desc)
 {
     SLANG_RETURN_ON_FAIL(m_ctx.api.init());
     API& api = m_ctx.api;

--- a/src/wgpu/wgpu-device.h
+++ b/src/wgpu/wgpu-device.h
@@ -22,7 +22,7 @@ struct Context
 class DeviceImpl : public Device
 {
 public:
-    Desc m_desc;
+    DeviceDesc m_desc;
     DeviceInfo m_info;
     std::string m_adapterName;
 
@@ -30,7 +30,7 @@ public:
     RefPtr<CommandQueueImpl> m_queue;
 
     ~DeviceImpl();
-    virtual SLANG_NO_THROW Result SLANG_MCALL initialize(const Desc& desc) override;
+    virtual SLANG_NO_THROW Result SLANG_MCALL initialize(const DeviceDesc& desc) override;
 
     void handleError(WGPUErrorType type, char const* message);
 
@@ -98,7 +98,7 @@ public:
 
     // void waitForGpu();
     virtual SLANG_NO_THROW const DeviceInfo& SLANG_MCALL getDeviceInfo() const override;
-    virtual SLANG_NO_THROW Result SLANG_MCALL getNativeDeviceHandles(NativeHandles* outHandles) override;
+    virtual SLANG_NO_THROW Result SLANG_MCALL getNativeDeviceHandles(DeviceNativeHandles* outHandles) override;
 };
 
 } // namespace rhi::wgpu

--- a/src/wgpu/wgpu-helper-functions.cpp
+++ b/src/wgpu/wgpu-helper-functions.cpp
@@ -35,7 +35,7 @@ Result SLANG_MCALL getWGPUAdapters(std::vector<AdapterInfo>& outAdapters)
     return SLANG_OK;
 }
 
-Result SLANG_MCALL createWGPUDevice(const IDevice::Desc* desc, IDevice** outRenderer)
+Result SLANG_MCALL createWGPUDevice(const DeviceDesc* desc, IDevice** outRenderer)
 {
     RefPtr<wgpu::DeviceImpl> result = new wgpu::DeviceImpl();
     SLANG_RETURN_ON_FAIL(result->initialize(*desc));

--- a/src/wgpu/wgpu-helper-functions.h
+++ b/src/wgpu/wgpu-helper-functions.h
@@ -7,6 +7,6 @@
 namespace rhi {
 
 Result SLANG_MCALL getWGPUAdapters(std::vector<AdapterInfo>& outAdapters);
-Result SLANG_MCALL createWGPUDevice(const IDevice::Desc* desc, IDevice** outRenderer);
+Result SLANG_MCALL createWGPUDevice(const DeviceDesc* desc, IDevice** outRenderer);
 
 } // namespace rhi

--- a/src/wgpu/wgpu-texture.cpp
+++ b/src/wgpu/wgpu-texture.cpp
@@ -60,8 +60,7 @@ Result DeviceImpl::createTexture(const TextureDesc& desc_, const SubresourceData
 
     if (initData)
     {
-        FormatInfo formatInfo;
-        rhiGetFormatInfo(desc.format, &formatInfo);
+        const FormatInfo& formatInfo = getFormatInfo(desc.format);
 
         WGPUQueue queue = m_ctx.api.wgpuDeviceGetQueue(m_ctx.device);
         SLANG_RHI_DEFERRED({ m_ctx.api.wgpuQueueRelease(queue); });

--- a/tests/test-existing-device-handle.cpp
+++ b/tests/test-existing-device-handle.cpp
@@ -6,11 +6,11 @@ using namespace rhi::testing;
 void testExistingDeviceHandle(GpuTestContext* ctx, DeviceType deviceType)
 {
     ComPtr<IDevice> existingDevice = createTestingDevice(ctx, deviceType);
-    IDevice::NativeHandles handles;
+    DeviceNativeHandles handles;
     CHECK_CALL(existingDevice->getNativeDeviceHandles(&handles));
 
     ComPtr<IDevice> device;
-    IDevice::Desc deviceDesc = {};
+    DeviceDesc deviceDesc = {};
     deviceDesc.deviceType = deviceType;
     deviceDesc.existingDeviceHandles.handles[0] = handles.handles[0];
     if (deviceType == DeviceType::Vulkan)

--- a/tests/test-existing-device-handle.cpp
+++ b/tests/test-existing-device-handle.cpp
@@ -22,7 +22,7 @@ void testExistingDeviceHandle(GpuTestContext* ctx, DeviceType deviceType)
     auto searchPaths = getSlangSearchPaths();
     deviceDesc.slang.searchPaths = searchPaths.data();
     deviceDesc.slang.searchPathCount = searchPaths.size();
-    CHECK_CALL(rhiCreateDevice(&deviceDesc, device.writeRef()));
+    CHECK_CALL(getRHI()->createDevice(deviceDesc, device.writeRef()));
 
     ComPtr<ITransientResourceHeap> transientHeap;
     ITransientResourceHeap::Desc transientHeapDesc = {};

--- a/tests/test-formats.cpp
+++ b/tests/test-formats.cpp
@@ -72,15 +72,14 @@ struct TestFormats
 
     bool isFormatSupported(Format format)
     {
-        FormatInfo info;
-        REQUIRE_CALL(rhiGetFormatInfo(format, &info));
+        const FormatInfo& info = getFormatInfo(format);
 
         if (format == Format::R32G32B32_FLOAT || format == Format::R32G32B32_UINT || format == Format::R32G32B32_SINT ||
             format == Format::R32G32B32_TYPELESS)
             return false;
 
         // for WebGPU
-        if (rhiIsTypelessFormat(format))
+        if (info.isTypeless)
             return false;
         if (format == Format::B4G4R4A4_UNORM || format == Format::B5G6R5_UNORM || format == Format::B5G5R5A1_UNORM)
             return false;
@@ -103,7 +102,7 @@ struct TestFormats
 
         ComPtr<ITextureView> view;
         TextureViewDesc viewDesc = {};
-        viewDesc.format = rhiIsTypelessFormat(format) ? convertTypelessFormat(format) : format;
+        viewDesc.format = getFormatInfo(format).isTypeless ? convertTypelessFormat(format) : format;
         REQUIRE_CALL(device->createTextureView(texture, viewDesc, view.writeRef()));
         return view;
     }
@@ -169,8 +168,7 @@ struct TestFormats
             return;
         }
 
-        FormatInfo info;
-        REQUIRE_CALL(rhiGetFormatInfo(format, &info));
+        const FormatInfo& info = getFormatInfo(format);
 
         // MESSAGE("Checking format: ", doctest::String(info.name));
 

--- a/tests/test-resource-states.cpp
+++ b/tests/test-resource-states.cpp
@@ -71,8 +71,7 @@ void testTextureResourceStates(GpuTestContext* ctx, DeviceType deviceType)
     for (uint32_t i = 1; i < (uint32_t)Format::_Count; ++i)
     {
         auto format = (Format)i;
-        FormatInfo info;
-        rhiGetFormatInfo(format, &info);
+        const FormatInfo& info = getFormatInfo(format);
         FormatSupport formatSupport;
         REQUIRE_CALL(device->getFormatSupport(format, &formatSupport));
 

--- a/tests/test-shader-cache.cpp
+++ b/tests/test-shader-cache.cpp
@@ -177,7 +177,7 @@ struct ShaderCacheTest
 
     void createDevice()
     {
-        IDevice::Desc deviceDesc = {};
+        DeviceDesc deviceDesc = {};
         deviceDesc.deviceType = deviceType;
         deviceDesc.slang.slangGlobalSession = ctx->slangGlobalSession;
         auto searchPaths = getSlangSearchPaths();

--- a/tests/test-shader-cache.cpp
+++ b/tests/test-shader-cache.cpp
@@ -210,7 +210,7 @@ struct ShaderCacheTest
         rhiEnableDebugLayer();
 #endif
 
-        REQUIRE_CALL(rhiCreateDevice(&deviceDesc, device.writeRef()));
+        REQUIRE_CALL(getRHI()->createDevice(deviceDesc, device.writeRef()));
     }
 
     void createComputeResources()

--- a/tests/test-shader-cache.cpp
+++ b/tests/test-shader-cache.cpp
@@ -207,7 +207,8 @@ struct ShaderCacheTest
         // (And in general reduce the differences (and duplication) between
         // here and render-test-main.cpp)
 #ifdef _DEBUG
-        rhiEnableDebugLayer();
+        deviceDesc.enableValidation = true;
+        deviceDesc.enableBackendValidation = true;
 #endif
 
         REQUIRE_CALL(getRHI()->createDevice(deviceDesc, device.writeRef()));

--- a/tests/test-shared-buffer.cpp
+++ b/tests/test-shared-buffer.cpp
@@ -80,7 +80,7 @@ void testSharedBuffer(GpuTestContext* ctx, DeviceType deviceType)
 #if SLANG_WIN64
 TEST_CASE("shared-buffer-cuda")
 {
-    if (!rhiIsDeviceTypeSupported(DeviceType::CUDA))
+    if (!getRHI()->isDeviceTypeSupported(DeviceType::CUDA))
         SKIP("CUDA not supported");
 
     runGpuTests(

--- a/tests/test-shared-texture.cpp
+++ b/tests/test-shared-texture.cpp
@@ -156,7 +156,7 @@ void testSharedTexture(GpuTestContext* ctx, DeviceType deviceType)
 #if SLANG_WIN64
 TEST_CASE("shared-texture-cuda")
 {
-    if (!rhiIsDeviceTypeSupported(DeviceType::CUDA))
+    if (!getRHI()->isDeviceTypeSupported(DeviceType::CUDA))
         SKIP("CUDA not supported");
 
     runGpuTests(

--- a/tests/testing.cpp
+++ b/tests/testing.cpp
@@ -395,8 +395,9 @@ ComPtr<IDevice> createTestingDevice(
     // (And in general reduce the differences (and duplication) between
     // here and render-test-main.cpp)
 #ifdef _DEBUG
-    rhiEnableDebugLayer();
-    rhiSetDebugCallback(&sDebugCallback);
+    deviceDesc.enableValidation = true;
+    deviceDesc.enableBackendValidation = true;
+    deviceDesc.debugCallback = &sDebugCallback;
 #endif
 
     REQUIRE_CALL(getRHI()->createDevice(deviceDesc, device.writeRef()));

--- a/tests/testing.cpp
+++ b/tests/testing.cpp
@@ -533,7 +533,7 @@ void runGpuTests(GpuTestFunc func, std::initializer_list<DeviceType> deviceTypes
 {
     for (auto deviceType : deviceTypes)
     {
-        if (!rhiIsDeviceTypeSupported(deviceType))
+        if (!getRHI()->isDeviceTypeSupported(deviceType))
         {
             continue;
         }

--- a/tests/testing.cpp
+++ b/tests/testing.cpp
@@ -399,7 +399,7 @@ ComPtr<IDevice> createTestingDevice(
     rhiSetDebugCallback(&sDebugCallback);
 #endif
 
-    REQUIRE_CALL(rhiCreateDevice(&deviceDesc, device.writeRef()));
+    REQUIRE_CALL(getRHI()->createDevice(deviceDesc, device.writeRef()));
 
     if (useCachedDevice)
     {

--- a/tests/testing.cpp
+++ b/tests/testing.cpp
@@ -357,7 +357,7 @@ ComPtr<IDevice> createTestingDevice(
     }
 
     ComPtr<IDevice> device;
-    IDevice::Desc deviceDesc = {};
+    DeviceDesc deviceDesc = {};
     deviceDesc.deviceType = deviceType;
     deviceDesc.slang.slangGlobalSession = ctx->slangGlobalSession;
     auto searchPaths = getSlangSearchPaths();

--- a/tests/texture-utils.cpp
+++ b/tests/texture-utils.cpp
@@ -19,8 +19,7 @@ namespace rhi::testing {
 
 Size getTexelSize(Format format)
 {
-    FormatInfo info;
-    REQUIRE_CALL(rhiGetFormatInfo(format, &info));
+    const FormatInfo& info = getFormatInfo(format);
     return info.blockSizeInBytes / info.pixelsPerBlock;
 }
 


### PR DESCRIPTION
- introduce `IRHI` containing the global RHI API
- rename `IDevice::Desc` -> `DeviceDesc`
- add `enableValidation`, `enableBackendValidation` and `debugCallback` options to `DeviceDesc` and allow per-device setting of validation layers and debug printing