### PR TITLE
Fixed a typo in Vulkan createSampler

### DIFF
--- a/src/vulkan/vk-sampler.cpp
+++ b/src/vulkan/vk-sampler.cpp
@@ -27,8 +27,8 @@ Result DeviceImpl::createSampler(const SamplerDesc& desc, ISampler** outSampler)
 {
     VkSamplerCreateInfo samplerInfo = {VK_STRUCTURE_TYPE_SAMPLER_CREATE_INFO};
 
-    samplerInfo.magFilter = VulkanUtil::translateFilterMode(desc.minFilter);
-    samplerInfo.minFilter = VulkanUtil::translateFilterMode(desc.magFilter);
+    samplerInfo.magFilter = VulkanUtil::translateFilterMode(desc.magFilter);
+    samplerInfo.minFilter = VulkanUtil::translateFilterMode(desc.minFilter);
 
     samplerInfo.addressModeU = VulkanUtil::translateAddressingMode(desc.addressU);
     samplerInfo.addressModeV = VulkanUtil::translateAddressingMode(desc.addressV);


### PR DESCRIPTION
The `min` and `mag` filters were swapped between the RHI and Vulkan descriptors.