### PR TITLE
Fix issues with d3d12 textureViews (#220)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -730,6 +730,7 @@ if(SLANG_RHI_BUILD_TESTS)
         tests/test-texture-create.cpp
         tests/test-texture-layout.cpp
         tests/test-texture-shared.cpp
+        tests/test-texture-view.cpp
         tests/test-texture-types.cpp
         tests/test-uint16-structured-buffer.cpp
         tests/testing.cpp

--- a/cmake/FetchPackage.cmake
+++ b/cmake/FetchPackage.cmake
@@ -9,6 +9,7 @@ macro(FetchPackage name)
     FetchContent_Declare(
         ${name}
         URL ${FETCH_URL}
+        HTTP_HEADER "Authorization: token ${SLANG_GITHUB_TOKEN}"
     )
     FetchContent_GetProperties(${name})
     if(NOT ${name}_POPULATED)

--- a/include/slang-rhi.h
+++ b/include/slang-rhi.h
@@ -656,7 +656,7 @@ struct SubresourceRange
 
     // TODO: Check this comment - many areas explicitly specify a 3D offset / extents,
     // and this is expected to be 0 for 3D texture.
-    uint32_t baseArrayLayer; // For Texture3D, this is WSlice.
+    uint32_t baseArrayLayer;
 
     uint32_t layerCount; // For cube maps, this is a multiple of 6.
 
@@ -686,7 +686,7 @@ static const size_t kDefaultAlignment = 0xffffffff;
 /// "layers" of texels.
 ///
 /// For a texture with multiple mip levels or array elements,
-/// each mip level and array element is stores as a distinct
+/// each mip level and array element is stored as a distinct
 /// subresource. When indexing into an array of subresources,
 /// the index of a subresoruce for mip level `m` and array
 /// index `a` is `m + a*mipLevelCount`.

--- a/src/d3d12/d3d12-texture.cpp
+++ b/src/d3d12/d3d12-texture.cpp
@@ -215,8 +215,11 @@ D3D12_CPU_DESCRIPTOR_HANDLE TextureImpl::getUAV(
     case TextureType::Texture3D:
         viewDesc.ViewDimension = D3D12_UAV_DIMENSION_TEXTURE3D;
         viewDesc.Texture3D.MipSlice = range.mipLevel;
-        viewDesc.Texture3D.FirstWSlice = range.baseArrayLayer;
-        viewDesc.Texture3D.WSize = max(m_desc.size.depth >> range.mipLevel, 1);
+        // Set these to 0 and -1 for now to select all depth
+        // slices by default, as selecting a subset of depth slices
+        // is a concept currently only supported by d3d12.
+        viewDesc.Texture3D.FirstWSlice = 0;
+        viewDesc.Texture3D.WSize = -1;
         break;
     }
 
@@ -279,8 +282,11 @@ D3D12_CPU_DESCRIPTOR_HANDLE TextureImpl::getRTV(
     case TextureType::Texture3D:
         viewDesc.ViewDimension = D3D12_RTV_DIMENSION_TEXTURE3D;
         viewDesc.Texture3D.MipSlice = range.mipLevel;
-        viewDesc.Texture3D.FirstWSlice = range.baseArrayLayer;
-        viewDesc.Texture3D.WSize = max(m_desc.size.depth >> range.mipLevel, 1);
+        // Set these to 0 and -1 for now to select all depth
+        // slices by default, as selecting a subset of depth slices
+        // is a concept currently only supported by d3d12.
+        viewDesc.Texture3D.FirstWSlice = 0;
+        viewDesc.Texture3D.WSize = -1;
         break;
     }
 

--- a/src/rhi-shared.cpp
+++ b/src/rhi-shared.cpp
@@ -139,7 +139,7 @@ SubresourceRange Texture::resolveSubresourceRange(const SubresourceRange& range)
     SubresourceRange resolved = range;
     resolved.mipLevel = min(resolved.mipLevel, m_desc.mipLevelCount);
     resolved.mipLevelCount = min(resolved.mipLevelCount, m_desc.mipLevelCount - resolved.mipLevel);
-    resolved.baseArrayLayer = min(resolved.baseArrayLayer, m_desc.getLayerCount());
+    resolved.baseArrayLayer = min(resolved.baseArrayLayer, (m_desc.getLayerCount()-1));
     resolved.layerCount = min(resolved.layerCount, m_desc.getLayerCount() - resolved.baseArrayLayer);
     return resolved;
 }

