### PR TITLE
Fix build issue where chrono was not included

### DIFF
--- a/src/cpu/cpu-command.cpp
+++ b/src/cpu/cpu-command.cpp
@@ -5,6 +5,8 @@
 #include "../command-list.h"
 #include "../strings.h"
 
+#include <chrono>
+
 namespace rhi::cpu {
 
 class CommandExecutor


### PR DESCRIPTION
Slang CI is failing

https://github.com/shader-slang/slang/actions/runs/13563926029/job/37912665775?pr=6476


```
[688/1142] Building CXX object external\slang-rhi\CMakeFiles\slang-rhi.dir\Debug\src\cpu\cpu-command.cpp.obj
FAILED: external/slang-rhi/CMakeFiles/slang-rhi.dir/Debug/src/cpu/cpu-command.cpp.obj 
C:\PROGRA~1\MICROS~2\2022\ENTERP~1\VC\Tools\MSVC\1443~1.348\bin\Hostx64\x64\cl.exe  /nologo /TP -DNOMINMAX -DSLANG_RHI_ENABLE_AGILITY_SDK=0 -DSLANG_RHI_ENABLE_CPU=1 -DSLANG_RHI_ENABLE_CUDA=1 -DSLANG_RHI_ENABLE_D3D11=1 -DSLANG_RHI_ENABLE_D3D12=1 -DSLANG_RHI_ENABLE_METAL=0 -DSLANG_RHI_ENABLE_NVAPI=0 -DSLANG_RHI_ENABLE_OPTIX=1 -DSLANG_RHI_ENABLE_VULKAN=1 -DSLANG_RHI_ENABLE_WGPU=1 -DUNICODE -DCMAKE_INTDIR=\"Debug\" -ID:\a\slang\slang\include -ID:\a\slang\slang\include\..\prelude -ID:\a\slang\slang\external\slang-rhi\include -ID:\a\slang\slang\external\slang-rhi\src -ID:\a\slang\slang\build\_deps\optix-src -ID:\a\slang\slang\external\slang-rhi\external\vulkan-headers\include -external:ID:\a\slang\slang\build\_deps\dawn-src\include -external:W0 /DWIN32 /D_WINDOWS /EHsc /Ob0 /Od /RTC1 -std:c++17 -MTd -Zi /W0 -WX /showIncludes /Foexternal\slang-rhi\CMakeFiles\slang-rhi.dir\Debug\src\cpu\cpu-command.cpp.obj /Fdexternal\slang-rhi\CMakeFiles\slang-rhi.dir\Debug\slang-rhi.pdb /FS -c D:\a\slang\slang\external\slang-rhi\src\cpu\cpu-command.cpp
D:\a\slang\slang\external\slang-rhi\src\cpu\cpu-command.cpp(338): error C2039: 'high_resolution_clock': is not a member of 'std::chrono'
C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.43.34808\include\__msvc_chrono.hpp(286): note: see declaration of 'std::chrono'
D:\a\slang\slang\external\slang-rhi\src\cpu\cpu-command.cpp(338): error C3083: 'high_resolution_clock': the symbol to the left of a '::' must be a type
D:\a\slang\slang\external\slang-rhi\src\cpu\cpu-command.cpp(338): error C2039: 'now': is not a member of 'std::chrono'
C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.43.34808\include\__msvc_chrono.hpp(286): note: see declaration of 'std::chrono'
D:\a\slang\slang\external\slang-rhi\src\cpu\cpu-command.cpp(338): error C3861: 'now': identifier not found
[689/1142] Building CXX object external\slang-rhi\CMakeFiles\slang-rhi.dir\Debug\src\debug-layer\debug-surface.cpp.obj
[690/1142] Building CXX object external\slang-rhi\CMakeFiles\slang-rhi.dir\Debug\src\cpu\cpu-buffer.cpp.obj
[691/1142] Building CXX object external\slang-rhi\CMakeFiles\slang-rhi.dir\Debug\src\cpu\cpu-device.cpp.obj
[692/1142] Building CXX object external\slang-rhi\CMakeFiles\slang-rhi.dir\Debug\src\cpu\cpu-helper-functions.cpp.obj
[693/1142] Generating slang-core-module-generated.h, ../slang-glsl-module/slang-glsl-module-generated.h
Compiling core module on debug build, this can take a while.
```