### PR TITLE
Sampler improvements

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -710,6 +710,7 @@ if(SLANG_RHI_BUILD_TESTS)
         # tests/test-root-mutable-shader-object.cpp
         tests/test-root-shader-parameter.cpp
         tests/test-sampler-array.cpp
+        tests/test-sampler.cpp
         tests/test-shader-cache.cpp
         tests/test-staging-heap.cpp
         tests/test-surface.cpp

--- a/include/slang-rhi.h
+++ b/include/slang-rhi.h
@@ -909,7 +909,7 @@ struct SamplerDesc
     float mipLODBias = 0.0f;
     uint32_t maxAnisotropy = 1;
     ComparisonFunc comparisonFunc = ComparisonFunc::Never;
-    float borderColor[4] = {1.0f, 1.0f, 1.0f, 1.0f};
+    float borderColor[4] = {0.f, 0.f, 0.f, 0.f};
     float minLOD = 0.0f;
     float maxLOD = 1000.0f;
 

--- a/src/d3d11/d3d11-device.cpp
+++ b/src/d3d11/d3d11-device.cpp
@@ -219,6 +219,8 @@ Result DeviceImpl::initialize(const DeviceDesc& desc)
     m_features.push_back("surface");
     // Supports rasterization
     m_features.push_back("rasterization");
+    // Supports custom border color
+    m_features.push_back("custom-border-color");
 
     // NVAPI
 #if SLANG_RHI_ENABLE_NVAPI

--- a/src/d3d12/d3d12-device.cpp
+++ b/src/d3d12/d3d12-device.cpp
@@ -524,6 +524,8 @@ Result DeviceImpl::initialize(const DeviceDesc& desc)
     m_features.push_back("surface");
     // Supports rasterization
     m_features.push_back("rasterization");
