### PR TITLE
Add reporting for D3D11 double support

### DIFF
--- a/src/d3d11/d3d11-device.cpp
+++ b/src/d3d11/d3d11-device.cpp
@@ -257,7 +257,7 @@ Result DeviceImpl::initialize(const DeviceDesc& desc)
         D3D11_FEATURE_DATA_DOUBLES doublePrecisionFeature = {};
         if (SUCCEEDED(m_device->CheckFeatureSupport(
                 D3D11_FEATURE_DOUBLES,
-                &doublePrecisionFeature, 
+                &doublePrecisionFeature,
                 sizeof(doublePrecisionFeature))) &&
             doublePrecisionFeature.DoublePrecisionFloatShaderOps)
         {

--- a/src/d3d11/d3d11-device.cpp
+++ b/src/d3d11/d3d11-device.cpp
@@ -252,6 +252,16 @@ Result DeviceImpl::initialize(const DeviceDesc& desc)
     }
 #endif // SLANG_RHI_ENABLE_NVAPI
 
+    // Check double precision support
+    {
+        D3D11_FEATURE_DATA_DOUBLES doublePrecisionFeature = {};
+        if (SUCCEEDED(m_device->CheckFeatureSupport(D3D11_FEATURE_DOUBLES, &doublePrecisionFeature, sizeof(doublePrecisionFeature))) 
+            && doublePrecisionFeature.DoublePrecisionFloatShaderOps)
+        {
+            m_features.add("double");
+        }
+    }
+
     {
         // Create a TIMESTAMP_DISJOINT query object to query/update frequency info.
         D3D11_QUERY_DESC disjointQueryDesc = {};

--- a/src/d3d11/d3d11-device.cpp
+++ b/src/d3d11/d3d11-device.cpp
@@ -261,7 +261,7 @@ Result DeviceImpl::initialize(const DeviceDesc& desc)
                 sizeof(doublePrecisionFeature))) &&
             doublePrecisionFeature.DoublePrecisionFloatShaderOps)
         {
-            m_features.add("double");
+            m_features.push_back("double");
         }
     }
 

--- a/src/d3d11/d3d11-device.cpp
+++ b/src/d3d11/d3d11-device.cpp
@@ -255,8 +255,11 @@ Result DeviceImpl::initialize(const DeviceDesc& desc)
     // Check double precision support
     {
         D3D11_FEATURE_DATA_DOUBLES doublePrecisionFeature = {};
-        if (SUCCEEDED(m_device->CheckFeatureSupport(D3D11_FEATURE_DOUBLES, &doublePrecisionFeature, sizeof(doublePrecisionFeature))) 
-            && doublePrecisionFeature.DoublePrecisionFloatShaderOps)
+        if (SUCCEEDED(m_device->CheckFeatureSupport(
+                D3D11_FEATURE_DOUBLES,
+                &doublePrecisionFeature, 
+                sizeof(doublePrecisionFeature))) &&
+            doublePrecisionFeature.DoublePrecisionFloatShaderOps)
         {
             m_features.add("double");
         }


### PR DESCRIPTION
For https://github.com/shader-slang/slang/issues/6171

This adds logic for reporting double support to the d3d11 backend, to allow for checking for that support when running slang-test tests on GPUs that do not support D3D11_FEATURE_DOUBLES.