### PR TITLE
Texture copy tests and fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -679,6 +679,7 @@ if(SLANG_RHI_BUILD_TESTS)
         tests/test-cmd-clear-buffer.cpp
         tests/test-cmd-clear-texture.cpp
         tests/test-cmd-copy-buffer.cpp
+        tests/test-cmd-copy-texture.cpp
         tests/test-cmd-upload-buffer.cpp
         tests/test-cmd-upload-texture.cpp
         tests/test-compute-smoke.cpp

--- a/include/slang-rhi.h
+++ b/include/slang-rhi.h
@@ -723,6 +723,9 @@ struct Offset3D
     {
     }
 
+    bool operator==(const Offset3D& other) const { return x == other.x && y == other.y && z == other.z; }
+    bool operator!=(const Offset3D& other) const { return !(*this == other); }
+
     bool isZero() const { return x == 0 && y == 0 && z == 0; }
 };
 
@@ -741,6 +744,8 @@ struct Extents
     {
         return width == other.width && height == other.height && depth == other.depth;
     }
+
+    inline bool isWholeTexture() const { return *this == kWholeTexture; }
 };
 
 /// Layout of a single subresource in a texture. (see also SubresourceData)

--- a/include/slang-rhi.h
+++ b/include/slang-rhi.h
@@ -754,6 +754,9 @@ struct SubresourceLayout
     /// Dimensions of the subresource (in texels).
     Extents size;
 
+    /// Stride in bytes between columns (i.e. blocks of pixels) of the subresource tensor.
+    Size strideX;
+
     /// Stride in bytes between rows of the subresource tensor.
     Size strideY;
 

--- a/src/d3d/d3d-util.cpp
+++ b/src/d3d/d3d-util.cpp
@@ -610,10 +610,10 @@ uint32_t D3DUtil::getSubresourceIndex(
     uint32_t arrayIndex,
     uint32_t planeIndex,
     uint32_t mipLevelCount,
-    uint32_t arraySize
+    uint32_t layerCount
 )
 {
-    return mipIndex + arrayIndex * mipLevelCount + planeIndex * mipLevelCount * arraySize;
+    return mipIndex + arrayIndex * mipLevelCount + planeIndex * mipLevelCount * layerCount;
 }
 
 uint32_t D3DUtil::getSubresourceMipLevel(uint32_t subresourceIndex, uint32_t mipLevelCount)

--- a/src/d3d/d3d-util.h
+++ b/src/d3d/d3d-util.h
@@ -107,7 +107,7 @@ public:
         uint32_t arrayIndex,
         uint32_t planeIndex,
         uint32_t mipLevelCount,
-        uint32_t arraySize
+        uint32_t layoutCount
     );
 
     static uint32_t getSubresourceMipLevel(uint32_t subresourceIndex, uint32_t mipLevelCount);

--- a/src/d3d12/d3d12-command.cpp
+++ b/src/d3d12/d3d12-command.cpp
@@ -191,8 +191,9 @@ void CommandRecorder::cmdCopyTexture(const commands::CopyTexture& cmd)
     const Offset3D& srcOffset = cmd.srcOffset;
     const Extents& extent = cmd.extent;
 
+    // Fast path for copying whole resource.
     if (dstSubresource.layerCount == 0 && dstSubresource.mipLevelCount == 0 && srcSubresource.layerCount == 0 &&
-        srcSubresource.mipLevelCount == 0)
+        srcSubresource.mipLevelCount == 0 && srcOffset.isZero() && dstOffset.isZero() && extent.isWholeTexture())
     {
         requireTextureState(dst, kEntireTexture, ResourceState::CopyDestination);
         requireTextureState(src, kEntireTexture, ResourceState::CopySource);

--- a/src/debug-layer/debug-command-encoder.cpp
+++ b/src/debug-layer/debug-command-encoder.cpp
@@ -362,6 +362,70 @@ void DebugCommandEncoder::copyTexture(
         return;
     }
 
+    if (srcSubresource.layerCount != dstSubresource.layerCount)
+    {
+        RHI_VALIDATION_ERROR("Src and dest layer count must match.");
+        return;
+    }
+
+    if (srcSubresource.mipLevelCount != dstSubresource.mipLevelCount)
+    {
+        RHI_VALIDATION_ERROR("Src and dest mip level count must match.");
+        return;
+    }
+
+    if (srcSubresource.layerCount == 0 && srcDesc.getLayerCount() != dstDesc.getLayerCount())
+    {
+        RHI_VALIDATION_ERROR("Copy layer count is 0, so src and dest texture layer count must match.");
+        return;
+    }
+
+    if (srcSubresource.mipLevelCount == 0 && srcDesc.mipLevelCount != dstDesc.mipLevelCount)
+    {
+        RHI_VALIDATION_ERROR("Copy mip level count is 0, so src and dest texture mip level count must match.");
+        return;
+    }
+
+    if (srcSubresource.mipLevelCount != 1)
+    {
+        if (!srcOffset.isZero() || !dstOffset.isZero())
+        {
+            RHI_VALIDATION_ERROR("Copying multiple mip levels at once requires offset to be 0");
+            return;
+        }
+
+        if (!extent.isWholeTexture())
+        {
+            RHI_VALIDATION_ERROR("Copying multiple mip levels at once requires extent to be Extents::WholeTexture");
+            return;
+        }
+    }
+
+    if (extent.width == kRemainingTextureSize)
+    {
+        if (srcOffset.x != dstOffset.x)
+        {
+            RHI_VALIDATION_ERROR("Copying the remaining texture requires src and dst offset to be the same");
+            return;
+        }
+    }
+    if (extent.height == kRemainingTextureSize)
+    {
+        if (srcOffset.y != dstOffset.y)
+        {
+            RHI_VALIDATION_ERROR("Copying the remaining texture requires src and dst offset to be the same");
+            return;
+        }
+    }
+    if (extent.depth == kRemainingTextureSize)
+    {
+        if (srcOffset.z != dstOffset.z)
+        {
+            RHI_VALIDATION_ERROR("Copying the remaining texture requires src and dst offset to be the same");
+            return;
+        }
+    }
+
     baseObject->copyTexture(dst, dstSubresource, dstOffset, src, srcSubresource, srcOffset, extent);
 }
 

