### PR TITLE
wgpu: Specify which cube face is being written to

### DIFF
--- a/src/wgpu/wgpu-texture.cpp
+++ b/src/wgpu/wgpu-texture.cpp
@@ -102,7 +102,7 @@ Result DeviceImpl::createTexture(const TextureDesc& desc_, const SubresourceData
                 WGPUImageCopyTexture imageCopyTexture = {};
                 imageCopyTexture.texture = texture->m_texture;
                 imageCopyTexture.mipLevel = mipLevel;
-                imageCopyTexture.origin = {0, 0, 0};
+                imageCopyTexture.origin = {0, 0, desc.type == TextureType::TextureCube ? arrayLayer : 0U};
                 imageCopyTexture.aspect = WGPUTextureAspect_All;
 
                 WGPUExtent3D writeSize = {};


### PR DESCRIPTION
This helps to address https://github.com/shader-slang/slang/issues/4943