### PR TITLE
Don't enable D3D12 debug layers as part of device creation

### DIFF
--- a/include/slang-rhi.h
+++ b/include/slang-rhi.h
@@ -2512,6 +2512,10 @@ public:
         return AdapterList(blob);
     }
 
+    /// Enable debug layers, if available
+    /// If this is called, it must be called before creating any devices
+    virtual SLANG_NO_THROW void SLANG_MCALL enableDebugLayers() = 0;
+
     /// Creates a device.
     virtual SLANG_NO_THROW Result SLANG_MCALL createDevice(const DeviceDesc& desc, IDevice** outDevice) = 0;
 

--- a/src/d3d12/d3d12-device.cpp
+++ b/src/d3d12/d3d12-device.cpp
@@ -215,11 +215,6 @@ Result DeviceImpl::_createDevice(
     D3D12DeviceInfo& outDeviceInfo
 )
 {
-    if (m_dxDebug && (deviceCheckFlags & DeviceCheckFlag::UseDebug) && !g_isAftermathEnabled)
-    {
-        m_dxDebug->EnableDebugLayer();
-    }
-
     outDeviceInfo.clear();
 
     ComPtr<IDXGIFactory> dxgiFactory;

--- a/src/d3d12/d3d12-helper-functions.cpp
+++ b/src/d3d12/d3d12-helper-functions.cpp
@@ -449,4 +449,21 @@ Result SLANG_MCALL createD3D12Device(const DeviceDesc* desc, IDevice** outDevice
     return SLANG_OK;
 }
 
+void SLANG_MCALL enableD3D12DebugLayerIfAvailable()
+{
+    SharedLibraryHandle d3dModule;
+#if SLANG_WINDOWS_FAMILY
+    const char* libName = "d3d12";
+#else
+    const char* libName = "libvkd3d-proton-d3d12.so";
+#endif
+    if (SLANG_FAILED(loadSharedLibrary(libName, d3dModule)))
+        return;
+    PFN_D3D12_GET_DEBUG_INTERFACE d3d12GetDebugInterface =
+        (PFN_D3D12_GET_DEBUG_INTERFACE)findSymbolAddressByName(d3dModule, "D3D12GetDebugInterface");
+    ComPtr<ID3D12Debug> dxDebug;
+    if (d3d12GetDebugInterface && SLANG_SUCCEEDED(d3d12GetDebugInterface(IID_PPV_ARGS(dxDebug.writeRef()))))
+        dxDebug->EnableDebugLayer();
+}
+
 } // namespace rhi

--- a/src/d3d12/d3d12-helper-functions.h
+++ b/src/d3d12/d3d12-helper-functions.h
@@ -56,4 +56,6 @@ Result SLANG_MCALL getD3D12Adapters(std::vector<AdapterInfo>& outAdapters);
 
 Result SLANG_MCALL createD3D12Device(const DeviceDesc* desc, IDevice** outDevice);
 
+void SLANG_MCALL enableD3D12DebugLayerIfAvailable();
+
 } // namespace rhi

--- a/src/rhi.cpp
+++ b/src/rhi.cpp
@@ -28,6 +28,7 @@ Result SLANG_MCALL getMetalAdapters(std::vector<AdapterInfo>& outAdapters);
 Result SLANG_MCALL getCUDAAdapters(std::vector<AdapterInfo>& outAdapters);
 
 Result SLANG_MCALL reportD3DLiveObjects();
+void SLANG_MCALL enableD3D12DebugLayerIfAvailable();
 
 /* !!!!!!!!!!!!!!!!!!!!!!!!!!!!!! Global Functions !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! */
 
@@ -236,6 +237,7 @@ public:
 
     Result getAdapters(DeviceType type, ISlangBlob** outAdaptersBlob) override;
     Result createDevice(const DeviceDesc& desc, IDevice** outDevice) override;
+    void enableDebugLayers() override;
     Result reportLiveObjects() override;
 
     static RHI* getInstance()
@@ -401,6 +403,13 @@ inline Result _createDevice(const DeviceDesc* desc, IDevice** outDevice)
     default:
         return SLANG_FAIL;
     }
+}
+
+void RHI::enableDebugLayers()
+{
+#if SLANG_RHI_ENABLE_D3D12
+    enableD3D12DebugLayerIfAvailable();
+#endif
 }
 
 Result RHI::createDevice(const DeviceDesc& desc, IDevice** outDevice)


### PR DESCRIPTION
As [1] shows, creating a D3D12 device and then enabling debug layers causes future device creation to fail.
That means enabling debug layers is a process-wide decision that should be done at startup, and not just before creating an individual device.

This helps to address https://github.com/shader-slang/slang/issues/6172. In the case of the mentioned failure, the WebGPU backend happened to create a D3D12 device before Slang-RHI got to create a device and enable debug layers.

A new interface is added which lets the API user enable debug layers separately, before creating any devices.

After this, the fix for slang-test debug issue is https://github.com/shader-slang/slang/pull/6226.

[1] https://github.com/shader-slang/slang/issues/6172#issuecomment-2624177459