### PR TITLE
Add quad control device extensions

### DIFF
--- a/src/vulkan/vk-api.h
+++ b/src/vulkan/vk-api.h
@@ -334,6 +334,16 @@ struct VulkanExtendedFeatureProperties
     VkPhysicalDeviceRayTracingValidationFeaturesNV rayTracingValidationFeatures = {
         VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_RAY_TRACING_VALIDATION_FEATURES_NV
     };
+
+    // Maximal reconvergence features.
+    VkPhysicalDeviceShaderMaximalReconvergenceFeaturesKHR shaderMaximalReconvergenceFeatures{
+        VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_MAXIMAL_RECONVERGENCE_FEATURES_KHR
+    };
+
+    // Quad control features.
+    VkPhysicalDeviceShaderQuadControlFeaturesKHR shaderQuadControlFeatures{
+        VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_QUAD_CONTROL_FEATURES_KHR
+    };
 };
 
 struct VulkanApi

--- a/src/vulkan/vk-device.cpp
+++ b/src/vulkan/vk-device.cpp
@@ -547,6 +547,12 @@ Result DeviceImpl::initVulkanInstanceAndDevice(const NativeHandle* handles, bool
         extendedFeatures.formats4444Features.pNext = deviceFeatures2.pNext;
         deviceFeatures2.pNext = &extendedFeatures.formats4444Features;
 
+        extendedFeatures.shaderMaximalReconvergenceFeatures.pNext = deviceFeatures2.pNext;
+        deviceFeatures2.pNext = &extendedFeatures.shaderMaximalReconvergenceFeatures;
+
+        extendedFeatures.shaderQuadControlFeatures.pNext = deviceFeatures2.pNext;
+        deviceFeatures2.pNext = &extendedFeatures.shaderQuadControlFeatures;
+
         if (VK_MAKE_VERSION(majorVersion, minorVersion, 0) >= VK_API_VERSION_1_2)
         {
             extendedFeatures.vulkan12Features.pNext = deviceFeatures2.pNext;
@@ -772,6 +778,21 @@ Result DeviceImpl::initVulkanInstanceAndDevice(const NativeHandle* handles, bool
                 "ray-tracing-validation"
             );
         }
+
+        SIMPLE_EXTENSION_FEATURE(
+            extendedFeatures.shaderMaximalReconvergenceFeatures,
+            shaderMaximalReconvergence,
+            VK_KHR_SHADER_MAXIMAL_RECONVERGENCE_EXTENSION_NAME,
+            "shader-maximal-reconvergence"
+        );
+
+        SIMPLE_EXTENSION_FEATURE(
+            extendedFeatures.shaderQuadControlFeatures,
+            shaderQuadControl,
+            VK_KHR_SHADER_QUAD_CONTROL_EXTENSION_NAME,
+            "shader-quad-control"
+        );
+
 
 #undef SIMPLE_EXTENSION_FEATURE
 


### PR DESCRIPTION
Required for vulkan tests that use the quad control shader capabilities https://github.com/shader-slang/slang/pull/5981.