### PR TITLE
Surface improvements

### DIFF
--- a/examples/surface/example-surface.cpp
+++ b/examples/surface/example-surface.cpp
@@ -45,7 +45,7 @@ public:
     virtual void draw() override
     {
         ComPtr<ITexture> texture;
-        surface->getCurrentTexture(texture.writeRef());
+        surface->acquireNextImage(texture.writeRef());
         if (!texture)
         {
             return;

--- a/include/slang-rhi.h
+++ b/include/slang-rhi.h
@@ -2214,13 +2214,13 @@ public:
     virtual SLANG_NO_THROW const SurfaceInfo& SLANG_MCALL getInfo() = 0;
     virtual SLANG_NO_THROW const SurfaceConfig& SLANG_MCALL getConfig() = 0;
     virtual SLANG_NO_THROW Result SLANG_MCALL configure(const SurfaceConfig& config) = 0;
-    virtual SLANG_NO_THROW Result SLANG_MCALL getCurrentTexture(ITexture** outTexture) = 0;
+    virtual SLANG_NO_THROW Result SLANG_MCALL acquireNextImage(ITexture** outTexture) = 0;
     virtual SLANG_NO_THROW Result SLANG_MCALL present() = 0;
 
-    ComPtr<ITexture> getCurrentTexture()
+    ComPtr<ITexture> acquireNextImage()
     {
         ComPtr<ITexture> texture;
-        SLANG_RETURN_NULL_ON_FAIL(getCurrentTexture(texture.writeRef()));
+        SLANG_RETURN_NULL_ON_FAIL(acquireNextImage(texture.writeRef()));
         return texture;
     }
 };

--- a/src/cuda/cuda-surface.cpp
+++ b/src/cuda/cuda-surface.cpp
@@ -25,7 +25,7 @@
 // On the Vulkan side, we create a normal Vulkan based swapchain.
 // To allow passing textures to CUDA, a set of "virtual" swapchain images are created.
 // These images are allocated in Vulkan and shared with CUDA.
-// Calls to `ISurface::getCurrentTexture` return these shared textures.
+// Calls to `ISurface::acquireNextImage` return these shared textures.
 // Calls to `ISurface::present` copy the contents of the shared texture to the Vulkan swapchain image.
 
 namespace rhi::cuda {
@@ -101,7 +101,7 @@ public:
     void destroySharedTexture(SharedTexture& sharedTexture);
 
     virtual SLANG_NO_THROW Result SLANG_MCALL configure(const SurfaceConfig& config) override;
-    virtual SLANG_NO_THROW Result SLANG_MCALL getCurrentTexture(ITexture** outTexture) override;
+    virtual SLANG_NO_THROW Result SLANG_MCALL acquireNextImage(ITexture** outTexture) override;
     virtual SLANG_NO_THROW Result SLANG_MCALL present() override;
 };
 
@@ -753,7 +753,7 @@ Result SurfaceImpl::configure(const SurfaceConfig& config)
     return SLANG_OK;
 }
 
-Result SurfaceImpl::getCurrentTexture(ITexture** outTexture)
+Result SurfaceImpl::acquireNextImage(ITexture** outTexture)
 {
     if (!m_configured)
     {

--- a/src/d3d/d3d-surface.h
+++ b/src/d3d/d3d-surface.h
@@ -118,7 +118,7 @@ public:
         return SLANG_OK;
     }
 
-    virtual SLANG_NO_THROW Result SLANG_MCALL getCurrentTexture(ITexture** outTexture) override
+    virtual SLANG_NO_THROW Result SLANG_MCALL acquireNextImage(ITexture** outTexture) override
     {
         if (!m_configured)
         {

--- a/src/d3d11/d3d11-surface.h
+++ b/src/d3d11/d3d11-surface.h
@@ -18,8 +18,6 @@ public:
     virtual IUnknown* getOwningDevice() override { return m_d3dDevice; }
 
     virtual SLANG_NO_THROW Result SLANG_MCALL configure(const SurfaceConfig& config) override;
-    // virtual SLANG_NO_THROW Result SLANG_MCALL acquireNextImage(ITexture** outTexture) override;
-    // virtual SLANG_NO_THROW Result SLANG_MCALL present() override;
 };
 
 } // namespace rhi::d3d11

--- a/src/d3d11/d3d11-surface.h
+++ b/src/d3d11/d3d11-surface.h
@@ -18,7 +18,7 @@ public:
     virtual IUnknown* getOwningDevice() override { return m_d3dDevice; }
 
     virtual SLANG_NO_THROW Result SLANG_MCALL configure(const SurfaceConfig& config) override;
-    // virtual SLANG_NO_THROW Result SLANG_MCALL getCurrentTexture(ITexture** outTexture) override;
+    // virtual SLANG_NO_THROW Result SLANG_MCALL acquireNextImage(ITexture** outTexture) override;
     // virtual SLANG_NO_THROW Result SLANG_MCALL present() override;
 };
 

