### PR TITLE
Add Vulkan integer dot product extension

### DIFF
--- a/src/vulkan/vk-api.h
+++ b/src/vulkan/vk-api.h
@@ -346,6 +346,11 @@ struct VulkanExtendedFeatureProperties
     VkPhysicalDeviceShaderQuadControlFeaturesKHR shaderQuadControlFeatures{
         VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_QUAD_CONTROL_FEATURES_KHR
     };
+
+    // Integer dot product features.
+    VkPhysicalDeviceShaderIntegerDotProductFeaturesKHR shaderIntegerDotProductFeatures{
+        VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_INTEGER_DOT_PRODUCT_FEATURES_KHR,
+    };
 };
 
 struct VulkanApi

--- a/src/vulkan/vk-device.cpp
+++ b/src/vulkan/vk-device.cpp
@@ -553,6 +553,9 @@ Result DeviceImpl::initVulkanInstanceAndDevice(const NativeHandle* handles, bool
         extendedFeatures.shaderQuadControlFeatures.pNext = deviceFeatures2.pNext;
         deviceFeatures2.pNext = &extendedFeatures.shaderQuadControlFeatures;
 
+        extendedFeatures.shaderIntegerDotProductFeatures.pNext = deviceFeatures2.pNext;
+        deviceFeatures2.pNext = &extendedFeatures.shaderIntegerDotProductFeatures;
+
         if (VK_MAKE_VERSION(majorVersion, minorVersion, 0) >= VK_API_VERSION_1_2)
         {
             extendedFeatures.vulkan12Features.pNext = deviceFeatures2.pNext;
@@ -793,6 +796,12 @@ Result DeviceImpl::initVulkanInstanceAndDevice(const NativeHandle* handles, bool
             "shader-quad-control"
         );
 
+        SIMPLE_EXTENSION_FEATURE(
+            extendedFeatures.shaderIntegerDotProductFeatures,
+            shaderIntegerDotProduct,
+            VK_KHR_SHADER_INTEGER_DOT_PRODUCT_EXTENSION_NAME,
+            "integer-dot-product"
+        );
 
 #undef SIMPLE_EXTENSION_FEATURE
 


### PR DESCRIPTION
Required to run packed integer dot product tests, see https://github.com/shader-slang/slang/pull/6068.