### PR TITLE
introduce explicit TextureType

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -684,6 +684,7 @@ if(SLANG_RHI_BUILD_TESTS)
         tests/test-surface.cpp
         tests/test-texture-layout.cpp
         tests/test-texture-types.cpp
+        tests/test-texture.cpp
         tests/test-uint16-structured-buffer.cpp
         tests/testing.cpp
         tests/texture-utils.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -619,6 +619,7 @@ target_include_directories(slang-rhi PRIVATE src)
 # target_link_libraries(slang-rhi PRIVATE nanothread)
 target_compile_definitions(slang-rhi
     PRIVATE
+    SLANG_RHI_DEBUG=$<BOOL:$<CONFIG:Debug>>
     SLANG_RHI_ENABLE_CPU=$<BOOL:${SLANG_RHI_ENABLE_CPU}>
     SLANG_RHI_ENABLE_D3D11=$<BOOL:${SLANG_RHI_ENABLE_D3D11}>
     SLANG_RHI_ENABLE_D3D12=$<BOOL:${SLANG_RHI_ENABLE_D3D12}>
@@ -692,6 +693,7 @@ if(SLANG_RHI_BUILD_TESTS)
     )
     target_compile_definitions(slang-rhi-tests
         PRIVATE
+        SLANG_RHI_DEBUG=$<BOOL:$<CONFIG:Debug>>
         SLANG_RHI_TESTS_DIR="${CMAKE_CURRENT_SOURCE_DIR}/tests"
         SLANG_RHI_ENABLE_NVAPI=$<BOOL:${SLANG_RHI_ENABLE_NVAPI}>
         SLANG_RHI_NVAPI_INCLUDE_DIR="${SLANG_RHI_NVAPI_INCLUDE_DIR}"

--- a/src/core/common.h
+++ b/src/core/common.h
@@ -26,7 +26,7 @@ template<typename T, typename U>
 T checked_cast(U u)
 {
     static_assert(!std::is_same<T, U>::value, "Redundant checked_cast");
-#ifdef _DEBUG
+#if SLANG_RHI_DEBUG
     if (!u)
         return nullptr;
     T t = dynamic_cast<T>(u);

--- a/src/cpu/cpu-texture.h
+++ b/src/cpu/cpu-texture.h
@@ -12,10 +12,15 @@ struct CPUTextureBaseShapeInfo
 };
 
 static const CPUTextureBaseShapeInfo kCPUTextureBaseShapeInfos[] = {
-    /* Texture1D */ {1, 1, 1},
-    /* Texture2D */ {2, 2, 1},
-    /* Texture3D */ {3, 3, 1},
-    /* TextureCube */ {2, 3, 6},
+    {1, 1, 1}, // Texture1D
+    {1, 1, 1}, // Texture1DArray
+    {2, 2, 1}, // Texture2D
+    {2, 2, 1}, // Texture2DArray
+    {2, 2, 1}, // Texture2DMS
+    {2, 2, 1}, // Texture2DMSArray
+    {3, 3, 1}, // Texture3D
+    {2, 2, 6}, // TextureCube
+    {2, 2, 6}, // TextureCubeArray
 };
 
 typedef void (*CPUTextureUnpackFunc)(const void* texelData, void* outData, size_t outSize);
@@ -52,6 +57,8 @@ struct CPUFormatInfoMap
     CPUFormatInfoMap()
     {
         memset(m_infos, 0, sizeof(m_infos));
+
+        set(Format::R32G32B32A32_UINT, &_unpackUInt32Texel<4>);
 
         set(Format::R32G32B32A32_FLOAT, &_unpackFloatTexel<4>);
         set(Format::R32G32B32_FLOAT, &_unpackFloatTexel<3>);

--- a/src/cuda/cuda-buffer.cpp
+++ b/src/cuda/cuda-buffer.cpp
@@ -24,11 +24,6 @@ BufferImpl::~BufferImpl()
     }
 }
 