--- a/src/debug-layer/debug-command-encoder.cpp
+++ b/src/debug-layer/debug-command-encoder.cpp
@@ -426,6 +426,18 @@ void DebugCommandEncoder::copyTexture(
         }
     }
 
+    if ((srcDesc.type == TextureType::Texture3D) ^ (dstDesc.type == TextureType::Texture3D))
+    {
+        if (getFormatInfo(srcDesc.format).blockSizeInBytes == 12 ||
+            getFormatInfo(dstDesc.format).blockSizeInBytes == 12)
+        {
+            RHI_VALIDATION_ERROR(
+                "Copying individual slices of 3D textures with 12B formats is disabled due to poor D3D12 support."
+            );
+            return;
+        }
+    }
+
     baseObject->copyTexture(dst, dstSubresource, dstOffset, src, srcSubresource, srcOffset, extent);
 }
 

--- a/src/rhi-shared.cpp
+++ b/src/rhi-shared.cpp
@@ -109,6 +109,7 @@ Result calcSubresourceRegionLayout(
     size_t layerPitch = rowPitch * rowCount;
 
     outLayout->size = extents;
+    outLayout->strideX = formatInfo.blockSizeInBytes;
     outLayout->strideY = rowPitch;
     outLayout->strideZ = layerPitch;
     outLayout->sizeInBytes = layerPitch * extents.depth;

--- a/tests/test-cmd-copy-texture.cpp
+++ b/tests/test-cmd-copy-texture.cpp
@@ -8,7 +8,7 @@
 using namespace rhi;
 using namespace rhi::testing;
 
-GPU_TEST_CASE("cmd-copy-texture-full", D3D12 | Vulkan | Metal | CUDA | WGPU)
+GPU_TEST_CASE("cmd-copy-texture-full", D3D12 | Vulkan | WGPU)
 {
     TextureTestOptions options(device);
     options.addVariants(TTShape::All, TTArray::Both, TTMip::Both, TTMS::Both);

--- a/tests/test-cmd-copy-texture.cpp
+++ b/tests/test-cmd-copy-texture.cpp
@@ -72,7 +72,7 @@ GPU_TEST_CASE("cmd-copy-texture-arrayrange", D3D12 | Vulkan | WGPU)
             // Get cpu side data.
             TextureData& data = c->getTextureData();
 
-            fprintf(stderr, "Uploading texture %s\n", c->getTexture()->getDesc().label);
+            // fprintf(stderr, "Uploading texture %s\n", c->getTexture()->getDesc().label);
 
             // Create a new, random texture with same descriptor
             TextureData newData;
@@ -193,13 +193,15 @@ GPU_TEST_CASE("cmd-copy-texture-fromarray", D3D12 | Vulkan | WGPU)
             newDesc.arrayLength = 1;
             REQUIRE(getScalarType(data.desc.type, newDesc.type));
             TextureData newData;
-            newData.init(device, data.desc, TextureInitMode::None);
+            newData.init(device, newDesc, TextureInitMode::None);
             ComPtr<ITexture> newTexture;
             REQUIRE_CALL(newData.createTexture(newTexture.writeRef()));
 
             // Create command encoder
             auto queue = device->getQueue(QueueType::Graphics);
             auto commandEncoder = queue->createCommandEncoder();
+
+            // fprintf(stderr, "Copy:\n\t%s\n\t%s\n", newTexture->getDesc().label, c->getTexture()->getDesc().label);
 
             // Copy from layer 2 into layer 0
             commandEncoder->copyTexture(
@@ -241,13 +243,15 @@ GPU_TEST_CASE("cmd-copy-texture-toarray", D3D12 | Vulkan | WGPU)
             newDesc.arrayLength = 1;
             REQUIRE(getScalarType(data.desc.type, newDesc.type));
             TextureData newData;
-            newData.init(device, data.desc, TextureInitMode::Random);
+            newData.init(device, newDesc, TextureInitMode::Random);
             ComPtr<ITexture> newTexture;
             REQUIRE_CALL(newData.createTexture(newTexture.writeRef()));
 
             // Create command encoder
             auto queue = device->getQueue(QueueType::Graphics);
             auto commandEncoder = queue->createCommandEncoder();
+
+            // fprintf(stderr, "Copy:\n\t%s\n\t%s\n", newTexture->getDesc().label, c->getTexture()->getDesc().label);
 
             // Copy from layer 0 of the new texture into layer 2
             // of the one allocated by the testing system.
@@ -264,6 +268,111 @@ GPU_TEST_CASE("cmd-copy-texture-toarray", D3D12 | Vulkan | WGPU)
 
             // Check layers now match.
             newData.checkLayersEqual(c->getTexture(), 0, 2);
+        }
+    );
+}
+
+GPU_TEST_CASE("cmd-copy-texture-fromslice", D3D12 | Vulkan | WGPU)
+{
+    TextureTestOptions options(device);
+    options.addVariants(TTShape::D3, TTArray::Off, TTMip::Both, TTFmtDepth::Off);
+
+    runTextureTest(
+        options,
+        [](TextureTestContext* c)
+        {
+            auto device = c->getDevice();
+
+            // Get cpu side data.
+            TextureData& data = c->getTextureData();
+
+            // Currently slice copies of 12B formats is disabled due to poor D3D12 support.
+            if (data.formatInfo.blockSizeInBytes == 12)
+                return;
+
+            // Create a new, uninitialized 2d texture with the
+            // same width/height.
+            TextureDesc newDesc = data.desc;
+            newDesc.type = TextureType::Texture2D;
+            newDesc.size.depth = 1;
+            TextureData newData;
+            newData.init(device, newDesc, TextureInitMode::Invalid);
+            ComPtr<ITexture> newTexture;
+            REQUIRE_CALL(newData.createTexture(newTexture.writeRef()));
+
+            // Create command encoder
+            auto queue = device->getQueue(QueueType::Graphics);
+            auto commandEncoder = queue->createCommandEncoder();
+
+            // fprintf(stderr, "Copy:\n\t%s\n\t%s\n", newTexture->getDesc().label, c->getTexture()->getDesc().label);
+
+            // Copy 1 slice with a depth offset
+            commandEncoder->copyTexture(
+                newTexture,
+                {0, 1, 0, 1},
+                {0, 0, 0},
+                c->getTexture(),
+                {0, 1, 0, 1},
+                {0, 0, 1},
+                {kRemainingTextureSize, kRemainingTextureSize, 1}
+            );
+            queue->submit(commandEncoder->finish());
+
+            // Check the slice now matches the texture.
+            data.checkSliceEqual(newTexture, 0, 0, 1, 0, 0);
+        }
+    );
+}
+
+GPU_TEST_CASE("cmd-copy-texture-arrayfromslice", D3D12 | Vulkan | WGPU)
+{
+    TextureTestOptions options(device);
+    options.addVariants(TTShape::D3, TTArray::Off, TTMip::Both, TTFmtDepth::Off);
+
+    runTextureTest(
+        options,
+        [](TextureTestContext* c)
+        {
+            auto device = c->getDevice();
+
+            // Get cpu side data.
+            TextureData& data = c->getTextureData();
+
+            // Currently slice copies of 12B formats is disabled due to poor D3D12 support.
+            if (data.formatInfo.blockSizeInBytes == 12)
+                return;
+
+            // Create a new, uninitialized 2d array texture with the
+            // same width/height.
+            TextureDesc newDesc = data.desc;
+            newDesc.type = TextureType::Texture2DArray;
+            newDesc.size.depth = 1;
+            newDesc.arrayLength = 4;
+            TextureData newData;
+            newData.init(device, newDesc, TextureInitMode::Invalid);
+            ComPtr<ITexture> newTexture;
+            REQUIRE_CALL(newData.createTexture(newTexture.writeRef()));
+
+            // Create command encoder
+            auto queue = device->getQueue(QueueType::Graphics);
+            auto commandEncoder = queue->createCommandEncoder();
+
+            // fprintf(stderr, "Copy:\n\t%s\n\t%s\n", newTexture->getDesc().label, c->getTexture()->getDesc().label);
+
+            // Copy 1 slice with a depth offset
+            commandEncoder->copyTexture(
+                newTexture,
+                {0, 1, 2, 1},
+                {0, 0, 0},
+                c->getTexture(),
+                {0, 1, 0, 1},
+                {0, 0, 1},
+                {kRemainingTextureSize, kRemainingTextureSize, 1}
+            );
+            queue->submit(commandEncoder->finish());
+
+            // Check the slice now matches the texture.
+            data.checkSliceEqual(newTexture, 0, 0, 1, 2, 0);
         }
     );
 }

