### PR TITLE
Add cooperative matrix 1 extension

### DIFF
--- a/src/vulkan/vk-api.h
+++ b/src/vulkan/vk-api.h
@@ -368,6 +368,11 @@ struct VulkanExtendedFeatureProperties
     VkPhysicalDeviceRayTracingLinearSweptSpheresFeaturesNV rayTracingLinearSweptSpheresFeatures = {
         VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_RAY_TRACING_LINEAR_SWEPT_SPHERES_FEATURES_NV
     };
+
+    // Cooperative matrix 1 features.
+    VkPhysicalDeviceCooperativeMatrixFeaturesKHR cooperativeMatrix1Features = {
+        VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_COOPERATIVE_MATRIX_FEATURES_KHR
+    };
 };
 
 struct VulkanApi

--- a/src/vulkan/vk-device.cpp
+++ b/src/vulkan/vk-device.cpp
@@ -544,6 +544,9 @@ Result DeviceImpl::initVulkanInstanceAndDevice(
         extendedFeatures.rayTracingLinearSweptSpheresFeatures.pNext = deviceFeatures2.pNext;
         deviceFeatures2.pNext = &extendedFeatures.rayTracingLinearSweptSpheresFeatures;
 
+        extendedFeatures.cooperativeMatrix1Features.pNext = deviceFeatures2.pNext;
+        deviceFeatures2.pNext = &extendedFeatures.cooperativeMatrix1Features;
+
         if (VK_MAKE_VERSION(majorVersion, minorVersion, 0) >= VK_API_VERSION_1_2)
         {
             extendedFeatures.vulkan12Features.pNext = deviceFeatures2.pNext;
@@ -820,6 +823,13 @@ Result DeviceImpl::initVulkanInstanceAndDevice(
             cooperativeVector,
             VK_NV_COOPERATIVE_VECTOR_EXTENSION_NAME,
             "cooperative-vector"
+        );
+
+        SIMPLE_EXTENSION_FEATURE(
+            extendedFeatures.cooperativeMatrix1Features,
+            cooperativeMatrix,
+            VK_KHR_COOPERATIVE_MATRIX_EXTENSION_NAME,
+            "cooperative-matrix-1"
         );
 
 #undef SIMPLE_EXTENSION_FEATURE


### PR DESCRIPTION
Adds cooperative matrix 1 extension, required for https://github.com/shader-slang/slang/issues/6397.