--- a/tests/test-texture-view.cpp
+++ b/tests/test-texture-view.cpp
@@ -1,0 +1,186 @@
+// UnorderedAccess tests create textures with unique values at each pixel and then sets up textureViews on a subrange
+// of the texture. The textureViews are bound to shaders that read values off the subregion and stores them in a
+// buffer. The buffer output is then compared to the expected values for that region to verify that the textureView
+// was created and bound correctly. Tests should not result in API errors etc.
+
+// TODO: Implement RenderTarget tests.
+// RenderTarget tests should clear a render target texture or texture array and all mip levels to some default. Then
+// a specific region should be setup in a textureView such that this region can be cleared to a non default color
+// to verify correctness.
+
+// TODO: Implement additional tests for various TextureType's
+
+#include "testing.h"
+#include "../src/core/string.h"
+#include <map>
+#include <algorithm>
+
+using namespace rhi;
+using namespace rhi::testing;
+
+// Do we need to clean anything up like created resources?
+
+struct TestTextureViews
+{
+    ComPtr<IDevice> device;
+    std::map<std::string, ComPtr<IComputePipeline>> cachedPipelines;
+
+    void init(IDevice* device)
+    {
+        this->device = device;
+    }
+
+    ComPtr<IBuffer> createResultBuffer(int size)
+    {
+        BufferDesc bufferDesc = {};
+        bufferDesc.size = size;
+        bufferDesc.format = Format::R32Float;
+        bufferDesc.usage = BufferUsage::ShaderResource | BufferUsage::UnorderedAccess | BufferUsage::CopySource;
+        bufferDesc.defaultState = ResourceState::UnorderedAccess;
+        bufferDesc.memoryType = MemoryType::DeviceLocal;
+
+        ComPtr<IBuffer> resultBuffer = device->createBuffer(bufferDesc);
+        return resultBuffer;
+    }
+
+    ComPtr<ITextureView> createTextureAndTextureView(TextureType textureType, TextureUsage usage, uint32_t mipLevelCount, Extents textureSize, SubresourceRange textureViewRange, SubresourceData* data)
+    {
+        TextureDesc texDesc = {};
+        texDesc.type = textureType;
+        texDesc.mipLevelCount = mipLevelCount;
+        texDesc.size = textureSize;
+        texDesc.usage = usage;
+        texDesc.defaultState = usage == TextureUsage::UnorderedAccess ? ResourceState::UnorderedAccess : ResourceState::RenderTarget;
+        texDesc.format = Format::R32Float; // Assuming Format::R32Float until there are test that require something different
+
+        ComPtr<ITexture> texture;
+        REQUIRE_CALL(device->createTexture(texDesc, data, texture.writeRef()));
+
+        ComPtr<ITextureView> view;
+        TextureViewDesc viewDesc = {};
+        viewDesc.format = Format::R32Float;
+        viewDesc.subresourceRange = textureViewRange;
+        REQUIRE_CALL(device->createTextureView(texture, viewDesc, view.writeRef()));
+        return view;
+    }
+
+    void testTextureViewUnorderedAccess(
+        TextureType textureType,
+        uint32_t mipLevelCount,
+        Extents textureSize,
+        SubresourceRange textureViewRange,
+        SubresourceData* textureData
+    )
+    {
+        ComPtr<ITextureView> textureView = createTextureAndTextureView(textureType, TextureUsage::UnorderedAccess, mipLevelCount, textureSize, textureViewRange, textureData);
+
+        // Create result buffer
+        Extents textureViewSize = {
+                                    std::max(textureSize.width >> textureViewRange.mipLevel, 1),
+                                    std::max(textureSize.height >> textureViewRange.mipLevel, 1),
+                                    std::max(textureSize.depth >> textureViewRange.mipLevel, 1)
+                                  };
+        // In bytes
+        int dataLength = textureViewSize.width * textureViewSize.height * textureViewSize.depth * sizeof(float); // Assuming Format::R32Float
+        ComPtr<IBuffer> resultBuffer = createResultBuffer(dataLength);
+
+        // Do setup work ...
+
+        // Use this as a default until we run other tests
+        std::string entryPointName = "testRWTex3DViewFloat";
+
+        ComPtr<IComputePipeline>& pipeline = cachedPipelines[entryPointName.c_str()];
+        if (!pipeline)
+        {
+            ComPtr<IShaderProgram> shaderProgram;
+            slang::ProgramLayout* slangReflection;
+            REQUIRE_CALL(loadComputeProgram(device, shaderProgram, "test-texture-view", entryPointName.c_str(), slangReflection));
+
+            ComputePipelineDesc pipelineDesc = {};
+            pipelineDesc.program = shaderProgram.get();
+            REQUIRE_CALL(device->createComputePipeline(pipelineDesc, pipeline.writeRef()));
+        }
+
+        // We have done all the set up work, now it is time to start recording a command buffer for
+        // GPU execution.
+        {
+            auto queue = device->getQueue(QueueType::Graphics);
+            auto commandEncoder = queue->createCommandEncoder();
+
+            auto passEncoder = commandEncoder->beginComputePass();
+            auto rootObject = passEncoder->bindPipeline(pipeline);
+            ShaderCursor cursor(rootObject->getEntryPoint(0)); // get a cursor to the first entry-point.
+            // Bind texture view to the entry point
+            cursor["tex"].setBinding(textureView);
+
+            // Bind buffer view to the entry point.
+            cursor["buffer"].setBinding(resultBuffer);
+
+            // Dispatch compute shader with thread groups matching the dimensions of the textureView
+            // as the basic test shader runs 1x1x1 threads per group for easy texture sampling.
+            passEncoder->dispatchCompute(textureViewSize.width, textureViewSize.height, textureViewSize.depth);
+            passEncoder->end();
+
+            queue->submit(commandEncoder->finish());
+            queue->waitOnHost();
+        }
+
+        // Check results
+
+        // Read back the results.
+        ComPtr<ISlangBlob> bufferData;
+        REQUIRE(!SLANG_FAILED(device->readBuffer(resultBuffer, 0, dataLength, bufferData.writeRef())));
+        REQUIRE_EQ(bufferData->getBufferSize(), dataLength);
+        const float* result = reinterpret_cast<const float*>(bufferData->getBufferPointer());
+        const float* expectedResult = reinterpret_cast<const float*>(textureData[textureViewRange.mipLevel].data);
+
+        // We need to divide data length by sizeof(float) as the compare function
+        // does not compare on bytes.
+        compareResultFuzzy(result, expectedResult, dataLength/sizeof(float));
+    }
+
+    void run()
+    {
+
+
+        // Test a texture view for a 3D RW texture
+        {
+            // Enough space for a 16x16x16 Format::R32Float Texture3D and it's mip levels
+            float texData[4681] = {}; // 16^3 + 8^3 + ... + 1^3
+
+            // Populate it such that every element has a unique value.
+            // That will let us verify correct sampling of sub regions.
+            for (int i = 0; i < 4681; i++)
+            {
+                texData[i] = (float) i;
+            }
+
+            // Our SubresourceData array needs enough elements for each mip level
+            // 16x16x16 -> 8x8x8 -> ... -> 1x1x1
+            SubresourceData subData[5];
+            // SubresourceData expects strides to be in bytes, x4 since we are using Format::R32Float here
+            // Should probably use sizeof
+            subData[0] = {(void*)texData, 16*4, 16*16*4};
+            subData[1] = {(void*)&texData[4096], 8*4, 8*8*4};
+            subData[2] = {(void*)&texData[4608], 4*4, 4*4*4};
+            subData[3] = {(void*)&texData[4672], 2*4, 2*2*4};
+            subData[4] = {(void*)&texData[4680], 1*4, 1*1*4};
+
+            TextureType type = TextureType::Texture3D;
+            // Texture size
+            Extents size = {16 /*width*/, 16/*height*/, 16 /*depth*/};
+            // This subrange/textureView will give a 8x8x8 texture and verifies a fix for issue #220
+            // We use 3 for baseArrayLayer as this was previously used for FirstWSlice and we want
+            // to verify that selecting a subset of depth slices is not currently supported.
+            SubresourceRange range = { 1 /*mipLevel*/, 4 /*mipLevelCount*/, 3 /*baseArrayLayer*/, 1 /*layerCount*/};
+            testTextureViewUnorderedAccess(type, 5 /*mipLevelCount*/, size, range, subData);
+        }
+    }
+};
+
+GPU_TEST_CASE("texture-view-3d", D3D12 | Vulkan)
+{
+    TestTextureViews test;
+    test.init(device);
+    test.run();
+}

