### PR TITLE
Use device local memory in the transient resource heap base

### DIFF
--- a/src/transient-resource-heap-base.h
+++ b/src/transient-resource-heap-base.h
@@ -141,7 +141,7 @@ public:
 
         m_constantBufferPool.init(
             device,
-            MemoryType::Upload,
+            MemoryType::DeviceLocal,
             256,
             BufferUsage::ConstantBuffer | BufferUsage::CopySource | BufferUsage::CopyDestination
         );

--- a/src/wgpu/wgpu-device.cpp
+++ b/src/wgpu/wgpu-device.cpp
@@ -33,7 +33,11 @@ Context::~Context()
     }
 }
 
-DeviceImpl::~DeviceImpl() {}
+DeviceImpl::~DeviceImpl()
+{
+    m_shaderObjectLayoutCache = decltype(m_shaderObjectLayoutCache)();
+    m_queue.setNull();
+}
 
 Result DeviceImpl::getNativeDeviceHandles(DeviceNativeHandles* outHandles)
 {


### PR DESCRIPTION
This helps to address https://github.com/shader-slang/slang/issues/5222.