### PR TITLE
Propagate wsgl compilation errors

### DIFF
--- a/src/wgpu/wgpu-device.cpp
+++ b/src/wgpu/wgpu-device.cpp
@@ -47,6 +47,14 @@ Result DeviceImpl::getNativeDeviceHandles(DeviceNativeHandles* outHandles)
 void DeviceImpl::handleError(WGPUErrorType type, char const* message)
 {
     fprintf(stderr, "WGPU error: %s\n", message);
+    this->m_lastError = type;
+}
+
+WGPUErrorType DeviceImpl::getAndClearLastError()
+{
+    WGPUErrorType lastError = this->m_lastError;
+    this->m_lastError = WGPUErrorType_NoError;
+    return lastError;
 }
 
 Result DeviceImpl::initialize(const DeviceDesc& desc)

--- a/src/wgpu/wgpu-device.h
+++ b/src/wgpu/wgpu-device.h
@@ -33,6 +33,7 @@ public:
     virtual SLANG_NO_THROW Result SLANG_MCALL initialize(const DeviceDesc& desc) override;
 
     void handleError(WGPUErrorType type, char const* message);
+    WGPUErrorType getAndClearLastError();
 
     // IDevice implementation
     virtual SLANG_NO_THROW Result SLANG_MCALL getFormatSupport(Format format, FormatSupport* outFormatSupport) override;
@@ -99,6 +100,9 @@ public:
     // void waitForGpu();
     virtual SLANG_NO_THROW const DeviceInfo& SLANG_MCALL getDeviceInfo() const override;
     virtual SLANG_NO_THROW Result SLANG_MCALL getNativeDeviceHandles(DeviceNativeHandles* outHandles) override;
+
+private:
+    WGPUErrorType m_lastError = WGPUErrorType_NoError;
 };
 
 } // namespace rhi::wgpu

--- a/src/wgpu/wgpu-shader-program.cpp
+++ b/src/wgpu/wgpu-shader-program.cpp
@@ -31,6 +31,11 @@ Result ShaderProgramImpl::createShaderModule(slang::EntryPointReflection* entryP
         return SLANG_FAIL;
     }
 
+    if (m_device->getAndClearLastError() != WGPUErrorType_NoError)
+    {
+        return SLANG_FAIL;
+    }
+
     m_modules.push_back(module);
     return SLANG_OK;
 }


### PR DESCRIPTION
wgpuDeviceCreateShaderModule reports
errors via a callback. Previously, the callback
only printed the error, but now, the error
can be read back and used to report SLANG_FAIL from createShaderModule.

Work on Issue 5291