--- a/tests/test-texture-view.slang
+++ b/tests/test-texture-view.slang
@@ -1,0 +1,25 @@
+// test-texture-view.slang - Shaders used by the unit tests in test-texture-view.cpp
+
+// Simple shader to test that a RWTexture3D texture view has been bound correctly. If tex has been
+// bound correctly, only the contents contained within the specified texture view will be copied into
+// the output buffer. Outside the shader, the output buffer is compared to expected texture data for
+// the sub region specified in the texture view. Use numthreads 1,1,1 so dispatch can just be set to a
+// subRegions/textureView's dimensions for simplicity.
+
+[shader("compute")]
+[numthreads(1,1,1)]
+void testRWTex3DViewFloat(
+    uint3 sv_dispatchThreadID : SV_DispatchThreadID,
+    uniform RWTexture3D<float> tex,
+    uniform RWStructuredBuffer<float> buffer)
+{
+    uint width;
+    uint height;
+    uint depth;
+    tex.GetDimensions(width, height, depth);
+
+    float val = tex[uint3(sv_dispatchThreadID.x, sv_dispatchThreadID.y, sv_dispatchThreadID.z)];
+    uint  idx = sv_dispatchThreadID.x + sv_dispatchThreadID.y * width + sv_dispatchThreadID.z * width * height;
+
+    buffer[idx] = val;
+}

--- a/tests/testing.h
+++ b/tests/testing.h
@@ -104,7 +104,7 @@ void compareResult(const T* result, const T* expectedResult)
     }
 }
 
-inline void compareResultFuzzy(const float* result, float* expectedResult, size_t count)
+inline void compareResultFuzzy(const float* result, const float* expectedResult, size_t count)
 {
     for (size_t i = 0; i < count; ++i)
     {


### PR DESCRIPTION
Change makes a fix to how 3D texture UAVs and RTVs were handled that resulted in d3d12 errors.

Change also adds a new unit test to exercise the problematic pathway. This unit test was used to repro the issue in #220 and also used to verify the fixes in this change.

The change also makes some additional small fix ups discovered while investigating the original issue.