### PR TITLE
Turned all bool-cast operators explicit and fixed places it broke.

### DIFF
--- a/include/slang-rhi.h
+++ b/include/slang-rhi.h
@@ -442,7 +442,7 @@ struct NativeHandle
     NativeHandleType type = NativeHandleType::Undefined;
     uint64_t value = 0;
 
-    operator bool() const { return type != NativeHandleType::Undefined; }
+    explicit operator bool() const { return type != NativeHandleType::Undefined; }
 };
 
 struct InputElementDesc
@@ -963,7 +963,9 @@ struct BufferOffsetPair
     {
     }
 
-    operator bool() const { return buffer != nullptr; }
+    explicit operator bool() const { return buffer != nullptr; }
+    bool operator==(const BufferOffsetPair& rhs) const { return buffer == rhs.buffer && offset != rhs.offset; }
+    bool operator!=(const BufferOffsetPair& rhs) const { return !(*this == rhs); }
 
     DeviceAddress getDeviceAddress() const { return buffer->getDeviceAddress() + offset; }
 };

--- a/include/slang-rhi.h
+++ b/include/slang-rhi.h
@@ -964,7 +964,7 @@ struct BufferOffsetPair
     }
 
     explicit operator bool() const { return buffer != nullptr; }
-    bool operator==(const BufferOffsetPair& rhs) const { return buffer == rhs.buffer && offset != rhs.offset; }
+    bool operator==(const BufferOffsetPair& rhs) const { return buffer == rhs.buffer && offset == rhs.offset; }
     bool operator!=(const BufferOffsetPair& rhs) const { return !(*this == rhs); }
 
     DeviceAddress getDeviceAddress() const { return buffer->getDeviceAddress() + offset; }

--- a/src/core/offset-allocator.h
+++ b/src/core/offset-allocator.h
@@ -34,7 +34,7 @@ public:
         NodeIndex metadata = NO_SPACE; // internal: node index
 
         bool isValid() const { return offset != NO_SPACE; }
-        operator bool() const { return isValid(); }
+        explicit operator bool() const { return isValid(); }
     };
 
     struct StorageReport

--- a/src/d3d12/d3d12-descriptor-heap.h
+++ b/src/d3d12/d3d12-descriptor-heap.h
@@ -61,7 +61,7 @@ struct CPUDescriptorAllocation
 
     /// Returns true if the allocation is valid.
     bool isValid() const { return cpuHandle.ptr != 0; }
-    operator bool() const { return isValid(); }
+    explicit operator bool() const { return isValid(); }
 
 private:
     uint32_t heapIndex;
@@ -90,7 +90,7 @@ struct CPUDescriptorRangeAllocation
 
     /// Returns true if the allocation is valid.
     bool isValid() const { return firstCpuHandle.ptr != 0; }
-    operator bool() const { return isValid(); }
+    explicit operator bool() const { return isValid(); }
 
 private:
     uint16_t descriptorSize;
@@ -189,7 +189,7 @@ struct GPUDescriptorRange
 
     /// Returns true if the range is valid.
     bool isValid() const { return firstGpuHandle.ptr != 0; }
-    operator bool() const { return isValid(); }
+    explicit operator bool() const { return isValid(); }
 };
 
 /// Represents a range of allocated GPU descriptors.

--- a/src/d3d12/d3d12-texture.cpp
+++ b/src/d3d12/d3d12-texture.cpp
@@ -62,7 +62,7 @@ Result TextureImpl::getSharedHandle(NativeHandle* outHandle)
     return SLANG_E_NOT_AVAILABLE;
 #else
     // Check if a shared handle already exists for this resource.
-    if (m_sharedHandle != 0)
+    if (m_sharedHandle)
     {
         *outHandle = m_sharedHandle;
         return SLANG_OK;

--- a/src/nvapi/nvapi-util.h
+++ b/src/nvapi/nvapi-util.h
@@ -12,7 +12,7 @@ struct NVAPIShaderExtension
 {
     uint32_t uavSlot = uint32_t(-1);
     uint32_t registerSpace = 0;
-    operator bool() const { return uavSlot != uint32_t(-1); }
+    explicit operator bool() const { return uavSlot != uint32_t(-1); }
 };
 
 struct NVAPIUtil

--- a/src/shader-object.h
+++ b/src/shader-object.h
@@ -33,7 +33,7 @@ struct ResourceSlot
     {
         BufferRange bufferRange = kEntireBuffer;
     };
-    operator bool() const { return type != BindingType::Undefined && resource; }
+    explicit operator bool() const { return type != BindingType::Undefined && resource; }
 };
 
 const ShaderComponentID kInvalidComponentID = 0xFFFFFFFF;


### PR DESCRIPTION
I have made all casts to bool explicit. Pattern like `if (myNativeHandle)` will still work without an actual explicit cast, due to Contextual conversions:
https://en.cppreference.com/w/cpp/language/implicit_conversion

This prevents future introduce of the other bug fixed in this PR, where:
```
state.indexBuffer != m_renderState.indexBuffer
```
didn't actually compare if the buffers were the same, because the `BufferOffsetPair` type does not have operator !=, but instead it first cast both sides to bool and them compared those, effectively resulting on XOR on whether either of buffers exists.