--- a/tests/test-cmd-copy-texture.cpp
+++ b/tests/test-cmd-copy-texture.cpp
@@ -1,0 +1,57 @@
+#include "testing.h"
+
+#include "texture-utils.h"
+#include "texture-test.h"
+
+#include "core/common.h"
+
+using namespace rhi;
+using namespace rhi::testing;
+
+GPU_TEST_CASE("cmd-copy-texture-full", D3D12 | Vulkan | Metal | CUDA | WGPU)
+{
+    TextureTestOptions options(device);
+    options.addVariants(TTShape::All, TTArray::Both, TTMip::Both, TTMS::Both);
+
+    runTextureTest(
+        options,
+        [](TextureTestContext* c)
+        {
+            auto device = c->getDevice();
+
+            // Get cpu side data.
+            TextureData& data = c->getTextureData();
+
+            // Create a new, uninitialized texture with same descriptor
+            TextureData newData;
+            newData.init(device, data.desc, TextureInitMode::None);
+            ComPtr<ITexture> newTexture;
+            REQUIRE_CALL(newData.createTexture(newTexture.writeRef()));
+
+            // Create command encoder
+            auto queue = device->getQueue(QueueType::Graphics);
+            auto commandEncoder = queue->createCommandEncoder();
+
+            // Copy all subresources with offsets at 0 and size of whole texture.
+            commandEncoder->copyTexture(
+                newTexture,
+                {0, 0, 0, 0},
+                {0, 0, 0},
+                c->getTexture(),
+                {0, 0, 0, 0},
+                {0, 0, 0},
+                Extents::kWholeTexture
+            );
+            queue->submit(commandEncoder->finish());
+
+            // Can't read-back ms or depth/stencil formats
+            if (isMultisamplingType(data.desc.type))
+                return;
+            if (data.formatInfo.hasDepth && data.formatInfo.hasStencil)
+                return;
+
+            // Verify it uploaded correctly
+            data.checkEqual(newTexture);
+        }
+    );
+}

--- a/tests/test-cmd-copy-texture.cpp
+++ b/tests/test-cmd-copy-texture.cpp
@@ -2,6 +2,8 @@
 
 #include "texture-utils.h"
 #include "texture-test.h"
+#include "resource-desc-utils.h"
+
 
 #include "core/common.h"
 
@@ -52,6 +54,123 @@ GPU_TEST_CASE("cmd-copy-texture-full", D3D12 | Vulkan | WGPU)
 
             // Verify it uploaded correctly
             data.checkEqual(newTexture);
