### PR TITLE
Fix vulkan validation

### DIFF
--- a/include/slang-rhi.h
+++ b/include/slang-rhi.h
@@ -78,6 +78,8 @@ enum class StructType
 
     D3D12DeviceExtendedDesc,
     D3D12ExperimentalFeaturesDesc,
+
+    VulkanDeviceExtendedDesc,
 };
 
 // TODO: Implementation or backend or something else?
@@ -2891,6 +2893,14 @@ struct D3D12DeviceExtendedDesc
     const char* rootParameterShaderAttributeName = nullptr;
     bool debugBreakOnD3D12Error = false;
     uint32_t highestShaderModel = 0;
+};
+
+struct VulkanDeviceExtendedDesc
+{
+    StructType structType = StructType::VulkanDeviceExtendedDesc;
+    void* next = nullptr;
+
+    bool enableDebugPrintf = false;
 };
 
 } // namespace rhi

--- a/src/cuda/cuda-surface.cpp
+++ b/src/cuda/cuda-surface.cpp
@@ -45,6 +45,7 @@ struct FrameData
 {
     VkCommandPool commandPool;
     VkCommandBuffer commandBuffer;
+    // Fence to signal when the rendering to the swapchain image is finished.
     VkFence fence;
     // Semaphore to signal when the swapchain image is available.
     VkSemaphore imageAvailableSemaphore;

--- a/src/d3d12/d3d12-device.cpp
+++ b/src/d3d12/d3d12-device.cpp
@@ -367,7 +367,7 @@ Result DeviceImpl::initialize(const DeviceDesc& desc)
         switch (header->type)
         {
         case StructType::D3D12DeviceExtendedDesc:
-            memcpy((void*)&m_extendedDesc, header, sizeof(m_extendedDesc));
+            memcpy(static_cast<void*>(&m_extendedDesc), header, sizeof(m_extendedDesc));
             break;
         case StructType::D3D12ExperimentalFeaturesDesc:
             processExperimentalFeaturesDesc(d3dModule, header);

--- a/src/d3d12/d3d12-device.cpp
+++ b/src/d3d12/d3d12-device.cpp
@@ -367,7 +367,7 @@ Result DeviceImpl::initialize(const DeviceDesc& desc)
         switch (header->type)
         {
         case StructType::D3D12DeviceExtendedDesc:
-            memcpy(&m_extendedDesc, header, sizeof(m_extendedDesc));
+            memcpy((void*)&m_extendedDesc, header, sizeof(m_extendedDesc));
             break;
         case StructType::D3D12ExperimentalFeaturesDesc:
             processExperimentalFeaturesDesc(d3dModule, header);

--- a/src/metal/metal-texture.cpp
+++ b/src/metal/metal-texture.cpp
@@ -106,8 +106,6 @@ Result DeviceImpl::createTexture(const TextureDesc& desc_, const SubresourceData
         {
         case Format::R32Uint:
         case Format::R32Sint:
-            // case Format::RG32Uint:
-            // case Format::RG32Sint:
             textureUsage |= MTL::TextureUsageShaderAtomic;
             break;
         default:

--- a/src/metal/metal-texture.cpp
+++ b/src/metal/metal-texture.cpp
@@ -106,8 +106,8 @@ Result DeviceImpl::createTexture(const TextureDesc& desc_, const SubresourceData
         {
         case Format::R32Uint:
         case Format::R32Sint:
-        // case Format::RG32Uint:
-        // case Format::RG32Sint:
+            // case Format::RG32Uint:
+            // case Format::RG32Sint:
             textureUsage |= MTL::TextureUsageShaderAtomic;
             break;
         default:

--- a/src/vulkan/vk-command.cpp
+++ b/src/vulkan/vk-command.cpp
@@ -1375,6 +1375,15 @@ void CommandRecorder::commitBarriers()
         barrier.sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER;
         barrier.image = texture->m_image;
         barrier.oldLayout = translateImageLayout(textureBarrier.stateBefore);
+        // This is a bit of a hack.
+        // When we first transition a swapchain image, it starts in VK_IMAGE_LAYOUT_UNDEFINED.
+        // The default state for swapchain images (automatically transitioned to at the end of a command encoding is
+        // VK_IMAGE_LAYOUT_PRESENT_SRC_KHR).
+        if (texture->m_isSwapchainInitialState)
+        {
+            barrier.oldLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+            texture->m_isSwapchainInitialState = false;
+        }
         barrier.newLayout = translateImageLayout(textureBarrier.stateAfter);
         barrier.subresourceRange.aspectMask = getAspectMaskFromFormat(VulkanUtil::getVkFormat(texture->m_desc.format));
         barrier.subresourceRange.baseArrayLayer = textureBarrier.entireTexture ? 0 : textureBarrier.arrayLayer;
@@ -1492,7 +1501,6 @@ CommandQueueImpl::CommandQueueImpl(Device* device, QueueType type)
 CommandQueueImpl::~CommandQueueImpl()
 {
     m_api.vkQueueWaitIdle(m_queue);
-    m_api.vkDestroySemaphore(m_api.m_device, m_semaphore, nullptr);
     m_api.vkDestroySemaphore(m_api.m_device, m_trackingSemaphore, nullptr);
 }
 
@@ -1500,11 +1508,6 @@ void CommandQueueImpl::init(VkQueue queue, uint32_t queueFamilyIndex)
 {
     m_queue = queue;
     m_queueFamilyIndex = queueFamilyIndex;
-
-    {
-        VkSemaphoreCreateInfo semaphoreCreateInfo = {VK_STRUCTURE_TYPE_SEMAPHORE_CREATE_INFO};
-        m_api.vkCreateSemaphore(m_api.m_device, &semaphoreCreateInfo, nullptr, &m_semaphore);
-    }
 
     {
         VkSemaphoreTypeCreateInfo timelineCreateInfo = {VK_STRUCTURE_TYPE_SEMAPHORE_TYPE_CREATE_INFO};
@@ -1614,13 +1617,12 @@ Result CommandQueueImpl::submit(const SubmitDesc& desc)
         waitStages.push_back(stage);
     };
 
-    for (VkSemaphore s : m_pendingWaitSemaphores)
+    if (m_surfaceSync.imageAvailableSemaphore != VK_NULL_HANDLE)
     {
-        if (s != VK_NULL_HANDLE)
-        {
-            addWaitSemaphore(s, 0);
-        }
+        addWaitSemaphore(m_surfaceSync.imageAvailableSemaphore, 0, VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT);
+        m_surfaceSync.imageAvailableSemaphore = VK_NULL_HANDLE;
     }
+
     for (uint32_t i = 0; i < desc.waitFenceCount; ++i)
     {
         FenceImpl* fence = checked_cast<FenceImpl*>(desc.waitFences[i]);
@@ -1635,7 +1637,13 @@ Result CommandQueueImpl::submit(const SubmitDesc& desc)
         signalSemaphores.push_back(semaphore);
         signalValues.push_back(value);
     };
-    addSignalSemaphore(m_semaphore, 0);
+
+    if (m_surfaceSync.renderFinishedSemaphore != VK_NULL_HANDLE)
+    {
+        addSignalSemaphore(m_surfaceSync.renderFinishedSemaphore, 0);
+        m_surfaceSync.renderFinishedSemaphore = VK_NULL_HANDLE;
+    }
+
     addSignalSemaphore(m_trackingSemaphore, m_lastSubmittedID);
     for (uint32_t i = 0; i < desc.signalFenceCount; ++i)
     {
@@ -1668,10 +1676,8 @@ Result CommandQueueImpl::submit(const SubmitDesc& desc)
         timelineSubmitInfo.pSignalSemaphoreValues = signalValues.data();
     }
 
-    SLANG_VK_RETURN_ON_FAIL(m_api.vkQueueSubmit(m_queue, 1, &submitInfo, VK_NULL_HANDLE));
-
-    m_pendingWaitSemaphores[0] = m_semaphore;
-    m_pendingWaitSemaphores[1] = VK_NULL_HANDLE;
+    SLANG_VK_RETURN_ON_FAIL(m_api.vkQueueSubmit(m_queue, 1, &submitInfo, m_surfaceSync.fence));
+    m_surfaceSync.fence = VK_NULL_HANDLE;
 
     retireCommandBuffers();
 

--- a/src/vulkan/vk-command.cpp
+++ b/src/vulkan/vk-command.cpp
@@ -616,6 +616,8 @@ void CommandRecorder::cmdBeginRenderPass(const commands::BeginRenderPass& cmd)
         }
     }
 
+    commitBarriers();
+
     VkRenderingInfoKHR renderingInfo = {VK_STRUCTURE_TYPE_RENDERING_INFO_KHR};
     renderingInfo.renderArea = renderArea;
     renderingInfo.layerCount = layerCount;

--- a/src/vulkan/vk-command.h
+++ b/src/vulkan/vk-command.h
@@ -16,9 +16,14 @@ public:
     VkQueue m_queue;
     uint32_t m_queueFamilyIndex;
 
-    VkSemaphore m_pendingWaitSemaphores[2] = {VK_NULL_HANDLE, VK_NULL_HANDLE};
+    // Set by the surface for synchronization.
+    struct
+    {
+        VkFence fence = VK_NULL_HANDLE;
+        VkSemaphore imageAvailableSemaphore = VK_NULL_HANDLE;
+        VkSemaphore renderFinishedSemaphore = VK_NULL_HANDLE;
+    } m_surfaceSync;
 
-    VkSemaphore m_semaphore;
     VkSemaphore m_trackingSemaphore;
     uint64_t m_lastSubmittedID = 0;
     uint64_t m_lastFinishedID = 0;

--- a/src/vulkan/vk-device.cpp
+++ b/src/vulkan/vk-device.cpp
@@ -1083,7 +1083,7 @@ Result DeviceImpl::initialize(const DeviceDesc& desc)
         switch (header->type)
         {
         case StructType::VulkanDeviceExtendedDesc:
-            memcpy((void*)&m_extendedDesc, header, sizeof(m_extendedDesc));
+            memcpy(static_cast<void*>(&m_extendedDesc), header, sizeof(m_extendedDesc));
             break;
         default:
             break;

--- a/src/vulkan/vk-device.cpp
+++ b/src/vulkan/vk-device.cpp
@@ -1083,7 +1083,7 @@ Result DeviceImpl::initialize(const DeviceDesc& desc)
         switch (header->type)
         {
         case StructType::VulkanDeviceExtendedDesc:
-            memcpy(&m_extendedDesc, header, sizeof(m_extendedDesc));
+            memcpy((void*)&m_extendedDesc, header, sizeof(m_extendedDesc));
             break;
         default:
             break;

--- a/src/vulkan/vk-device.cpp
+++ b/src/vulkan/vk-device.cpp
@@ -222,11 +222,14 @@ Result DeviceImpl::initVulkanInstanceAndDevice(
                 instanceCreateInfo.enabledLayerCount = SLANG_COUNT_OF(layerNames);
                 instanceCreateInfo.ppEnabledLayerNames = layerNames;
 
-                // Include support for printf
-                validationFeatures.sType = VK_STRUCTURE_TYPE_VALIDATION_FEATURES_EXT;
-                validationFeatures.enabledValidationFeatureCount = 1;
-                validationFeatures.pEnabledValidationFeatures = enabledValidationFeatures;
-                instanceCreateInfo.pNext = &validationFeatures;
+                if (m_extendedDesc.enableDebugPrintf)
+                {
+                    // Include support for printf
+                    validationFeatures.sType = VK_STRUCTURE_TYPE_VALIDATION_FEATURES_EXT;
+                    validationFeatures.enabledValidationFeatureCount = 1;
+                    validationFeatures.pEnabledValidationFeatures = enabledValidationFeatures;
+                    instanceCreateInfo.pNext = &validationFeatures;
+                }
             }
         }
         uint32_t apiVersionsToTry[] = {VK_API_VERSION_1_3, VK_API_VERSION_1_2, VK_API_VERSION_1_1, VK_API_VERSION_1_0};
@@ -1073,6 +1076,19 @@ Result DeviceImpl::initialize(const DeviceDesc& desc)
     }
 
     m_desc = desc;
+
+    // Process chained descs
+    for (DescStructHeader* header = static_cast<DescStructHeader*>(desc.next); header; header = header->next)
+    {
+        switch (header->type)
+        {
+        case StructType::VulkanDeviceExtendedDesc:
+            memcpy(&m_extendedDesc, header, sizeof(m_extendedDesc));
+            break;
+        default:
+            break;
+        }
+    }
 
     SLANG_RETURN_ON_FAIL(Device::initialize(desc));
     Result initDeviceResult = SLANG_OK;

--- a/src/vulkan/vk-device.h
+++ b/src/vulkan/vk-device.h
@@ -141,7 +141,8 @@ public:
     uint32_t getQueueFamilyIndex(QueueType queueType);
 
 public:
-    // DeviceImpl members.
+    DeviceDesc m_desc;
+    VulkanDeviceExtendedDesc m_extendedDesc;
 
     DeviceInfo m_info;
     std::string m_adapterName;
@@ -156,8 +157,6 @@ public:
     VulkanDeviceQueue m_deviceQueue;
     uint32_t m_queueFamilyIndex;
     RefPtr<CommandQueueImpl> m_queue;
-
-    DeviceDesc m_desc;
 
     DescriptorSetAllocator descriptorSetAllocator;
 

--- a/src/vulkan/vk-surface.cpp
+++ b/src/vulkan/vk-surface.cpp
@@ -28,11 +28,6 @@ SurfaceImpl::~SurfaceImpl()
         api.vkDestroySurfaceKHR(api.m_instance, m_surface, nullptr);
     }
 
-    if (m_nextImageSemaphore)
-    {
-        api.vkDestroySemaphore(api.m_device, m_nextImageSemaphore, nullptr);
-    }
-
 #if SLANG_APPLE_FAMILY
     CocoaUtil::destroyMetalLayer(m_metalLayer);
 #endif
@@ -44,9 +39,6 @@ Result SurfaceImpl::init(DeviceImpl* device, WindowHandle windowHandle)
     m_windowHandle = windowHandle;
 
     auto& api = m_device->m_api;
-
-    VkSemaphoreCreateInfo semaphoreCreateInfo = {VK_STRUCTURE_TYPE_SEMAPHORE_CREATE_INFO};
-    SLANG_VK_RETURN_ON_FAIL(api.vkCreateSemaphore(api.m_device, &semaphoreCreateInfo, nullptr, &m_nextImageSemaphore));
 
     switch (windowHandle.type)
     {

--- a/src/vulkan/vk-surface.cpp
+++ b/src/vulkan/vk-surface.cpp
@@ -256,9 +256,18 @@ void SurfaceImpl::destroySwapchain()
     m_textures.clear();
     for (FrameData& frameData : m_frameData)
     {
-        api.vkDestroyFence(api.m_device, frameData.fence, nullptr);
-        api.vkDestroySemaphore(api.m_device, frameData.imageAvailableSemaphore, nullptr);
-        api.vkDestroySemaphore(api.m_device, frameData.renderFinishedSemaphore, nullptr);
+        if (frameData.fence != VK_NULL_HANDLE)
+        {
+            api.vkDestroyFence(api.m_device, frameData.fence, nullptr);
+        }
+        if (frameData.imageAvailableSemaphore != VK_NULL_HANDLE)
+        {
+            api.vkDestroySemaphore(api.m_device, frameData.imageAvailableSemaphore, nullptr);
+        }
+        if (frameData.renderFinishedSemaphore != VK_NULL_HANDLE)
+        {
+            api.vkDestroySemaphore(api.m_device, frameData.renderFinishedSemaphore, nullptr);
+        }
     }
     m_frameData.clear();
     if (m_swapchain != VK_NULL_HANDLE)

--- a/src/vulkan/vk-surface.cpp
+++ b/src/vulkan/vk-surface.cpp
@@ -221,6 +221,31 @@ Result SurfaceImpl::createSwapchain()
         m_textures.push_back(texture);
     }
 
+    m_frameData.resize(swapchainImageCount);
+    for (uint32_t i = 0; i < swapchainImageCount; ++i)
+    {
+        FrameData& frameData = m_frameData[i];
+        // Create fence.
+        {
+            VkFenceCreateInfo createInfo = {VK_STRUCTURE_TYPE_FENCE_CREATE_INFO};
+            createInfo.flags = VK_FENCE_CREATE_SIGNALED_BIT;
+            SLANG_VK_RETURN_ON_FAIL(api.vkCreateFence(api.m_device, &createInfo, nullptr, &frameData.fence));
+        }
+
+        // Create semaphores.
+        {
+            VkSemaphoreCreateInfo createInfo = {VK_STRUCTURE_TYPE_SEMAPHORE_CREATE_INFO};
+            SLANG_VK_RETURN_ON_FAIL(
+                api.vkCreateSemaphore(api.m_device, &createInfo, nullptr, &frameData.imageAvailableSemaphore)
+            );
+            SLANG_VK_RETURN_ON_FAIL(
+                api.vkCreateSemaphore(api.m_device, &createInfo, nullptr, &frameData.renderFinishedSemaphore)
+            );
+        }
+    }
+
+    m_currentFrameIndex = 0;
+
     return SLANG_OK;
 }
 
@@ -229,6 +254,13 @@ void SurfaceImpl::destroySwapchain()
     auto& api = m_device->m_api;
     api.vkQueueWaitIdle(m_device->m_queue->m_queue);
     m_textures.clear();
+    for (FrameData& frameData : m_frameData)
+    {
+        api.vkDestroyFence(api.m_device, frameData.fence, nullptr);
+        api.vkDestroySemaphore(api.m_device, frameData.imageAvailableSemaphore, nullptr);
+        api.vkDestroySemaphore(api.m_device, frameData.renderFinishedSemaphore, nullptr);
+    }
+    m_frameData.clear();
     if (m_swapchain != VK_NULL_HANDLE)
     {
         api.vkDestroySwapchainKHR(api.m_device, m_swapchain, nullptr);
@@ -268,16 +300,19 @@ Result SurfaceImpl::getCurrentTexture(ITexture** outTexture)
 
     if (m_textures.empty())
     {
-        m_device->m_queue->m_pendingWaitSemaphores[1] = VK_NULL_HANDLE;
         return -1;
     }
+
+    FrameData& frameData = m_frameData[m_currentFrameIndex];
+    SLANG_VK_RETURN_ON_FAIL(api.vkWaitForFences(api.m_device, 1, &frameData.fence, VK_TRUE, UINT64_MAX));
+    SLANG_VK_RETURN_ON_FAIL(api.vkResetFences(api.m_device, 1, &frameData.fence));
 
     m_currentTextureIndex = -1;
     VkResult result = api.vkAcquireNextImageKHR(
         api.m_device,
         m_swapchain,
         UINT64_MAX,
-        m_nextImageSemaphore,
+        frameData.imageAvailableSemaphore,
         VK_NULL_HANDLE,
         (uint32_t*)&m_currentTextureIndex
     );
@@ -291,8 +326,15 @@ Result SurfaceImpl::getCurrentTexture(ITexture** outTexture)
         return SLANG_FAIL;
     }
 
-    // Make the queue's next submit wait on `m_nextImageSemaphore`.
-    m_device->m_queue->m_pendingWaitSemaphores[1] = m_nextImageSemaphore;
+    // Setup queue's next submit for synchronization with the swapchain.
+    m_device->m_queue->m_surfaceSync.fence = frameData.fence;
+    m_device->m_queue->m_surfaceSync.imageAvailableSemaphore = frameData.imageAvailableSemaphore;
+    m_device->m_queue->m_surfaceSync.renderFinishedSemaphore = frameData.renderFinishedSemaphore;
+
+    // Mark texture to be in swapchain initial state.
+    // This is used by the first image barrier to transition the texture from the correct state.
+    m_textures[m_currentTextureIndex]->m_isSwapchainInitialState = true;
+
     returnComPtr(outTexture, m_textures[m_currentTextureIndex]);
     return SLANG_OK;
 }
@@ -306,26 +348,16 @@ Result SurfaceImpl::present()
         return SLANG_FAIL;
     }
 
+    FrameData& frameData = m_frameData[m_currentFrameIndex];
+    m_currentFrameIndex = (m_currentFrameIndex + 1) % m_frameData.size();
+
     VkPresentInfoKHR presentInfo = {};
     presentInfo.sType = VK_STRUCTURE_TYPE_PRESENT_INFO_KHR;
     presentInfo.swapchainCount = 1;
     presentInfo.pSwapchains = &m_swapchain;
     presentInfo.pImageIndices = &m_currentTextureIndex;
-    static_vector<VkSemaphore, 2> waitSemaphores;
-    for (auto s : m_device->m_queue->m_pendingWaitSemaphores)
-    {
-        if (s != VK_NULL_HANDLE)
-        {
-            waitSemaphores.push_back(s);
-        }
-    }
-    m_device->m_queue->m_pendingWaitSemaphores[0] = VK_NULL_HANDLE;
-    m_device->m_queue->m_pendingWaitSemaphores[1] = VK_NULL_HANDLE;
-    presentInfo.waitSemaphoreCount = (uint32_t)waitSemaphores.size();
-    if (presentInfo.waitSemaphoreCount)
-    {
-        presentInfo.pWaitSemaphores = waitSemaphores.data();
-    }
+    presentInfo.waitSemaphoreCount = 1;
+    presentInfo.pWaitSemaphores = &frameData.renderFinishedSemaphore;
     if (m_currentTextureIndex != -1)
     {
         api.vkQueuePresentKHR(m_device->m_queue->m_queue, &presentInfo);

--- a/src/vulkan/vk-surface.h
+++ b/src/vulkan/vk-surface.h
@@ -16,8 +16,6 @@ public:
     std::vector<Format> m_supportedFormats;
     VkSurfaceKHR m_surface = VK_NULL_HANDLE;
     VkSwapchainKHR m_swapchain = VK_NULL_HANDLE;
-    /// Semaphore to signal after `acquireNextImage`.
-    VkSemaphore m_nextImageSemaphore = VK_NULL_HANDLE;
     short_vector<RefPtr<TextureImpl>> m_textures;
 
     struct FrameData

--- a/src/vulkan/vk-surface.h
+++ b/src/vulkan/vk-surface.h
@@ -19,6 +19,19 @@ public:
     /// Semaphore to signal after `acquireNextImage`.
     VkSemaphore m_nextImageSemaphore = VK_NULL_HANDLE;
     short_vector<RefPtr<TextureImpl>> m_textures;
+
+    struct FrameData
+    {
+        // Fence to signal when the rendering to the swapchain image is finished.
+        VkFence fence;
+        // Semaphore to signal when the swapchain image is available.
+        VkSemaphore imageAvailableSemaphore;
+        // Semaphore to signal when the rendering to the swapchain image is finished.
+        VkSemaphore renderFinishedSemaphore;
+    };
+    short_vector<FrameData> m_frameData;
+
+    uint32_t m_currentFrameIndex = 0;
     uint32_t m_currentTextureIndex = -1;
 #if SLANG_APPLE_FAMILY
     void* m_metalLayer;

--- a/src/vulkan/vk-texture.h
+++ b/src/vulkan/vk-texture.h
@@ -21,6 +21,8 @@ public:
     VkDeviceMemory m_imageMemory = VK_NULL_HANDLE;
     bool m_isWeakImageReference = false;
 
+    bool m_isSwapchainInitialState = false;
+
     virtual SLANG_NO_THROW Result SLANG_MCALL getNativeHandle(NativeHandle* outHandle) override;
 
     virtual SLANG_NO_THROW Result SLANG_MCALL getSharedHandle(NativeHandle* outHandle) override;


### PR DESCRIPTION
- disable debug printf unless specifically enabled using the new `VulkanDeviceExtendedDesc` (this gets rid of the annoying validation message)
- fix semaphore wait stages in `submit`
- fix surface <-> submit synchronization
- fix initial swapchain image barrier