-uint64_t BufferImpl::getBindlessHandle()
-{
-    return (uint64_t)m_cudaMemory;
-}
-
 DeviceAddress BufferImpl::getDeviceAddress()
 {
     return (DeviceAddress)m_cudaMemory;
@@ -37,7 +32,7 @@ DeviceAddress BufferImpl::getDeviceAddress()
 Result BufferImpl::getNativeHandle(NativeHandle* outHandle)
 {
     outHandle->type = NativeHandleType::CUdeviceptr;
-    outHandle->value = getBindlessHandle();
+    outHandle->value = (uint64_t)m_cudaMemory;
     return SLANG_OK;
 }
 

--- a/src/cuda/cuda-buffer.h
+++ b/src/cuda/cuda-buffer.h
@@ -10,13 +10,8 @@ public:
     BufferImpl(Device* device, const BufferDesc& desc);
     ~BufferImpl();
 
-    uint64_t getBindlessHandle();
-
     void* m_cudaExternalMemory = nullptr;
     void* m_cudaMemory = nullptr;
-
-    // Hack: This is set when buffer represents a CPU buffer.
-    void* m_cpuBuffer = nullptr;
 
     virtual SLANG_NO_THROW DeviceAddress SLANG_MCALL getDeviceAddress() override;
     virtual SLANG_NO_THROW Result SLANG_MCALL getNativeHandle(NativeHandle* outHandle) override;

--- a/src/cuda/cuda-texture.h
+++ b/src/cuda/cuda-texture.h
@@ -10,17 +10,16 @@ public:
     TextureImpl(Device* device, const TextureDesc& desc);
     ~TextureImpl();
 
-    uint64_t getBindlessHandle();
-
     // The texObject is for reading 'texture' like things. This is an opaque type, that's backed by
     // a long long
-    CUtexObject m_cudaTexObj = CUtexObject();
+    CUtexObject m_cudaTexObj = 0;
 
     // The surfObj is for reading/writing 'texture like' things, but not for sampling.
-    CUsurfObject m_cudaSurfObj = CUsurfObject();
+    CUsurfObject m_cudaSurfObj = 0;
 
-    CUarray m_cudaArray = CUarray();
-    CUmipmappedArray m_cudaMipMappedArray = CUmipmappedArray();
+    // Texture is either stored in cuda array or mip mapped array.
+    CUarray m_cudaArray = 0;
+    CUmipmappedArray m_cudaMipMappedArray = 0;
 
     void* m_cudaExternalMemory = nullptr;
 

--- a/src/d3d11/d3d11-device.cpp
+++ b/src/d3d11/d3d11-device.cpp
@@ -99,7 +99,7 @@ Result DeviceImpl::initialize(const DeviceDesc& desc)
         // to override UseDebug of default rather than leave it
         // up to each back-end to specify.
 
-#if _DEBUG
+#if SLANG_RHI_DEBUG
         /// First try debug then non debug
         combiner.add(DeviceCheckFlag::UseDebug, ChangeType::OnOff);
 #else

--- a/src/d3d11/d3d11-helper-functions.cpp
+++ b/src/d3d11/d3d11-helper-functions.cpp
@@ -295,36 +295,36 @@ void initSrvDesc(const TextureDesc& textureDesc, DXGI_FORMAT pixelFormat, D3D11_
     switch (textureDesc.type)
     {
     case TextureType::Texture1D:
-        if (textureDesc.arrayLength > 1)
-        {
-            descOut.ViewDimension = D3D11_SRV_DIMENSION_TEXTURE1DARRAY;
-            descOut.Texture1DArray.MostDetailedMip = 0;
-            descOut.Texture1DArray.MipLevels = textureDesc.mipLevelCount;
-            descOut.Texture1DArray.FirstArraySlice = 0;
-            descOut.Texture1DArray.ArraySize = textureDesc.arrayLength;
-        }
-        else
-        {
-            descOut.ViewDimension = D3D11_SRV_DIMENSION_TEXTURE1D;
-            descOut.Texture1D.MostDetailedMip = 0;
-            descOut.Texture1D.MipLevels = textureDesc.mipLevelCount;
-        }
+        descOut.ViewDimension = D3D11_SRV_DIMENSION_TEXTURE1D;
+        descOut.Texture1D.MostDetailedMip = 0;
+        descOut.Texture1D.MipLevels = textureDesc.mipLevelCount;
+        break;
+    case TextureType::Texture1DArray:
+        descOut.ViewDimension = D3D11_SRV_DIMENSION_TEXTURE1DARRAY;
+        descOut.Texture1DArray.MostDetailedMip = 0;
+        descOut.Texture1DArray.MipLevels = textureDesc.mipLevelCount;
+        descOut.Texture1DArray.FirstArraySlice = 0;
+        descOut.Texture1DArray.ArraySize = textureDesc.arrayLength;
         break;
     case TextureType::Texture2D:
-        if (textureDesc.arrayLength > 1)
-        {
-            descOut.ViewDimension = D3D11_SRV_DIMENSION_TEXTURE2DARRAY;
-            descOut.Texture2DArray.MostDetailedMip = 0;
-            descOut.Texture2DArray.MipLevels = textureDesc.mipLevelCount;
-            descOut.Texture2DArray.FirstArraySlice = 0;
-            descOut.Texture2DArray.ArraySize = textureDesc.arrayLength;
-        }
-        else
-        {
-            descOut.ViewDimension = D3D11_SRV_DIMENSION_TEXTURE2D;
-            descOut.Texture2D.MostDetailedMip = 0;
-            descOut.Texture2D.MipLevels = textureDesc.mipLevelCount;
-        }
+        descOut.ViewDimension = D3D11_SRV_DIMENSION_TEXTURE2D;
+        descOut.Texture2D.MostDetailedMip = 0;
+        descOut.Texture2D.MipLevels = textureDesc.mipLevelCount;
+        break;
+    case TextureType::Texture2DArray:
+        descOut.ViewDimension = D3D11_SRV_DIMENSION_TEXTURE2DARRAY;
+        descOut.Texture2DArray.MostDetailedMip = 0;
+        descOut.Texture2DArray.MipLevels = textureDesc.mipLevelCount;
+        descOut.Texture2DArray.FirstArraySlice = 0;
+        descOut.Texture2DArray.ArraySize = textureDesc.arrayLength;
+        break;
+    case TextureType::Texture2DMS:
+        descOut.ViewDimension = D3D11_SRV_DIMENSION_TEXTURE2DMS;
+        break;
+    case TextureType::Texture2DMSArray:
+        descOut.ViewDimension = D3D11_SRV_DIMENSION_TEXTURE2DMSARRAY;
+        descOut.Texture2DMSArray.FirstArraySlice = 0;
+        descOut.Texture2DMSArray.ArraySize = textureDesc.arrayLength;
         break;
     case TextureType::Texture3D:
         descOut.ViewDimension = D3D11_SRV_DIMENSION_TEXTURE3D;
@@ -332,20 +332,16 @@ void initSrvDesc(const TextureDesc& textureDesc, DXGI_FORMAT pixelFormat, D3D11_
         descOut.Texture3D.MipLevels = textureDesc.mipLevelCount;
         break;
     case TextureType::TextureCube:
-        if (textureDesc.arrayLength > 1)
-        {
-            descOut.ViewDimension = D3D11_SRV_DIMENSION_TEXTURECUBEARRAY;
-            descOut.TextureCubeArray.MostDetailedMip = 0;
-            descOut.TextureCubeArray.MipLevels = textureDesc.mipLevelCount;
-            descOut.TextureCubeArray.First2DArrayFace = 0;
-            descOut.TextureCubeArray.NumCubes = textureDesc.arrayLength;
-        }
-        else
-        {
-            descOut.ViewDimension = D3D11_SRV_DIMENSION_TEXTURECUBE;
-            descOut.TextureCube.MostDetailedMip = 0;
-            descOut.TextureCube.MipLevels = textureDesc.mipLevelCount;
-        }
+        descOut.ViewDimension = D3D11_SRV_DIMENSION_TEXTURECUBE;
+        descOut.TextureCube.MostDetailedMip = 0;
+        descOut.TextureCube.MipLevels = textureDesc.mipLevelCount;
+        break;
+    case TextureType::TextureCubeArray:
+        descOut.ViewDimension = D3D11_SRV_DIMENSION_TEXTURECUBEARRAY;
+        descOut.TextureCubeArray.MostDetailedMip = 0;
+        descOut.TextureCubeArray.MipLevels = textureDesc.mipLevelCount;
+        descOut.TextureCubeArray.First2DArrayFace = 0;
+        descOut.TextureCubeArray.NumCubes = textureDesc.arrayLength;
         break;
     }
 }

--- a/src/d3d12/d3d12-device.cpp
+++ b/src/d3d12/d3d12-device.cpp
@@ -1078,8 +1078,8 @@ Result DeviceImpl::createTexture(const TextureDesc& descIn, const SubresourceDat
         ID3D12Resource* uploadResource = uploadTexture;
 
         uint32_t subresourceIndex = 0;
-        uint32_t arrayLayerCount = srcDesc.arrayLength * (srcDesc.type == TextureType::TextureCube ? 6 : 1);
-        for (uint32_t arrayIndex = 0; arrayIndex < arrayLayerCount; arrayIndex++)
+        uint32_t layerCount = srcDesc.getLayerCount();
+        for (uint32_t layer = 0; layer < layerCount; layer++)
         {
             uint8_t* p;
             uploadResource->Map(0, nullptr, reinterpret_cast<void**>(&p));

--- a/src/d3d12/d3d12-helper-functions.cpp
+++ b/src/d3d12/d3d12-helper-functions.cpp
@@ -49,17 +49,19 @@ D3D12_RESOURCE_DIMENSION calcResourceDimension(TextureType type)
     switch (type)
     {
     case TextureType::Texture1D:
+    case TextureType::Texture1DArray:
         return D3D12_RESOURCE_DIMENSION_TEXTURE1D;
-    case TextureType::TextureCube:
     case TextureType::Texture2D:
-    {
+    case TextureType::Texture2DArray:
+    case TextureType::Texture2DMS:
+    case TextureType::Texture2DMSArray:
+    case TextureType::TextureCube:
+    case TextureType::TextureCubeArray:
         return D3D12_RESOURCE_DIMENSION_TEXTURE2D;
-    }
     case TextureType::Texture3D:
         return D3D12_RESOURCE_DIMENSION_TEXTURE3D;
-    default:
-        return D3D12_RESOURCE_DIMENSION_UNKNOWN;
     }
+    return D3D12_RESOURCE_DIMENSION_UNKNOWN;
 }
 
 DXGI_FORMAT getTypelessFormatFromDepthFormat(Format format)
@@ -200,7 +202,7 @@ Result initTextureDesc(D3D12_RESOURCE_DESC& resourceDesc, const TextureDesc& src
     }
     else
     {
-        resourceDesc.DepthOrArraySize = srcDesc.arrayLength * (srcDesc.type == TextureType::TextureCube ? 6 : 1);
+        resourceDesc.DepthOrArraySize = srcDesc.getLayerCount();
     }
 
     resourceDesc.MipLevels = srcDesc.mipLevelCount;

--- a/src/d3d12/d3d12-texture.cpp
+++ b/src/d3d12/d3d12-texture.cpp
@@ -91,8 +91,6 @@ TextureImpl::getSRV(Format format, TextureType type, TextureAspect aspect, const
     if (allocation)
         return allocation.cpuHandle;
 
-    bool isArray = m_desc.arrayLength > 1;
-    bool isMultiSample = m_desc.sampleCount > 1;
     D3D12_SHADER_RESOURCE_VIEW_DESC viewDesc = {};
     viewDesc.Format = D3DUtil::getMapFormat(format);
     viewDesc.Shader4ComponentMapping = D3D12_DEFAULT_SHADER_4_COMPONENT_MAPPING;
@@ -100,54 +98,38 @@ TextureImpl::getSRV(Format format, TextureType type, TextureAspect aspect, const
     switch (type)
     {
     case TextureType::Texture1D:
-        if (isArray)
-        {
-            viewDesc.ViewDimension = D3D12_SRV_DIMENSION_TEXTURE1DARRAY;
-            viewDesc.Texture1DArray.MostDetailedMip = range.mipLevel;
-            viewDesc.Texture1DArray.MipLevels = range.mipLevelCount;
-            viewDesc.Texture1DArray.FirstArraySlice = range.baseArrayLayer;
-            viewDesc.Texture1DArray.ArraySize = range.layerCount;
-        }
-        else
-        {
-            viewDesc.ViewDimension = D3D12_SRV_DIMENSION_TEXTURE1D;
-            viewDesc.Texture1D.MostDetailedMip = range.mipLevel;
-            viewDesc.Texture1D.MipLevels = range.mipLevelCount;
-        }
+        viewDesc.ViewDimension = D3D12_SRV_DIMENSION_TEXTURE1D;
+        viewDesc.Texture1D.MostDetailedMip = range.mipLevel;
+        viewDesc.Texture1D.MipLevels = range.mipLevelCount;
+        break;
+    case TextureType::Texture1DArray:
+        viewDesc.ViewDimension = D3D12_SRV_DIMENSION_TEXTURE1DARRAY;
+        viewDesc.Texture1DArray.MostDetailedMip = range.mipLevel;
+        viewDesc.Texture1DArray.MipLevels = range.mipLevelCount;
+        viewDesc.Texture1DArray.FirstArraySlice = range.baseArrayLayer;
+        viewDesc.Texture1DArray.ArraySize = range.layerCount;
         break;
     case TextureType::Texture2D:
-        if (isArray)
-        {
-            if (isMultiSample)
-            {
-                viewDesc.ViewDimension = D3D12_SRV_DIMENSION_TEXTURE2DMSARRAY;
-                viewDesc.Texture2DMSArray.FirstArraySlice = range.baseArrayLayer;
-                viewDesc.Texture2DMSArray.ArraySize = range.layerCount;
-            }
-            else
-            {
-                viewDesc.ViewDimension = D3D12_SRV_DIMENSION_TEXTURE2DARRAY;
-                viewDesc.Texture2DArray.MostDetailedMip = range.mipLevel;
-                viewDesc.Texture2DArray.MipLevels = range.mipLevelCount;
-                viewDesc.Texture2DArray.FirstArraySlice = range.baseArrayLayer;
-                viewDesc.Texture2DArray.ArraySize = range.layerCount;
-                viewDesc.Texture2DArray.PlaneSlice = D3DUtil::getPlaneSlice(viewDesc.Format, aspect);
-            }
-        }
-        else
-        {
-            if (isMultiSample)
-            {
-                viewDesc.ViewDimension = D3D12_SRV_DIMENSION_TEXTURE2DMS;
-            }
-            else
-            {
-                viewDesc.ViewDimension = D3D12_SRV_DIMENSION_TEXTURE2D;
-                viewDesc.Texture2D.MostDetailedMip = range.mipLevel;
-                viewDesc.Texture2D.MipLevels = range.mipLevelCount;
-                viewDesc.Texture2D.PlaneSlice = D3DUtil::getPlaneSlice(viewDesc.Format, aspect);
-            }
-        }
+        viewDesc.ViewDimension = D3D12_SRV_DIMENSION_TEXTURE2D;
+        viewDesc.Texture2D.MostDetailedMip = range.mipLevel;
+        viewDesc.Texture2D.MipLevels = range.mipLevelCount;
+        viewDesc.Texture2D.PlaneSlice = D3DUtil::getPlaneSlice(viewDesc.Format, aspect);
+        break;
+    case TextureType::Texture2DArray:
+        viewDesc.ViewDimension = D3D12_SRV_DIMENSION_TEXTURE2DARRAY;
+        viewDesc.Texture2DArray.MostDetailedMip = range.mipLevel;
+        viewDesc.Texture2DArray.MipLevels = range.mipLevelCount;
+        viewDesc.Texture2DArray.FirstArraySlice = range.baseArrayLayer;
+        viewDesc.Texture2DArray.ArraySize = range.layerCount;
+        viewDesc.Texture2DArray.PlaneSlice = D3DUtil::getPlaneSlice(viewDesc.Format, aspect);
+        break;
+    case TextureType::Texture2DMS:
+        viewDesc.ViewDimension = D3D12_SRV_DIMENSION_TEXTURE2DMS;
+        break;
+    case TextureType::Texture2DMSArray:
+        viewDesc.ViewDimension = D3D12_SRV_DIMENSION_TEXTURE2DMSARRAY;
+        viewDesc.Texture2DMSArray.FirstArraySlice = range.baseArrayLayer;
+        viewDesc.Texture2DMSArray.ArraySize = range.layerCount;
         break;
     case TextureType::Texture3D:
         viewDesc.ViewDimension = D3D12_SRV_DIMENSION_TEXTURE3D;
@@ -155,20 +137,16 @@ TextureImpl::getSRV(Format format, TextureType type, TextureAspect aspect, const
         viewDesc.Texture3D.MipLevels = range.mipLevelCount;
         break;
     case TextureType::TextureCube:
-        if (isArray)
-        {
-            viewDesc.ViewDimension = D3D12_SRV_DIMENSION_TEXTURECUBEARRAY;
-            viewDesc.TextureCubeArray.MostDetailedMip = range.mipLevel;
-            viewDesc.TextureCubeArray.MipLevels = range.mipLevelCount;
-            viewDesc.TextureCubeArray.First2DArrayFace = range.baseArrayLayer;
-            viewDesc.TextureCubeArray.NumCubes = range.layerCount / 6;
-        }
-        else
-        {
-            viewDesc.ViewDimension = D3D12_SRV_DIMENSION_TEXTURECUBE;
-            viewDesc.TextureCube.MostDetailedMip = range.mipLevel;
-            viewDesc.TextureCube.MipLevels = range.mipLevelCount;
-        }
+        viewDesc.ViewDimension = D3D12_SRV_DIMENSION_TEXTURECUBE;
+        viewDesc.TextureCube.MostDetailedMip = range.mipLevel;
+        viewDesc.TextureCube.MipLevels = range.mipLevelCount;
+        break;
+    case TextureType::TextureCubeArray:
+        viewDesc.ViewDimension = D3D12_SRV_DIMENSION_TEXTURECUBEARRAY;
+        viewDesc.TextureCubeArray.MostDetailedMip = range.mipLevel;
+        viewDesc.TextureCubeArray.MipLevels = range.mipLevelCount;
+        viewDesc.TextureCubeArray.First2DArrayFace = range.baseArrayLayer;
+        viewDesc.TextureCubeArray.NumCubes = range.layerCount / 6;
         break;
     }
 
@@ -192,52 +170,48 @@ D3D12_CPU_DESCRIPTOR_HANDLE TextureImpl::getUAV(
     if (allocation)
         return allocation.cpuHandle;
 
-    bool isArray = m_desc.arrayLength > 1;
     D3D12_UNORDERED_ACCESS_VIEW_DESC viewDesc = {};
     viewDesc.Format =
         getFormatInfo(m_desc.format).isTypeless ? D3DUtil::getMapFormat(m_desc.format) : D3DUtil::getMapFormat(format);
     switch (type)
     {
     case TextureType::Texture1D:
-        viewDesc.ViewDimension = isArray ? D3D12_UAV_DIMENSION_TEXTURE1DARRAY : D3D12_UAV_DIMENSION_TEXTURE1D;
-        if (isArray)
-        {
-            viewDesc.Texture1D.MipSlice = range.mipLevel;
-        }
-        else
-        {
-            viewDesc.Texture1DArray.MipSlice = range.mipLevel;
-            viewDesc.Texture1DArray.ArraySize = range.layerCount;
-            viewDesc.Texture1DArray.FirstArraySlice = range.baseArrayLayer;
-        }
+        viewDesc.ViewDimension = D3D12_UAV_DIMENSION_TEXTURE1D;
+        viewDesc.Texture1DArray.MipSlice = range.mipLevel;
+        viewDesc.Texture1DArray.ArraySize = range.layerCount;
+        viewDesc.Texture1DArray.FirstArraySlice = range.baseArrayLayer;
+        break;
+    case TextureType::Texture1DArray:
+        viewDesc.ViewDimension = D3D12_UAV_DIMENSION_TEXTURE1DARRAY;
+        viewDesc.Texture1D.MipSlice = range.mipLevel;
         break;
     case TextureType::Texture2D:
-        viewDesc.ViewDimension = isArray ? D3D12_UAV_DIMENSION_TEXTURE2DARRAY : D3D12_UAV_DIMENSION_TEXTURE2D;
-        if (isArray)
-        {
-            viewDesc.Texture2DArray.MipSlice = range.mipLevel;
-            viewDesc.Texture2DArray.ArraySize = range.layerCount;
-            viewDesc.Texture2DArray.FirstArraySlice = range.baseArrayLayer;
-            viewDesc.Texture2DArray.PlaneSlice = D3DUtil::getPlaneSlice(viewDesc.Format, aspect);
-        }
-        else
-        {
-            viewDesc.Texture2D.MipSlice = range.mipLevel;
-            viewDesc.Texture2D.PlaneSlice = D3DUtil::getPlaneSlice(viewDesc.Format, aspect);
-        }
+        viewDesc.ViewDimension = D3D12_UAV_DIMENSION_TEXTURE2D;
+        viewDesc.Texture2D.MipSlice = range.mipLevel;
+        viewDesc.Texture2D.PlaneSlice = D3DUtil::getPlaneSlice(viewDesc.Format, aspect);
+        break;
+    case TextureType::Texture2DArray:
+    case TextureType::TextureCube:
+    case TextureType::TextureCubeArray:
+        viewDesc.ViewDimension = D3D12_UAV_DIMENSION_TEXTURE2DARRAY;
+        viewDesc.Texture2DArray.MipSlice = range.mipLevel;
+        viewDesc.Texture2DArray.ArraySize = range.layerCount;
+        viewDesc.Texture2DArray.FirstArraySlice = range.baseArrayLayer;
+        viewDesc.Texture2DArray.PlaneSlice = D3DUtil::getPlaneSlice(viewDesc.Format, aspect);
+        break;
+    case TextureType::Texture2DMS:
+        viewDesc.ViewDimension = D3D12_UAV_DIMENSION_TEXTURE2DMS;
+        break;
+    case TextureType::Texture2DMSArray:
+        viewDesc.ViewDimension = D3D12_UAV_DIMENSION_TEXTURE2DMSARRAY;
+        viewDesc.Texture2DMSArray.FirstArraySlice = range.baseArrayLayer;
+        viewDesc.Texture2DMSArray.ArraySize = range.layerCount;
         break;
     case TextureType::Texture3D:
         viewDesc.ViewDimension = D3D12_UAV_DIMENSION_TEXTURE3D;
         viewDesc.Texture3D.MipSlice = range.mipLevel;
         viewDesc.Texture3D.FirstWSlice = range.baseArrayLayer;
         viewDesc.Texture3D.WSize = m_desc.size.depth;
-        break;
-    case TextureType::TextureCube:
-        viewDesc.ViewDimension = D3D12_UAV_DIMENSION_TEXTURE2DARRAY;
-        viewDesc.Texture2DArray.MipSlice = range.mipLevel;
-        viewDesc.Texture2DArray.ArraySize = range.layerCount;
-        viewDesc.Texture2DArray.FirstArraySlice = range.baseArrayLayer;
-        viewDesc.Texture2DArray.PlaneSlice = D3DUtil::getPlaneSlice(viewDesc.Format, aspect);
         break;
     }
 
@@ -261,64 +235,47 @@ D3D12_CPU_DESCRIPTOR_HANDLE TextureImpl::getRTV(
     if (allocation)
         return allocation.cpuHandle;
 
-    bool isArray = m_desc.arrayLength > 1;
-    bool isMultiSample = m_desc.sampleCount > 1;
     D3D12_RENDER_TARGET_VIEW_DESC viewDesc = {};
     viewDesc.Format = D3DUtil::getMapFormat(format);
     switch (type)
     {
     case TextureType::Texture1D:
-        viewDesc.ViewDimension = isArray ? D3D12_RTV_DIMENSION_TEXTURE1DARRAY : D3D12_RTV_DIMENSION_TEXTURE1D;
-        if (isArray)
-        {
-            viewDesc.Texture1DArray.MipSlice = range.mipLevel;
-            viewDesc.Texture1DArray.FirstArraySlice = range.baseArrayLayer;
-            viewDesc.Texture1DArray.ArraySize = range.layerCount;
-        }
-        else
-        {
-            viewDesc.Texture1D.MipSlice = range.mipLevel;
-        }
+        viewDesc.ViewDimension = D3D12_RTV_DIMENSION_TEXTURE1D;
+        viewDesc.Texture1D.MipSlice = range.mipLevel;
+        break;
+    case TextureType::Texture1DArray:
+        viewDesc.ViewDimension = D3D12_RTV_DIMENSION_TEXTURE1DARRAY;
+        viewDesc.Texture1DArray.MipSlice = range.mipLevel;
+        viewDesc.Texture1DArray.FirstArraySlice = range.baseArrayLayer;
+        viewDesc.Texture1DArray.ArraySize = range.layerCount;
         break;
     case TextureType::Texture2D:
-        if (isMultiSample)
-        {
-            viewDesc.ViewDimension = isArray ? D3D12_RTV_DIMENSION_TEXTURE2DMSARRAY : D3D12_RTV_DIMENSION_TEXTURE2DMS;
-            if (isArray)
-            {
-                viewDesc.Texture2DMSArray.ArraySize = range.layerCount;
-                viewDesc.Texture2DMSArray.FirstArraySlice = range.baseArrayLayer;
-            }
-        }
-        else
-        {
-            viewDesc.ViewDimension = isArray ? D3D12_RTV_DIMENSION_TEXTURE2DARRAY : D3D12_RTV_DIMENSION_TEXTURE2D;
-            if (isArray)
-            {
-                viewDesc.Texture2DArray.MipSlice = range.mipLevel;
-                viewDesc.Texture2DArray.ArraySize = range.layerCount;
-                viewDesc.Texture2DArray.FirstArraySlice = range.baseArrayLayer;
-                viewDesc.Texture2DArray.PlaneSlice = D3DUtil::getPlaneSlice(viewDesc.Format, aspect);
-            }
-            else
-            {
-                viewDesc.Texture2D.MipSlice = range.mipLevel;
-                viewDesc.Texture2D.PlaneSlice = D3DUtil::getPlaneSlice(viewDesc.Format, aspect);
-            }
-        }
+        viewDesc.ViewDimension = D3D12_RTV_DIMENSION_TEXTURE2D;
+        viewDesc.Texture2D.MipSlice = range.mipLevel;
+        viewDesc.Texture2D.PlaneSlice = D3DUtil::getPlaneSlice(viewDesc.Format, aspect);
+        break;
+    case TextureType::Texture2DArray:
+    case TextureType::TextureCube:
+    case TextureType::TextureCubeArray:
+        viewDesc.ViewDimension = D3D12_RTV_DIMENSION_TEXTURE2DARRAY;
+        viewDesc.Texture2DArray.MipSlice = range.mipLevel;
+        viewDesc.Texture2DArray.ArraySize = range.layerCount;
+        viewDesc.Texture2DArray.FirstArraySlice = range.baseArrayLayer;
+        viewDesc.Texture2DArray.PlaneSlice = D3DUtil::getPlaneSlice(viewDesc.Format, aspect);
+        break;
+    case TextureType::Texture2DMS:
+        viewDesc.ViewDimension = D3D12_RTV_DIMENSION_TEXTURE2DMS;
+        break;
+    case TextureType::Texture2DMSArray:
+        viewDesc.ViewDimension = D3D12_RTV_DIMENSION_TEXTURE2DMSARRAY;
+        viewDesc.Texture2DMSArray.ArraySize = range.layerCount;
+        viewDesc.Texture2DMSArray.FirstArraySlice = range.baseArrayLayer;
         break;
     case TextureType::Texture3D:
         viewDesc.ViewDimension = D3D12_RTV_DIMENSION_TEXTURE3D;
         viewDesc.Texture3D.MipSlice = range.mipLevel;
         viewDesc.Texture3D.FirstWSlice = range.baseArrayLayer;
         viewDesc.Texture3D.WSize = m_desc.size.depth;
-        break;
-    case TextureType::TextureCube:
-        viewDesc.ViewDimension = D3D12_RTV_DIMENSION_TEXTURE2DARRAY;
-        viewDesc.Texture2DArray.MipSlice = range.mipLevel;
-        viewDesc.Texture2DArray.ArraySize = range.layerCount;
-        viewDesc.Texture2DArray.FirstArraySlice = range.baseArrayLayer;
-        viewDesc.Texture2DArray.PlaneSlice = D3DUtil::getPlaneSlice(viewDesc.Format, aspect);
         break;
     }
 
@@ -342,8 +299,6 @@ D3D12_CPU_DESCRIPTOR_HANDLE TextureImpl::getDSV(
     if (allocation)
         return allocation.cpuHandle;
 
-    bool isArray = m_desc.arrayLength > 1;
-    bool isMultiSample = m_desc.sampleCount > 1;
     D3D12_DEPTH_STENCIL_VIEW_DESC viewDesc = {};
     viewDesc.Format = D3DUtil::getMapFormat(format);
     switch (type)
@@ -352,39 +307,39 @@ D3D12_CPU_DESCRIPTOR_HANDLE TextureImpl::getDSV(
         viewDesc.ViewDimension = D3D12_DSV_DIMENSION_TEXTURE1D;
         viewDesc.Texture1D.MipSlice = range.mipLevel;
         break;
-    case TextureType::Texture2D:
-        if (isMultiSample)
-        {
-            viewDesc.ViewDimension = isArray ? D3D12_DSV_DIMENSION_TEXTURE2DMSARRAY : D3D12_DSV_DIMENSION_TEXTURE2DMS;
-            if (isArray)
-            {
-                viewDesc.Texture2DMSArray.ArraySize = range.layerCount;
-                viewDesc.Texture2DMSArray.FirstArraySlice = range.baseArrayLayer;
-            }
-        }
-        else
-        {
-            viewDesc.ViewDimension = isArray ? D3D12_DSV_DIMENSION_TEXTURE2DARRAY : D3D12_DSV_DIMENSION_TEXTURE2D;
-            if (isArray)
-            {
-                viewDesc.Texture2DArray.MipSlice = range.mipLevel;
-                viewDesc.Texture2DArray.ArraySize = range.layerCount;
-                viewDesc.Texture2DArray.FirstArraySlice = range.baseArrayLayer;
-            }
-            else
-            {
-                viewDesc.Texture2D.MipSlice = range.mipLevel;
-            }
-        }
+    case TextureType::Texture1DArray:
+        viewDesc.ViewDimension = D3D12_DSV_DIMENSION_TEXTURE1DARRAY;
+        viewDesc.Texture1DArray.MipSlice = range.mipLevel;
+        viewDesc.Texture1DArray.ArraySize = range.layerCount;
+        viewDesc.Texture1DArray.FirstArraySlice = range.baseArrayLayer;
         break;
-    case TextureType::TextureCube:
+    case TextureType::Texture2D:
+        viewDesc.ViewDimension = D3D12_DSV_DIMENSION_TEXTURE2D;
+        viewDesc.Texture2D.MipSlice = range.mipLevel;
+        break;
+    case TextureType::Texture2DArray:
         viewDesc.ViewDimension = D3D12_DSV_DIMENSION_TEXTURE2DARRAY;
         viewDesc.Texture2DArray.MipSlice = range.mipLevel;
         viewDesc.Texture2DArray.ArraySize = range.layerCount;
         viewDesc.Texture2DArray.FirstArraySlice = range.baseArrayLayer;
         break;
-    default:
-        SLANG_RHI_ASSERT_FAILURE("Unsupported texture type");
+    case TextureType::Texture2DMS:
+        viewDesc.ViewDimension = D3D12_DSV_DIMENSION_TEXTURE2DMS;
+        break;
+    case TextureType::Texture2DMSArray:
+        viewDesc.ViewDimension = D3D12_DSV_DIMENSION_TEXTURE2DMSARRAY;
+        viewDesc.Texture2DMSArray.ArraySize = range.layerCount;
+        viewDesc.Texture2DMSArray.FirstArraySlice = range.baseArrayLayer;
+        break;
+    case TextureType::Texture3D:
+        SLANG_RHI_ASSERT_FAILURE("Not supported");
+        break;
+    case TextureType::TextureCube:
+    case TextureType::TextureCubeArray:
+        viewDesc.ViewDimension = D3D12_DSV_DIMENSION_TEXTURE2DARRAY;
+        viewDesc.Texture2DArray.MipSlice = range.mipLevel;
+        viewDesc.Texture2DArray.ArraySize = range.layerCount;
+        viewDesc.Texture2DArray.FirstArraySlice = range.baseArrayLayer;
         break;
     }
 

--- a/src/debug-layer/debug-device.cpp
+++ b/src/debug-layer/debug-device.cpp
@@ -106,6 +106,13 @@ Result DebugDevice::createTexture(const TextureDesc& desc, const SubresourceData
         return SLANG_E_INVALID_ARG;
     }
 
+    if (desc.type != TextureType::Texture1DArray && desc.type != TextureType::Texture2DArray &&
+        desc.type != TextureType::TextureCubeArray && desc.arrayLength > 1)
+    {
+        RHI_VALIDATION_ERROR("Texture array length must be 1 for non-array textures");
+        return SLANG_E_INVALID_ARG;
+    }
+
     switch (desc.type)
     {
     case TextureType::Texture1D:

--- a/src/debug-layer/debug-device.cpp
+++ b/src/debug-layer/debug-device.cpp
@@ -107,7 +107,8 @@ Result DebugDevice::createTexture(const TextureDesc& desc, const SubresourceData
     }
 
     if (desc.type != TextureType::Texture1DArray && desc.type != TextureType::Texture2DArray &&
-        desc.type != TextureType::TextureCubeArray && desc.arrayLength > 1)
+        desc.type != TextureType::Texture2DMSArray && desc.type != TextureType::TextureCubeArray &&
+        desc.arrayLength > 1)
     {
         RHI_VALIDATION_ERROR("Texture array length must be 1 for non-array textures");
         return SLANG_E_INVALID_ARG;

--- a/src/debug-layer/debug-device.cpp
+++ b/src/debug-layer/debug-device.cpp
@@ -70,6 +70,79 @@ Result DebugDevice::createTexture(const TextureDesc& desc, const SubresourceData
 {
     SLANG_RHI_API_FUNC;
 
+    if (uint32_t(desc.type) > uint32_t(TextureType::TextureCubeArray))
+    {
+        RHI_VALIDATION_ERROR("Invalid texture type");
+        return SLANG_E_INVALID_ARG;
+    }
+    if (desc.size.width < 1)
+    {
+        RHI_VALIDATION_ERROR("Texture width must be at least 1");
+        return SLANG_E_INVALID_ARG;
+    }
+    if (desc.size.height < 1)
+    {
+        RHI_VALIDATION_ERROR("Texture height must be at least 1");
+        return SLANG_E_INVALID_ARG;
+    }
+    if (desc.size.depth < 1)
+    {
+        RHI_VALIDATION_ERROR("Texture depth must be at least 1");
+        return SLANG_E_INVALID_ARG;
+    }
+    if (desc.arrayLength < 1)
+    {
+        RHI_VALIDATION_ERROR("Texture array length must be at least 1");
+        return SLANG_E_INVALID_ARG;
+    }
+    if (desc.mipLevelCount < 1)
+    {
+        RHI_VALIDATION_ERROR("Texture mip level count must be at least 1");
+        return SLANG_E_INVALID_ARG;
+    }
+    if (desc.format == Format::Undefined)
+    {
+        RHI_VALIDATION_ERROR("Texture format must be specified");
+        return SLANG_E_INVALID_ARG;
+    }
+
+    switch (desc.type)
+    {
+    case TextureType::Texture1D:
+    case TextureType::Texture1DArray:
+        if (desc.size.height != 1 || desc.size.depth != 1)
+        {
+            RHI_VALIDATION_ERROR("1D textures must have height and depth set to 1");
+            return SLANG_E_INVALID_ARG;
+        }
+        break;
+    case TextureType::Texture2D:
+    case TextureType::Texture2DArray:
+    case TextureType::Texture2DMS:
+    case TextureType::Texture2DMSArray:
+        if (desc.size.depth != 1)
+        {
+            RHI_VALIDATION_ERROR("2D textures must have depth set to 1");
+            return SLANG_E_INVALID_ARG;
+        }
+        break;
+    case TextureType::Texture3D:
+        break;
+    case TextureType::TextureCube:
+    case TextureType::TextureCubeArray:
+        if (desc.size.width != desc.size.height)
+        {
+            RHI_VALIDATION_ERROR("Cube textures must have width equal to height");
+            return SLANG_E_INVALID_ARG;
+        }
+        if (desc.size.depth != 1)
+        {
+            RHI_VALIDATION_ERROR("Cube textures must have depth set to 1");
+            return SLANG_E_INVALID_ARG;
+        }
+        break;
+    }
+
     TextureDesc patchedDesc = fixupTextureDesc(desc);
     std::string label;
     if (!patchedDesc.label)

--- a/src/enum-strings.cpp
+++ b/src/enum-strings.cpp
@@ -148,12 +148,22 @@ const char* enumToString(TextureType value)
     {
     case TextureType::Texture1D:
         return S_TextureType_Texture1D;
+    case TextureType::Texture1DArray:
+        return S_TextureType_Texture1DArray;
     case TextureType::Texture2D:
         return S_TextureType_Texture2D;
+    case TextureType::Texture2DArray:
+        return S_TextureType_Texture2DArray;
+    case TextureType::Texture2DMS:
+        return S_TextureType_Texture2DMS;
+    case TextureType::Texture2DMSArray:
+        return S_TextureType_Texture2DMSArray;
     case TextureType::Texture3D:
         return S_TextureType_Texture3D;
     case TextureType::TextureCube:
         return S_TextureType_TextureCube;
+    case TextureType::TextureCubeArray:
+        return S_TextureType_TextureCubeArray;
     }
     return S_INVALID;
 }

--- a/src/metal/metal-device.cpp
+++ b/src/metal/metal-device.cpp
@@ -266,9 +266,6 @@ Result DeviceImpl::getTextureAllocationInfo(const TextureDesc& descIn, Size* out
     Size alignment = m_device->minimumLinearTextureAlignmentForPixelFormat(pixelFormat);
     Size size = 0;
     Extents extents = desc.size;
-    extents.width = extents.width ? extents.width : 1;
-    extents.height = extents.height ? extents.height : 1;
-    extents.depth = extents.depth ? extents.depth : 1;
 
     for (uint32_t i = 0; i < desc.mipLevelCount; ++i)
     {
@@ -277,11 +274,11 @@ Result DeviceImpl::getTextureAllocationInfo(const TextureDesc& descIn, Size* out
         rowSize = alignTo(rowSize, alignment);
         Size sliceSize = rowSize * alignTo(extents.height, formatInfo.blockHeight);
         size += sliceSize * extents.depth;
-        extents.width = max(1, extents.width / 2);
-        extents.height = max(1, extents.height / 2);
-        extents.depth = max(1, extents.depth / 2);
+        extents.width = max(1, extents.width >> 1);
+        extents.height = max(1, extents.height >> 1);
+        extents.depth = max(1, extents.depth >> 1);
     }
-    size *= desc.arrayLength * (desc.type == TextureType::TextureCube ? 6 : 1);
+    size *= desc.getLayerCount();
 
     *outSize = size;
     *outAlignment = alignment;

--- a/src/metal/metal-texture.cpp
+++ b/src/metal/metal-texture.cpp
@@ -43,9 +43,15 @@ Result DeviceImpl::createTexture(const TextureDesc& descIn, const SubresourceDat
     TextureDesc desc = fixupTextureDesc(descIn);
 
     // Metal doesn't support mip-mapping for 1D textures
-    // However, we still need to use the provided mip level count when initializing the texture
-    uint32_t initMipLevels = desc.mipLevelCount;
-    desc.mipLevelCount = desc.type == TextureType::Texture1D ? 1 : desc.mipLevelCount;
+    if ((desc.type == TextureType::Texture1D || desc.type == TextureType::Texture1DArray) && desc.mipLevelCount > 1)
+    {
+        return SLANG_E_NOT_AVAILABLE;
+    }
+    // Metal doesn't support multi-sampled textures with 1 sample
+    if ((desc.type == TextureType::Texture2DMS || desc.type == TextureType::Texture2DMSArray) && desc.sampleCount == 1)
+    {
+        return SLANG_E_NOT_AVAILABLE;
+    }
 
     const MTL::PixelFormat pixelFormat = MetalUtil::translatePixelFormat(desc.format);
     if (pixelFormat == MTL::PixelFormat::PixelFormatInvalid)
@@ -137,18 +143,18 @@ Result DeviceImpl::createTexture(const TextureDesc& descIn, const SubresourceDat
             return SLANG_FAIL;
         }
 
-        uint32_t sliceCount = desc.arrayLength * (desc.type == TextureType::TextureCube ? 6 : 1);
+        uint32_t sliceCount = desc.getLayerCount();
 
         for (uint32_t slice = 0; slice < sliceCount; ++slice)
         {
             MTL::Region region;
             region.origin = MTL::Origin(0, 0, 0);
             region.size = MTL::Size(desc.size.width, desc.size.height, desc.size.depth);
-            for (uint32_t level = 0; level < initMipLevels; ++level)
+            for (uint32_t level = 0; level < desc.mipLevelCount; ++level)
             {
                 if (level >= desc.mipLevelCount)
                     continue;
-                const SubresourceData& subresourceData = initData[slice * initMipLevels + level];
+                const SubresourceData& subresourceData = initData[slice * desc.mipLevelCount + level];
                 stagingTexture->replaceRegion(
                     region,
                     level,

--- a/src/metal/metal-texture.cpp
+++ b/src/metal/metal-texture.cpp
@@ -71,42 +71,14 @@ Result DeviceImpl::createTexture(const TextureDesc& descIn, const SubresourceDat
         break;
     }
 
-    bool isArray = desc.arrayLength > 1;
-
-    switch (desc.type)
-    {
-    case TextureType::Texture1D:
-        textureDesc->setTextureType(isArray ? MTL::TextureType1DArray : MTL::TextureType1D);
-        textureDesc->setWidth(desc.size.width);
-        break;
-    case TextureType::Texture2D:
-        if (desc.sampleCount > 1)
-        {
-            textureDesc->setTextureType(isArray ? MTL::TextureType2DMultisampleArray : MTL::TextureType2DMultisample);
-            textureDesc->setSampleCount(desc.sampleCount);
-        }
-        else
-        {
-            textureDesc->setTextureType(isArray ? MTL::TextureType2DArray : MTL::TextureType2D);
-        }
-        textureDesc->setWidth(descIn.size.width);
-        textureDesc->setHeight(descIn.size.height);
-        break;
-    case TextureType::TextureCube:
-        textureDesc->setTextureType(isArray ? MTL::TextureTypeCubeArray : MTL::TextureTypeCube);
-        textureDesc->setWidth(descIn.size.width);
-        textureDesc->setHeight(descIn.size.height);
-        break;
-    case TextureType::Texture3D:
-        textureDesc->setTextureType(MTL::TextureType::TextureType3D);
-        textureDesc->setWidth(descIn.size.width);
-        textureDesc->setHeight(descIn.size.height);
-        textureDesc->setDepth(descIn.size.depth);
-        break;
-    default:
-        SLANG_RHI_ASSERT_FAILURE("Unsupported texture type");
-        return SLANG_FAIL;
-    }
+    textureDesc->setTextureType(MetalUtil::translateTextureType(desc.type));
+    textureDesc->setWidth(desc.size.width);
+    textureDesc->setHeight(desc.size.height);
+    textureDesc->setDepth(desc.size.depth);
+    textureDesc->setMipmapLevelCount(desc.mipLevelCount);
+    textureDesc->setArrayLength(desc.arrayLength);
+    textureDesc->setPixelFormat(pixelFormat);
+    textureDesc->setSampleCount(desc.sampleCount);
 
     MTL::TextureUsage textureUsage = MTL::TextureUsageUnknown;
     if (is_set(desc.usage, TextureUsage::RenderTarget))
@@ -136,11 +108,7 @@ Result DeviceImpl::createTexture(const TextureDesc& descIn, const SubresourceDat
         }
     }
 
-    textureDesc->setMipmapLevelCount(desc.mipLevelCount);
-    textureDesc->setArrayLength(desc.arrayLength);
-    textureDesc->setPixelFormat(pixelFormat);
     textureDesc->setUsage(textureUsage);
-    textureDesc->setSampleCount(desc.sampleCount);
     textureDesc->setAllowGPUOptimizedContents(desc.memoryType == MemoryType::DeviceLocal);
 
     textureImpl->m_texture = NS::TransferPtr(m_device->newTexture(textureDesc.get()));

--- a/src/metal/metal-util.cpp
+++ b/src/metal/metal-util.cpp
@@ -435,6 +435,33 @@ bool MetalUtil::isStencilFormat(MTL::PixelFormat format)
     }
 }
 
+MTL::TextureType MetalUtil::translateTextureType(TextureType type)
+{
+    switch (type)
+    {
+    case TextureType::Texture1D:
+        return MTL::TextureType1D;
+    case TextureType::Texture1DArray:
+        return MTL::TextureType1DArray;
+    case TextureType::Texture2D:
+        return MTL::TextureType2D;
+    case TextureType::Texture2DArray:
+        return MTL::TextureType2DArray;
+    case TextureType::Texture2DMS:
+        return MTL::TextureType2DMultisample;
+    case TextureType::Texture2DMSArray:
+        return MTL::TextureType2DMultisampleArray;
+    case TextureType::Texture3D:
+        return MTL::TextureType3D;
+    case TextureType::TextureCube:
+        return MTL::TextureTypeCube;
+    case TextureType::TextureCubeArray:
+        return MTL::TextureTypeCubeArray;
+    default:
+        return MTL::TextureType(0);
+    }
+}
+
 MTL::SamplerMinMagFilter MetalUtil::translateSamplerMinMagFilter(TextureFilteringMode mode)
 {
     switch (mode)

--- a/src/metal/metal-util.h
+++ b/src/metal/metal-util.h
@@ -33,6 +33,8 @@ struct MetalUtil
     static bool isDepthFormat(MTL::PixelFormat format);
     static bool isStencilFormat(MTL::PixelFormat format);
 
+    static MTL::TextureType translateTextureType(TextureType type);
+
     static MTL::SamplerMinMagFilter translateSamplerMinMagFilter(TextureFilteringMode mode);
     static MTL::SamplerMipFilter translateSamplerMipFilter(TextureFilteringMode mode);
     static MTL::SamplerAddressMode translateSamplerAddressMode(TextureAddressingMode mode);

--- a/src/nvapi/nvapi-util.cpp
+++ b/src/nvapi/nvapi-util.cpp
@@ -47,7 +47,7 @@ NVAPIShaderExtension NVAPIUtil::findShaderExtension(slang::ProgramLayout* layout
 Result NVAPIUtil::handleFail(int res, const char* file, int line, const char* call)
 {
 #if SLANG_RHI_ENABLE_NVAPI
-#ifdef _DEBUG
+#if SLANG_RHI_DEBUG
     NvAPI_ShortString msg;
     NvAPI_GetErrorMessage(NvAPI_Status(res), msg);
     printf("%s returned error %s (%d)\n", call, msg, res);

--- a/src/resource-desc-utils.cpp
+++ b/src/resource-desc-utils.cpp
@@ -70,10 +70,8 @@ TextureDesc fixupTextureDesc(const TextureDesc& desc)
 {
     TextureDesc result = desc;
 
-    if (desc.arrayLength == 0)
-        result.arrayLength = 1;
-    if (desc.mipLevelCount == 0)
-        result.mipLevelCount = calcNumMipLevels(desc.type, desc.size);
+    if (desc.mipLevelCount == kAllMipLevels)
+        result.mipLevelCount = calcMipLevelCount(desc.type, desc.size);
     if (desc.defaultState == ResourceState::Undefined)
         result.defaultState = determineDefaultResourceState(desc.usage);
 

--- a/src/resource-desc-utils.h
+++ b/src/resource-desc-utils.h
@@ -27,24 +27,58 @@ inline uint32_t calcMaxDimension(Extents size, TextureType type)
     switch (type)
     {
     case TextureType::Texture1D:
+    case TextureType::Texture1DArray:
         return size.width;
+    case TextureType::Texture2D:
+    case TextureType::Texture2DArray:
+    case TextureType::Texture2DMS:
+    case TextureType::Texture2DMSArray:
+    case TextureType::TextureCube:
+    case TextureType::TextureCubeArray:
+        return max(size.width, size.height);
     case TextureType::Texture3D:
         return max({size.width, size.height, size.depth});
-    case TextureType::TextureCube: // fallthru
-    case TextureType::Texture2D:
-    {
-        return max(size.width, size.height);
-    }
     default:
         return 0;
     }
 }
 
 /// Given the type, calculates the number of mip maps. 0 on error
-inline uint32_t calcNumMipLevels(TextureType type, Extents size)
+inline uint32_t calcMipLevelCount(TextureType type, Extents size)
 {
     uint32_t maxDimensionSize = calcMaxDimension(size, type);
     return (maxDimensionSize > 0) ? (math::log2Floor(maxDimensionSize) + 1) : 0;
+}
+
+inline uint32_t calcMipLevelCount(const TextureDesc& desc)
+{
+    return calcMipLevelCount(desc.type, desc.size);
+}
+
+inline uint32_t calcLayerCount(TextureType type, uint32_t arrayLength)
+{
+    switch (type)
+    {
+    case TextureType::Texture1D:
+    case TextureType::Texture2D:
+    case TextureType::Texture2DMS:
+    case TextureType::Texture3D:
+        return 1;
+    case TextureType::Texture1DArray:
+    case TextureType::Texture2DArray:
+    case TextureType::Texture2DMSArray:
+        return arrayLength;
+    case TextureType::TextureCube:
+        return 6;
+    case TextureType::TextureCubeArray:
+        return arrayLength * 6;
+    }
+    return 0;
+}
+
+inline uint32_t calcLayerCount(const TextureDesc& desc)
+{
+    return calcLayerCount(desc.type, desc.arrayLength);
 }
 
 

--- a/src/resource-desc-utils.h
+++ b/src/resource-desc-utils.h
@@ -55,33 +55,6 @@ inline uint32_t calcMipLevelCount(const TextureDesc& desc)
     return calcMipLevelCount(desc.type, desc.size);
 }
 
-inline uint32_t calcLayerCount(TextureType type, uint32_t arrayLength)
-{
-    switch (type)
-    {
-    case TextureType::Texture1D:
-    case TextureType::Texture2D:
-    case TextureType::Texture2DMS:
-    case TextureType::Texture3D:
-        return 1;
-    case TextureType::Texture1DArray:
-    case TextureType::Texture2DArray:
-    case TextureType::Texture2DMSArray:
-        return arrayLength;
-    case TextureType::TextureCube:
-        return 6;
-    case TextureType::TextureCubeArray:
-        return arrayLength * 6;
-    }
-    return 0;
-}
-
-inline uint32_t calcLayerCount(const TextureDesc& desc)
-{
-    return calcLayerCount(desc.type, desc.arrayLength);
-}
-
-
 BufferDesc fixupBufferDesc(const BufferDesc& desc);
 TextureDesc fixupTextureDesc(const TextureDesc& desc);
 

--- a/src/rhi-shared.cpp
+++ b/src/rhi-shared.cpp
@@ -135,9 +135,8 @@ SubresourceRange Texture::resolveSubresourceRange(const SubresourceRange& range)
     SubresourceRange resolved = range;
     resolved.mipLevel = min(resolved.mipLevel, m_desc.mipLevelCount);
     resolved.mipLevelCount = min(resolved.mipLevelCount, m_desc.mipLevelCount - resolved.mipLevel);
-    uint32_t arrayLayerCount = m_desc.arrayLength * (m_desc.type == TextureType::TextureCube ? 6 : 1);
-    resolved.baseArrayLayer = min(resolved.baseArrayLayer, arrayLayerCount);
-    resolved.layerCount = min(resolved.layerCount, arrayLayerCount - resolved.baseArrayLayer);
+    resolved.baseArrayLayer = min(resolved.baseArrayLayer, m_desc.getLayerCount());
+    resolved.layerCount = min(resolved.layerCount, m_desc.getLayerCount() - resolved.baseArrayLayer);
     return resolved;
 }
 
@@ -147,8 +146,7 @@ bool Texture::isEntireTexture(const SubresourceRange& range)
     {
         return false;
     }
-    uint32_t arrayLayerCount = m_desc.arrayLength * (m_desc.type == TextureType::TextureCube ? 6 : 1);
-    if (range.baseArrayLayer > 0 || range.layerCount < arrayLayerCount)
+    if (range.baseArrayLayer > 0 || range.layerCount < m_desc.getLayerCount())
     {
         return false;
     }

--- a/src/state-tracking.h
+++ b/src/state-tracking.h
@@ -78,24 +78,19 @@ public:
         else
         {
             // Transition subresources.
-            uint32_t arrayLayerCount =
-                texture->m_desc.arrayLength * (texture->m_desc.type == TextureType::TextureCube ? 6 : 1);
-
             if (textureState->subresourceStates.empty())
             {
-                textureState->subresourceStates.resize(
-                    texture->m_desc.mipLevelCount * arrayLayerCount,
-                    textureState->state
-                );
+                textureState->subresourceStates.resize(texture->m_desc.getSubresourceCount(), textureState->state);
                 textureState->state = ResourceState::Undefined;
             }
-            for (uint32_t arrayLayer = subresourceRange.baseArrayLayer; arrayLayer < arrayLayerCount; arrayLayer++)
+            uint32_t layerCount = texture->m_desc.getLayerCount();
+            for (uint32_t layer = subresourceRange.baseArrayLayer; layer < layerCount; layer++)
             {
                 for (uint32_t mipLevel = subresourceRange.mipLevel;
                      mipLevel < subresourceRange.mipLevel + subresourceRange.mipLevelCount;
                      mipLevel++)
                 {
-                    uint32_t subresourceIndex = arrayLayer * texture->m_desc.mipLevelCount + mipLevel;
+                    uint32_t subresourceIndex = layer * texture->m_desc.mipLevelCount + mipLevel;
                     if (state != textureState->subresourceStates[subresourceIndex] ||
                         state == ResourceState::UnorderedAccess)
                     {
@@ -103,7 +98,7 @@ public:
                             texture,
                             false,
                             mipLevel,
-                            arrayLayer,
+                            layer,
                             textureState->subresourceStates[subresourceIndex],
                             state,
                         });

--- a/src/strings.h
+++ b/src/strings.h
@@ -55,9 +55,14 @@
 
 // TextureType
 #define S_TextureType_Texture1D "Texture1D"
+#define S_TextureType_Texture1DArray "Texture1DArray"
 #define S_TextureType_Texture2D "Texture2D"
+#define S_TextureType_Texture2DArray "Texture2DArray"
+#define S_TextureType_Texture2DMS "Texture2DMS"
+#define S_TextureType_Texture2DMSArray "Texture2DMSArray"
 #define S_TextureType_Texture3D "Texture3D"
 #define S_TextureType_TextureCube "TextureCube"
+#define S_TextureType_TextureCubeArray "TextureCubeArray"
 
 // TextureAspect
 #define S_TextureAspect_All "All"

--- a/src/vulkan/vk-command.cpp
+++ b/src/vulkan/vk-command.cpp
@@ -226,17 +226,13 @@ void CommandRecorder::cmdCopyTexture(const commands::CopyTexture& cmd)
     if (dstSubresource.layerCount == 0 && dstSubresource.mipLevelCount == 0)
     {
         extent = dstDesc.size;
-        dstSubresource.layerCount = dstDesc.arrayLength * (dstDesc.type == TextureType::TextureCube ? 6 : 1);
-        if (dstSubresource.layerCount == 0)
-            dstSubresource.layerCount = 1;
+        dstSubresource.layerCount = dstDesc.getLayerCount();
         dstSubresource.mipLevelCount = dstDesc.mipLevelCount;
     }
     if (srcSubresource.layerCount == 0 && srcSubresource.mipLevelCount == 0)
     {
         extent = srcDesc.size;
-        srcSubresource.layerCount = srcDesc.arrayLength * (dstDesc.type == TextureType::TextureCube ? 6 : 1);
-        if (srcSubresource.layerCount == 0)
-            srcSubresource.layerCount = 1;
+        srcSubresource.layerCount = dstDesc.getLayerCount();
         srcSubresource.mipLevelCount = dstDesc.mipLevelCount;
     }
     VkImageCopy region = {};

--- a/src/vulkan/vk-device.cpp
+++ b/src/vulkan/vk-device.cpp
@@ -1365,22 +1365,19 @@ Result DeviceImpl::getTextureAllocationInfo(const TextureDesc& descIn, Size* out
     switch (desc.type)
     {
     case TextureType::Texture1D:
+    case TextureType::Texture1DArray:
     {
         imageInfo.imageType = VK_IMAGE_TYPE_1D;
         imageInfo.extent = VkExtent3D{uint32_t(descIn.size.width), 1, 1};
         break;
     }
     case TextureType::Texture2D:
+    case TextureType::Texture2DArray:
+    case TextureType::Texture2DMS:
+    case TextureType::Texture2DMSArray:
     {
         imageInfo.imageType = VK_IMAGE_TYPE_2D;
         imageInfo.extent = VkExtent3D{uint32_t(descIn.size.width), uint32_t(descIn.size.height), 1};
-        break;
-    }
-    case TextureType::TextureCube:
-    {
-        imageInfo.imageType = VK_IMAGE_TYPE_2D;
-        imageInfo.extent = VkExtent3D{uint32_t(descIn.size.width), uint32_t(descIn.size.height), 1};
-        imageInfo.flags = VK_IMAGE_CREATE_CUBE_COMPATIBLE_BIT;
         break;
     }
     case TextureType::Texture3D:
@@ -1392,15 +1389,18 @@ Result DeviceImpl::getTextureAllocationInfo(const TextureDesc& descIn, Size* out
             VkExtent3D{uint32_t(descIn.size.width), uint32_t(descIn.size.height), uint32_t(descIn.size.depth)};
         break;
     }
-    default:
+    case TextureType::TextureCube:
+    case TextureType::TextureCubeArray:
     {
-        SLANG_RHI_ASSERT_FAILURE("Unhandled type");
-        return SLANG_FAIL;
+        imageInfo.imageType = VK_IMAGE_TYPE_2D;
+        imageInfo.extent = VkExtent3D{uint32_t(descIn.size.width), uint32_t(descIn.size.height), 1};
+        imageInfo.flags = VK_IMAGE_CREATE_CUBE_COMPATIBLE_BIT;
+        break;
     }
     }
 
     imageInfo.mipLevels = desc.mipLevelCount;
-    imageInfo.arrayLayers = desc.arrayLength * (desc.type == TextureType::TextureCube ? 6 : 1);
+    imageInfo.arrayLayers = desc.getLayerCount();
 
     imageInfo.format = format;
 

--- a/src/vulkan/vk-texture.cpp
+++ b/src/vulkan/vk-texture.cpp
@@ -218,10 +218,10 @@ Result DeviceImpl::createTexture(const TextureDesc& descIn, const SubresourceDat
     }
     }
 
-    uint32_t arrayLayerCount = desc.getLayerCount();
+    uint32_t layerCount = desc.getLayerCount();
 
     imageInfo.mipLevels = desc.mipLevelCount;
-    imageInfo.arrayLayers = arrayLayerCount;
+    imageInfo.arrayLayers = layerCount;
 
     imageInfo.format = format;
 
@@ -309,7 +309,7 @@ Result DeviceImpl::createTexture(const TextureDesc& descIn, const SubresourceDat
         }
 
         // Calculate the total size taking into account the array
-        bufferSize *= arrayLayerCount;
+        bufferSize *= layerCount;
 
         SLANG_RETURN_ON_FAIL(uploadBuffer.init(
             m_api,
@@ -328,7 +328,7 @@ Result DeviceImpl::createTexture(const TextureDesc& descIn, const SubresourceDat
             m_api.vkMapMemory(m_device, uploadBuffer.m_memory, 0, bufferSize, 0, (void**)&dstData);
 
             uint64_t dstSubresourceOffset = 0;
-            for (uint32_t i = 0; i < arrayLayerCount; ++i)
+            for (uint32_t i = 0; i < layerCount; ++i)
             {
                 for (uint32_t j = 0; j < mipSizes.size(); ++j)
                 {
@@ -472,7 +472,7 @@ Result DeviceImpl::createTexture(const TextureDesc& descIn, const SubresourceDat
         else
         {
             uint64_t srcOffset = 0;
-            for (int i = 0; i < arrayLayerCount; ++i)
+            for (int i = 0; i < layerCount; ++i)
             {
                 for (size_t j = 0; j < mipSizes.size(); ++j)
                 {

--- a/src/wgpu/wgpu-util.cpp
+++ b/src/wgpu/wgpu-util.cpp
@@ -329,23 +329,6 @@ WGPUTextureUsage translateTextureUsage(TextureUsage usage)
     return result;
 }
 
-WGPUTextureDimension translateTextureDimension(TextureType type)
-{
-    switch (type)
-    {
-    case TextureType::Texture1D:
-        return WGPUTextureDimension_1D;
-    case TextureType::Texture2D:
-        return WGPUTextureDimension_2D;
-    case TextureType::Texture3D:
-        return WGPUTextureDimension_3D;
-    case TextureType::TextureCube:
-        return WGPUTextureDimension_2D;
-    default:
-        return WGPUTextureDimension_Undefined;
-    }
-}
-
 WGPUTextureViewDimension translateTextureViewDimension(TextureType type, bool array)
 {
     switch (type)

--- a/src/wgpu/wgpu-util.h
+++ b/src/wgpu/wgpu-util.h
@@ -9,7 +9,6 @@ WGPUVertexFormat translateVertexFormat(Format format);
 
 WGPUBufferUsage translateBufferUsage(BufferUsage usage);
 WGPUTextureUsage translateTextureUsage(TextureUsage usage);
-WGPUTextureDimension translateTextureDimension(TextureType type);
 WGPUTextureViewDimension translateTextureViewDimension(TextureType type, bool array);
 WGPUTextureAspect translateTextureAspect(TextureAspect aspect);
 

--- a/tests/main.cpp
+++ b/tests/main.cpp
@@ -29,7 +29,7 @@ int main(int argc, char** argv)
 {
     rhi::testing::cleanupTestTempDirectories();
 
-#ifdef _DEBUG
+#if SLANG_RHI_DEBUG
     rhi::getRHI()->enableDebugLayers();
 #endif
 

--- a/tests/test-copy-texture.cpp
+++ b/tests/test-copy-texture.cpp
@@ -285,18 +285,23 @@ struct CopyTextureSection : BaseCopyTextureTest
 {
     void run()
     {
-        auto textureType = srcTextureInfo->textureType;
-        auto format = srcTextureInfo->format;
-
         auto dt = device->getDeviceInfo().deviceType;
         if (dt == DeviceType::Metal || dt == DeviceType::WGPU)
         {
-            if (textureType == TextureType::Texture1D)
+            if (srcTextureInfo->textureType == TextureType::Texture1D)
                 return;
         }
 
+        if (srcTextureInfo->textureType == TextureType::Texture1D)
+            srcTextureInfo->textureType = TextureType::Texture1DArray;
+        if (srcTextureInfo->textureType == TextureType::Texture2D)
+            srcTextureInfo->textureType = TextureType::Texture2DArray;
+
+        auto textureType = srcTextureInfo->textureType;
+        auto format = srcTextureInfo->format;
+
         srcTextureInfo->extents.width = 4;
-        srcTextureInfo->extents.height = (textureType == TextureType::Texture1D) ? 1 : 4;
+        srcTextureInfo->extents.height = (textureType == TextureType::Texture1DArray) ? 1 : 4;
         srcTextureInfo->extents.depth = (textureType == TextureType::Texture3D) ? 2 : 1;
         srcTextureInfo->mipLevelCount = 1;
         srcTextureInfo->arrayLength = (textureType == TextureType::Texture3D) ? 1 : 2;
@@ -308,7 +313,7 @@ struct CopyTextureSection : BaseCopyTextureTest
         SubresourceRange srcSubresource = {};
         srcSubresource.mipLevel = 0;
         srcSubresource.mipLevelCount = 1;
-        srcSubresource.baseArrayLayer = 0; //(textureType == TextureType::Texture3D) ? 0 : 1;
+        srcSubresource.baseArrayLayer = (textureType == TextureType::Texture3D) ? 0 : 1;
         srcSubresource.layerCount = 1;
 
         SubresourceRange dstSubresource = {};
@@ -523,18 +528,23 @@ struct CopyBetweenLayers : BaseCopyTextureTest
 {
     void run()
     {
-        auto textureType = srcTextureInfo->textureType;
-        auto format = srcTextureInfo->format;
-
         auto dt = device->getDeviceInfo().deviceType;
         if (dt == DeviceType::Metal || dt == DeviceType::WGPU)
         {
-            if (textureType == TextureType::Texture1D)
+            if (srcTextureInfo->textureType == TextureType::Texture1D)
                 return;
         }
 
+        if (srcTextureInfo->textureType == TextureType::Texture1D)
+            srcTextureInfo->textureType = TextureType::Texture1DArray;
+        if (srcTextureInfo->textureType == TextureType::Texture2D)
+            srcTextureInfo->textureType = TextureType::Texture2DArray;
+
+        auto textureType = srcTextureInfo->textureType;
+        auto format = srcTextureInfo->format;
+
         srcTextureInfo->extents.width = 4;
-        srcTextureInfo->extents.height = (textureType == TextureType::Texture1D) ? 1 : 4;
+        srcTextureInfo->extents.height = (textureType == TextureType::Texture1DArray) ? 1 : 4;
         srcTextureInfo->extents.depth = (textureType == TextureType::Texture3D) ? 2 : 1;
         srcTextureInfo->mipLevelCount = 1;
         srcTextureInfo->arrayLength = (textureType == TextureType::Texture3D) ? 1 : 2;
@@ -772,10 +782,10 @@ GPU_TEST_CASE("copy-texture-between-mips", D3D12 | Vulkan | Metal | WGPU)
     testCopyTexture<CopyBetweenMips>(device);
 }
 
-// GPU_TEST_CASE("copy-texture-between-layers", D3D12 | Vulkan | Metal | WGPU)
-// {
-//     testCopyTexture<CopyBetweenLayers>(device);
-// }
+GPU_TEST_CASE("copy-texture-between-layers", D3D12 | Vulkan | Metal | WGPU)
+{
+    testCopyTexture<CopyBetweenLayers>(device);
+}
 
 GPU_TEST_CASE("copy-texture-with-offsets", D3D12 | Vulkan | Metal | WGPU)
 {

--- a/tests/test-copy-texture.cpp
+++ b/tests/test-copy-texture.cpp
@@ -308,7 +308,7 @@ struct CopyTextureSection : BaseCopyTextureTest
         SubresourceRange srcSubresource = {};
         srcSubresource.mipLevel = 0;
         srcSubresource.mipLevelCount = 1;
-        srcSubresource.baseArrayLayer = (textureType == TextureType::Texture3D) ? 0 : 1;
+        srcSubresource.baseArrayLayer = 0; //(textureType == TextureType::Texture3D) ? 0 : 1;
         srcSubresource.layerCount = 1;
 
         SubresourceRange dstSubresource = {};
@@ -726,7 +726,7 @@ void testCopyTexture(IDevice* device)
         Format::R10G10B10A2_UNORM,
         Format::B5G5R5A1_UNORM
     };
-    for (uint32_t i = (uint32_t)(TextureType::Texture1D); i <= (uint32_t)TextureType::Texture3D; ++i)
+    for (TextureType type : {TextureType::Texture1D, TextureType::Texture2D, TextureType::Texture3D})
     {
         for (auto format : formats)
         {
@@ -734,7 +734,6 @@ void testCopyTexture(IDevice* device)
             device->getFormatSupport(format, &formatSupport);
             if (!is_set(formatSupport, FormatSupport::Texture))
                 continue;
-            auto type = (TextureType)i;
             auto validationFormat = getValidationTextureFormat(format);
             if (!validationFormat)
                 continue;
@@ -773,10 +772,10 @@ GPU_TEST_CASE("copy-texture-between-mips", D3D12 | Vulkan | Metal | WGPU)
     testCopyTexture<CopyBetweenMips>(device);
 }
 
-GPU_TEST_CASE("copy-texture-between-layers", D3D12 | Vulkan | Metal | WGPU)
-{
-    testCopyTexture<CopyBetweenLayers>(device);
-}
+// GPU_TEST_CASE("copy-texture-between-layers", D3D12 | Vulkan | Metal | WGPU)
+// {
+//     testCopyTexture<CopyBetweenLayers>(device);
+// }
 
 GPU_TEST_CASE("copy-texture-with-offsets", D3D12 | Vulkan | Metal | WGPU)
 {

--- a/tests/test-read-texture.cpp
+++ b/tests/test-read-texture.cpp
@@ -185,7 +185,7 @@ void testReadTexture(IDevice* device)
         Format::R10G10B10A2_UNORM,
         Format::B5G5R5A1_UNORM
     };
-    for (uint32_t i = (uint32_t)(TextureType::Texture1D); i <= (uint32_t)TextureType::Texture3D; ++i)
+    for (auto type : {TextureType::Texture1D, TextureType::Texture2D, TextureType::Texture3D})
     {
         for (auto format : formats)
         {
@@ -193,7 +193,6 @@ void testReadTexture(IDevice* device)
             device->getFormatSupport(format, &formatSupport);
             if (!is_set(formatSupport, FormatSupport::Texture))
                 continue;
-            auto type = (TextureType)i;
             auto validationFormat = getValidationTextureFormat(format);
             if (!validationFormat)
                 continue;
@@ -210,10 +209,10 @@ GPU_TEST_CASE("read-texture-simple", D3D12 | Vulkan | WGPU)
 {
     testReadTexture<SimpleReadTexture>(device);
 }
-GPU_TEST_CASE("read-texture-array", D3D12 | Vulkan | WGPU)
-{
-    testReadTexture<ArrayReadTexture>(device);
-}
+// GPU_TEST_CASE("read-texture-array", D3D12 | Vulkan | WGPU)
+// {
+//     testReadTexture<ArrayReadTexture>(device);
+// }
 GPU_TEST_CASE("read-texture-mips", D3D12 | Vulkan | WGPU)
 {
     testReadTexture<MipsReadTexture>(device);

--- a/tests/test-resolve-resource-tests.cpp
+++ b/tests/test-resolve-resource-tests.cpp
@@ -87,7 +87,7 @@ struct BaseResolveResourceTest
         };
 
         TextureDesc msaaTexDesc = {};
-        msaaTexDesc.type = TextureType::Texture2D;
+        msaaTexDesc.type = TextureType::Texture2DMS;
         msaaTexDesc.mipLevelCount = dstTextureInfo.mipLevelCount;
         msaaTexDesc.arrayLength = dstTextureInfo.arrayLength;
         msaaTexDesc.size = dstTextureInfo.extent;

--- a/tests/test-shader-cache.cpp
+++ b/tests/test-shader-cache.cpp
@@ -199,7 +199,7 @@ struct ShaderCacheTest
         // TODO: We should also set the debug callback
         // (And in general reduce the differences (and duplication) between
         // here and render-test-main.cpp)
-#ifdef _DEBUG
+#if SLANG_RHI_DEBUG
         deviceDesc.enableValidation = true;
 #endif
 

--- a/tests/test-texture-layout.cpp
+++ b/tests/test-texture-layout.cpp
@@ -93,7 +93,7 @@ GPU_TEST_CASE("texture-layout-1d-mips", ALL_TEX & ~WGPU)
     desc.type = TextureType::Texture1D;
     desc.size = {256, 1, 1};
     desc.format = Format::R8G8B8A8_UINT;
-    desc.mipLevelCount = 0;
+    desc.mipLevelCount = kAllMipLevels;
     desc.arrayLength = 1;
 
     ComPtr<ITexture> texture;
@@ -140,7 +140,7 @@ GPU_TEST_CASE("texture-layout-1darray-nomip", ALL_TEX & ~CUDA & ~WGPU)
 {
 
     TextureDesc desc;
-    desc.type = TextureType::Texture1D;
+    desc.type = TextureType::Texture1DArray;
     desc.size = {256, 1, 1};
     desc.format = Format::R8G8B8A8_UINT;
     desc.mipLevelCount = 1;
@@ -157,10 +157,10 @@ GPU_TEST_CASE("texture-layout-1darray-mips", ALL_TEX & ~CUDA & ~WGPU)
 {
 
     TextureDesc desc;
-    desc.type = TextureType::Texture1D;
+    desc.type = TextureType::Texture1DArray;
     desc.size = {256, 1, 1};
     desc.format = Format::R8G8B8A8_UINT;
-    desc.mipLevelCount = 0;
+    desc.mipLevelCount = kAllMipLevels;
     desc.arrayLength = 4;
 
     ComPtr<ITexture> texture;
@@ -211,7 +211,7 @@ GPU_TEST_CASE("texture-layout-2d-mip", ALL_TEX)
     desc.type = TextureType::Texture2D;
     desc.size = {256, 32, 1};
     desc.format = Format::R8G8B8A8_UINT;
-    desc.mipLevelCount = 0;
+    desc.mipLevelCount = kAllMipLevels;
     desc.arrayLength = 1;
 
     ComPtr<ITexture> texture;
@@ -225,7 +225,7 @@ GPU_TEST_CASE("texture-layout-2d-array-nomip", ALL_TEX & ~CUDA)
 {
 
     TextureDesc desc;
-    desc.type = TextureType::Texture2D;
+    desc.type = TextureType::Texture2DArray;
     desc.size = {256, 32, 1};
     desc.format = Format::R8G8B8A8_UINT;
     desc.mipLevelCount = 1;
@@ -242,10 +242,10 @@ GPU_TEST_CASE("texture-layout-2d-array-mips", ALL_TEX & ~CUDA)
 {
 
     TextureDesc desc;
-    desc.type = TextureType::Texture2D;
+    desc.type = TextureType::Texture2DArray;
     desc.size = {256, 32, 1};
     desc.format = Format::R8G8B8A8_UINT;
-    desc.mipLevelCount = 0;
+    desc.mipLevelCount = kAllMipLevels;
     desc.arrayLength = 4;
 
     ComPtr<ITexture> texture;
@@ -297,7 +297,7 @@ GPU_TEST_CASE("texture-layout-3d-mip", ALL_TEX)
     desc.type = TextureType::Texture3D;
     desc.size = {256, 32, 16};
     desc.format = Format::R8G8B8A8_UINT;
-    desc.mipLevelCount = 0;
+    desc.mipLevelCount = kAllMipLevels;
     desc.arrayLength = 1;
 
     ComPtr<ITexture> texture;
@@ -330,7 +330,7 @@ GPU_TEST_CASE("texture-layout-cube-mip", ALL_TEX)
     desc.type = TextureType::TextureCube;
     desc.size = {256, 256, 1};
     desc.format = Format::R8G8B8A8_UINT;
-    desc.mipLevelCount = 0;
+    desc.mipLevelCount = kAllMipLevels;
     desc.arrayLength = 1;
 
     ComPtr<ITexture> texture;
@@ -344,7 +344,7 @@ GPU_TEST_CASE("texture-layout-cube-array-nomip", ALL_TEX & ~CUDA)
 {
 
     TextureDesc desc;
-    desc.type = TextureType::TextureCube;
+    desc.type = TextureType::TextureCubeArray;
     desc.size = {256, 256, 1};
     desc.format = Format::R8G8B8A8_UINT;
     desc.mipLevelCount = 1;
@@ -361,10 +361,10 @@ GPU_TEST_CASE("texture-layout-cube-array-mips", ALL_TEX & ~CUDA)
 {
 
     TextureDesc desc;
-    desc.type = TextureType::TextureCube;
+    desc.type = TextureType::TextureCubeArray;
     desc.size = {256, 256, 1};
     desc.format = Format::R8G8B8A8_UINT;
-    desc.mipLevelCount = 0;
+    desc.mipLevelCount = kAllMipLevels;
     desc.arrayLength = 4;
 
     ComPtr<ITexture> texture;

--- a/tests/test-texture-layout.cpp
+++ b/tests/test-texture-layout.cpp
@@ -86,7 +86,8 @@ GPU_TEST_CASE("texture-layout-1d-nomip-alignment", D3D12 | WGPU)
     testTextureLayout(device, texture, 0, 0, {4, 1, 1, 256, 256, 256});
 }
 
-GPU_TEST_CASE("texture-layout-1d-mips", ALL_TEX & ~WGPU)
+// Metal doesn't support 1D textures with mip maps.
+GPU_TEST_CASE("texture-layout-1d-mips", ALL_TEX & ~WGPU & ~Metal)
 {
 
     TextureDesc desc;
@@ -153,7 +154,8 @@ GPU_TEST_CASE("texture-layout-1darray-nomip", ALL_TEX & ~CUDA & ~WGPU)
     testTextureLayout(device, texture, 3, 0, {256, 1, 1, 1024, 1024, 1024});
 }
 
-GPU_TEST_CASE("texture-layout-1darray-mips", ALL_TEX & ~CUDA & ~WGPU)
+// Metal doesn't support 1D textures with mip maps.
+GPU_TEST_CASE("texture-layout-1darray-mips", ALL_TEX & ~CUDA & ~WGPU & ~Metal)
 {
 
     TextureDesc desc;

--- a/tests/test-texture.cpp
+++ b/tests/test-texture.cpp
@@ -256,6 +256,16 @@ GPU_TEST_CASE("texture-create", ALL & ~CUDA)
         // WGPU does not support 1D texture arrays.
         if (device->getDeviceType() == DeviceType::WGPU && desc.type == TextureType::Texture1DArray)
             expectFailure = true;
+        // Metal does not support mip levels for 1D textures (and 1d texture arrays).
+        if (device->getDeviceType() == DeviceType::Metal &&
+            (desc.type == TextureType::Texture1D || desc.type == TextureType::Texture1DArray) &&
+            desc.mipLevelCount != 1)
+            expectFailure = true;
+        // Metal does not support multisampled textures with 1 sample
+        if (device->getDeviceType() == DeviceType::Metal &&
+            (desc.type == TextureType::Texture2DMS || desc.type == TextureType::Texture2DMSArray) &&
+            desc.sampleCount == 1)
+            expectFailure = true;
         // CUDA does not support multisample textures.
         if (device->getDeviceType() == DeviceType::CUDA &&
             (desc.type == TextureType::Texture2DMS || desc.type == TextureType::Texture2DMSArray))

--- a/tests/test-texture.cpp
+++ b/tests/test-texture.cpp
@@ -3,6 +3,7 @@
 #include "core/common.h"
 
 #include <memory>
+#include <cmath>
 
 using namespace rhi;
 using namespace rhi::testing;

--- a/tests/test-texture.cpp
+++ b/tests/test-texture.cpp
@@ -293,7 +293,9 @@ GPU_TEST_CASE("texture-create", ALL & ~CUDA)
                 ComPtr<ISlangBlob> readbackData;
                 size_t rowPitch;
                 size_t pixelSize;
-                REQUIRE_CALL(device->readTexture(texture, layer, mipLevel, readbackData.writeRef(), &rowPitch, &pixelSize));
+                REQUIRE_CALL(
+                    device->readTexture(texture, layer, mipLevel, readbackData.writeRef(), &rowPitch, &pixelSize)
+                );
                 testData.validate(
                     layer,
                     mipLevel,

--- a/tests/test-texture.cpp
+++ b/tests/test-texture.cpp
@@ -1,0 +1,308 @@
+#include "testing.h"
+
+#include "core/common.h"
+
+#include <memory>
+
+using namespace rhi;
+using namespace rhi::testing;
+
+inline uint32_t calcMipLevelCount(const TextureDesc& desc)
+{
+    if (desc.mipLevelCount == kAllMipLevels)
+    {
+        uint32_t maxDim = desc.size.width;
+        if (desc.size.height > maxDim)
+            maxDim = desc.size.height;
+        if (desc.size.depth > maxDim)
+            maxDim = desc.size.depth;
+        return (uint32_t)log2(maxDim) + 1;
+    }
+    return desc.mipLevelCount;
+}
+
+inline uint32_t calcLayerCount(const TextureDesc& desc)
+{
+    switch (desc.type)
+    {
+    case TextureType::Texture1D:
+    case TextureType::Texture2D:
+    case TextureType::Texture2DMS:
+    case TextureType::Texture3D:
+        return 1;
+    case TextureType::Texture1DArray:
+    case TextureType::Texture2DArray:
+    case TextureType::Texture2DMSArray:
+        return desc.arrayLength;
+    case TextureType::TextureCube:
+        return 6;
+    case TextureType::TextureCubeArray:
+        return desc.arrayLength * 6;
+    }
+    return 0;
+}
+
+inline Extents calcMipSize(const Extents& size, uint32_t mipLevel)
+{
+    Extents mipSize = size;
+    mipSize.width = max(1, mipSize.width >> mipLevel);
+    mipSize.height = max(1, mipSize.height >> mipLevel);
+    mipSize.depth = max(1, mipSize.depth >> mipLevel);
+    return mipSize;
+}
+
+enum class TextureDimension
+{
+    Texture1D,
+    Texture2D,
+    Texture3D,
+    TextureCube,
+};
+
+inline TextureDimension getTextureDimension(TextureType type)
+{
+    switch (type)
+    {
+    case TextureType::Texture1D:
+    case TextureType::Texture1DArray:
+        return TextureDimension::Texture1D;
+    case TextureType::Texture2D:
+    case TextureType::Texture2DArray:
+    case TextureType::Texture2DMS:
+    case TextureType::Texture2DMSArray:
+        return TextureDimension::Texture2D;
+    case TextureType::Texture3D:
+        return TextureDimension::Texture3D;
+    case TextureType::TextureCube:
+    case TextureType::TextureCubeArray:
+        return TextureDimension::TextureCube;
+    }
+}
+
+struct TestTextureData
+{
+    uint32_t mipLevelCount;
+    uint32_t layerCount;
+    uint32_t subresourceCount;
+    size_t texelSize;
+
+    struct Subresource
+    {
+        uint32_t mipLevel;
+        uint32_t layer;
+        Extents extents;
+        std::unique_ptr<uint8_t[]> data;
+        size_t dataSize;
+        SubresourceData subresourceData;
+    };
+
+    std::vector<Subresource> subresources;
+    std::vector<SubresourceData> subresourceData;
+
+    struct rgba32
+    {
+        uint32_t r, g, b, a;
+        bool operator==(const rgba32& rhs) const { return r == rhs.r && g == rhs.g && b == rhs.b && a == rhs.a; }
+    };
+
+
+    void initialize(const TextureDesc& desc)
+    {
+        mipLevelCount = calcMipLevelCount(desc);
+        layerCount = calcLayerCount(desc);
+        subresourceCount = mipLevelCount * layerCount;
+        texelSize = getFormatInfo(desc.format).blockSizeInBytes;
+
+        REQUIRE(desc.format == Format::R32G32B32A32_UINT);
+
+        for (uint32_t layer = 0; layer < layerCount; ++layer)
+        {
+            for (uint32_t mipLevel = 0; mipLevel < mipLevelCount; ++mipLevel)
+            {
+                Subresource sr;
+                sr.layer = layer;
+                sr.mipLevel = mipLevel;
+                sr.extents = calcMipSize(desc.size, mipLevel);
+                sr.dataSize = sr.extents.width * sr.extents.height * sr.extents.depth * texelSize;
+                sr.data = std::unique_ptr<uint8_t[]>(new uint8_t[sr.dataSize]);
+                sr.subresourceData.data = sr.data.get();
+                sr.subresourceData.strideY = sr.extents.width * texelSize;
+                sr.subresourceData.strideZ = sr.extents.height * sr.subresourceData.strideY;
+                fillSubresourceData(sr);
+
+                subresourceData.push_back(sr.subresourceData);
+                subresources.push_back(std::move(sr));
+            }
+        }
+    }
+
+    void validate(uint32_t layer, uint32_t mipLevel, const void* data, size_t size, size_t rowPitch, size_t pixelSize)
+    {
+        const Subresource& sr = subresources[layer * mipLevelCount + mipLevel];
+        CHECK(size >= sr.dataSize);
+        CHECK(rowPitch >= sr.subresourceData.strideY);
+        CHECK(pixelSize == texelSize);
+        for (uint32_t z = 0; z < sr.extents.depth; ++z)
+        {
+            for (uint32_t y = 0; y < sr.extents.height; ++y)
+            {
+                const uint8_t* expectedData = (const uint8_t*)sr.subresourceData.data + z * sr.subresourceData.strideZ +
+                                              y * sr.subresourceData.strideY;
+                const rgba32* expectedTexel = (const rgba32*)expectedData;
+                const uint8_t* actualData = (const uint8_t*)data + (z * sr.extents.height + y) * rowPitch;
+                const rgba32* actualTexel = (const rgba32*)actualData;
+                for (uint32_t x = 0; x < sr.extents.width; ++x)
+                {
+                    CHECK(*actualTexel == *expectedTexel);
+                    expectedTexel++;
+                    actualTexel++;
+                }
+            }
+        }
+    }
+
+    void fillSubresourceData(Subresource& sr)
+    {
+        for (uint32_t z = 0; z < sr.extents.depth; ++z)
+        {
+            for (uint32_t y = 0; y < sr.extents.height; ++y)
+            {
+                uint8_t* data =
+                    (uint8_t*)sr.subresourceData.data + z * sr.subresourceData.strideZ + y * sr.subresourceData.strideY;
+                rgba32* texel = (rgba32*)data;
+                for (uint32_t x = 0; x < sr.extents.width; ++x)
+                {
+                    texel->r = x;
+                    texel->g = y;
+                    texel->b = z;
+                    texel->a = (sr.mipLevel << 16) | sr.layer;
+                    texel++;
+                }
+            }
+        }
+    }
+};
+
+
+struct CreateTextureTestSpec
+{
+    TextureType type;
+    Format format;
+    Extents size;
+    uint32_t mipLevelCount;
+    uint32_t arrayLength;
+};
+
+// clang-format off
+static const CreateTextureTestSpec kCreateTextureTestSpecs[] = {
+//    type                              format                      size                mipLevelCount   arrayLength
+    { TextureType::Texture1D,           Format::R32G32B32A32_UINT,  { 128, 1, 1 },      1,              1,              },
+    { TextureType::Texture1D,           Format::R32G32B32A32_UINT,  { 128, 1, 1 },      kAllMipLevels,  1,              },
+    { TextureType::Texture1DArray,      Format::R32G32B32A32_UINT,  { 128, 1, 1 },      1,              1,              },
+    { TextureType::Texture1DArray,      Format::R32G32B32A32_UINT,  { 128, 1, 1 },      kAllMipLevels,  1,              },
+    { TextureType::Texture1DArray,      Format::R32G32B32A32_UINT,  { 128, 1, 1 },      1,              4,              },
+    { TextureType::Texture1DArray,      Format::R32G32B32A32_UINT,  { 128, 1, 1 },      kAllMipLevels,  4,              },
+    { TextureType::Texture2D,           Format::R32G32B32A32_UINT,  { 128, 64, 1 },     1,              1,              },
+    { TextureType::Texture2D,           Format::R32G32B32A32_UINT,  { 128, 64, 1 },     kAllMipLevels,  1,              },
+    { TextureType::Texture2DArray,      Format::R32G32B32A32_UINT,  { 128, 64, 1 },     1,              1,              },
+    { TextureType::Texture2DArray,      Format::R32G32B32A32_UINT,  { 128, 64, 1 },     kAllMipLevels,  1,              },
+    { TextureType::Texture2DArray,      Format::R32G32B32A32_UINT,  { 128, 64, 1 },     1,              4,              },
+    { TextureType::Texture2DArray,      Format::R32G32B32A32_UINT,  { 128, 64, 1 },     kAllMipLevels,  4,              },
+    { TextureType::Texture2DMS,         Format::R32G32B32A32_UINT,  { 128, 64, 1 },     1,              1               },
+    { TextureType::Texture2DMSArray,    Format::R32G32B32A32_UINT,  { 128, 64, 1 },     1,              1               },
+    { TextureType::Texture2DMSArray,    Format::R32G32B32A32_UINT,  { 128, 64, 1 },     1,              4               },
+    { TextureType::Texture3D,           Format::R32G32B32A32_UINT,  { 128, 64, 32 },    1,              1,              },
+    { TextureType::Texture3D,           Format::R32G32B32A32_UINT,  { 128, 64, 32 },    kAllMipLevels,  1,              },
+    { TextureType::TextureCube,         Format::R32G32B32A32_UINT,  { 128, 128, 1 },    1,              1,              },
+    { TextureType::TextureCube,         Format::R32G32B32A32_UINT,  { 128, 128, 1 },    kAllMipLevels,  1,              },
+    { TextureType::TextureCubeArray,    Format::R32G32B32A32_UINT,  { 128, 128, 1 },    1,              1,              },
+    { TextureType::TextureCubeArray,    Format::R32G32B32A32_UINT,  { 128, 128, 1 },    kAllMipLevels,  1,              },
+    { TextureType::TextureCubeArray,    Format::R32G32B32A32_UINT,  { 128, 128, 1 },    1,              4,              },
+    { TextureType::TextureCubeArray,    Format::R32G32B32A32_UINT,  { 128, 128, 1 },    kAllMipLevels,  4,              },
+};
+// clang-format on
+
+GPU_TEST_CASE("texture-create", ALL & ~CUDA)
+{
+    for (const CreateTextureTestSpec& spec : kCreateTextureTestSpecs)
+    {
+        TextureDesc desc = {};
+        desc.type = spec.type;
+        desc.size = spec.size;
+        desc.mipLevelCount = spec.mipLevelCount;
+        desc.arrayLength = spec.arrayLength;
+        desc.format = spec.format;
+        desc.usage = TextureUsage::ShaderResource | TextureUsage::CopySource;
+
+        TestTextureData testData;
+        testData.initialize(desc);
+
+        CAPTURE(desc.type);
+        CAPTURE(desc.size.width);
+        CAPTURE(desc.size.height);
+        CAPTURE(desc.size.depth);
+        CAPTURE(desc.mipLevelCount);
+        CAPTURE(desc.arrayLength);
+        CAPTURE(desc.format);
+
+        ComPtr<ITexture> texture;
+        Result result = device->createTexture(desc, testData.subresourceData.data(), texture.writeRef());
+
+        bool expectFailure = false;
+        // WGPU does not support mip levels for 1D textures.
+        if (device->getDeviceType() == DeviceType::WGPU && desc.type == TextureType::Texture1D &&
+            desc.mipLevelCount != 1)
+            expectFailure = true;
+        // WGPU does not support 1D texture arrays.
+        if (device->getDeviceType() == DeviceType::WGPU && desc.type == TextureType::Texture1DArray)
+            expectFailure = true;
+        // CUDA does not support multisample textures.
+        if (device->getDeviceType() == DeviceType::CUDA &&
+            (desc.type == TextureType::Texture2DMS || desc.type == TextureType::Texture2DMSArray))
+            expectFailure = true;
+
+        if (expectFailure)
+        {
+            CHECK(!SLANG_SUCCEEDED(result));
+            continue;
+        }
+        REQUIRE_CALL(result);
+
+        uint32_t expectedMipLevelCount = calcMipLevelCount(desc);
+        uint32_t expectedLayerCount = calcLayerCount(desc);
+
+        CHECK(texture->getDesc().type == desc.type);
+        CHECK(texture->getDesc().size.width == desc.size.width);
+        CHECK(texture->getDesc().size.height == desc.size.height);
+        CHECK(texture->getDesc().size.depth == desc.size.depth);
+        CHECK(texture->getDesc().arrayLength == desc.arrayLength);
+        CHECK(texture->getDesc().mipLevelCount == expectedMipLevelCount);
+        CHECK(texture->getDesc().format == desc.format);
+        CHECK(texture->getDesc().getLayerCount() == expectedLayerCount);
+
+        // TODO: CPU readback not implemented
+        if (device->getDeviceType() == DeviceType::CPU || device->getDeviceType() == DeviceType::D3D11)
+        {
+            continue;
+        }
+
+        for (uint32_t layer = 0; layer < expectedLayerCount; ++layer)
+        {
+            for (uint32_t mipLevel = 0; mipLevel < expectedMipLevelCount; ++mipLevel)
+            {
+                ComPtr<ISlangBlob> readbackData;
+                size_t rowPitch;
+                size_t pixelSize;
+                REQUIRE_CALL(device->readTexture(texture, layer, mipLevel, readbackData.writeRef(), &rowPitch, &pixelSize));
+                testData.validate(
+                    layer,
+                    mipLevel,
+                    readbackData->getBufferPointer(),
+                    readbackData->getBufferSize(),
+                    rowPitch,
+                    pixelSize
+                );
+            }
+        }
+    }
+}

--- a/tests/testing.cpp
+++ b/tests/testing.cpp
@@ -409,7 +409,7 @@ ComPtr<IDevice> createTestingDevice(
         deviceDesc.next = &extDesc;
     }
 
-#ifdef _DEBUG
+#if SLANG_RHI_DEBUG
     deviceDesc.enableValidation = true;
     deviceDesc.enableRayTracingValidation = true;
     deviceDesc.debugCallback = &sDebugCallback;
@@ -417,7 +417,7 @@ ComPtr<IDevice> createTestingDevice(
 
     REQUIRE_CALL(getRHI()->createDevice(deviceDesc, device.writeRef()));
 
-#ifdef _DEBUG
+#if SLANG_RHI_DEBUG
     const char* features[128];
     uint32_t featureCount;
     REQUIRE_CALL(device->getFeatures(features, SLANG_COUNT_OF(features), &featureCount));

--- a/tests/testing.h
+++ b/tests/testing.h
@@ -4,6 +4,7 @@
 #include <slang-rhi.h>
 #include <slang-rhi/shader-cursor.h>
 
+#include "enum-strings.h"
 #include "../src/core/blob.h"
 
 #include <array>
@@ -210,3 +211,14 @@ enum TestFlags
         return;                                                                                                        \
     }                                                                                                                  \
     while (0)
+
+namespace rhi {
+inline doctest::String toString(Format value)
+{
+    return enumToString(value);
+}
+inline doctest::String toString(TextureType value)
+{
+    return enumToString(value);
+}
+} // namespace rhi

--- a/tests/texture-utils.cpp
+++ b/tests/texture-utils.cpp
@@ -217,11 +217,11 @@ RefPtr<ValidationTextureFormatBase> getValidationTextureFormat(Format format)
 void generateTextureData(RefPtr<TextureInfo> texture, ValidationTextureFormatBase* validationFormat)
 {
     auto extents = texture->extents;
-    auto arrayLayers = texture->arrayLength;
+    auto layerCount = texture->arrayLength;
     auto mipLevels = texture->mipLevelCount;
     auto texelSize = getTexelSize(texture->format);
 
-    for (uint32_t layer = 0; layer < arrayLayers; ++layer)
+    for (uint32_t layer = 0; layer < layerCount; ++layer)
     {
         for (uint32_t mip = 0; mip < mipLevels; ++mip)
         {


### PR DESCRIPTION
- make `TextureType` the full set of types: `Texture1D`, `Texture1DArray`, `Texture2D`, `Texture2DArray`, `Texture2DMS`, `Texture2DMSArray`, `Texture3D`, `TextureCube`, `TextureCubeArray`
- add a test for creating textures with initial data
- add `SLANG_RHI_DEBUG`, replacing `_DEBUG` that now works on all platforms