+        }
+    );
+}
+
+GPU_TEST_CASE("cmd-copy-texture-arrayrange", D3D12 | Vulkan | WGPU)
+{
+    TextureTestOptions options(device);
+    options.addVariants(TTShape::All, TTArray::On, TTMip::Both, TTFmtDepth::Off);
+
+    runTextureTest(
+        options,
+        [](TextureTestContext* c)
+        {
+            auto device = c->getDevice();
+
+            // Get cpu side data.
+            TextureData& data = c->getTextureData();
+
+            fprintf(stderr, "Uploading texture %s\n", c->getTexture()->getDesc().label);
+
+            // Create a new, uninitialized texture with same descriptor
+            TextureData newData;
+            newData.init(device, data.desc, TextureInitMode::Random, 1323);
+            ComPtr<ITexture> newTexture;
+            REQUIRE_CALL(newData.createTexture(newTexture.writeRef()));
+
+            // Create command encoder
+            auto queue = device->getQueue(QueueType::Graphics);
+            auto commandEncoder = queue->createCommandEncoder();
+
+            uint32_t halfLayerCount = data.desc.arrayLength / 2;
+
+            // Copy the 1st half of the layers to the 2nd half
+            commandEncoder->copyTexture(
+                newTexture,
+                {0, 0, 0, halfLayerCount},
+                {0, 0, 0},
+                c->getTexture(),
+                {0, 0, halfLayerCount, halfLayerCount},
+                {0, 0, 0},
+                Extents::kWholeTexture
+            );
+            queue->submit(commandEncoder->finish());
+
+            // Verify 1st half of layers are stomped over by 2nd half
+            // of the source texture.
+            for (uint32_t i = 0; i < halfLayerCount; i++)
+            {
+                // 1st half should be equal to 2nd half of source
+                data.checkLayersEqual(newTexture, i + halfLayerCount, i);
+
+                // 2nd half should be unchanged
+                newData.checkLayersEqual(newTexture, i + halfLayerCount, i + halfLayerCount);
+            }
+        }
+    );
+}
+
+GPU_TEST_CASE("cmd-copy-texture-miprange", D3D12 | Vulkan | WGPU)
+{
+    TextureTestOptions options(device);
+    options.addVariants(TTShape::All, TTArray::Both, TTMip::On, TTFmtDepth::Off);
+
+    runTextureTest(
+        options,
+        [](TextureTestContext* c)
+        {
+            auto device = c->getDevice();
+
+            // Get cpu side data.
+            TextureData& data = c->getTextureData();
+
+            fprintf(stderr, "Uploading texture %s\n", c->getTexture()->getDesc().label);
+
+            // Create a new, uninitialized texture with same descriptor
+            TextureData newData;
+            newData.init(device, data.desc, TextureInitMode::Random, 1323);
+            ComPtr<ITexture> newTexture;
+            REQUIRE_CALL(newData.createTexture(newTexture.writeRef()));
+
+            // Create command encoder
+            auto queue = device->getQueue(QueueType::Graphics);
+            auto commandEncoder = queue->createCommandEncoder();
+
+            uint32_t halfMipCount = calcMipLevelCount(data.desc) / 2;
+
+            // Copy the 1st half of the mips for all layers
+            commandEncoder->copyTexture(
+                newTexture,
+                {0, halfMipCount, 0, 0},
+                {0, 0, 0},
+                c->getTexture(),
+                {0, halfMipCount, 0, 0},
+                {0, 0, 0},
+                Extents::kWholeTexture
+            );
+            queue->submit(commandEncoder->finish());
+
+            // Verify 1st half of layers are stomped over by 2nd half
+            // of the source texture.
+            for (uint32_t layer = 0; layer < data.desc.getLayerCount(); layer++)
+            {
+                for (uint32_t mipLevel = 0; mipLevel < halfMipCount; mipLevel++)
+                {
+                    // 1st half should be the copy
+                    data.checkMipLevelsEqual(newTexture, layer, mipLevel, layer, mipLevel);
+
+                    // 2nd half should be unchanged
+                    newData.checkMipLevelsEqual(
+                        newTexture,
+                        layer,
+                        mipLevel + halfMipCount,
+                        layer,
+                        mipLevel + halfMipCount
+                    );
+                }
+            }
         }
     );
 }

--- a/tests/test-cmd-upload-texture.cpp
+++ b/tests/test-cmd-upload-texture.cpp
@@ -333,18 +333,3 @@ GPU_TEST_CASE("cmd-upload-texture-mipsizeoffset", D3D12 | Vulkan | Metal | CUDA 
         }
     );
 }
-
-/*
-GPU_TEST_CASE("cmd-upload-texture-array", D3D12 | Vulkan | WGPU)
-{
-    testUploadTexture<ArrayUploadTexture>(device);
-}
-GPU_TEST_CASE("cmd-upload-texture-mips", D3D12 | Vulkan | WGPU)
-{
-    testUploadTexture<MipsUploadTexture>(device);
-}
-GPU_TEST_CASE("cmd-upload-texture-arraymips", D3D12 | Vulkan | WGPU)
-{
-    testUploadTexture<ArrayMipsUploadTexture>(device);
-}
-*/

--- a/tests/test-cmd-upload-texture.cpp
+++ b/tests/test-cmd-upload-texture.cpp
@@ -208,8 +208,8 @@ GPU_TEST_CASE("cmd-upload-texture-offset", D3D12 | Vulkan | Metal | CUDA | WGPU)
 
             // Verify region. The inverse region should be the same as the original data,
             // and the interior of the region should match the new data.
-            currentData.checkEqual(c->getTexture(), offset, Extents::kWholeTexture, true);
-            newData.checkEqual(c->getTexture(), offset, Extents::kWholeTexture, false);
+            currentData.checkEqual(offset, c->getTexture(), offset, Extents::kWholeTexture, true);
+            newData.checkEqual({0, 0, 0}, c->getTexture(), offset, Extents::kWholeTexture, false);
         }
     );
 }
@@ -261,8 +261,8 @@ GPU_TEST_CASE("cmd-upload-texture-sizeoffset", D3D12 | Vulkan | Metal | CUDA | W
 
             // Verify region. The inverse region should be the same as the original data,
             // and the interior of the region should match the new data.
-            currentData.checkEqual(c->getTexture(), offset, extents, true);
-            newData.checkEqual(c->getTexture(), offset, extents, false);
+            currentData.checkEqual(offset, c->getTexture(), offset, extents, true);
+            newData.checkEqual({0, 0, 0}, c->getTexture(), offset, extents, false);
         }
     );
 }
