### PR TITLE
Remove test noise

### DIFF
--- a/tests/test-benchmark-command.cpp
+++ b/tests/test-benchmark-command.cpp
@@ -89,7 +89,7 @@ GPU_TEST_CASE("benchmark-command", ALL)
 
     end = std::chrono::high_resolution_clock::now();
     auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(end - start).count();
-    INFO("Duration: " << duration << " ms");
+    fprintf(stderr, ": Duration: %lld ms)", duration);
 
     queue->waitOnHost();
 

--- a/tests/test-benchmark-command.cpp
+++ b/tests/test-benchmark-command.cpp
@@ -89,7 +89,7 @@ GPU_TEST_CASE("benchmark-command", ALL)
 
     end = std::chrono::high_resolution_clock::now();
     auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(end - start).count();
-    MESSAGE("Duration: " << duration << " ms");
+    INFO("Duration: " << duration << " ms");
 
     queue->waitOnHost();
 

--- a/tests/test-formats.cpp
+++ b/tests/test-formats.cpp
@@ -38,7 +38,6 @@ struct TestFormats
 
         if (!is_set(formatSupport, FormatSupport::Texture))
         {
-            MESSAGE("Skipping format ", format);
             return false;
         }
 

--- a/tests/test-texture-types.slang
+++ b/tests/test-texture-types.slang
@@ -131,13 +131,12 @@ void testTexture2D(
 
     uint tmp = tid;
     uint x = tmp % width; tmp /= width;
-    uint y = tmp % height; tmp /= height;
-    uint z = tmp;
+    uint y = tmp % height;
 
-    uint3 coord = uint3(x, y, z);
+    uint2 coord = uint2(x, y);
 
     // Read from texture
-    Element elem = texture[coord.xy];
+    Element elem = texture[coord];
 
     // Write something to results
     results[tid] = elem;
@@ -156,14 +155,10 @@ void testTexture1D(
     uint tid = sv_dispatchThreadID.x;
 
     uint tmp = tid;
-    uint x = tmp % width; tmp /= width;
-    uint y = tmp % height; tmp /= height;
-    uint z = tmp;
-
-    uint3 coord = uint3(x, y, z);
+    uint x = tmp % width;
 
     // Read from texture
-    Element elem = texture[coord.x];
+    Element elem = texture[x];
 
     // Write something to results
     results[tid] = elem;

--- a/tests/test-texture-types.slang
+++ b/tests/test-texture-types.slang
@@ -46,16 +46,15 @@ void testRWTexture2D(
 
     uint tmp = tid;
     uint x = tmp % width; tmp /= width;
-    uint y = tmp % height; tmp /= height;
-    uint z = tmp;
+    uint y = tmp % height;
 
-    uint3 coord = uint3(x, y, z);
+    uint2 coord = uint2(x, y);
 
     // Read from texture
-    Element elem = texture[coord.xy];
+    Element elem = texture[coord];
 
     // Write to texture (if possible)
-    texture[coord.xy] = Element(1);
+    texture[coord] = Element(1);
 
     // Write something to results
     results[tid] = elem;
@@ -74,17 +73,13 @@ void testRWTexture1D(
     uint tid = sv_dispatchThreadID.x;
 
     uint tmp = tid;
-    uint x = tmp % width; tmp /= width;
-    uint y = tmp % height; tmp /= height;
-    uint z = tmp;
-
-    uint3 coord = uint3(x, y, z);
+    uint x = tmp % width;
 
     // Read from texture
-    Element elem = texture[coord.x];
+    Element elem = texture[x];
 
     // Write to texture (if possible)
-    texture[coord.x] = Element(1);
+    texture[x] = Element(1);
 
     // Write something to results
     results[tid] = elem;

--- a/tests/testing.cpp
+++ b/tests/testing.cpp
@@ -92,7 +92,28 @@ public:
     {
         if (!doctest::is_running_in_test)
             return;
-        MESSAGE(doctest::String(message));
+        if (type == DebugMessageType::Info)
+        {
+            INFO(doctest::String(message));
+        }
+        else if (type == DebugMessageType::Warning)
+        {
+            INFO(doctest::String(message));
+        }
+        else if (type == DebugMessageType::Error)
+        {
+            // Don't print the Vulkan validation warning for co-op vec being initialized unless test fails.
+            // (VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_COOPERATIVE_VECTOR_FEATURES_NV)
+            // TODO: Remove once this warning is fixed in the Vulkan SDK.
+            if (strstr(message, "includes a structure with unknown VkStructureType (1000491000)"))
+            {
+                INFO(doctest::String(message));
+            }
+            else
+            {
+                FAIL(doctest::String(message));
+            }
+        }
     }
 };
 
@@ -428,7 +449,7 @@ ComPtr<IDevice> createTestingDevice(
         if (i < featureCount - 1)
             featureStr += " ";
     }
-    MESSAGE("Device features: ", featureStr);
+    INFO("Device features: ", featureStr);
 #endif
 
     if (useCachedDevice)
@@ -624,7 +645,7 @@ bool isDeviceTypeAvailable(DeviceType deviceType)
     auto it = available.find(deviceType);
     if (it == available.end())
     {
-        available[deviceType] = checkDeviceTypeAvailable(deviceType);
+        available[deviceType] = checkDeviceTypeAvailable(deviceType, false);
     }
     return available[deviceType];
 }

--- a/tests/testing.h
+++ b/tests/testing.h
@@ -207,7 +207,6 @@ enum TestFlags
 #define SKIP(msg)                                                                                                      \
     do                                                                                                                 \
     {                                                                                                                  \
-        MESSAGE("Skipping (" msg ")");                                                                                 \
         return;                                                                                                        \
     }                                                                                                                  \
     while (0)

--- a/tests/testing.h
+++ b/tests/testing.h
@@ -204,7 +204,7 @@ enum TestFlags
 #define CHECK_CALL(x) CHECK(!SLANG_FAILED(x))
 #define REQUIRE_CALL(x) REQUIRE(!SLANG_FAILED(x))
 
-#define SKIP(msg)                                                                                                      \
+#define SKIP(reason)                                                                                                   \
     do                                                                                                                 \
     {                                                                                                                  \
         return;                                                                                                        \


### PR DESCRIPTION
- Shifted a load of 'MESSAGE" calls to 'INFO'
- Removed logging of skipped tests
- Removed logging of skipped formats
- Hide Vulkan warning about coop vec structure