### PR TITLE
fix(d3d11): use correct cbvCount when binding constant buffers

### DIFF
--- a/src/d3d11/d3d11-command.cpp
+++ b/src/d3d11/d3d11-command.cpp
@@ -323,7 +323,7 @@ void CommandExecutor::cmdSetRenderState(const commands::SetRenderState& cmd)
         // Bind constant buffers, shader resource views, and samplers.
         m_immediateContext->VSSetConstantBuffers1(
             0,
-            m_bindingData->uavCount,
+            m_bindingData->cbvCount,
             m_bindingData->cbvsBuffer,
             m_bindingData->cbvsFirst,
             m_bindingData->cbvsCount


### PR DESCRIPTION
The D3D11 backend was incorrectly using uavCount instead of cbvCount when binding constant buffers in VSSetConstantBuffers1. This caused rendering tests to fail as constant buffers weren't properly provided to the pipeline.

Fixes shader-slang/slang#6531


#262 Already has the fix !. So either we update the submodule for Top of the tree shader-slang/slang or pick this.