@@ -328,8 +328,8 @@ GPU_TEST_CASE("cmd-upload-texture-mipsizeoffset", D3D12 | Vulkan | Metal | CUDA 
 
             // Verify region. The inverse region should be the same as the original data,
             // and the interior of the region should match the new data.
-            currentData.checkMipLevelsEqual(c->getTexture(), 0, 1, 0, 1, offset, extents, true);
-            newData.checkMipLevelsEqual(c->getTexture(), 0, 0, 0, 1, offset, extents, false);
+            currentData.checkMipLevelsEqual(c->getTexture(), 0, 1, offset, 0, 1, offset, extents, true);
+            newData.checkMipLevelsEqual(c->getTexture(), 0, 0, {0, 0, 0}, 0, 1, offset, extents, false);
         }
     );
 }

--- a/tests/test-texture-layout.cpp
+++ b/tests/test-texture-layout.cpp
@@ -26,6 +26,7 @@ void testTextureLayout(
     CHECK_EQ(layout.size.height, expectedLayout.size.height);
     CHECK_EQ(layout.size.depth, expectedLayout.size.depth);
     CHECK_EQ(layout.sizeInBytes, expectedLayout.sizeInBytes);
+    CHECK_EQ(layout.strideX, expectedLayout.strideX);
     CHECK_EQ(layout.strideY, expectedLayout.strideY);
     CHECK_EQ(layout.strideZ, expectedLayout.strideZ);
 }
@@ -67,7 +68,7 @@ GPU_TEST_CASE("texture-layout-1d-nomip", ALL_TEX)
     ComPtr<ITexture> texture;
     REQUIRE_CALL(device->createTexture(desc, nullptr, texture.writeRef()));
 
-    testTextureLayout(device, texture, 0, 0, {256, 1, 1, 1024, 1024, 1024});
+    testTextureLayout(device, texture, 0, 0, {256, 1, 1, 4, 1024, 1024, 1024});
 }
 
 // Checks layout adheres to the known 256B alignment of D3D12 and WGPU
@@ -85,7 +86,7 @@ GPU_TEST_CASE("texture-layout-1d-nomip-alignment", D3D12 | WGPU)
     ComPtr<ITexture> texture;
     REQUIRE_CALL(device->createTexture(desc, nullptr, texture.writeRef()));
 
-    testTextureLayout(device, texture, 0, 0, {4, 1, 1, 256, 256, 256});
+    testTextureLayout(device, texture, 0, 0, {4, 1, 1, 4, 256, 256, 256});
 }
 
 // Metal doesn't support 1D textures with mip maps.
@@ -103,8 +104,8 @@ GPU_TEST_CASE("texture-layout-1d-mips", ALL_TEX & ~WGPU & ~Metal)
     ComPtr<ITexture> texture;
     REQUIRE_CALL(device->createTexture(desc, nullptr, texture.writeRef()));
 
-    testTextureLayout(device, texture, 0, 0, {256, 1, 1, 1024, 1024, 1024});
-    testTextureLayout(device, texture, 0, 1, {128, 1, 1, 512, 512, 512});
+    testTextureLayout(device, texture, 0, 0, {256, 1, 1, 4, 1024, 1024, 1024});
+    testTextureLayout(device, texture, 0, 1, {128, 1, 1, 4, 512, 512, 512});
 }
 
 GPU_TEST_CASE("texture-layout-1d-region", ALL_TEX)
@@ -121,7 +122,7 @@ GPU_TEST_CASE("texture-layout-1d-region", ALL_TEX)
     ComPtr<ITexture> texture;
     REQUIRE_CALL(device->createTexture(desc, nullptr, texture.writeRef()));
 
-    testTextureLayout2(device, texture, 0, 0, {16, 0, 0}, {64, 1, 1}, {64, 1, 1, 256, 256, 256});
+    testTextureLayout2(device, texture, 0, 0, {16, 0, 0}, {64, 1, 1}, {64, 1, 1, 4, 256, 256, 256});
 }
 
 // Restrict to D3D12/WGPU as alignment needs accounting for
@@ -139,7 +140,15 @@ GPU_TEST_CASE("texture-layout-1d-region-rts", D3D12 | WGPU)
     ComPtr<ITexture> texture;
     REQUIRE_CALL(device->createTexture(desc, nullptr, texture.writeRef()));
 
-    testTextureLayout2(device, texture, 0, 0, {16, 0, 0}, {kRemainingTextureSize, 1, 1}, {240, 1, 1, 1024, 1024, 1024});
+    testTextureLayout2(
+        device,
+        texture,
+        0,
+        0,
+        {16, 0, 0},
+        {kRemainingTextureSize, 1, 1},
+        {240, 1, 1, 4, 1024, 1024, 1024}
+    );
 }
 
 GPU_TEST_CASE("texture-layout-1darray-nomip", ALL_TEX & ~CUDA & ~WGPU)
@@ -156,8 +165,8 @@ GPU_TEST_CASE("texture-layout-1darray-nomip", ALL_TEX & ~CUDA & ~WGPU)
     ComPtr<ITexture> texture;
     REQUIRE_CALL(device->createTexture(desc, nullptr, texture.writeRef()));
 
-    testTextureLayout(device, texture, 0, 0, {256, 1, 1, 1024, 1024, 1024});
-    testTextureLayout(device, texture, 3, 0, {256, 1, 1, 1024, 1024, 1024});
+    testTextureLayout(device, texture, 0, 0, {256, 1, 1, 4, 1024, 1024, 1024});
+    testTextureLayout(device, texture, 3, 0, {256, 1, 1, 4, 1024, 1024, 1024});
 }
 
 // Metal doesn't support 1D textures with mip maps.
@@ -175,10 +184,10 @@ GPU_TEST_CASE("texture-layout-1darray-mips", ALL_TEX & ~CUDA & ~WGPU & ~Metal)
     ComPtr<ITexture> texture;
     REQUIRE_CALL(device->createTexture(desc, nullptr, texture.writeRef()));
 
