### PR TITLE
metal: parameter block fix

### DIFF
--- a/include/slang-rhi.h
+++ b/include/slang-rhi.h
@@ -1310,7 +1310,8 @@ enum class ShaderObjectContainerType
 {
     None,
     Array,
-    StructuredBuffer
+    StructuredBuffer,
+    ParameterBlock
 };
 
 enum class BindingType

--- a/src/metal/metal-shader-object-layout.cpp
+++ b/src/metal/metal-shader-object-layout.cpp
@@ -158,13 +158,16 @@ Result ShaderObjectLayoutImpl::Builder::setElementTypeLayout(slang::TypeLayoutRe
         {
         default:
         {
-            // In the case of `ConstantBuffer<X>` or `ParameterBlock<X>`
-            // we can construct a layout from the element type directly.
-            //
             auto elementTypeLayout = slangLeafTypeLayout->getElementTypeLayout();
             createForElementType(m_device, m_session, elementTypeLayout, subObjectLayout.writeRef());
         }
         break;
+        case slang::BindingType::ParameterBlock:
+        case slang::BindingType::ConstantBuffer:
+            // On metal, ParameterBlock and ConstantBuffer are represented as a single argument buffer. We will let _unwrapParameterGroups to handle
+            // the dereference logic.
+            createForElementType(m_device, m_session, slangLeafTypeLayout, subObjectLayout.writeRef());
+            break;
         case slang::BindingType::ExistentialValue:
             // In the case of an interface-type sub-object range, we can only
             // construct a layout if we have static specialization information

--- a/src/metal/metal-shader-object-layout.h
+++ b/src/metal/metal-shader-object-layout.h
@@ -144,7 +144,7 @@ public:
 
     uint32_t getTotalOrdinaryDataSize() const { return m_totalOrdinaryDataSize; }
 
-    slang::TypeLayoutReflection* getParameterBlockTypeLayout();
+    virtual slang::TypeLayoutReflection* getParameterBlockTypeLayout() override;
 
     // ShaderObjectLayout interface
     virtual uint32_t getSlotCount() const override { return m_slotCount; }

--- a/src/metal/metal-shader-object.h
+++ b/src/metal/metal-shader-object.h
@@ -64,13 +64,6 @@ struct BindingDataBuilder
         ShaderObjectLayoutImpl* specializedLayout,
         BufferImpl*& outArgumentBuffer
     );
-
-    Result writeOrdinaryDataIntoArgumentBuffer(
-        slang::TypeLayoutReflection* argumentBufferTypeLayout,
-        slang::TypeLayoutReflection* defaultTypeLayout,
-        uint8_t* argumentBuffer,
-        uint8_t* srcData
-    );
 };
 
 struct BindingDataImpl : BindingData

--- a/src/shader-object.cpp
+++ b/src/shader-object.cpp
@@ -108,7 +108,8 @@ Result ShaderObject::setObject(const ShaderOffset& offset, IShaderObject* object
     //    field, a constant buffer or a parameter block.
     // We handle each case separately below.
 
-    if (m_layout->getContainerType() != ShaderObjectContainerType::None)
+    if (m_layout->getContainerType() != ShaderObjectContainerType::None &&
+        m_layout->getContainerType() != ShaderObjectContainerType::ParameterBlock)
     {
         // Case 1:
         // We are setting an element into a `StructuredBuffer` object.
@@ -411,7 +412,17 @@ Result ShaderObject::init(Device* device, ShaderObjectLayout* layout)
     // uniform data (which includes values from this object and
     // any existential-type sub-objects).
     //
-    size_t uniformSize = layout->getElementTypeLayout()->getSize();
+    size_t uniformSize = 0;
+    if (layout->getContainerType() == ShaderObjectContainerType::ParameterBlock)
+    {
+        auto parameterBlockTypeLayout = layout->getParameterBlockTypeLayout();
+        uniformSize = parameterBlockTypeLayout->getSize();
+    }
+    else
+    {
+        uniformSize = layout->getElementTypeLayout()->getSize();
+    }
+
     if (uniformSize)
     {
         m_data.resize(uniformSize);

--- a/src/shader-object.h
+++ b/src/shader-object.h
@@ -162,6 +162,7 @@ public:
                 return typeLayout;
             case slang::TypeReflection::Kind::ConstantBuffer:
             case slang::TypeReflection::Kind::ParameterBlock:
+                outContainerType = ShaderObjectContainerType::ParameterBlock;
                 typeLayout = typeLayout->getElementTypeLayout();
                 continue;
             default:
@@ -195,6 +196,7 @@ public:
         return dummy;
     }
     virtual ShaderObjectLayout* getEntryPointLayout(uint32_t index) const { return nullptr; }
+    virtual slang::TypeLayoutReflection* getParameterBlockTypeLayout() { return m_elementTypeLayout; }
 
     void initBase(Device* device, slang::ISession* session, slang::TypeLayoutReflection* elementTypeLayout);
 };

--- a/tests/test-nested-parameter-block.cpp
+++ b/tests/test-nested-parameter-block.cpp
@@ -117,6 +117,12 @@ GPU_TEST_CASE("nested-parameter-block", ALL)
     compareComputeResult(device, resultBuffer, makeArray<uint32_t>(1123u, 1123u, 1123u, 1123u));
 }
 
+// In this test, we change the method of feeding data to a parameter block.
+// We first create the root shader object, and feed data directly to the ParameterBlock instead of
+// using `setObject`, because we want to cover more cases on Metal.
+// On Metal, ParameterBlock variable will have the different type layout because we will map that
+// object to ArgumentBuffer, so RHI has to explicity change the layout by applying Argument Buffer Tier2
+// rule, otherwise the size of such variable will always be 0, and all the `setData` call could fail.
 GPU_TEST_CASE("nested-parameter-block-2", ALL)
 {
     if (!device->hasFeature("parameter-block"))


### PR DESCRIPTION
- When set element type layout for Metal target, if the bindingType is parameter block, we will add the container type, `ParameterBlock`, to indicate that.

- When creating ShaderObject on Metal target, we have to use 'MetalArgumentBufferTier2' when the type layout is parameter block to get the uniformSize, otherwise, it will always be 0.

- Fix the issue in calculating the offset of argument buffer. We should use "MetalArgumentBufferTier2" consistently.

- Simplify the ordinary data writing. We can write the orinary data at beginning, the offsets where resource types located will just be 0. And following up process will fill up those offsets with device address (for buffers) and resource IDs (for texture/sampler).