### PR TITLE
fix optix acceleration structure build

### DIFF
--- a/include/slang-rhi/acceleration-structure-utils.h
+++ b/include/slang-rhi/acceleration-structure-utils.h
@@ -109,7 +109,7 @@ inline void convertAccelerationStructureInstanceDesc(
         dstMetal->options = (uint32_t)src->flags;
         dstMetal->mask = src->instanceMask;
         dstMetal->intersectionFunctionTableOffset = src->instanceContributionToHitGroupIndex;
-        dstMetal->accelerationStructureIndex = src->accelerationStructure.value;
+        dstMetal->accelerationStructureIndex = (uint32_t)src->accelerationStructure.value;
         dstMetal->userID = src->instanceID;
         break;
     }

--- a/src/cuda/cuda-acceleration-structure.cpp
+++ b/src/cuda/cuda-acceleration-structure.cpp
@@ -121,7 +121,8 @@ Result AccelerationStructureBuildDescConverter::convert(
             buildInput.triangleArray.numSbtRecords = 1;
             buildInput.triangleArray.preTransform =
                 triangles.preTransformBuffer ? triangles.preTransformBuffer.getDeviceAddress() : 0;
-            buildInput.triangleArray.transformFormat = OPTIX_TRANSFORM_FORMAT_MATRIX_FLOAT12;
+            buildInput.triangleArray.transformFormat =
+                triangles.preTransformBuffer ? OPTIX_TRANSFORM_FORMAT_MATRIX_FLOAT12 : OPTIX_TRANSFORM_FORMAT_NONE;
         }
         break;
     }


### PR DESCRIPTION
correctly set `transformFormat` when no pre transform is passed in