### PR TITLE
Enable Agility SDK

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -90,7 +90,7 @@ set(SLANG_RHI_FETCH_DXC_URL "https://github.com/microsoft/DirectXShaderCompiler/
 
 # Fetch Agility SDK options
 option(SLANG_RHI_FETCH_AGILITY_SDK "Fetch Agility SDK" ON)
-set(SLANG_RHI_FETCH_AGILITY_SDK_VERSION "1.614.1" CACHE STRING "Agility SDK version to fetch")
+set(SLANG_RHI_FETCH_AGILITY_SDK_VERSION "1.615.1" CACHE STRING "Agility SDK version to fetch")
 
 # Fetch NVAPI options
 option(SLANG_RHI_FETCH_NVAPI "Fetch NVAPI" ON)

--- a/include/slang-rhi/agility-sdk.h
+++ b/include/slang-rhi/agility-sdk.h
@@ -11,13 +11,13 @@
 #include <d3d12.h>
 
 #define SLANG_RHI_AGILITY_SDK_VERSION D3D12_SDK_VERSION
-#define SLANG_RHI_AGILITY_SDK_PATH ".\\d3d12\\"
+#define SLANG_RHI_AGILITY_SDK_PATH ".\\D3D12\\"
 
 // To enable the D3D12 Agility SDK, this macro needs to be added to the main source file of the executable.
 #define SLANG_RHI_EXPORT_AGILITY_SDK                                                                                   \
     extern "C"                                                                                                         \
     {                                                                                                                  \
-        __declspec(dllexport) extern const unsigned int D3D12SDKVersion = SLANG_RHI_AGILITY_SDK_VERSION;               \
+        __declspec(dllexport) extern const UINT D3D12SDKVersion = SLANG_RHI_AGILITY_SDK_VERSION;                       \
     }                                                                                                                  \
     extern "C"                                                                                                         \
     {                                                                                                                  \

--- a/tests/main.cpp
+++ b/tests/main.cpp
@@ -7,7 +7,7 @@
 #include "doctest-reporter.h"
 
 // Due to current issues in slang we don't enable Agility SDK yet
-// SLANG_RHI_EXPORT_AGILITY_SDK
+SLANG_RHI_EXPORT_AGILITY_SDK
 
 namespace rhi::testing {
 


### PR DESCRIPTION
- update Agility SDK to 1.615.1
- enable Agility SDK in unit tests