--- a/src/d3d12/d3d12-surface.cpp
+++ b/src/d3d12/d3d12-surface.cpp
@@ -56,7 +56,7 @@ Result SurfaceImpl::configure(const SurfaceConfig& config)
     return D3DSurface::configure(config);
 }
 
-Result SurfaceImpl::getCurrentTexture(ITexture** outTexture)
+Result SurfaceImpl::acquireNextImage(ITexture** outTexture)
 {
     auto result = (int)m_swapChain3->GetCurrentBackBufferIndex();
     WaitForSingleObject(m_frameEvents[result], INFINITE);

--- a/src/d3d12/d3d12-surface.h
+++ b/src/d3d12/d3d12-surface.h
@@ -23,7 +23,7 @@ public:
     virtual IUnknown* getOwningDevice() override { return m_queue; }
 
     virtual SLANG_NO_THROW Result SLANG_MCALL configure(const SurfaceConfig& config) override;
-    virtual SLANG_NO_THROW Result SLANG_MCALL getCurrentTexture(ITexture** outTexture) override;
+    virtual SLANG_NO_THROW Result SLANG_MCALL acquireNextImage(ITexture** outTexture) override;
     virtual SLANG_NO_THROW Result SLANG_MCALL present() override;
 };
 

--- a/src/debug-layer/debug-surface.cpp
+++ b/src/debug-layer/debug-surface.cpp
@@ -66,7 +66,7 @@ Result DebugSurface::configure(const SurfaceConfig& config)
     return result;
 }
 
-Result DebugSurface::getCurrentTexture(ITexture** outTexture)
+Result DebugSurface::acquireNextImage(ITexture** outTexture)
 {
     SLANG_RHI_API_FUNC;
 
@@ -82,7 +82,7 @@ Result DebugSurface::getCurrentTexture(ITexture** outTexture)
         return SLANG_FAIL;
     }
 
-    Result result = baseObject->getCurrentTexture(outTexture);
+    Result result = baseObject->acquireNextImage(outTexture);
 
     if (SLANG_SUCCEEDED(result))
     {

--- a/src/debug-layer/debug-surface.cpp
+++ b/src/debug-layer/debug-surface.cpp
@@ -56,7 +56,13 @@ Result DebugSurface::configure(const SurfaceConfig& config)
     }
 
     Result result = baseObject->configure(config);
-    m_configured = SLANG_SUCCEEDED(result);
+
+    if (SLANG_SUCCEEDED(result))
+    {
+        m_configured = true;
+        m_state = State::Initial;
+    }
+
     return result;
 }
 
@@ -70,7 +76,20 @@ Result DebugSurface::getCurrentTexture(ITexture** outTexture)
         return SLANG_FAIL;
     }
 
-    return baseObject->getCurrentTexture(outTexture);
+    if (m_state == State::ImageAcquired)
+    {
+        RHI_VALIDATION_ERROR("Image already aquired. Image needs to be presented before acquiring a new one.");
+        return SLANG_FAIL;
+    }
+
+    Result result = baseObject->getCurrentTexture(outTexture);
+
+    if (SLANG_SUCCEEDED(result))
+    {
+        m_state = State::ImageAcquired;
+    }
+
+    return result;
 }
 
 Result DebugSurface::present()