+    // Supports custom border color
+    m_features.push_back("custom-border-color");
 
     if (m_deviceInfo.m_isSoftware)
     {

--- a/src/debug-layer/debug-device.cpp
+++ b/src/debug-layer/debug-device.cpp
@@ -331,12 +331,28 @@ Result DebugDevice::createSampler(const SamplerDesc& desc, ISampler** outSampler
     if (desc.addressU == TextureAddressingMode::ClampToBorder ||
         desc.addressV == TextureAddressingMode::ClampToBorder || desc.addressW == TextureAddressingMode::ClampToBorder)
     {
-        if (desc.borderColor[0] < 0.f || desc.borderColor[0] > 1.f || desc.borderColor[1] < 0.f ||
-            desc.borderColor[1] > 1.f || desc.borderColor[2] < 0.f || desc.borderColor[2] > 1.f ||
-            desc.borderColor[3] < 0.f || desc.borderColor[3] > 1.f)
+        if (ctx->deviceType == DeviceType::WGPU)
+        {
+            RHI_VALIDATION_WARNING("WebGPU doesn't support ClampToBorder addressing mode");
+        }
+
+        const float* color = desc.borderColor;
+        if (color[0] < 0.f || color[0] > 1.f || color[1] < 0.f || color[1] > 1.f || color[2] < 0.f || color[2] > 1.f ||
+            color[3] < 0.f || color[3] > 1.f)
         {
             RHI_VALIDATION_ERROR("Invalid border color (must be in range [0, 1])");
             return SLANG_E_INVALID_ARG;
+        }
+
+        if (!(color[0] == 0.f && color[1] == 0.f && color[2] == 0.f && color[3] == 0.f) &&
+            !(color[0] == 0.f && color[1] == 0.f && color[2] == 0.f && color[3] == 1.f) &&
+            !(color[0] == 1.f && color[1] == 1.f && color[2] == 1.f && color[3] == 1.f) &&
+            !baseObject->hasFeature("custom-border-color"))
+        {
+            RHI_VALIDATION_WARNING(
+                "Border color is not a predefined color and custom border color is not supported. "
+                "Using transparent black instead."
+            );
         }
     }
 

--- a/src/debug-layer/debug-device.cpp
+++ b/src/debug-layer/debug-device.cpp
@@ -287,6 +287,59 @@ Result DebugDevice::createSampler(const SamplerDesc& desc, ISampler** outSampler
 {
     SLANG_RHI_API_FUNC;
 
+    if (desc.minFilter > TextureFilteringMode::Linear)
+    {
+        RHI_VALIDATION_ERROR("Invalid min filter mode");
+        return SLANG_E_INVALID_ARG;
+    }
+    if (desc.magFilter > TextureFilteringMode::Linear)
+    {
+        RHI_VALIDATION_ERROR("Invalid mag filter mode");
+        return SLANG_E_INVALID_ARG;
+    }
+    if (desc.mipFilter > TextureFilteringMode::Linear)
+    {
+        RHI_VALIDATION_ERROR("Invalid mip filter mode");
+        return SLANG_E_INVALID_ARG;
+    }
+    if (desc.reductionOp > TextureReductionOp::Maximum)
+    {
+        RHI_VALIDATION_ERROR("Invalid reduction op");
+        return SLANG_E_INVALID_ARG;
+    }
+    if (desc.addressU > TextureAddressingMode::MirrorOnce)
+    {
+        RHI_VALIDATION_ERROR("Invalid address U mode");
+        return SLANG_E_INVALID_ARG;
+    }
+    if (desc.addressV > TextureAddressingMode::MirrorOnce)
+    {
+        RHI_VALIDATION_ERROR("Invalid address V mode");
+        return SLANG_E_INVALID_ARG;
+    }
+    if (desc.addressW > TextureAddressingMode::MirrorOnce)
+    {
+        RHI_VALIDATION_ERROR("Invalid address W mode");
+        return SLANG_E_INVALID_ARG;
+    }
+    if (desc.comparisonFunc > ComparisonFunc::Always)
+    {
+        RHI_VALIDATION_ERROR("Invalid comparison func");
+        return SLANG_E_INVALID_ARG;
+    }
+
+    if (desc.addressU == TextureAddressingMode::ClampToBorder ||
+        desc.addressV == TextureAddressingMode::ClampToBorder || desc.addressW == TextureAddressingMode::ClampToBorder)
+    {
+        if (desc.borderColor[0] < 0.f || desc.borderColor[0] > 1.f || desc.borderColor[1] < 0.f ||
+            desc.borderColor[1] > 1.f || desc.borderColor[2] < 0.f || desc.borderColor[2] > 1.f ||
+            desc.borderColor[3] < 0.f || desc.borderColor[3] > 1.f)
+        {
+            RHI_VALIDATION_ERROR("Invalid border color (must be in range [0, 1])");
+            return SLANG_E_INVALID_ARG;
+        }
+    }
+
     SamplerDesc patchedDesc = desc;
     std::string label;
     if (!patchedDesc.label)

--- a/src/vulkan/vk-api.h
+++ b/src/vulkan/vk-api.h
@@ -327,6 +327,10 @@ struct VulkanExtendedFeatureProperties
         VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DYNAMIC_RENDERING_FEATURES_KHR
     };
 
+    VkPhysicalDeviceCustomBorderColorFeaturesEXT customBorderColorFeatures = {
+        VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_CUSTOM_BORDER_COLOR_FEATURES_EXT
+    };
+
     VkPhysicalDeviceDynamicRenderingLocalReadFeaturesKHR dynamicRenderingLocalReadFeatures = {
         VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DYNAMIC_RENDERING_LOCAL_READ_FEATURES_KHR
     };

--- a/src/vulkan/vk-device.cpp
+++ b/src/vulkan/vk-device.cpp
@@ -519,6 +519,10 @@ Result DeviceImpl::initVulkanInstanceAndDevice(
         extendedFeatures.dynamicRenderingFeatures.pNext = deviceFeatures2.pNext;
         deviceFeatures2.pNext = &extendedFeatures.dynamicRenderingFeatures;
 
+        // custom border color features
+        extendedFeatures.customBorderColorFeatures.pNext = deviceFeatures2.pNext;
+        deviceFeatures2.pNext = &extendedFeatures.customBorderColorFeatures;
+
         extendedFeatures.dynamicRenderingLocalReadFeatures.pNext = deviceFeatures2.pNext;
         deviceFeatures2.pNext = &extendedFeatures.dynamicRenderingLocalReadFeatures;
 
@@ -662,6 +666,13 @@ Result DeviceImpl::initVulkanInstanceAndDevice(
             extendedDynamicState,
             VK_EXT_EXTENDED_DYNAMIC_STATE_EXTENSION_NAME,
             "extended-dynamic-states"
+        );
+
+        SIMPLE_EXTENSION_FEATURE(
+            extendedFeatures.customBorderColorFeatures,
+            customBorderColors,
+            VK_EXT_CUSTOM_BORDER_COLOR_EXTENSION_NAME,
+            "custom-border-color"
         );
 
         if (extendedFeatures.accelerationStructureFeatures.accelerationStructure &&

--- a/src/vulkan/vk-sampler.cpp
+++ b/src/vulkan/vk-sampler.cpp
@@ -44,7 +44,7 @@ Result DeviceImpl::createSampler(const SamplerDesc& desc, ISampler** outSampler)
     // Determine border color.
     // First, we check for predefined border colors.
     // If no match is found, we use custom border color if supported.
-    // If custom border color is not supported, we use opaque black.
+    // If custom border color is not supported, we use transparent black.
     {
         struct BorderColor
         {
@@ -80,7 +80,7 @@ Result DeviceImpl::createSampler(const SamplerDesc& desc, ISampler** outSampler)
             }
             else
             {
-                samplerInfo.borderColor = VK_BORDER_COLOR_FLOAT_OPAQUE_BLACK;
+                samplerInfo.borderColor = VK_BORDER_COLOR_FLOAT_TRANSPARENT_BLACK;
             }
         }
     }

--- a/tests/test-sampler.cpp
+++ b/tests/test-sampler.cpp
@@ -150,7 +150,7 @@ static void testSampler(IDevice* device, const SamplerDesc& samplerDesc, span<Te
     test.check(sampler, testRecords);
 }
 
-GPU_TEST_CASE("sampler-filter-point", D3D11 | D3D12 | Vulkan | WGPU)
+GPU_TEST_CASE("sampler-filter-point", D3D11 | D3D12 | Vulkan | Metal | WGPU)
 {
     SamplerDesc desc = {};
     desc.minFilter = TextureFilteringMode::Point;
@@ -178,7 +178,7 @@ GPU_TEST_CASE("sampler-filter-point", D3D11 | D3D12 | Vulkan | WGPU)
     testSampler(device, desc, testRecords);
 }
 
-GPU_TEST_CASE("sampler-filter-linear", D3D11 | D3D12 | Vulkan | WGPU)
+GPU_TEST_CASE("sampler-filter-linear", D3D11 | D3D12 | Vulkan | Metal | WGPU)
 {
     SamplerDesc desc = {};
     desc.minFilter = TextureFilteringMode::Linear;
@@ -208,7 +208,7 @@ GPU_TEST_CASE("sampler-filter-linear", D3D11 | D3D12 | Vulkan | WGPU)
     testSampler(device, desc, testRecords);
 }
 
-GPU_TEST_CASE("sampler-border-black-opaque", D3D11 | D3D12 | Vulkan)
+GPU_TEST_CASE("sampler-border-black-transparent", D3D11 | D3D12 | Vulkan | Metal)
 {
     SamplerDesc desc = {};
     desc.addressU = TextureAddressingMode::ClampToBorder;
@@ -223,7 +223,27 @@ GPU_TEST_CASE("sampler-border-black-opaque", D3D11 | D3D12 | Vulkan)
     testSampler(device, desc, testRecords);
 }
 
-GPU_TEST_CASE("sampler-border-white-opaque", D3D11 | D3D12 | Vulkan)
+GPU_TEST_CASE("sampler-border-black-opaque", D3D11 | D3D12 | Vulkan | Metal)
+{
+    SamplerDesc desc = {};
+    desc.addressU = TextureAddressingMode::ClampToBorder;
+    desc.addressV = TextureAddressingMode::ClampToBorder;
+    desc.addressW = TextureAddressingMode::ClampToBorder;
+    desc.borderColor[0] = 0.f;
+    desc.borderColor[1] = 0.f;
+    desc.borderColor[2] = 0.f;
+    desc.borderColor[3] = 1.f;
+
+
+    TestRecord testRecords[] = {
+        // outside of texture
+        {-0.5f, -0.5f, 0.f, {0.f, 0.f, 0.f, 1.f}},
+    };
+
+    testSampler(device, desc, testRecords);
+}
+
+GPU_TEST_CASE("sampler-border-white-opaque", D3D11 | D3D12 | Vulkan | Metal)
 {
     SamplerDesc desc = {};
     desc.addressU = TextureAddressingMode::ClampToBorder;
@@ -242,8 +262,11 @@ GPU_TEST_CASE("sampler-border-white-opaque", D3D11 | D3D12 | Vulkan)
     testSampler(device, desc, testRecords);
 }
 
-GPU_TEST_CASE("sampler-border-custom-color", D3D11 | D3D12 | Vulkan)
+GPU_TEST_CASE("sampler-border-custom-color", D3D11 | D3D12 | Vulkan | Metal)
 {
+    if (!device->hasFeature("custom-border-color"))
+        return;
+
     SamplerDesc desc = {};
     desc.addressU = TextureAddressingMode::ClampToBorder;
     desc.addressV = TextureAddressingMode::ClampToBorder;

--- a/tests/test-sampler.cpp
+++ b/tests/test-sampler.cpp
@@ -1,0 +1,262 @@
+#include "testing.h"
+#include "core/span.h"
+
+using namespace rhi;
+using namespace rhi::testing;
+
+static Result createTestTexture(IDevice* device, ITexture** outTexture)
+{
+    ComPtr<ITexture> texture;
+    TextureDesc desc = {};
+    desc.type = TextureType::Texture2D;
+    desc.format = Format::RGBA32Float;
+    desc.size = {2, 2, 1};
+    desc.mipLevelCount = 2;
+    desc.memoryType = MemoryType::DeviceLocal;
+    desc.usage = TextureUsage::ShaderResource | TextureUsage::CopyDestination | TextureUsage::CopySource;
+
+    // mip 0
+    // ---------------------
+    // |         |         |
+    // | 1,0,0,0 | 0,1,0,0 |
+    // |         |         |
+    // ---------------------
+    // |         |         |
+    // | 0,0,1,0 | 0,0,0,1 |
+    // |         |         |
+    // ---------------------
+    // mip 1
+    // -----------
+    // |         |
+    // | 1,1,1,1 |
+    // |         |
+    // -----------
+
+    float mip0Data[] = {1.f, 0.f, 0.f, 0.f, 0.f, 1.f, 0.f, 0.f, 0.f, 0.f, 1.f, 0.f, 0.f, 0.f, 0.f, 1.f};
+    float mip1Data[] = {1.f, 1.f, 1.f, 1.f};
+    SubresourceData subResourceData[2] = {
+        {mip0Data, 32, 0},
+        {mip1Data, 16, 0},
+    };
+    return device->createTexture(desc, subResourceData, outTexture);
+}
+
+struct TestInput
+{
+    float u;
+    float v;
+    float level;
+    float padding;
+};
+
+struct TestOutput
+{
+    float color[4];
+};
+
+struct TestRecord
+{
+    float u;
+    float v;
+    float level;
+    float expectedColor[4];
+};
+
+struct SamplerTest
+{
+    static constexpr size_t kMaxRecords = 32;
+
+    ComPtr<IDevice> device;
+    ComPtr<ITexture> texture;
+    ComPtr<IBuffer> inputBuffer;
+    ComPtr<IBuffer> resultBuffer;
+    ComPtr<IComputePipeline> pipeline;
+
+    void init(IDevice* device)
+    {
+        this->device = device;
+        REQUIRE_CALL(createTestTexture(device, texture.writeRef()));
+
+        ComPtr<IShaderProgram> shaderProgram;
+        slang::ProgramLayout* slangReflection;
+        REQUIRE_CALL(loadComputeProgram(device, shaderProgram, "test-sampler", "sampleTexture", slangReflection));
+
+        ComputePipelineDesc pipelineDesc = {};
+        pipelineDesc.program = shaderProgram.get();
+        REQUIRE_CALL(device->createComputePipeline(pipelineDesc, pipeline.writeRef()));
+
+        BufferDesc bufferDesc = {};
+        bufferDesc.size = kMaxRecords * sizeof(TestInput);
+        bufferDesc.elementSize = sizeof(TestInput);
+        bufferDesc.usage = BufferUsage::ShaderResource | BufferUsage::CopyDestination;
+        REQUIRE_CALL(device->createBuffer(bufferDesc, nullptr, inputBuffer.writeRef()));
+
+        bufferDesc.size = kMaxRecords * sizeof(TestOutput);
+        bufferDesc.elementSize = sizeof(TestOutput);
+        bufferDesc.usage = BufferUsage::UnorderedAccess | BufferUsage::CopySource;
+        REQUIRE_CALL(device->createBuffer(bufferDesc, nullptr, resultBuffer.writeRef()));
+    }
+
+    void check(ISampler* sampler, span<TestRecord> testRecords)
+    {
+        REQUIRE(testRecords.size() <= kMaxRecords);
+        std::vector<TestInput> inputData;
+        for (const auto& record : testRecords)
+        {
+            inputData.push_back({record.u, record.v, record.level, 0.f});
+        }
+        ComPtr<ICommandQueue> queue = device->getQueue(QueueType::Graphics);
+        ComPtr<ICommandEncoder> encoder = queue->createCommandEncoder();
+        encoder->uploadBufferData(inputBuffer, 0, inputData.size() * sizeof(TestInput), inputData.data());
+        IComputePassEncoder* passEncoder = encoder->beginComputePass();
+        IShaderObject* rootObject = passEncoder->bindPipeline(pipeline);
+        ShaderCursor cursor(rootObject);
+        cursor["texture"].setBinding(texture);
+        cursor["sampler"].setBinding(sampler);
+        cursor["inputs"].setBinding(inputBuffer);
+        cursor["results"].setBinding(resultBuffer);
+        cursor["count"].setData((uint32_t)testRecords.size());
+        passEncoder->dispatchCompute((uint32_t)testRecords.size(), 1, 1);
+        passEncoder->end();
+        queue->submit(encoder->finish());
+        queue->waitOnHost();
+
+        ComPtr<ISlangBlob> resultData;
+        REQUIRE_CALL(device->readBuffer(resultBuffer, 0, testRecords.size() * sizeof(TestOutput), resultData.writeRef())
+        );
+        const TestOutput* output = (const TestOutput*)resultData->getBufferPointer();
+        for (size_t i = 0; i < testRecords.size(); i++)
+        {
+            const TestRecord& record = testRecords[i];
+            CAPTURE(record.u);
+            CAPTURE(record.v);
+            CAPTURE(record.level);
+            for (size_t j = 0; j < 4; j++)
+            {
+                CAPTURE(j);
+                REQUIRE_EQ(output[i].color[j], testRecords[i].expectedColor[j]);
+            }
+        }
+    }
+};
+
+static void testSampler(IDevice* device, const SamplerDesc& samplerDesc, span<TestRecord> testRecords)
+{
+    ComPtr<ISampler> sampler;
+    REQUIRE_CALL(device->createSampler(samplerDesc, sampler.writeRef()));
+
+    SamplerTest test;
+    test.init(device);
+    test.check(sampler, testRecords);
+}
+
+GPU_TEST_CASE("sampler-filter-point", D3D11 | D3D12 | Vulkan | WGPU)
+{
+    SamplerDesc desc = {};
+    desc.minFilter = TextureFilteringMode::Point;
+    desc.magFilter = TextureFilteringMode::Point;
+
+    TestRecord testRecords[] = {
+        // top-left texel
+        {0.01f, 0.01f, 0.f, {1.f, 0.f, 0.f, 0.f}},
+        {0.25f, 0.25f, 0.f, {1.f, 0.f, 0.f, 0.f}},
+        {0.49f, 0.49f, 0.f, {1.f, 0.f, 0.f, 0.f}},
+        // top-right texel
+        {0.51f, 0.01f, 0.f, {0.f, 1.f, 0.f, 0.f}},
+        {0.75f, 0.25f, 0.f, {0.f, 1.f, 0.f, 0.f}},
+        {0.99f, 0.49f, 0.f, {0.f, 1.f, 0.f, 0.f}},
+        // bottom-left texel
+        {0.01f, 0.51f, 0.f, {0.f, 0.f, 1.f, 0.f}},
+        {0.25f, 0.75f, 0.f, {0.f, 0.f, 1.f, 0.f}},
+        {0.49f, 0.99f, 0.f, {0.f, 0.f, 1.f, 0.f}},
+        // bottom-right texel
+        {0.51f, 0.51f, 0.f, {0.f, 0.f, 0.f, 1.f}},
+        {0.75f, 0.75f, 0.f, {0.f, 0.f, 0.f, 1.f}},
+        {0.99f, 0.99f, 0.f, {0.f, 0.f, 0.f, 1.f}},
+    };
+
+    testSampler(device, desc, testRecords);
+}
+
+GPU_TEST_CASE("sampler-filter-linear", D3D11 | D3D12 | Vulkan | WGPU)
+{
+    SamplerDesc desc = {};
+    desc.minFilter = TextureFilteringMode::Linear;
+    desc.magFilter = TextureFilteringMode::Linear;
+
+    TestRecord testRecords[] = {
+        // top-left texel
+        {0.25f, 0.25f, 0.f, {1.f, 0.f, 0.f, 0.f}},
+        // top-right texel
+        {0.75f, 0.25f, 0.f, {0.f, 1.f, 0.f, 0.f}},
+        // bottom-left texel
+        {0.25f, 0.75f, 0.f, {0.f, 0.f, 1.f, 0.f}},
+        // bottom-right texel
+        {0.75f, 0.75f, 0.f, {0.f, 0.f, 0.f, 1.f}},
+        // left (interpolated)
+        {0.25f, 0.5f, 0.f, {0.5f, 0.f, 0.5f, 0.f}},
+        // right (interpolated)
+        {0.75f, 0.5f, 0.f, {0.f, 0.5f, 0.f, 0.5f}},
+        // top (interpolated)
+        {0.5f, 0.25f, 0.f, {0.5f, 0.5f, 0.f, 0.f}},
+        // bottom (interpolated)
+        {0.5f, 0.75f, 0.f, {0.f, 0.f, 0.5f, 0.5f}},
+        // middle (interpolated)
+        {0.5f, 0.5f, 0.f, {0.25f, 0.25f, 0.25f, 0.25f}},
+    };
+
+    testSampler(device, desc, testRecords);
+}
+
+GPU_TEST_CASE("sampler-border-black-opaque", D3D11 | D3D12 | Vulkan)
+{
+    SamplerDesc desc = {};
+    desc.addressU = TextureAddressingMode::ClampToBorder;
+    desc.addressV = TextureAddressingMode::ClampToBorder;
+    desc.addressW = TextureAddressingMode::ClampToBorder;
+
+    TestRecord testRecords[] = {
+        // outside of texture
+        {-0.5f, -0.5f, 0.f, {0.f, 0.f, 0.f, 0.f}},
+    };
+
+    testSampler(device, desc, testRecords);
+}
+
+GPU_TEST_CASE("sampler-border-white-opaque", D3D11 | D3D12 | Vulkan)
+{
+    SamplerDesc desc = {};
+    desc.addressU = TextureAddressingMode::ClampToBorder;
+    desc.addressV = TextureAddressingMode::ClampToBorder;
+    desc.addressW = TextureAddressingMode::ClampToBorder;
+    desc.borderColor[0] = 1.f;
+    desc.borderColor[1] = 1.f;
+    desc.borderColor[2] = 1.f;
+    desc.borderColor[3] = 1.f;
+
+    TestRecord testRecords[] = {
+        // outside of texture
+        {-0.5f, -0.5f, 0.f, {1.f, 1.f, 1.f, 1.f}},
+    };
+
+    testSampler(device, desc, testRecords);
+}
+
+GPU_TEST_CASE("sampler-border-custom-color", D3D11 | D3D12 | Vulkan)
+{
+    SamplerDesc desc = {};
+    desc.addressU = TextureAddressingMode::ClampToBorder;
+    desc.addressV = TextureAddressingMode::ClampToBorder;
+    desc.addressW = TextureAddressingMode::ClampToBorder;
+    desc.borderColor[0] = 0.25f;
+    desc.borderColor[1] = 0.5f;
+    desc.borderColor[2] = 0.75f;
+    desc.borderColor[3] = 1.f;
+
+    TestRecord testRecords[] = {
+        // outside of texture
+        {-0.5f, -0.5f, 0.f, {0.25f, 0.5f, 0.75f, 1.f}},
+    };
+
+    testSampler(device, desc, testRecords);
+}

--- a/tests/test-sampler.slang
+++ b/tests/test-sampler.slang
@@ -1,0 +1,25 @@
+
+struct TestInput
+{
+    float2 uv;
+    float level;
+    float padding;
+};
+
+[shader("compute")]
+[numthreads(1, 1, 1)]
+void sampleTexture(
+    uint tid: SV_DispatchThreadID,
+    Texture2D texture,
+    SamplerState sampler,
+    StructuredBuffer<TestInput> inputs,
+    RWStructuredBuffer<float4> results,
+    uniform uint count
+)
+{
+    if (tid >= count)
+        return;
+
+    uint index = tid;
+    results[index] = texture.SampleLevel(sampler, inputs[index].uv, inputs[index].level);
+}


### PR DESCRIPTION
- set default border color to transparent black
- add `custom-border-color` device feature (d3d11, d3d12, vulkan)
- add basic sampler tests
- add basic sampler validation
- add support for predefined and custom border color in vulkan
- add support for predefined border color in metal