### PR TITLE
Fix invalid use of barriers in vulkan renderpass.

### DIFF
--- a/src/vulkan/vk-api.h
+++ b/src/vulkan/vk-api.h
@@ -322,6 +322,10 @@ struct VulkanExtendedFeatureProperties
         VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DYNAMIC_RENDERING_FEATURES_KHR
     };
 
+    VkPhysicalDeviceDynamicRenderingLocalReadFeaturesKHR dynamicRenderingLocalReadFeatures = {
+        VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DYNAMIC_RENDERING_LOCAL_READ_FEATURES_KHR
+    };
+
     VkPhysicalDevice4444FormatsFeaturesEXT formats4444Features = {
         VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_4444_FORMATS_FEATURES_EXT
     };

--- a/src/vulkan/vk-device.cpp
+++ b/src/vulkan/vk-device.cpp
@@ -541,6 +541,9 @@ Result DeviceImpl::initVulkanInstanceAndDevice(const NativeHandle* handles, bool
         extendedFeatures.dynamicRenderingFeatures.pNext = deviceFeatures2.pNext;
         deviceFeatures2.pNext = &extendedFeatures.dynamicRenderingFeatures;
 
+        extendedFeatures.dynamicRenderingLocalReadFeatures.pNext = deviceFeatures2.pNext;
+        deviceFeatures2.pNext = &extendedFeatures.dynamicRenderingLocalReadFeatures;
+
         extendedFeatures.formats4444Features.pNext = deviceFeatures2.pNext;
         deviceFeatures2.pNext = &extendedFeatures.formats4444Features;
 
@@ -616,6 +619,13 @@ Result DeviceImpl::initVulkanInstanceAndDevice(const NativeHandle* handles, bool
             extendedFeatures.dynamicRenderingFeatures,
             dynamicRendering,
             VK_KHR_DYNAMIC_RENDERING_EXTENSION_NAME,
+            "dynamic-rendering"
+        );
+
+        SIMPLE_EXTENSION_FEATURE(
+            extendedFeatures.dynamicRenderingLocalReadFeatures,
+            dynamicRenderingLocalRead,
+            VK_KHR_DYNAMIC_RENDERING_LOCAL_READ_EXTENSION_NAME,
             "dynamic-rendering"
         );
 


### PR DESCRIPTION
This fixes the vulkan validation error on use of barriers inside render pass by going through the commands in the render pass and submit the required barriers before actually entering the render pass. This technically can lead to wrong behavior if there are actually non-trivial use of barriers within the render pass, but this is the simplest fix I can come up with without significantly changing the API.