-    testTextureLayout(device, texture, 0, 0, {256, 1, 1, 1024, 1024, 1024});
-    testTextureLayout(device, texture, 0, 1, {128, 1, 1, 512, 512, 512});
-    testTextureLayout(device, texture, 3, 0, {256, 1, 1, 1024, 1024, 1024});
-    testTextureLayout(device, texture, 3, 1, {128, 1, 1, 512, 512, 512});
+    testTextureLayout(device, texture, 0, 0, {256, 1, 1, 4, 1024, 1024, 1024});
+    testTextureLayout(device, texture, 0, 1, {128, 1, 1, 4, 512, 512, 512});
+    testTextureLayout(device, texture, 3, 0, {256, 1, 1, 4, 1024, 1024, 1024});
+    testTextureLayout(device, texture, 3, 1, {128, 1, 1, 4, 512, 512, 512});
 }
 
 GPU_TEST_CASE("texture-layout-2d-nomip", ALL_TEX)
@@ -195,7 +204,7 @@ GPU_TEST_CASE("texture-layout-2d-nomip", ALL_TEX)
     ComPtr<ITexture> texture;
     REQUIRE_CALL(device->createTexture(desc, nullptr, texture.writeRef()));
 
-    testTextureLayout(device, texture, 0, 0, {256, 32, 1, 1024, 1024 * 32, 1024 * 32});
+    testTextureLayout(device, texture, 0, 0, {256, 32, 1, 4, 1024, 1024 * 32, 1024 * 32});
 }
 
 GPU_TEST_CASE("texture-layout-2d-region", ALL_TEX)
@@ -212,7 +221,7 @@ GPU_TEST_CASE("texture-layout-2d-region", ALL_TEX)
     ComPtr<ITexture> texture;
     REQUIRE_CALL(device->createTexture(desc, nullptr, texture.writeRef()));
 
-    testTextureLayout2(device, texture, 0, 0, {16, 8, 0}, {64, 16, 1}, {64, 16, 1, 256, 256 * 16, 256 * 16});
+    testTextureLayout2(device, texture, 0, 0, {16, 8, 0}, {64, 16, 1}, {64, 16, 1, 4, 256, 256 * 16, 256 * 16});
 }
 
 GPU_TEST_CASE("texture-layout-2d-mip", ALL_TEX)
@@ -229,8 +238,8 @@ GPU_TEST_CASE("texture-layout-2d-mip", ALL_TEX)
     ComPtr<ITexture> texture;
     REQUIRE_CALL(device->createTexture(desc, nullptr, texture.writeRef()));
 
-    testTextureLayout(device, texture, 0, 0, {256, 32, 1, 1024, 1024 * 32, 1024 * 32});
-    testTextureLayout(device, texture, 0, 1, {128, 16, 1, 512, 512 * 16, 512 * 16});
+    testTextureLayout(device, texture, 0, 0, {256, 32, 1, 4, 1024, 1024 * 32, 1024 * 32});
+    testTextureLayout(device, texture, 0, 1, {128, 16, 1, 4, 512, 512 * 16, 512 * 16});
 }
 
 GPU_TEST_CASE("texture-layout-2d-array-nomip", ALL_TEX & ~CUDA)
@@ -247,8 +256,8 @@ GPU_TEST_CASE("texture-layout-2d-array-nomip", ALL_TEX & ~CUDA)
     ComPtr<ITexture> texture;
     REQUIRE_CALL(device->createTexture(desc, nullptr, texture.writeRef()));
 
-    testTextureLayout(device, texture, 0, 0, {256, 32, 1, 1024, 1024 * 32, 1024 * 32});
-    testTextureLayout(device, texture, 3, 0, {256, 32, 1, 1024, 1024 * 32, 1024 * 32});
+    testTextureLayout(device, texture, 0, 0, {256, 32, 1, 4, 1024, 1024 * 32, 1024 * 32});
+    testTextureLayout(device, texture, 3, 0, {256, 32, 1, 4, 1024, 1024 * 32, 1024 * 32});
 }
 
 GPU_TEST_CASE("texture-layout-2d-array-mips", ALL_TEX & ~CUDA)
@@ -265,10 +274,10 @@ GPU_TEST_CASE("texture-layout-2d-array-mips", ALL_TEX & ~CUDA)
     ComPtr<ITexture> texture;
     REQUIRE_CALL(device->createTexture(desc, nullptr, texture.writeRef()));
 
-    testTextureLayout(device, texture, 0, 0, {256, 32, 1, 1024, 1024 * 32, 1024 * 32});
-    testTextureLayout(device, texture, 0, 1, {128, 16, 1, 512, 512 * 16, 512 * 16});
-    testTextureLayout(device, texture, 3, 0, {256, 32, 1, 1024, 1024 * 32, 1024 * 32});
-    testTextureLayout(device, texture, 3, 1, {128, 16, 1, 512, 512 * 16, 512 * 16});
+    testTextureLayout(device, texture, 0, 0, {256, 32, 1, 4, 1024, 1024 * 32, 1024 * 32});
+    testTextureLayout(device, texture, 0, 1, {128, 16, 1, 4, 512, 512 * 16, 512 * 16});
+    testTextureLayout(device, texture, 3, 0, {256, 32, 1, 4, 1024, 1024 * 32, 1024 * 32});
+    testTextureLayout(device, texture, 3, 1, {128, 16, 1, 4, 512, 512 * 16, 512 * 16});
 }
 
 GPU_TEST_CASE("texture-layout-3d-nomip", ALL_TEX)
@@ -285,7 +294,7 @@ GPU_TEST_CASE("texture-layout-3d-nomip", ALL_TEX)
     ComPtr<ITexture> texture;
     REQUIRE_CALL(device->createTexture(desc, nullptr, texture.writeRef()));
 
-    testTextureLayout(device, texture, 0, 0, {256, 32, 16, 1024, 1024 * 32, 1024 * 32 * 16});
+    testTextureLayout(device, texture, 0, 0, {256, 32, 16, 4, 1024, 1024 * 32, 1024 * 32 * 16});
 }
 
 GPU_TEST_CASE("texture-layout-3d-region", ALL_TEX)
