### PR TITLE
Build presets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,14 +27,15 @@ jobs:
           - { os: macos, compiler: gcc }
         include:
           # Builds running on self-hosted runners (build + tests)
-          - {os: windows, platform: "x86_64", compiler: msvc, flags: "unit-test", runs-on: { group: nvrgfx, labels: [Windows, X64] } }
-          - {os: linux, platform: "x86_64", compiler: gcc, flags: "unit-test", runs-on: { group: nvrgfx, labels: [Linux, X64] } }
+          - {os: windows, platform: "x86_64", compiler: msvc, preset: default, flags: "unit-test", runs-on: { group: nvrgfx, labels: [Windows, X64] } }
+          - {os: linux, platform: "x86_64", compiler: gcc, preset: gcc, flags: "unit-test", runs-on: { group: nvrgfx, labels: [Linux, X64] } }
           # Builds running on GitHub hosted runners (build + tests)
-          - { os: macos, platform: "aarch64", compiler: clang, flags: "unit-test", runs-on: macos-latest }
+          - { os: macos, platform: "aarch64", compiler: clang, preset: default, flags: "unit-test", runs-on: macos-latest }
           # Builds running on GitHub hosted runners (build only)
-          - { os: linux, platform: "x86_64", compiler: clang, runs-on: ubuntu-latest }
-          - { os: windows, platform: "aarch64", runs-on: windows-latest }
-          - { os: linux, platform: "aarch64", runs-on: ubuntu-24.04-arm }
+          - { os: linux, platform: "x86_64", compiler: clang, preset: clang, runs-on: ubuntu-latest }
+          - { os: windows, platform: "aarch64", compiler: msvc, preset: default, runs-on: windows-latest }
+          - { os: linux, platform: "aarch64", compiler: clang, preset: clang, runs-on: ubuntu-24.04-arm }
+          - { os: linux, platform: "aarch64", compiler: gcc, preset: gcc, runs-on: ubuntu-24.04-arm }
 
     runs-on: ${{ matrix.runs-on }}
 
@@ -56,7 +57,7 @@ jobs:
         uses: lukka/get-cmake@latest
 
       - name: Configure
-        run: cmake --preset default -S . -B build
+        run: cmake --preset ${{matrix.preset}} -S . -B build
 
       - name: Build
         run: cmake --build build --config ${{matrix.config}}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,6 +19,6 @@ exclude: |
   (?x)^(
       build/.*|
       external/.*|
-      src/prelude/.*|
+      src/cuda/kernels/.*|
       tools/.*|
   )$

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -403,21 +403,30 @@ target_compile_options(slang-rhi PRIVATE
         /wd4127 # conditional expression is constant
         /wd4389 # signed/unsigned mismatch
     >
-    $<$<CXX_COMPILER_ID:GNU,Clang>:
-        -Wall -Wextra -Wpedantic -Wshadow=local -Werror
+    $<$<CXX_COMPILER_ID:GNU>:
+        -Wall -Wextra -Wpedantic -Werror
+        -Wshadow=local
         -Wno-unused-parameter
         -Wno-missing-field-initializers
         -Wno-sign-compare
     >
+    $<$<CXX_COMPILER_ID:Clang>:
+        -Wall -Wextra -Wpedantic -Werror
+        -Wshadow
+        -Wno-unused-parameter
+        -Wno-missing-field-initializers
+        -Wno-sign-compare
+        -Wno-gnu-zero-variadic-macro-arguments
+    >
     $<$<CXX_COMPILER_ID:AppleClang>:
         -Wall -Wextra -Wpedantic -Werror
+        -Wshadow
         -Wno-unused-parameter
         -Wno-missing-field-initializers
         -Wno-sign-compare
         -Wno-gnu-anonymous-struct
         -Wno-gnu-zero-variadic-macro-arguments
         -Wno-nested-anon-types
-        -Wshadow
     >
 )
 

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -13,6 +13,24 @@
             "binaryDir": "${sourceDir}/build"
         },
         {
+            "name": "gcc",
+            "inherits": "default",
+            "description": "Ninja Multi-Config generator with gcc",
+            "cacheVariables": {
+                "CMAKE_C_COMPILER": "gcc",
+                "CMAKE_CXX_COMPILER": "g++"
+            }
+        },
+        {
+            "name": "clang",
+            "inherits": "default",
+            "description": "Ninja Multi-Config generator with Clang",
+            "cacheVariables": {
+                "CMAKE_C_COMPILER": "clang",
+                "CMAKE_CXX_COMPILER": "clang++"
+            }
+        },
+        {
             "name": "msvc-base",
             "hidden": true,
             "inherits": "default",
@@ -66,6 +84,36 @@
         {
             "name": "RelWithDebInfo",
             "configurePreset": "default",
+            "configuration": "RelWithDebInfo"
+        },
+        {
+            "name": "gcc-Debug",
+            "configurePreset": "gcc",
+            "configuration": "Debug"
+        },
+        {
+            "name": "gcc-Release",
+            "configurePreset": "gcc",
+            "configuration": "Release"
+        },
+        {
+            "name": "gcc-RelWithDebInfo",
+            "configurePreset": "gcc",
+            "configuration": "RelWithDebInfo"
+        },
+        {
+            "name": "clang-Debug",
+            "configurePreset": "clang",
+            "configuration": "Debug"
+        },
+        {
+            "name": "clang-Release",
+            "configurePreset": "clang",
+            "configuration": "Release"
+        },
+        {
+            "name": "clang-RelWithDebInfo",
+            "configurePreset": "clang",
             "configuration": "RelWithDebInfo"
         },
         {

--- a/include/slang-rhi/shader-cursor.h
+++ b/include/slang-rhi/shader-cursor.h
@@ -215,9 +215,8 @@ inline Result ShaderCursor::getField(const char* name, const char* nameEnd, Shad
 
         outCursor = fieldCursor;
         return SLANG_OK;
+        break;
     }
-    break;
-
     // In some cases the user might be trying to acess a field by name
     // from a cursor that references a constant buffer or parameter block,
     // and in these cases we want the access to Just Work.
@@ -231,8 +230,10 @@ inline Result ShaderCursor::getField(const char* name, const char* nameEnd, Shad
         //
         ShaderCursor d = getDereferenced();
         return d.getField(name, nameEnd, outCursor);
+        break;
     }
-    break;
+    default:
+        break;
     }
 
     // If a cursor is pointing at a root shader object (created for a
@@ -340,9 +341,8 @@ inline ShaderCursor ShaderCursor::getElement(uint32_t index) const
         elementCursor.m_offset.bindingArrayIndex =
             m_offset.bindingArrayIndex * (uint32_t)m_typeLayout->getElementCount() + index;
         return elementCursor;
+        break;
     }