@@ -83,7 +102,20 @@ Result DebugSurface::present()
         return SLANG_FAIL;
     }
 
-    return baseObject->present();
+    if (m_state != State::ImageAcquired)
+    {
+        RHI_VALIDATION_ERROR("No image acquired to present.");
+        return SLANG_FAIL;
+    }
+
+    Result result = baseObject->present();
+
+    if (SLANG_SUCCEEDED(result))
+    {
+        m_state = State::ImagePresented;
+    }
+
+    return result;
 }
 
 } // namespace rhi::debug

--- a/src/debug-layer/debug-surface.h
+++ b/src/debug-layer/debug-surface.h
@@ -16,6 +16,15 @@ public:
 public:
     bool m_configured = false;
 
+    enum class State
+    {
+        Initial,
+        ImageAcquired,
+        ImagePresented,
+    };
+
+    State m_state = State::Initial;
+
     virtual SLANG_NO_THROW const SurfaceInfo& SLANG_MCALL getInfo() override;
     virtual SLANG_NO_THROW const SurfaceConfig& SLANG_MCALL getConfig() override;
     virtual SLANG_NO_THROW Result SLANG_MCALL configure(const SurfaceConfig& config) override;

--- a/src/debug-layer/debug-surface.h
+++ b/src/debug-layer/debug-surface.h
@@ -28,7 +28,7 @@ public:
     virtual SLANG_NO_THROW const SurfaceInfo& SLANG_MCALL getInfo() override;
     virtual SLANG_NO_THROW const SurfaceConfig& SLANG_MCALL getConfig() override;
     virtual SLANG_NO_THROW Result SLANG_MCALL configure(const SurfaceConfig& config) override;
-    virtual SLANG_NO_THROW Result SLANG_MCALL getCurrentTexture(ITexture** outTexture) override;
+    virtual SLANG_NO_THROW Result SLANG_MCALL acquireNextImage(ITexture** outTexture) override;
     virtual SLANG_NO_THROW Result SLANG_MCALL present() override;
 };
 

--- a/src/metal/metal-surface.cpp
+++ b/src/metal/metal-surface.cpp
@@ -41,7 +41,7 @@ Result SurfaceImpl::configure(const SurfaceConfig& config)
     return SLANG_OK;
 }
 
-Result SurfaceImpl::getCurrentTexture(ITexture** outTexture)
+Result SurfaceImpl::acquireNextImage(ITexture** outTexture)
 {
     m_currentDrawable = NS::RetainPtr(m_metalLayer->nextDrawable());
     if (!m_currentDrawable)

--- a/src/metal/metal-surface.h
+++ b/src/metal/metal-surface.h
@@ -16,7 +16,7 @@ public:
     ~SurfaceImpl();
 
     virtual SLANG_NO_THROW Result SLANG_MCALL configure(const SurfaceConfig& config) override;
-    virtual SLANG_NO_THROW Result SLANG_MCALL getCurrentTexture(ITexture** outTexture) override;
+    virtual SLANG_NO_THROW Result SLANG_MCALL acquireNextImage(ITexture** outTexture) override;
     virtual SLANG_NO_THROW Result SLANG_MCALL present() override;
 };
 

--- a/src/vulkan/vk-surface.cpp
+++ b/src/vulkan/vk-surface.cpp
@@ -290,7 +290,7 @@ Result SurfaceImpl::configure(const SurfaceConfig& config)
     return SLANG_OK;
 }
 
-Result SurfaceImpl::getCurrentTexture(ITexture** outTexture)
+Result SurfaceImpl::acquireNextImage(ITexture** outTexture)
 {
     auto& api = m_device->m_api;
 

--- a/src/vulkan/vk-surface.h
+++ b/src/vulkan/vk-surface.h
@@ -44,7 +44,7 @@ public:
     void destroySwapchain();
 
     virtual SLANG_NO_THROW Result SLANG_MCALL configure(const SurfaceConfig& config) override;
-    virtual SLANG_NO_THROW Result SLANG_MCALL getCurrentTexture(ITexture** outTexture) override;
+    virtual SLANG_NO_THROW Result SLANG_MCALL acquireNextImage(ITexture** outTexture) override;
     virtual SLANG_NO_THROW Result SLANG_MCALL present() override;
 };
 

