### PR TITLE
Null views

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -668,6 +668,7 @@ if(SLANG_RHI_BUILD_TESTS)
         tests/test-link-time-type.cpp
         tests/test-native-handle.cpp
         tests/test-nested-parameter-block.cpp
+        tests/test-null-views.cpp
         tests/test-offset-allocator.cpp
         # tests/test-precompiled-module-cache.cpp
         tests/test-precompiled-module.cpp

--- a/src/cuda/cuda-device.cpp
+++ b/src/cuda/cuda-device.cpp
@@ -167,12 +167,10 @@ Result DeviceImpl::getNativeDeviceHandles(DeviceNativeHandles* outHandles)
 
 Result DeviceImpl::initialize(const DeviceDesc& desc)
 {
-    SLANG_RETURN_ON_FAIL(m_slangContext.initialize(
-        desc.slang,
-        SLANG_PTX,
-        "sm_5_1",
-        std::array{slang::PreprocessorMacroDesc{"__CUDA_COMPUTE__", "1"}}
-    ));
+    SLANG_RETURN_ON_FAIL(
+        m_slangContext
+            .initialize(desc.slang, SLANG_PTX, "sm_5_1", std::array{slang::PreprocessorMacroDesc{"__CUDA__", "1"}})
+    );
 
     SLANG_RETURN_ON_FAIL(Device::initialize(desc));
 

--- a/src/d3d11/d3d11-command.cpp
+++ b/src/d3d11/d3d11-command.cpp
@@ -317,24 +317,33 @@ void CommandExecutor::cmdSetRenderState(const commands::SetRenderState& cmd)
         m_bindingData = static_cast<BindingDataImpl*>(cmd.bindingData);
 
         // Bind constant buffers, shader resource views, and samplers.
-        m_immediateContext->VSSetConstantBuffers1(
-            0,
-            m_bindingData->uavCount,
-            m_bindingData->cbvsBuffer,
-            m_bindingData->cbvsFirst,
-            m_bindingData->cbvsCount
-        );
-        m_immediateContext->PSSetConstantBuffers1(
-            0,
-            m_bindingData->cbvCount,
-            m_bindingData->cbvsBuffer,
-            m_bindingData->cbvsFirst,
-            m_bindingData->cbvsCount
-        );
-        m_immediateContext->VSSetShaderResources(0, m_bindingData->srvCount, m_bindingData->srvs);
-        m_immediateContext->PSSetShaderResources(0, m_bindingData->srvCount, m_bindingData->srvs);
-        m_immediateContext->VSSetSamplers(0, m_bindingData->samplerCount, m_bindingData->samplers);
-        m_immediateContext->PSSetSamplers(0, m_bindingData->samplerCount, m_bindingData->samplers);
+        if (m_bindingData->cbvsCount > 0)
+        {
+            m_immediateContext->VSSetConstantBuffers1(
+                0,
+                m_bindingData->uavCount,
+                m_bindingData->cbvsBuffer,
+                m_bindingData->cbvsFirst,
+                m_bindingData->cbvsCount
+            );
+            m_immediateContext->PSSetConstantBuffers1(
+                0,
+                m_bindingData->cbvCount,
+                m_bindingData->cbvsBuffer,
+                m_bindingData->cbvsFirst,
+                m_bindingData->cbvsCount
+            );
+        }
+        if (m_bindingData->srvCount > 0)
+        {
+            m_immediateContext->VSSetShaderResources(0, m_bindingData->srvCount, m_bindingData->srvs);
+            m_immediateContext->PSSetShaderResources(0, m_bindingData->srvCount, m_bindingData->srvs);
+        }
+        if (m_bindingData->samplerCount > 0)
+        {
+            m_immediateContext->VSSetSamplers(0, m_bindingData->samplerCount, m_bindingData->samplers);
+            m_immediateContext->PSSetSamplers(0, m_bindingData->samplerCount, m_bindingData->samplers);
+        }
 
         // Bind unordered access views.
         //
@@ -535,16 +544,28 @@ void CommandExecutor::cmdSetComputeState(const commands::SetComputeState& cmd)
     {
         m_bindingData = static_cast<BindingDataImpl*>(cmd.bindingData);
 
-        m_immediateContext->CSSetConstantBuffers1(
-            0,
-            m_bindingData->cbvCount,
-            m_bindingData->cbvsBuffer,
-            m_bindingData->cbvsFirst,
-            m_bindingData->cbvsCount
-        );
-        m_immediateContext->CSSetShaderResources(0, m_bindingData->srvCount, m_bindingData->srvs);
-        m_immediateContext->CSSetSamplers(0, m_bindingData->samplerCount, m_bindingData->samplers);
-        m_immediateContext->CSSetUnorderedAccessViews(0, m_bindingData->uavCount, m_bindingData->uavs, nullptr);
+        if (m_bindingData->cbvsCount > 0)
+        {
+            m_immediateContext->CSSetConstantBuffers1(
+                0,
+                m_bindingData->cbvCount,
+                m_bindingData->cbvsBuffer,
+                m_bindingData->cbvsFirst,
+                m_bindingData->cbvsCount
+            );
+        }
+        if (m_bindingData->srvCount > 0)
+        {
+            m_immediateContext->CSSetShaderResources(0, m_bindingData->srvCount, m_bindingData->srvs);
+        }
+        if (m_bindingData->samplerCount)
+        {
+            m_immediateContext->CSSetSamplers(0, m_bindingData->samplerCount, m_bindingData->samplers);
+        }
+        if (m_bindingData->uavCount > 0)
+        {
+            m_immediateContext->CSSetUnorderedAccessViews(0, m_bindingData->uavCount, m_bindingData->uavs, nullptr);
+        }
     }
 
     m_computeStateValid = true;

--- a/src/d3d11/d3d11-shader-object.cpp
+++ b/src/d3d11/d3d11-shader-object.cpp
@@ -144,10 +144,13 @@ Result BindingDataBuilder::bindAsValue(
             {
                 const ResourceSlot& slot = shaderObject->m_slots[slotIndex + i];
                 TextureViewImpl* textureView = checked_cast<TextureViewImpl*>(slot.resource.get());
-                uint32_t registerIndex = bindingRange.registerOffset + offset.srv + i;
-                SLANG_RHI_ASSERT(registerIndex < D3D11_COMMONSHADER_INPUT_RESOURCE_SLOT_COUNT);
-                m_bindingData->srvs[registerIndex] = textureView->getSRV();
-                m_bindingData->srvCount = max(m_bindingData->srvCount, registerIndex + 1);
+                if (textureView)
+                {
+                    uint32_t registerIndex = bindingRange.registerOffset + offset.srv + i;
+                    SLANG_RHI_ASSERT(registerIndex < D3D11_COMMONSHADER_INPUT_RESOURCE_SLOT_COUNT);
+                    m_bindingData->srvs[registerIndex] = textureView->getSRV();
+                    m_bindingData->srvCount = max(m_bindingData->srvCount, registerIndex + 1);
+                }
             }
             break;
         case slang::BindingType::MutableTexture:
@@ -155,10 +158,13 @@ Result BindingDataBuilder::bindAsValue(
             {
                 const ResourceSlot& slot = shaderObject->m_slots[slotIndex + i];
                 TextureViewImpl* textureView = checked_cast<TextureViewImpl*>(slot.resource.get());
-                uint32_t registerIndex = bindingRange.registerOffset + offset.uav + i;
-                SLANG_RHI_ASSERT(registerIndex < D3D11_PS_CS_UAV_REGISTER_COUNT);
-                m_bindingData->uavs[registerIndex] = textureView->getUAV();
-                m_bindingData->uavCount = max(m_bindingData->uavCount, registerIndex + 1);
+                if (textureView)
+                {
+                    uint32_t registerIndex = bindingRange.registerOffset + offset.uav + i;
+                    SLANG_RHI_ASSERT(registerIndex < D3D11_PS_CS_UAV_REGISTER_COUNT);
+                    m_bindingData->uavs[registerIndex] = textureView->getUAV();
+                    m_bindingData->uavCount = max(m_bindingData->uavCount, registerIndex + 1);
+                }
             }
             break;
         case slang::BindingType::Sampler:
@@ -166,10 +172,13 @@ Result BindingDataBuilder::bindAsValue(
             {
                 const ResourceSlot& slot = shaderObject->m_slots[slotIndex + i];
                 SamplerImpl* sampler = checked_cast<SamplerImpl*>(slot.resource.get());
-                uint32_t registerIndex = bindingRange.registerOffset + offset.sampler + i;
-                SLANG_RHI_ASSERT(registerIndex < D3D11_COMMONSHADER_SAMPLER_REGISTER_COUNT);
-                m_bindingData->samplers[registerIndex] = sampler->m_sampler;
-                m_bindingData->samplerCount = max(m_bindingData->samplerCount, registerIndex + 1);
+                if (sampler)
+                {
+                    uint32_t registerIndex = bindingRange.registerOffset + offset.sampler + i;
+                    SLANG_RHI_ASSERT(registerIndex < D3D11_COMMONSHADER_SAMPLER_REGISTER_COUNT);
+                    m_bindingData->samplers[registerIndex] = sampler->m_sampler;
+                    m_bindingData->samplerCount = max(m_bindingData->samplerCount, registerIndex + 1);
+                }
             }
             break;
         case slang::BindingType::RawBuffer:
@@ -178,10 +187,13 @@ Result BindingDataBuilder::bindAsValue(
             {
                 const ResourceSlot& slot = shaderObject->m_slots[slotIndex + i];
                 BufferImpl* buffer = checked_cast<BufferImpl*>(slot.resource.get());
-                uint32_t registerIndex = bindingRange.registerOffset + offset.srv + i;
-                SLANG_RHI_ASSERT(registerIndex < D3D11_COMMONSHADER_INPUT_RESOURCE_SLOT_COUNT);
-                m_bindingData->srvs[registerIndex] = buffer->getSRV(slot.format, slot.bufferRange);
-                m_bindingData->srvCount = max(m_bindingData->srvCount, registerIndex + 1);
+                if (buffer)
+                {
+                    uint32_t registerIndex = bindingRange.registerOffset + offset.srv + i;
+                    SLANG_RHI_ASSERT(registerIndex < D3D11_COMMONSHADER_INPUT_RESOURCE_SLOT_COUNT);
+                    m_bindingData->srvs[registerIndex] = buffer->getSRV(slot.format, slot.bufferRange);
+                    m_bindingData->srvCount = max(m_bindingData->srvCount, registerIndex + 1);
+                }
             }
             break;
         case slang::BindingType::MutableRawBuffer:
@@ -190,10 +202,13 @@ Result BindingDataBuilder::bindAsValue(
             {
                 const ResourceSlot& slot = shaderObject->m_slots[slotIndex + i];
                 BufferImpl* buffer = checked_cast<BufferImpl*>(slot.resource.get());
-                uint32_t registerIndex = bindingRange.registerOffset + offset.uav + i;
-                SLANG_RHI_ASSERT(registerIndex < D3D11_PS_CS_UAV_REGISTER_COUNT);
-                m_bindingData->uavs[registerIndex] = buffer->getUAV(slot.format, slot.bufferRange);
-                m_bindingData->uavCount = max(m_bindingData->uavCount, registerIndex + 1);
+                if (buffer)
+                {
+                    uint32_t registerIndex = bindingRange.registerOffset + offset.uav + i;
+                    SLANG_RHI_ASSERT(registerIndex < D3D11_PS_CS_UAV_REGISTER_COUNT);
+                    m_bindingData->uavs[registerIndex] = buffer->getUAV(slot.format, slot.bufferRange);
+                    m_bindingData->uavCount = max(m_bindingData->uavCount, registerIndex + 1);
+                }
             }
             break;
         default:

--- a/src/d3d12/d3d12-device.h
+++ b/src/d3d12/d3d12-device.h
@@ -217,6 +217,14 @@ public:
 
     void flushValidationMessages();
 
+
+    using NullDescriptorKey = std::pair<slang::BindingType, SlangResourceShape>;
+    std::map<NullDescriptorKey, CPUDescriptorAllocation> m_nullDescriptors;
+    CPUDescriptorAllocation m_nullSamplerDescriptor;
+    std::mutex m_nullDescriptorsMutex;
+    D3D12_CPU_DESCRIPTOR_HANDLE getNullDescriptor(slang::BindingType bindingType, SlangResourceShape resourceShape);
+    D3D12_CPU_DESCRIPTOR_HANDLE getNullSamplerDescriptor();
+
 private:
     void processExperimentalFeaturesDesc(SharedLibraryHandle d3dModule, void* desc);
 };

--- a/src/metal/metal-shader-object.cpp
+++ b/src/metal/metal-shader-object.cpp
@@ -167,9 +167,12 @@ Result BindingDataBuilder::bindAsValue(
             {
                 const ResourceSlot& slot = shaderObject->m_slots[slotIndex + i];
                 TextureViewImpl* textureView = checked_cast<TextureViewImpl*>(slot.resource.get());
-                uint32_t registerIndex = bindingRangeInfo.registerOffset + offset.texture + i;
-                SLANG_RHI_ASSERT(registerIndex < m_bindingData->textureCount);
-                m_bindingData->textures[registerIndex] = textureView->m_textureView.get();
+                if (textureView)
+                {
+                    uint32_t registerIndex = bindingRangeInfo.registerOffset + offset.texture + i;
+                    SLANG_RHI_ASSERT(registerIndex < m_bindingData->textureCount);
+                    m_bindingData->textures[registerIndex] = textureView->m_textureView.get();
+                }
             }
             break;
         case slang::BindingType::Sampler:
@@ -177,9 +180,12 @@ Result BindingDataBuilder::bindAsValue(
             {
                 const ResourceSlot& slot = shaderObject->m_slots[slotIndex + i];
                 SamplerImpl* sampler = checked_cast<SamplerImpl*>(slot.resource.get());
-                uint32_t registerIndex = bindingRangeInfo.registerOffset + offset.sampler + i;
-                SLANG_RHI_ASSERT(registerIndex < m_bindingData->samplerCount);
-                m_bindingData->samplers[registerIndex] = sampler->m_samplerState.get();
+                if (sampler)
+                {
+                    uint32_t registerIndex = bindingRangeInfo.registerOffset + offset.sampler + i;
+                    SLANG_RHI_ASSERT(registerIndex < m_bindingData->samplerCount);
+                    m_bindingData->samplers[registerIndex] = sampler->m_samplerState.get();
+                }
             }
             break;
         case slang::BindingType::RawBuffer:
@@ -190,9 +196,12 @@ Result BindingDataBuilder::bindAsValue(
             {
                 const ResourceSlot& slot = shaderObject->m_slots[slotIndex + i];
                 BufferImpl* buffer = checked_cast<BufferImpl*>(slot.resource.get());
-                uint32_t registerIndex = bindingRangeInfo.registerOffset + offset.buffer + i;
-                m_bindingData->bufferCount = max(m_bindingData->bufferCount, registerIndex + 1);
-                m_bindingData->buffers[registerIndex] = buffer->m_buffer.get();
+                if (buffer)
+                {
+                    uint32_t registerIndex = bindingRangeInfo.registerOffset + offset.buffer + i;
+                    m_bindingData->bufferCount = max(m_bindingData->bufferCount, registerIndex + 1);
+                    m_bindingData->buffers[registerIndex] = buffer->m_buffer.get();
+                }
             }
             break;
         case slang::BindingType::VaryingInput:

--- a/src/metal/metal-shader-object.cpp
+++ b/src/metal/metal-shader-object.cpp
@@ -20,13 +20,13 @@ Result BindingDataBuilder::bindAsRoot(
 
     // TODO(shaderobject): we should count number of buffers/textures in the layout and allocate appropriately
     uint32_t bufferCount = 100;
+    uint32_t textureCount = 100;
     m_bindingData->bufferCount = 0;
     m_bindingData->buffers = m_allocator->allocate<MTL::Buffer*>(bufferCount);
     ::memset(m_bindingData->buffers, 0, sizeof(MTL::Buffer*) * bufferCount);
     m_bindingData->bufferOffsets = m_allocator->allocate<NS::UInteger>(bufferCount);
     ::memset(m_bindingData->bufferOffsets, 0, sizeof(NS::UInteger) * bufferCount);
-    uint32_t textureCount = specializedLayout->getTotalTextureCount();
-    m_bindingData->textureCount = textureCount;
+    m_bindingData->textureCount = 0;
     m_bindingData->textures = m_allocator->allocate<MTL::Texture*>(textureCount);
     ::memset(m_bindingData->textures, 0, sizeof(MTL::Texture*) * textureCount);
     uint32_t samplerCount = specializedLayout->getTotalSamplerCount();
@@ -168,7 +168,7 @@ Result BindingDataBuilder::bindAsValue(
                 const ResourceSlot& slot = shaderObject->m_slots[slotIndex + i];
                 TextureViewImpl* textureView = checked_cast<TextureViewImpl*>(slot.resource.get());
                 uint32_t registerIndex = bindingRangeInfo.registerOffset + offset.texture + i;
-                SLANG_RHI_ASSERT(registerIndex < m_bindingData->textureCount);
+                m_bindingData->textureCount = max(m_bindingData->textureCount, registerIndex + 1);
                 m_bindingData->textures[registerIndex] = textureView ? textureView->m_textureView.get() : nullptr;
             }
             break;

--- a/src/metal/metal-shader-object.cpp
+++ b/src/metal/metal-shader-object.cpp
@@ -167,12 +167,9 @@ Result BindingDataBuilder::bindAsValue(
             {
                 const ResourceSlot& slot = shaderObject->m_slots[slotIndex + i];
                 TextureViewImpl* textureView = checked_cast<TextureViewImpl*>(slot.resource.get());
-                if (textureView)
-                {
-                    uint32_t registerIndex = bindingRangeInfo.registerOffset + offset.texture + i;
-                    SLANG_RHI_ASSERT(registerIndex < m_bindingData->textureCount);
-                    m_bindingData->textures[registerIndex] = textureView->m_textureView.get();
-                }
+                uint32_t registerIndex = bindingRangeInfo.registerOffset + offset.texture + i;
+                SLANG_RHI_ASSERT(registerIndex < m_bindingData->textureCount);
+                m_bindingData->textures[registerIndex] = textureView ? textureView->m_textureView.get() : nullptr;
             }
             break;
         case slang::BindingType::Sampler:
@@ -180,12 +177,9 @@ Result BindingDataBuilder::bindAsValue(
             {
                 const ResourceSlot& slot = shaderObject->m_slots[slotIndex + i];
                 SamplerImpl* sampler = checked_cast<SamplerImpl*>(slot.resource.get());
-                if (sampler)
-                {
-                    uint32_t registerIndex = bindingRangeInfo.registerOffset + offset.sampler + i;
-                    SLANG_RHI_ASSERT(registerIndex < m_bindingData->samplerCount);
-                    m_bindingData->samplers[registerIndex] = sampler->m_samplerState.get();
-                }
+                uint32_t registerIndex = bindingRangeInfo.registerOffset + offset.sampler + i;
+                SLANG_RHI_ASSERT(registerIndex < m_bindingData->samplerCount);
+                m_bindingData->samplers[registerIndex] = sampler ? sampler->m_samplerState.get() : nullptr;
             }
             break;
         case slang::BindingType::RawBuffer:
@@ -196,12 +190,9 @@ Result BindingDataBuilder::bindAsValue(
             {
                 const ResourceSlot& slot = shaderObject->m_slots[slotIndex + i];
                 BufferImpl* buffer = checked_cast<BufferImpl*>(slot.resource.get());
-                if (buffer)
-                {
-                    uint32_t registerIndex = bindingRangeInfo.registerOffset + offset.buffer + i;
-                    m_bindingData->bufferCount = max(m_bindingData->bufferCount, registerIndex + 1);
-                    m_bindingData->buffers[registerIndex] = buffer->m_buffer.get();
-                }
+                uint32_t registerIndex = bindingRangeInfo.registerOffset + offset.buffer + i;
+                m_bindingData->bufferCount = max(m_bindingData->bufferCount, registerIndex + 1);
+                m_bindingData->buffers[registerIndex] = buffer ? buffer->m_buffer.get() : nullptr;
             }
             break;
         case slang::BindingType::VaryingInput:

--- a/src/vulkan/vk-device.cpp
+++ b/src/vulkan/vk-device.cpp
@@ -1104,7 +1104,7 @@ Result DeviceImpl::initialize(const DeviceDesc& desc)
 
     SLANG_RETURN_ON_FAIL(
         m_slangContext
-            .initialize(desc.slang, SLANG_SPIRV, "sm_6_0", std::array{slang::PreprocessorMacroDesc{"__VK__", "1"}})
+            .initialize(desc.slang, SLANG_SPIRV, "sm_6_0", std::array{slang::PreprocessorMacroDesc{"__VULKAN__", "1"}})
     );
 
     // Create default sampler.

--- a/src/vulkan/vk-shader-object.cpp
+++ b/src/vulkan/vk-shader-object.cpp
@@ -388,7 +388,10 @@ Result BindingDataBuilder::bindAsValue(
                 const ResourceSlot& slot = shaderObject->m_slots[slotIndex + i];
                 TextureViewImpl* textureView = checked_cast<TextureViewImpl*>(slot.resource.get());
                 writeTextureDescriptor(device, descriptorSet, binding, i, descriptorType, textureView);
-                m_bindingData->textureStates[m_bindingData->textureStateCount++] = {textureView, requiredState};
+                if (textureView)
+                {
+                    m_bindingData->textureStates[m_bindingData->textureStateCount++] = {textureView, requiredState};
+                }
             }
             break;
         }
@@ -402,7 +405,10 @@ Result BindingDataBuilder::bindAsValue(
                 TextureViewImpl* textureView = checked_cast<TextureViewImpl*>(slot.resource.get());
                 SamplerImpl* sampler = checked_cast<SamplerImpl*>(slot.resource2.get());
                 writeTextureSamplerDescriptor(device, descriptorSet, binding, i, textureView, sampler);
-                m_bindingData->textureStates[m_bindingData->textureStateCount++] = {textureView, requiredState};
+                if (textureView)
+                {
+                    m_bindingData->textureStates[m_bindingData->textureStateCount++] = {textureView, requiredState};
+                }
             }
             break;
         }
@@ -431,7 +437,10 @@ Result BindingDataBuilder::bindAsValue(
                 const ResourceSlot& slot = shaderObject->m_slots[slotIndex + i];
                 BufferImpl* buffer = checked_cast<BufferImpl*>(slot.resource.get());
                 writePlainBufferDescriptor(device, descriptorSet, binding, i, descriptorType, buffer, slot.bufferRange);
-                m_bindingData->bufferStates[m_bindingData->bufferStateCount++] = {buffer, requiredState};
+                if (buffer)
+                {
+                    m_bindingData->bufferStates[m_bindingData->bufferStateCount++] = {buffer, requiredState};
+                }
             }
             break;
         }
@@ -459,7 +468,10 @@ Result BindingDataBuilder::bindAsValue(
                     slot.format,
                     slot.bufferRange
                 );
-                m_bindingData->bufferStates[m_bindingData->bufferStateCount++] = {buffer, requiredState};
+                if (buffer)
+                {
+                    m_bindingData->bufferStates[m_bindingData->bufferStateCount++] = {buffer, requiredState};
+                }
             }
             break;
         }

--- a/tests/test-null-views.cpp
+++ b/tests/test-null-views.cpp
@@ -1,0 +1,147 @@
+#include "testing.h"
+
+using namespace rhi;
+using namespace rhi::testing;
+
+// skip D3D11: too many UAVs
+// skip CPU: invalid results
+// skip WGPU: null views don't exist, would need to create dummy resources
+GPU_TEST_CASE("null-views", ALL & ~(D3D11 | CPU | WGPU))
+{
+    ComPtr<IShaderProgram> shaderProgram;
+    slang::ProgramLayout* slangReflection;
+    REQUIRE_CALL(loadComputeProgram(device, shaderProgram, "test-null-views", "compute_main", slangReflection));
+
+    ComputePipelineDesc pipelineDesc = {};
+    pipelineDesc.program = shaderProgram.get();
+    ComPtr<IComputePipeline> pipeline;
+    REQUIRE_CALL(device->createComputePipeline(pipelineDesc, pipeline.writeRef()));
+
+    ComPtr<IBuffer> buffer;
+    {
+        BufferDesc desc = {};
+        desc.size = 4;
+        desc.format = Format::R32_FLOAT;
+        desc.usage = BufferUsage::ShaderResource;
+        float data = 1.f;
+        REQUIRE_CALL(device->createBuffer(desc, &data, buffer.writeRef()));
+    }
+
+    ComPtr<IBuffer> rwBuffer;
+    {
+        BufferDesc desc = {};
+        desc.size = 4;
+        desc.format = Format::R32_FLOAT;
+        desc.usage = BufferUsage::UnorderedAccess;
+        float data = 2.f;
+        REQUIRE_CALL(device->createBuffer(desc, &data, rwBuffer.writeRef()));
+    }
+
+    ComPtr<IBuffer> structuredBuffer;
+    {
+        BufferDesc desc = {};
+        desc.size = 4;
+        desc.usage = BufferUsage::ShaderResource;
+        float data = 3.f;
+        REQUIRE_CALL(device->createBuffer(desc, &data, structuredBuffer.writeRef()));
+    }
+
+    ComPtr<IBuffer> rwStructuredBuffer;
+    {
+        BufferDesc desc = {};
+        desc.size = 4;
+        desc.usage = BufferUsage::UnorderedAccess;
+        float data = 4.f;
+        REQUIRE_CALL(device->createBuffer(desc, &data, rwStructuredBuffer.writeRef()));
+    }
+
+    ComPtr<ITexture> texture;
+    {
+        TextureDesc desc = {};
+        desc.type = TextureType::Texture2D;
+        desc.size = {1, 1, 1};
+        desc.format = Format::R32_FLOAT;
+        desc.usage = TextureUsage::ShaderResource;
+        float data = 5.f;
+        SubresourceData subresourceData[] = {{&data, 4, 0}};
+        REQUIRE_CALL(device->createTexture(desc, subresourceData, texture.writeRef()));
+    }
+
+    ComPtr<ITexture> rwTexture;
+    {
+        TextureDesc desc = {};
+        desc.type = TextureType::Texture2D;
+        desc.size = {1, 1, 1};
+        desc.format = Format::R32_FLOAT;
+        desc.usage = TextureUsage::UnorderedAccess;
+        float data = 6.f;
+        SubresourceData subresourceData[] = {{&data, 4, 0}};
+        REQUIRE_CALL(device->createTexture(desc, subresourceData, rwTexture.writeRef()));
+    }
+
+    ComPtr<ITexture> textureArray;
+    {
+        TextureDesc desc = {};
+        desc.type = TextureType::Texture2DArray;
+        desc.size = {1, 1, 1};
+        desc.arrayLength = 2;
+        desc.format = Format::R32_FLOAT;
+        desc.usage = TextureUsage::ShaderResource;
+        float data = 7.f;
+        SubresourceData subresourceData[] = {{&data, 4, 0}, {&data, 4, 0}};
+        REQUIRE_CALL(device->createTexture(desc, subresourceData, textureArray.writeRef()));
+    }
+
+    ComPtr<ITexture> rwTextureArray;
+    {
+        TextureDesc desc = {};
+        desc.type = TextureType::Texture2DArray;
+        desc.size = {1, 1, 1};
+        desc.arrayLength = 2;
+        desc.format = Format::R32_FLOAT;
+        desc.usage = TextureUsage::UnorderedAccess;
+        float data = 8.f;
+        SubresourceData subresourceData[] = {{&data, 4, 0}, {&data, 4, 0}};
+        REQUIRE_CALL(device->createTexture(desc, subresourceData, rwTextureArray.writeRef()));
+    }
+
+    ComPtr<ISampler> sampler;
+    {
+        SamplerDesc desc = {};
+        REQUIRE_CALL(device->createSampler(desc, sampler.writeRef()));
+    }
+
+    ComPtr<IBuffer> result;
+    {
+        BufferDesc desc = {};
+        desc.size = 64;
+        desc.usage = BufferUsage::UnorderedAccess | BufferUsage::CopySource;
+        REQUIRE_CALL(device->createBuffer(desc, nullptr, result.writeRef()));
+    }
+
+    {
+        auto queue = device->getQueue(QueueType::Graphics);
+        auto commandEncoder = queue->createCommandEncoder();
+        auto passEncoder = commandEncoder->beginComputePass();
+        IShaderObject* rootObject = passEncoder->bindPipeline(pipeline);
+        ShaderCursor cursor(rootObject);
+        cursor["buffer2"].setBinding(buffer);
+        cursor["rwBuffer2"].setBinding(rwBuffer);
+        cursor["structuredBuffer2"].setBinding(structuredBuffer);
+        cursor["rwStructuredBuffer2"].setBinding(rwStructuredBuffer);
+        cursor["texture2"].setBinding(texture);
+        cursor["rwTexture2"].setBinding(rwTexture);
+        cursor["textureArray2"].setBinding(textureArray);
+        cursor["rwTextureArray2"].setBinding(rwTextureArray);
+        cursor["samplerState2"].setBinding(sampler);
+        cursor["result"].setBinding(result);
+
+        passEncoder->dispatchCompute(1, 1, 1);
+        passEncoder->end();
+
+        queue->submit(commandEncoder->finish());
+        queue->waitOnHost();
+    }
+
+    compareComputeResult(device, result, std::array{1.f, 2.f, 3.f, 4.f, 5.f, 6.f, 7.f, 8.f, 5.f});
+}

--- a/tests/test-null-views.slang
+++ b/tests/test-null-views.slang
@@ -37,7 +37,8 @@ RWStructuredBuffer<float> result;
 [numthreads(1, 1, 1)]
 void compute_main()
 {
-#ifndef __CUDA__
+    // TODO: CUDA/Metal don't fully support typed buffers yet
+#if !(defined(__CUDA__) || defined(__METAL__))
     result[0] = buffer2[0];
     result[1] = rwBuffer2[0];
 #else
@@ -46,7 +47,7 @@ void compute_main()
 #endif
     result[2] = structuredBuffer2[0];
     result[3] = rwStructuredBuffer2[0];
-#ifndef __CUDA__
+#if !defined(__CUDA__)
     result[4] = texture2.Load(int3(0));
     result[5] = rwTexture2.Load(int2(0));
     result[6] = textureArray2.Load(int4(0));

--- a/tests/test-null-views.slang
+++ b/tests/test-null-views.slang
@@ -1,0 +1,61 @@
+Buffer<float> buffer1;
+Buffer<float> buffer2;
+Buffer<float> buffer3;
+RWBuffer<float> rwBuffer1;
+RWBuffer<float> rwBuffer2;
+RWBuffer<float> rwBuffer3;
+StructuredBuffer<float> structuredBuffer1;
+StructuredBuffer<float> structuredBuffer2;
+StructuredBuffer<float> structuredBuffer3;
+RWStructuredBuffer<float> rwStructuredBuffer1;
+RWStructuredBuffer<float> rwStructuredBuffer2;
+RWStructuredBuffer<float> rwStructuredBuffer3;
+Texture2D<float> texture1;
+Texture2D<float> texture2;
+Texture2D<float> texture3;
+RWTexture2D<float> rwTexture1;
+RWTexture2D<float> rwTexture2;
+RWTexture2D<float> rwTexture3;
+Texture2DArray<float> textureArray1;
+Texture2DArray<float> textureArray2;
+Texture2DArray<float> textureArray3;
+RWTexture2DArray<float> rwTextureArray1;
+RWTexture2DArray<float> rwTextureArray2;
+RWTexture2DArray<float> rwTextureArray3;
+SamplerState samplerState1;
+SamplerState samplerState2;
+SamplerState samplerState3;
+#if defined(__D3D12__) || defined(__VULKAN__)
+RaytracingAccelerationStructure as1;
+RaytracingAccelerationStructure as2;
+RaytracingAccelerationStructure as3;
+#endif
+
+RWStructuredBuffer<float> result;
+
+[shader("compute")]
+[numthreads(1, 1, 1)]
+void compute_main()
+{
+#ifndef __CUDA__
+    result[0] = buffer2[0];
+    result[1] = rwBuffer2[0];
+#else
+    result[0] = 1.0;
+    result[1] = 2.0;
+#endif
+    result[2] = structuredBuffer2[0];
+    result[3] = rwStructuredBuffer2[0];
+#ifndef __CUDA__
+    result[4] = texture2.Load(int3(0));
+    result[5] = rwTexture2.Load(int2(0));
+    result[6] = textureArray2.Load(int4(0));
+    result[7] = rwTextureArray2.Load(int3(0));
+#else
+    result[4] = 5.0;
+    result[5] = 6.0;
+    result[6] = 7.0;
+    result[7] = 8.0;
+#endif
+    result[8] = texture2.SampleLevel(samplerState2, float2(0), 0.f);
+}


### PR DESCRIPTION
- allow resource binding in shader objects to be unbound (null)
- create null views on D3D12