-    break;
-
     case slang::TypeReflection::Kind::Struct:
     {
         // The logic here is similar to `getField()` except that we don't
@@ -360,11 +360,9 @@ inline ShaderCursor ShaderCursor::getElement(uint32_t index) const
         fieldCursor.m_offset.bindingRangeIndex =
             m_offset.bindingRangeIndex + (uint32_t)m_typeLayout->getFieldBindingRangeOffset(fieldIndex);
         fieldCursor.m_offset.bindingArrayIndex = m_offset.bindingArrayIndex;
-
         return fieldCursor;
+        break;
     }
-    break;
-
     case slang::TypeReflection::Kind::Vector:
     case slang::TypeReflection::Kind::Matrix:
     {
@@ -376,8 +374,10 @@ inline ShaderCursor ShaderCursor::getElement(uint32_t index) const
         fieldCursor.m_offset.bindingRangeIndex = m_offset.bindingRangeIndex;
         fieldCursor.m_offset.bindingArrayIndex = m_offset.bindingArrayIndex;
         return fieldCursor;
+        break;
     }
-    break;
+    default:
+        break;
     }
 
     return ShaderCursor();

--- a/src/cuda/cuda-device.cpp
+++ b/src/cuda/cuda-device.cpp
@@ -61,7 +61,6 @@ Result DeviceImpl::_findMaxFlopsDeviceIndex(int* outDeviceIndex)
     int smPerMultiproc = 0;
     int maxPerfDevice = -1;
     int deviceCount = 0;
-    int devicesProhibited = 0;
 
     uint64_t maxComputePerf = 0;
     SLANG_CUDA_RETURN_ON_FAIL(cuDeviceGetCount(&deviceCount));
@@ -101,10 +100,6 @@ Result DeviceImpl::_findMaxFlopsDeviceIndex(int* outDeviceIndex)
                 maxComputePerf = compute_perf;
                 maxPerfDevice = currentDevice;
             }
-        }
-        else
-        {
-            devicesProhibited++;
         }
     }
 

--- a/src/cuda/cuda-surface.cpp
+++ b/src/cuda/cuda-surface.cpp
@@ -662,7 +662,6 @@ Result SurfaceImpl::createSharedTexture(SharedTexture& sharedTexture)
     m_api.vkBindImageMemory(m_device, sharedTexture.vulkanImage, sharedTexture.vulkanMemory, 0);
 
     // Create shared handle
-    NativeHandle sharedHandle;
 #if SLANG_WINDOWS_FAMILY
     VkMemoryGetWin32HandleInfoKHR getHandleInfo = {VK_STRUCTURE_TYPE_MEMORY_GET_WIN32_HANDLE_INFO_KHR};
     getHandleInfo.memory = sharedTexture.vulkanMemory;

--- a/tests/test-native-handle.cpp
+++ b/tests/test-native-handle.cpp
@@ -54,6 +54,8 @@ GPU_TEST_CASE("native-handle-buffer", D3D12 | Vulkan | Metal)
         CHECK_NE(handle.value, 0);
         break;
     }
+    default:
+        break;
     }
 }
 
@@ -104,6 +106,8 @@ GPU_TEST_CASE("native-handle-texture", D3D12 | Vulkan | Metal)
         CHECK_NE(handle.value, 0);
         break;
     }
+    default:
+        break;
     }
 }
 
@@ -142,6 +146,8 @@ GPU_TEST_CASE("native-handle-command-queue", D3D12 | Vulkan | Metal)
         CHECK_NE(handle.value, 0);
         break;
     }
+    default:
+        break;
     }
 }
 
@@ -182,5 +188,7 @@ GPU_TEST_CASE("native-handle-command-buffer", D3D12 | Vulkan | Metal)
         CHECK_NE(handle.value, 0);
         break;
     }
+    default:
+        break;
     }
 }


### PR DESCRIPTION
- add support for building with clang
- add `clang` and `gcc` presets to `CMakePresets.json`
- change CI workflow to actually build for different compilers