### PR TITLE
D3D11 support working

### DIFF
--- a/src/staging-heap.cpp
+++ b/src/staging-heap.cpp
@@ -114,7 +114,7 @@ Result StagingHeap::allocPage(size_t size, StagingHeap::Page** outPage)
 
     ComPtr<IBuffer> bufferPtr;
     BufferDesc bufferDesc;
-    bufferDesc.usage = BufferUsage::CopyDestination | BufferUsage::CopySource | BufferUsage::ConstantBuffer;
+    bufferDesc.usage = BufferUsage::CopyDestination | BufferUsage::CopySource;
     bufferDesc.defaultState = ResourceState::General;
     bufferDesc.memoryType = MemoryType::Upload;
     bufferDesc.size = size;

--- a/tests/test-upload.cpp
+++ b/tests/test-upload.cpp
@@ -248,12 +248,12 @@ GPU_TEST_CASE("cmd-upload-buffer-offset", ALL)
     testUploadToBuffer(device, 2048, 128, 1);
 }
 
-GPU_TEST_CASE("cmd-upload-buffer-multi", ALL & ~D3D11)
+GPU_TEST_CASE("cmd-upload-buffer-multi", ALL)
 {
     testUploadToBuffer(device, 16, 0, 30);
 }
 
-GPU_TEST_CASE("cmd-upload-buffer-multienc", ALL & ~D3D11)
+GPU_TEST_CASE("cmd-upload-buffer-multienc", ALL)
 {
     testUploadToBuffer(device, 16, 0, 30);
 }


### PR DESCRIPTION
D3D11 upload buffers now will use a 'STAGING' type for upload heaps in read/write mode if no other D3D11 usage flags are provided (i.e the user has said the buffer won't be used for any shader stages). 

Map will now selectively choose WRITE_DISCARD or READ_WRITE depending on whether buffer is dynamic or staging.

Staging heap specifies the buffers are copy only, so they can now safely use the heap like other targets.