@@ -302,7 +311,7 @@ GPU_TEST_CASE("texture-layout-3d-region", ALL_TEX)
     ComPtr<ITexture> texture;
     REQUIRE_CALL(device->createTexture(desc, nullptr, texture.writeRef()));
 
-    testTextureLayout2(device, texture, 0, 0, {16, 8, 4}, {64, 16, 8}, {64, 16, 8, 256, 256 * 16, 256 * 16 * 8});
+    testTextureLayout2(device, texture, 0, 0, {16, 8, 4}, {64, 16, 8}, {64, 16, 8, 4, 256, 256 * 16, 256 * 16 * 8});
 }
 
 
@@ -320,8 +329,8 @@ GPU_TEST_CASE("texture-layout-3d-mip", ALL_TEX)
     ComPtr<ITexture> texture;
     REQUIRE_CALL(device->createTexture(desc, nullptr, texture.writeRef()));
 
-    testTextureLayout(device, texture, 0, 0, {256, 32, 16, 1024, 1024 * 32, 1024 * 32 * 16});
-    testTextureLayout(device, texture, 0, 1, {128, 16, 8, 512, 512 * 16, 512 * 16 * 8});
+    testTextureLayout(device, texture, 0, 0, {256, 32, 16, 4, 1024, 1024 * 32, 1024 * 32 * 16});
+    testTextureLayout(device, texture, 0, 1, {128, 16, 8, 4, 512, 512 * 16, 512 * 16 * 8});
 }
 
 GPU_TEST_CASE("texture-layout-cube-nomip", ALL_TEX)
@@ -338,7 +347,7 @@ GPU_TEST_CASE("texture-layout-cube-nomip", ALL_TEX)
     ComPtr<ITexture> texture;
     REQUIRE_CALL(device->createTexture(desc, nullptr, texture.writeRef()));
 
-    testTextureLayout(device, texture, 0, 0, {256, 256, 1, 1024, 1024 * 256, 1024 * 256});
+    testTextureLayout(device, texture, 0, 0, {256, 256, 1, 4, 1024, 1024 * 256, 1024 * 256});
 }
 
 GPU_TEST_CASE("texture-layout-cube-mip", ALL_TEX)
@@ -355,8 +364,8 @@ GPU_TEST_CASE("texture-layout-cube-mip", ALL_TEX)
     ComPtr<ITexture> texture;
     REQUIRE_CALL(device->createTexture(desc, nullptr, texture.writeRef()));
 
-    testTextureLayout(device, texture, 0, 0, {256, 256, 1, 1024, 1024 * 256, 1024 * 256});
-    testTextureLayout(device, texture, 0, 1, {128, 128, 1, 512, 512 * 128, 512 * 128});
+    testTextureLayout(device, texture, 0, 0, {256, 256, 1, 4, 1024, 1024 * 256, 1024 * 256});
+    testTextureLayout(device, texture, 0, 1, {128, 128, 1, 4, 512, 512 * 128, 512 * 128});
 }
 
 GPU_TEST_CASE("texture-layout-cube-array-nomip", ALL_TEX & ~CUDA)
@@ -373,8 +382,8 @@ GPU_TEST_CASE("texture-layout-cube-array-nomip", ALL_TEX & ~CUDA)
     ComPtr<ITexture> texture;
     REQUIRE_CALL(device->createTexture(desc, nullptr, texture.writeRef()));
 
-    testTextureLayout(device, texture, 0, 0, {256, 256, 1, 1024, 1024 * 256, 1024 * 256});
-    testTextureLayout(device, texture, 3 * 6, 0, {256, 256, 1, 1024, 1024 * 256, 1024 * 256});
+    testTextureLayout(device, texture, 0, 0, {256, 256, 1, 4, 1024, 1024 * 256, 1024 * 256});
+    testTextureLayout(device, texture, 3 * 6, 0, {256, 256, 1, 4, 1024, 1024 * 256, 1024 * 256});
 }
 
 GPU_TEST_CASE("texture-layout-cube-array-mips", ALL_TEX & ~CUDA)
@@ -391,8 +400,8 @@ GPU_TEST_CASE("texture-layout-cube-array-mips", ALL_TEX & ~CUDA)
     ComPtr<ITexture> texture;
     REQUIRE_CALL(device->createTexture(desc, nullptr, texture.writeRef()));
 
-    testTextureLayout(device, texture, 0, 0, {256, 256, 1, 1024, 1024 * 256, 1024 * 256});
-    testTextureLayout(device, texture, 0, 1, {128, 128, 1, 512, 512 * 128, 512 * 128});
-    testTextureLayout(device, texture, 3 * 6, 0, {256, 256, 1, 1024, 1024 * 256, 1024 * 256});
-    testTextureLayout(device, texture, 3 * 6, 1, {128, 128, 1, 512, 512 * 128, 512 * 128});
+    testTextureLayout(device, texture, 0, 0, {256, 256, 1, 4, 1024, 1024 * 256, 1024 * 256});
+    testTextureLayout(device, texture, 0, 1, {128, 128, 1, 4, 512, 512 * 128, 512 * 128});
+    testTextureLayout(device, texture, 3 * 6, 0, {256, 256, 1, 4, 1024, 1024 * 256, 1024 * 256});
+    testTextureLayout(device, texture, 3 * 6, 1, {128, 128, 1, 4, 512, 512 * 128, 512 * 128});
 }

