### PR TITLE
Read texture cpu and d3d11

### DIFF
--- a/src/cpu/cpu-buffer.cpp
+++ b/src/cpu/cpu-buffer.cpp
@@ -51,65 +51,6 @@ Result DeviceImpl::unmapBuffer(IBuffer* buffer)
     return SLANG_OK;
 }
 
-Result DeviceImpl::readTexture(
-    ITexture* texture,
-    uint32_t layer,
-    uint32_t mipLevel,
-    ISlangBlob** outBlob,
-    Size* outRowPitch,
-    Size* outPixelSize
-)
-{
-    auto textureImpl = checked_cast<TextureImpl*>(texture);
-
-    // Calculate layout info.
-    SubresourceLayout layout;
-    SLANG_RETURN_ON_FAIL(texture->getSubresourceLayout(mipLevel, &layout));
-
-    // Create blob for result.
-    auto blob = OwnedBlob::create(layout.sizeInBytes);
-
-    // Get src + dest buffers.
-    uint8_t* srcBuffer = (uint8_t*)textureImpl->m_data;
-    uint8_t* dstBuffer = (uint8_t*)blob->getBufferPointer();
-
-    // Should be able to make assumption that subresource layout info
-    // matches those stored in the mip. If they don't match, this is a bug.
-    TextureImpl::MipLevel mipLevelInfo = textureImpl->m_mipLevels[mipLevel];
-    SLANG_RHI_ASSERT(mipLevelInfo.extents[0] == layout.size.width);
-    SLANG_RHI_ASSERT(mipLevelInfo.extents[1] == layout.size.height);
-    SLANG_RHI_ASSERT(mipLevelInfo.extents[2] == layout.size.depth);
-    SLANG_RHI_ASSERT(mipLevelInfo.strides[1] == layout.strideY);
-    SLANG_RHI_ASSERT(mipLevelInfo.strides[2] == layout.strideZ);
-
-    // Step forward to the mip data in the texture.
-    srcBuffer += mipLevelInfo.offset;
-
-    // Copy a row at a time.
-    for (int z = 0; z < layout.size.depth; z++)
-    {
-        uint8_t* srcRow = srcBuffer;
-        uint8_t* dstRow = dstBuffer;
-        for (int y = 0; y < layout.rowCount; y++)
-        {
-            std::memcpy(dstRow, srcRow, layout.strideY);
-            srcRow += layout.strideY;
-            dstRow += layout.strideY;
-        }
-        srcBuffer += layout.strideZ;
-        dstBuffer += layout.strideZ;
-    }
-
-    // Return data.
-    returnComPtr(outBlob, blob);
-    if (outRowPitch)
-        *outRowPitch = layout.strideY;
-    if (outPixelSize)
-        *outPixelSize = layout.sizeInBytes / layout.size.width;
-    return SLANG_OK;
-}
-
-
 Result DeviceImpl::readBuffer(IBuffer* buffer, Offset offset, Size size, ISlangBlob** outBlob)
 {
     BufferImpl* bufferImpl = checked_cast<BufferImpl*>(buffer);

--- a/src/cpu/cpu-device.cpp
+++ b/src/cpu/cpu-device.cpp
@@ -51,6 +51,12 @@ Result DeviceImpl::getFormatSupport(Format format, FormatSupport* outFormatSuppo
     return SLANG_OK;
 }
 
+Result DeviceImpl::getTextureRowAlignment(Format format, Size* outAlignment)
+{
+    *outAlignment = 1;
+    return SLANG_OK;
+}
+
 Result DeviceImpl::createShaderObjectLayout(
     slang::ISession* session,
     slang::TypeLayoutReflection* typeLayout,

--- a/src/cpu/cpu-device.h
+++ b/src/cpu/cpu-device.h
@@ -16,6 +16,8 @@ public:
 
     virtual SLANG_NO_THROW Result SLANG_MCALL getFormatSupport(Format format, FormatSupport* outFormatSupport) override;
 
+    virtual SLANG_NO_THROW Result SLANG_MCALL getTextureRowAlignment(Format format, Size* outAlignment) override;
+
     virtual SLANG_NO_THROW Result SLANG_MCALL
     createTexture(const TextureDesc& desc, const SubresourceData* initData, ITexture** outTexture) override;
 
@@ -25,6 +27,15 @@ public:
     virtual SLANG_NO_THROW Result SLANG_MCALL mapBuffer(IBuffer* buffer, CpuAccessMode mode, void** outData) override;
 
     virtual SLANG_NO_THROW Result SLANG_MCALL unmapBuffer(IBuffer* buffer) override;
+
+    virtual SLANG_NO_THROW Result SLANG_MCALL readTexture(
+        ITexture* texture,
+        uint32_t layer,
+        uint32_t mipLevel,
+        ISlangBlob** outBlob,
+        Size* outRowPitch,
+        Size* outPixelSize
+    ) override;
 
     virtual SLANG_NO_THROW Result SLANG_MCALL
     createTextureView(ITexture* inTexture, const TextureViewDesc& desc, ITextureView** outView) override;

--- a/src/cpu/cpu-texture.cpp
+++ b/src/cpu/cpu-texture.cpp
@@ -399,4 +399,62 @@ Result DeviceImpl::createTextureView(ITexture* texture, const TextureViewDesc& d
     return SLANG_OK;
 }
 
+Result DeviceImpl::readTexture(
+    ITexture* texture,
+    uint32_t layer,
+    uint32_t mipLevel,
+    ISlangBlob** outBlob,
+    Size* outRowPitch,
+    Size* outPixelSize
+)
+{
+    auto textureImpl = checked_cast<TextureImpl*>(texture);
+
+    // Calculate layout info.
+    SubresourceLayout layout;
+    SLANG_RETURN_ON_FAIL(texture->getSubresourceLayout(mipLevel, &layout));
+
+    // Create blob for result.
+    auto blob = OwnedBlob::create(layout.sizeInBytes);
+
+    // Get src + dest buffers.
+    uint8_t* srcBuffer = (uint8_t*)textureImpl->m_data;
+    uint8_t* dstBuffer = (uint8_t*)blob->getBufferPointer();
+
+    // Should be able to make assumption that subresource layout info
+    // matches those stored in the mip. If they don't match, this is a bug.
+    TextureImpl::MipLevel mipLevelInfo = textureImpl->m_mipLevels[mipLevel];
+    SLANG_RHI_ASSERT(mipLevelInfo.extents[0] == layout.size.width);
+    SLANG_RHI_ASSERT(mipLevelInfo.extents[1] == layout.size.height);
+    SLANG_RHI_ASSERT(mipLevelInfo.extents[2] == layout.size.depth);
+    SLANG_RHI_ASSERT(mipLevelInfo.strides[1] == layout.strideY);
+    SLANG_RHI_ASSERT(mipLevelInfo.strides[2] == layout.strideZ);
+
+    // Step forward to the mip data in the texture.
+    srcBuffer += mipLevelInfo.offset;
+
+    // Copy a row at a time.
+    for (int z = 0; z < layout.size.depth; z++)
+    {
+        uint8_t* srcRow = srcBuffer;
+        uint8_t* dstRow = dstBuffer;
+        for (int y = 0; y < layout.rowCount; y++)
+        {
+            std::memcpy(dstRow, srcRow, layout.strideY);
+            srcRow += layout.strideY;
+            dstRow += layout.strideY;
+        }
+        srcBuffer += layout.strideZ;
+        dstBuffer += layout.strideZ;
+    }
+
+    // Return data.
+    returnComPtr(outBlob, blob);
+    if (outRowPitch)
+        *outRowPitch = layout.strideY;
+    if (outPixelSize)
+        *outPixelSize = layout.sizeInBytes / layout.size.width;
+    return SLANG_OK;
+}
+
 } // namespace rhi::cpu

--- a/src/cuda/cuda-device.cpp
+++ b/src/cuda/cuda-device.cpp
@@ -348,7 +348,6 @@ Result DeviceImpl::getCUDAFormat(Format format, CUarray_format* outFormat)
     switch (format)
     {
     case Format::RGBA32Float:
-    case Format::RGB32Float:
     case Format::RG32Float:
     case Format::R32Float:
     case Format::D32Float:
@@ -360,7 +359,6 @@ Result DeviceImpl::getCUDAFormat(Format format, CUarray_format* outFormat)
         *outFormat = CU_AD_FORMAT_HALF;
         return SLANG_OK;
     case Format::RGBA32Uint:
-    case Format::RGB32Uint:
     case Format::RG32Uint:
     case Format::R32Uint:
         *outFormat = CU_AD_FORMAT_UNSIGNED_INT32;
@@ -377,7 +375,6 @@ Result DeviceImpl::getCUDAFormat(Format format, CUarray_format* outFormat)
         *outFormat = CU_AD_FORMAT_UNSIGNED_INT8;
         return SLANG_OK;
     case Format::RGBA32Sint:
-    case Format::RGB32Sint:
     case Format::RG32Sint:
     case Format::R32Sint:
         *outFormat = CU_AD_FORMAT_SIGNED_INT32;
@@ -427,9 +424,6 @@ Result DeviceImpl::getFormatSupport(Format format, FormatSupport* outFormatSuppo
     case Format::RG32Uint:
     case Format::RG32Sint:
     case Format::RG32Float:
-    case Format::RGB32Uint:
-    case Format::RGB32Sint:
-    case Format::RGB32Float:
     case Format::RGBA32Uint:
     case Format::RGBA32Sint:
     case Format::RGBA32Float:

--- a/src/d3d11/d3d11-device.cpp
+++ b/src/d3d11/d3d11-device.cpp
@@ -452,8 +452,6 @@ Result DeviceImpl::readTexture(
 
     // Now just read back texels from the staging textures
     {
-        uint32_t subResourceIdx = D3D11CalcSubresource(mipLevel, layer, desc.mipLevelCount);
-
         D3D11_MAPPED_SUBRESOURCE mappedResource;
         SLANG_RETURN_ON_FAIL(
             m_immediateContext

--- a/src/d3d11/d3d11-texture.cpp
+++ b/src/d3d11/d3d11-texture.cpp
@@ -309,6 +309,31 @@ Result DeviceImpl::createTexture(const TextureDesc& desc_, const SubresourceData
     }
 
     UINT accessFlags = _calcResourceAccessFlags(desc.memoryType);
+    D3D11_USAGE d3dUsage = D3D11_USAGE_DEFAULT;
+
+    // If texture will be used for upload, then:
+    //  - if pure copying, create as a staging texture (D3D11_USAGE_STAGING)
+    //  - if not, create as a dynamic texture (D3D11_USAGE_DYNAMIC) unless unordered access is specified
+    if (desc.memoryType == MemoryType::Upload)
+    {
+        accessFlags |= D3D11_CPU_ACCESS_WRITE;
+        if ((desc.usage & (TextureUsage::CopySource | TextureUsage::CopyDestination)) == desc.usage)
+        {
+            d3dUsage = D3D11_USAGE_STAGING;
+            accessFlags |= D3D11_CPU_ACCESS_READ; // Support read, so can be mapped as read/write
+        }
+        else if (!is_set(desc.usage, TextureUsage::UnorderedAccess))
+        {
+            d3dUsage = D3D11_USAGE_DYNAMIC;
+        }
+    }
+
+    // If texture will be used for read-back, then it must be staging.
+    if (desc.memoryType == MemoryType::ReadBack)
+    {
+        accessFlags |= D3D11_CPU_ACCESS_READ;
+        d3dUsage = D3D11_USAGE_STAGING;
+    }
 
     switch (desc.type)
     {
@@ -323,7 +348,7 @@ Result DeviceImpl::createTexture(const TextureDesc& desc_, const SubresourceData
         d3dDesc.MipLevels = mipLevelCount;
         d3dDesc.ArraySize = layerCount;
         d3dDesc.Width = desc.size.width;
-        d3dDesc.Usage = D3D11_USAGE_DEFAULT;
+        d3dDesc.Usage = d3dUsage;
 
         ComPtr<ID3D11Texture1D> texture1D;
         SLANG_RETURN_ON_FAIL(m_device->CreateTexture1D(&d3dDesc, subresourcesPtr, texture1D.writeRef()));
@@ -348,7 +373,7 @@ Result DeviceImpl::createTexture(const TextureDesc& desc_, const SubresourceData
 
         d3dDesc.Width = desc.size.width;
         d3dDesc.Height = desc.size.height;
-        d3dDesc.Usage = D3D11_USAGE_DEFAULT;
+        d3dDesc.Usage = d3dUsage;
         d3dDesc.SampleDesc.Count = desc.sampleCount;
         d3dDesc.SampleDesc.Quality = desc.sampleQuality;
         if (desc.type == TextureType::TextureCube || desc.type == TextureType::TextureCubeArray)
@@ -373,7 +398,7 @@ Result DeviceImpl::createTexture(const TextureDesc& desc_, const SubresourceData
         d3dDesc.Width = desc.size.width;
         d3dDesc.Height = desc.size.height;
         d3dDesc.Depth = desc.size.depth;
-        d3dDesc.Usage = D3D11_USAGE_DEFAULT;
+        d3dDesc.Usage = d3dUsage;
 
         ComPtr<ID3D11Texture3D> texture3D;
         SLANG_RETURN_ON_FAIL(m_device->CreateTexture3D(&d3dDesc, subresourcesPtr, texture3D.writeRef()));

--- a/src/d3d12/d3d12-command.cpp
+++ b/src/d3d12/d3d12-command.cpp
@@ -270,7 +270,8 @@ void CommandRecorder::cmdCopyTextureToBuffer(const commands::CopyTextureToBuffer
     if (srcSubresource.mipLevelCount == 0)
         srcSubresource.mipLevelCount = src->m_desc.mipLevelCount;
     if (srcSubresource.layerCount == 0)
-        srcSubresource.layerCount = src->m_desc.arrayLength;
+        srcSubresource.layerCount = src->m_desc.arrayLength; // TODO: This is wrong - should we be allowing
+                                                             // layerCount==0 at all anyway
 
     const FormatInfo& formatInfo = getFormatInfo(src->m_desc.format);
 

--- a/tests/test-create-texture.cpp
+++ b/tests/test-create-texture.cpp
@@ -9,7 +9,7 @@ using namespace rhi::testing;
 
 GPU_TEST_CASE("texturetest-create", ALL)
 {
-    TextureTestOptions options(device, 1);
+    TextureTestOptions options(device, TextureInitMode::Random);
     options.addVariants(TTShape::All, TTArray::Both, TTMip::Both, TTMS::Both);
 
 

--- a/tests/test-create-texture.cpp
+++ b/tests/test-create-texture.cpp
@@ -18,8 +18,7 @@ GPU_TEST_CASE("texturetest-create", ALL)
         [](TextureTestContext* c)
         {
             // read-back not implemented
-            if (c->getDevice()->getDeviceType() == DeviceType::CPU ||
-                c->getDevice()->getDeviceType() == DeviceType::D3D11)
+            if (c->getDevice()->getDeviceType() == DeviceType::D3D11)
                 return;
 
             c->getTextureData(0).checkEqual(c->getTexture(0));

--- a/tests/test-create-texture.cpp
+++ b/tests/test-create-texture.cpp
@@ -13,15 +13,5 @@ GPU_TEST_CASE("texturetest-create", ALL)
     options.addVariants(TTShape::All, TTArray::Both, TTMip::Both, TTMS::Both);
 
 
-    runTextureTest(
-        options,
-        [](TextureTestContext* c)
-        {
-            // read-back not implemented
-            if (c->getDevice()->getDeviceType() == DeviceType::D3D11)
-                return;
-
-            c->getTextureData(0).checkEqual(c->getTexture(0));
-        }
-    );
+    runTextureTest(options, [](TextureTestContext* c) { c->getTextureData(0).checkEqual(c->getTexture(0)); });
 }

--- a/tests/texture-test.cpp
+++ b/tests/texture-test.cpp
@@ -124,6 +124,9 @@ void TextureData::init(IDevice* _device, const TextureDesc& _desc, TextureInitMo
             case rhi::testing::TextureInitMode::Invalid:
                 memset(sr.data.get(), 0xcd, sr.layout.sizeInBytes);
                 break;
+            case rhi::testing::TextureInitMode::MipLevel:
+                memset(sr.data.get(), mipLevel, sr.layout.sizeInBytes);
+                break;
             case rhi::testing::TextureInitMode::Random:
                 std::mt19937 rng(initSeed);
                 std::uniform_int_distribution<int> dist(0, 255);
@@ -269,8 +272,7 @@ void TextureTestOptions::addProcessedVariants(std::vector<VariantGen>& variants)
             TextureTestVariant newVariant;
             for (int i = 0; i < m_numTextures; i++)
             {
-                auto mode = m_initMode ? m_initMode[i] : TextureInitMode::Random;
-                newVariant.descriptors.push_back({desc, mode});
+                newVariant.descriptors.push_back({desc, m_initMode[i]});
             }
             addVariant(newVariant);
         }

--- a/tests/texture-test.h
+++ b/tests/texture-test.h
@@ -14,7 +14,8 @@ enum class TextureInitMode
 {
     Zeros,   // Start with 0s
     Invalid, // Start with 0xcd
-    Random   // Start with deterministic random data
+    Random,  // Start with deterministic random data
+    MipLevel // Set each byte to its mip level
 };
 
 /// CPU equivalent of a texture, along with helpers to create textures
@@ -132,8 +133,25 @@ public:
     TextureTestOptions(IDevice* device, int numTextures = 1, TextureInitMode* initMode = nullptr)
         : m_device(device)
         , m_numTextures(numTextures)
-        , m_initMode(initMode)
     {
+        m_initMode.resize(numTextures);
+        if (initMode)
+        {
+            for (int i = 0; i < numTextures; i++)
+                m_initMode[i] = initMode[i];
+        }
+        else
+        {
+            for (int i = 0; i < numTextures; i++)
+                m_initMode[i] = TextureInitMode::Random;
+        }
+    }
+
+    TextureTestOptions(IDevice* device, TextureInitMode initMode = TextureInitMode::Random)
+        : m_device(device)
+        , m_numTextures(1)
+    {
+        m_initMode.push_back(initMode);
     }
 
     /// Manually add a specific variant.
@@ -164,7 +182,7 @@ public:
 private:
     IDevice* m_device;
     int m_numTextures;
-    TextureInitMode* m_initMode;
+    std::vector<TextureInitMode> m_initMode;
     std::vector<TextureTestVariant> m_variants;
 
 


### PR DESCRIPTION
Fixed up readTexture implementations for cpu + d3d11, and fixed issue with cuda:
- CPU is basically just a better memcpy
- D3D11 now supports creation of textures in staging mode, and uses this to create a single layer staging texture to copy from of the correct size for the subresource
- Removed 3-component formats from CUDA as cuArrayCreate requires 1/2/4 channels.