--- a/src/wgpu/wgpu-surface.cpp
+++ b/src/wgpu/wgpu-surface.cpp
@@ -172,7 +172,7 @@ Result SurfaceImpl::configure(const SurfaceConfig& config)
     return SLANG_OK;
 }
 
-Result SurfaceImpl::getCurrentTexture(ITexture** outTexture)
+Result SurfaceImpl::acquireNextImage(ITexture** outTexture)
 {
     if (!m_configured)
     {

--- a/src/wgpu/wgpu-surface.h
+++ b/src/wgpu/wgpu-surface.h
@@ -21,7 +21,7 @@ public:
     Result init(DeviceImpl* device, WindowHandle windowHandle);
 
     virtual SLANG_NO_THROW Result SLANG_MCALL configure(const SurfaceConfig& config) override;
-    virtual SLANG_NO_THROW Result SLANG_MCALL getCurrentTexture(ITexture** outTexture) override;
+    virtual SLANG_NO_THROW Result SLANG_MCALL acquireNextImage(ITexture** outTexture) override;
     virtual SLANG_NO_THROW Result SLANG_MCALL present() override;
 };
 

--- a/tests/test-surface.cpp
+++ b/tests/test-surface.cpp
@@ -254,11 +254,24 @@ struct ComputeSurfaceTest : SurfaceTest
         if (!allowUnorderedAccess)
         {
             Offset3D offset = {0, 0, 0};
-            Extents extents = {int32_t(width), int32_t(height), 1};
-            commandEncoder->copyTexture(texture, {0, 0, 0, 0}, offset, renderTexture, {0, 0, 0, 0}, offset, extents);
+            commandEncoder->copyTexture(
+                texture,
+                {0, 0, 0, 0},
+                offset,
+                renderTexture,
+                {0, 0, 0, 0},
+                offset,
+                Extents::kWholeTexture
+            );
         }
         queue->submit(commandEncoder->finish());
     }
+};
+
+struct NoRenderSurfaceTest : SurfaceTest
+{
+    void initResources() override {}
+    void renderFrame(ITexture* texture, uint32_t width, uint32_t height, uint32_t frameIndex) override {}
 };
 
 template<typename Test>
@@ -289,4 +302,10 @@ GPU_TEST_CASE("surface-compute", D3D11 | D3D12 | Vulkan | Metal | CUDA)
 {
     CHECK(device->hasFeature("surface"));
     testSurface<ComputeSurfaceTest>(device);
+}
+
+GPU_TEST_CASE("surface-no-render", D3D11 | D3D12 | Vulkan | Metal | CUDA)
+{
+    CHECK(device->hasFeature("surface"));
+    testSurface<NoRenderSurfaceTest>(device);
 }

--- a/tests/test-surface.cpp
+++ b/tests/test-surface.cpp
@@ -93,7 +93,7 @@ struct SurfaceTest
         for (uint32_t i = 0; i < 10; ++i)
         {
             glfwPollEvents();
-            ComPtr<ITexture> texture = surface->getCurrentTexture();
+            ComPtr<ITexture> texture = surface->acquireNextImage();
             CHECK(texture->getDesc().size.width == width);
             CHECK(texture->getDesc().size.height == height);
             renderFrame(texture, width, height, i);
@@ -108,7 +108,7 @@ struct SurfaceTest
         for (uint32_t i = 0; i < 10; ++i)
         {
             glfwPollEvents();
-            ComPtr<ITexture> texture = surface->getCurrentTexture();
+            ComPtr<ITexture> texture = surface->acquireNextImage();
             CHECK(texture->getDesc().size.width == width);
             CHECK(texture->getDesc().size.height == height);
             renderFrame(texture, width, height, i);


### PR DESCRIPTION
- rename `getCurrentTexture` to `acquireNextImage` which is what that functions does
- allow presenting an image that has not been rendered to
- add validation for the `acquireNextImage` -> `present` dependency