--- a/tests/texture-test.cpp
+++ b/tests/texture-test.cpp
@@ -256,6 +256,22 @@ void checkRegionsEqual(
     Extents extents
 )
 {
+    /*
+    fprintf(
+        stderr,
+        "    Oa: [%d,%d,%d], Ob: [%d,%d,%d], Ex: [%d,%d,%d]\n",
+        offsetA.x,
+        offsetA.y,
+        offsetA.z,
+        offsetB.x,
+        offsetB.y,
+        offsetB.z,
+        extents.width,
+        extents.height,
+        extents.depth
+    );
+    */
+
     const uint8_t* dataA = (const uint8_t*)dataA_;
     const uint8_t* dataB = (const uint8_t*)dataB_;
 
@@ -365,6 +381,8 @@ void TextureData::checkMipLevelsEqual(
 
     if (!compareOutsideRegion)
     {
+        // fprintf(stderr, "  Compare internal region\n");
+
         // Simple case - comparing the internal regions of 2 textures.
         checkRegionsEqual(
             thisSubresource.data.get(),
@@ -378,6 +396,8 @@ void TextureData::checkMipLevelsEqual(
     }
     else
     {
+        // fprintf(stderr, "  Compare external region\n");
+
         // More complex case, comparing the whole of 2 textures with the
         // region excluded. For this case the offsets must match, and the
         // offset/extents refer to the region to exclude.

--- a/tests/texture-test.cpp
+++ b/tests/texture-test.cpp
@@ -70,6 +70,28 @@ bool getArrayType(TextureType type, TextureType& outArrayType)
     }
 }
 
+bool getScalarType(TextureType type, TextureType& outScalarType)
+{
+    switch (type)
+    {
+    case TextureType::Texture1DArray:
+        outScalarType = TextureType::Texture1D;
+        return true;
+    case TextureType::Texture2DArray:
+        outScalarType = TextureType::Texture2D;
+        return true;
+    case TextureType::Texture2DMSArray:
+        outScalarType = TextureType::Texture2DMS;
+        return true;
+    case TextureType::TextureCubeArray:
+        outScalarType = TextureType::TextureCube;
+        return true;
+    default:
+        outScalarType = type;
+        return true;
+    }
+}
+
 bool getMultisampleType(TextureType type, TextureType& outArrayType)
 {
     switch (type)

--- a/tests/texture-test.h
+++ b/tests/texture-test.h
@@ -62,22 +62,33 @@ struct TextureData
     /// In both cases, the resulting region size being checked should match the full
     /// size of this TextureData.
     void checkEqual(
+        Offset3D thisOffset,
         ITexture* texture,
         Offset3D textureOffset = {0, 0, 0},
         Extents textureExtents = Extents::kWholeTexture,
         bool compareOutsideRegion = false
     ) const;
 
+    /// Helper for checkEqual that requies no offsets/extents
+    inline void checkEqual(ITexture* texture) const { checkEqual({0, 0, 0}, texture); }
+
     /// Compare cpu data for a layer in this TextureData against a layer
     /// in a gpu texture. For details of region comparison see checkEqual.
     void checkLayersEqual(
         ITexture* texture,
         int thisLayer,
+        Offset3D thisOffset,
         int textureLayer,
-        Offset3D textureOffset = {0, 0, 0},
-        Extents textureExtents = Extents::kWholeTexture,
+        Offset3D textureOffset,
+        Extents textureExtents,
         bool compareOutsideRegion = false
     ) const;
+
+    /// Helper for checkLayersEqual that requires no offsets/extents
+    inline void checkLayersEqual(ITexture* texture, int thisLayer, int textureLayer) const
+    {
+        checkLayersEqual(texture, thisLayer, {0, 0, 0}, textureLayer, {0, 0, 0}, Extents::kWholeTexture);
+    }
 
     /// Compare mip levels for a layer in this TextureData against a layer
     /// in a gpu texture. For details of region comparison see checkEqual.
@@ -85,12 +96,34 @@ struct TextureData
         ITexture* texture,
         int thisLayer,
         int thisMipLevel,
+        Offset3D thisOffset,
         int textureLayer,
         int textureMipLevel,
-        Offset3D textureOffset = {0, 0, 0},
-        Extents textureExtents = Extents::kWholeTexture,
+        Offset3D textureOffset,
+        Extents textureExtents,
         bool compareOutsideRegion = false
     ) const;
+
+    /// Helper for checkMipLevelsEqual that requires no offsets/extents
+    inline void checkMipLevelsEqual(
+        ITexture* texture,
+        int thisLayer,
+        int thisMipLevel,
+        int textureLayer,
+        int textureMipLevel
+    ) const
+    {
+        checkMipLevelsEqual(
+            texture,
+            thisLayer,
+            thisMipLevel,
+            {0, 0, 0},
+            textureLayer,
+            textureMipLevel,
+            {0, 0, 0},
+            Extents::kWholeTexture
+        );
+    }
 
     /// Compare a slice of this TextureData (must be 3D) against a 2D
     /// layer of a texture.

--- a/tests/texture-test.h
+++ b/tests/texture-test.h
@@ -209,6 +209,9 @@ bool isValidDescriptor(IDevice* device, const TextureDesc& desc);
 /// Checks and gets corresponding array type for texture type
 bool getArrayType(TextureType type, TextureType& outArrayType);
 
+/// Checks and gets corresponding scalar (none-array) type for texture type
+bool getScalarType(TextureType type, TextureType& outScalarType);
+
 /// Checks and gets corresponding multisample type for texture type
 bool getMultisampleType(TextureType type, TextureType& outArrayType);
 

--- a/tests/texture-test.h
+++ b/tests/texture-test.h
@@ -92,6 +92,18 @@ struct TextureData
         bool compareOutsideRegion = false
     ) const;
 
+    /// Compare a slice of this TextureData (must be 3D) against a 2D
+    /// layer of a texture.
+    void checkSliceEqual(
+        ITexture* texture,
+        int thisLayer,
+        int thisMipLevel,
+        int thisSlice,
+        int textureLayer,
+        int textureMipLevel
+    ) const;
+
+
     void checkEqualFloat(ITexture* texture, float epsilon = 0.f) const;
 
     const Subresource& getSubresource(uint32_t layer, uint32_t mipLevel) const


### PR DESCRIPTION
Test and corresponding fixes for texture copying, working on D3D12, Vulkan and WebGPU.

Plan is delete old tests + tweak the test function signatures in 2nd PR once this one is confirmed solid. Also need to rename the strideX/Y/Z in layouts at some point soon.
