### PR TITLE
adjust offset / extent types

### DIFF
--- a/include/slang-rhi.h
+++ b/include/slang-rhi.h
@@ -717,14 +717,14 @@ struct SubresourceData
     Size slicePitch;
 };
 
-static const int32_t kRemainingTextureSize = 0xffffffff;
+static const uint32_t kRemainingTextureSize = 0xffffffff;
 struct Offset3D
 {
-    int32_t x = 0;
-    int32_t y = 0;
-    int32_t z = 0;
+    uint32_t x = 0;
+    uint32_t y = 0;
+    uint32_t z = 0;
     Offset3D() = default;
-    Offset3D(int32_t _x, int32_t _y, int32_t _z)
+    Offset3D(uint32_t _x, uint32_t _y, uint32_t _z)
         : x(_x)
         , y(_y)
         , z(_z)
@@ -740,11 +740,11 @@ struct Offset3D
 struct Extents
 {
     /// Width in pixels.
-    int32_t width = 0;
+    uint32_t width = 0;
     /// Height in pixels (if 2d or 3d).
-    int32_t height = 0;
+    uint32_t height = 0;
     /// Depth (if 3d).
-    int32_t depth = 0;
+    uint32_t depth = 0;
 
     static Extents kWholeTexture;
 

--- a/include/slang-rhi.h
+++ b/include/slang-rhi.h
@@ -1678,12 +1678,12 @@ class IRayTracingPipeline : public IPipeline
 
 struct ScissorRect
 {
-    int32_t minX = 0;
-    int32_t minY = 0;
-    int32_t maxX = 0;
-    int32_t maxY = 0;
+    uint32_t minX = 0;
+    uint32_t minY = 0;
+    uint32_t maxX = 0;
+    uint32_t maxY = 0;
 
-    static ScissorRect fromSize(int32_t width, int32_t height)
+    static ScissorRect fromSize(uint32_t width, uint32_t height)
     {
         ScissorRect scissorRect;
         scissorRect.maxX = width;

--- a/include/slang-rhi.h
+++ b/include/slang-rhi.h
@@ -737,7 +737,7 @@ struct Offset3D
     bool isZero() const { return x == 0 && y == 0 && z == 0; }
 };
 
-struct Extents
+struct Extent3D
 {
     /// Width in pixels.
     uint32_t width = 0;
@@ -746,9 +746,9 @@ struct Extents
     /// Depth (if 3d).
     uint32_t depth = 0;
 
-    static Extents kWholeTexture;
+    static Extent3D kWholeTexture;
 
-    inline bool operator==(const Extents& other) const
+    inline bool operator==(const Extent3D& other) const
     {
         return width == other.width && height == other.height && depth == other.depth;
     }
@@ -760,7 +760,7 @@ struct Extents
 struct SubresourceLayout
 {
     /// Dimensions of the subresource (in texels).
-    Extents size;
+    Extent3D size;
 
     /// Stride in bytes between columns (i.e. blocks of pixels) of the subresource tensor.
     Size colPitch;
@@ -797,7 +797,7 @@ struct TextureDesc
     TextureType type = TextureType::Texture2D;
 
     /// Size of the texture.
-    Extents size = {1, 1, 1};
+    Extent3D size = {1, 1, 1};
     /// Array length.
     uint32_t arrayLength = 1;
     /// Number of mip levels.
@@ -2035,7 +2035,7 @@ public:
         ITexture* src,
         SubresourceRange srcSubresource,
         Offset3D srcOffset,
-        Extents extent
+        Extent3D extent
     ) = 0;
 
     /// Copies texture to a buffer. Each row is aligned to dstRowPitch.
@@ -2048,7 +2048,7 @@ public:
         uint32_t srcLayer,
         uint32_t srcMipLevel,
         Offset3D srcOffset,
-        Extents extent
+        Extent3D extent
     ) = 0;
 
 
@@ -2062,14 +2062,14 @@ public:
         Offset srcOffset,
         Size srcSize,
         Size srcRowPitch,
-        Extents extent
+        Extent3D extent
     ) = 0;
 
     virtual SLANG_NO_THROW Result SLANG_MCALL uploadTextureData(
         ITexture* dst,
         SubresourceRange subresourceRange,
         Offset3D offset,
-        Extents extent,
+        Extent3D extent,
         const SubresourceData* subresourceData,
         uint32_t subresourceDataCount
     ) = 0;

--- a/src/command-buffer.cpp
+++ b/src/command-buffer.cpp
@@ -476,7 +476,7 @@ void CommandEncoder::copyTexture(
     ITexture* src,
     SubresourceRange srcSubresource,
     Offset3D srcOffset,
-    Extents extent
+    Extent3D extent
 )
 {
     commands::CopyTexture cmd;
@@ -499,7 +499,7 @@ void CommandEncoder::copyTextureToBuffer(
     uint32_t srcLayer,
     uint32_t srcMipLevel,
     Offset3D srcOffset,
-    Extents extent
+    Extent3D extent
 )
 {
     commands::CopyTextureToBuffer cmd;
@@ -524,7 +524,7 @@ void CommandEncoder::copyBufferToTexture(
     Offset srcOffset,
     Size srcSize,
     Size srcRowPitch,
-    Extents extent
+    Extent3D extent
 )
 {
     SubresourceLayout* layout = static_cast<SubresourceLayout*>(m_commandList->allocData(sizeof(SubresourceLayout)));
@@ -556,7 +556,7 @@ Result CommandEncoder::uploadTextureData(
     ITexture* dst,
     SubresourceRange subresourceRange,
     Offset3D offset,
-    Extents extent,
+    Extent3D extent,
     const SubresourceData* subresourceData,
     uint32_t subresourceDataCount
 )

--- a/src/command-buffer.h
+++ b/src/command-buffer.h
@@ -210,7 +210,7 @@ public:
         ITexture* src,
         SubresourceRange srcSubresource,
         Offset3D srcOffset,
-        Extents extent
+        Extent3D extent
     ) override;
 
     virtual SLANG_NO_THROW void SLANG_MCALL copyTextureToBuffer(
@@ -222,7 +222,7 @@ public:
         uint32_t srcLayer,
         uint32_t srcMipLevel,
         Offset3D srcOffset,
-        Extents extent
+        Extent3D extent
     ) override;
 
     virtual SLANG_NO_THROW void SLANG_MCALL copyBufferToTexture(
@@ -234,7 +234,7 @@ public:
         Offset srcOffset,
         Size srcSize,
         Size srcRowPitch,
-        Extents extent
+        Extent3D extent
     ) override;
 
 
@@ -242,7 +242,7 @@ public:
         ITexture* dst,
         SubresourceRange subresourceRange,
         Offset3D offset,
-        Extents extent,
+        Extent3D extent,
         const SubresourceData* subresourceData,
         uint32_t subresourceDataCount
     ) override;

--- a/src/command-list.h
+++ b/src/command-list.h
@@ -85,7 +85,7 @@ struct CopyTexture
     ITexture* src;
     SubresourceRange srcSubresource;
     Offset3D srcOffset;
-    Extents extent;
+    Extent3D extent;
 };
 
 struct CopyTextureToBuffer
@@ -98,7 +98,7 @@ struct CopyTextureToBuffer
     uint32_t srcLayer;
     uint32_t srcMipLevel;
     Offset3D srcOffset;
-    Extents extent;
+    Extent3D extent;
 };
 
 struct ClearBuffer
@@ -136,7 +136,7 @@ struct UploadTextureData
     ITexture* dst;
     SubresourceRange subresourceRange;
     Offset3D offset;
-    Extents extent;
+    Extent3D extent;
 
     // Inside uploadTextureData, layouts for each subresource are stored.
     // src and offset are the location of the staged data in the staging heap.

--- a/src/cuda/cuda-clear-engine.cpp
+++ b/src/cuda/cuda-clear-engine.cpp
@@ -180,7 +180,7 @@ void ClearEngine::clearTexture(
     for (uint32_t mipOffset = 0; mipOffset < subresourceRange.mipLevelCount; ++mipOffset)
     {
         uint32_t mipLevel = subresourceRange.mipLevel + mipOffset;
-        Extents mipSize = calcMipSize(texture->m_desc.size, mipLevel);
+        Extent3D mipSize = calcMipSize(texture->m_desc.size, mipLevel);
         for (uint32_t layerOffset = 0; layerOffset < subresourceRange.layerCount; ++layerOffset)
         {
             uint32_t layer = subresourceRange.baseArrayLayer + layerOffset;

--- a/src/cuda/cuda-clear-engine.cpp
+++ b/src/cuda/cuda-clear-engine.cpp
@@ -186,8 +186,7 @@ void ClearEngine::clearTexture(
             uint32_t layer = subresourceRange.baseArrayLayer + layerOffset;
             SubresourceRange sr = {mipLevel, 1, layer, 1};
             CUsurfObject surface = texture->getSurfObject(sr);
-            uint32_t sizeAndLayer[4] =
-                {(uint32_t)mipSize.width, (uint32_t)mipSize.height, (uint32_t)mipSize.depth, layer};
+            uint32_t sizeAndLayer[4] = {mipSize.width, mipSize.height, mipSize.depth, layer};
             launch(stream, function, blockDim, surface, sizeAndLayer, reinterpret_cast<const uint32_t*>(clearValue));
         }
     }

--- a/src/cuda/cuda-command.cpp
+++ b/src/cuda/cuda-command.cpp
@@ -135,7 +135,7 @@ void CommandExecutor::cmdCopyTexture(const commands::CopyTexture& cmd)
     const Offset3D& dstOffset = cmd.dstOffset;
     SubresourceRange srcSubresource = cmd.srcSubresource;
     const Offset3D& srcOffset = cmd.srcOffset;
-    const Extents& extent = cmd.extent;
+    const Extent3D& extent = cmd.extent;
 
     // Fix up sub resource ranges if they are 0 (meaning use entire range)
     if (dstSubresource.mipLevelCount == 0)
@@ -148,7 +148,7 @@ void CommandExecutor::cmdCopyTexture(const commands::CopyTexture& cmd)
         srcSubresource.layerCount = src->m_desc.getLayerCount();
 
     const FormatInfo& formatInfo = getFormatInfo(src->m_desc.format);
-    Extents srcTextureSize = src->m_desc.size;
+    Extent3D srcTextureSize = src->m_desc.size;
 
     // Copy each layer and mip level
     for (uint32_t layerOffset = 0; layerOffset < srcSubresource.layerCount; layerOffset++)
@@ -164,8 +164,8 @@ void CommandExecutor::cmdCopyTexture(const commands::CopyTexture& cmd)
             // Calculate adjusted extents. Note it is required and enforced
             // by debug layer that if 'remaining texture' is used, src and
             // dst offsets are the same.
-            Extents srcMipSize = calcMipSize(srcTextureSize, srcMipLevel);
-            Extents adjustedExtent = extent;
+            Extent3D srcMipSize = calcMipSize(srcTextureSize, srcMipLevel);
+            Extent3D adjustedExtent = extent;
             if (adjustedExtent.width == kRemainingTextureSize)
             {
                 SLANG_RHI_ASSERT(srcOffset.x == dstOffset.x);
@@ -223,7 +223,7 @@ void CommandExecutor::cmdCopyTextureToBuffer(const commands::CopyTextureToBuffer
     TextureImpl* src = checked_cast<TextureImpl*>(cmd.src);
 
     const TextureDesc& srcDesc = src->getDesc();
-    Extents textureSize = srcDesc.size;
+    Extent3D textureSize = srcDesc.size;
     const FormatInfo& formatInfo = getFormatInfo(srcDesc.format);
 
     const uint64_t dstOffset = cmd.dstOffset;
@@ -231,13 +231,13 @@ void CommandExecutor::cmdCopyTextureToBuffer(const commands::CopyTextureToBuffer
     uint32_t srcLayer = cmd.srcLayer;
     uint32_t srcMipLevel = cmd.srcMipLevel;
     const Offset3D& srcOffset = cmd.srcOffset;
-    const Extents& extent = cmd.extent;
+    const Extent3D& extent = cmd.extent;
 
     // Calculate adjusted extents. Note it is required and enforced
     // by debug layer that if 'remaining texture' is used, src and
     // dst offsets are the same.
-    Extents srcMipSize = calcMipSize(textureSize, srcMipLevel);
-    Extents adjustedExtent = extent;
+    Extent3D srcMipSize = calcMipSize(textureSize, srcMipLevel);
+    Extent3D adjustedExtent = extent;
     if (adjustedExtent.width == kRemainingTextureSize)
     {
         SLANG_RHI_ASSERT(srcMipSize.width >= srcOffset.x);

--- a/src/cuda/cuda-texture.cpp
+++ b/src/cuda/cuda-texture.cpp
@@ -399,7 +399,7 @@ Result DeviceImpl::createTexture(const TextureDesc& desc_, const SubresourceData
             {
                 const SubresourceData& subresourceData = initData[subresourceIndex++];
 
-                Extents mipSize = calcMipSize(desc.size, mipLevel);
+                Extent3D mipSize = calcMipSize(desc.size, mipLevel);
 
                 CUarray dstArray = tex->m_cudaArray;
                 if (tex->m_cudaMipMappedArray)

--- a/src/d3d11/d3d11-command.cpp
+++ b/src/d3d11/d3d11-command.cpp
@@ -505,10 +505,10 @@ void CommandExecutor::cmdSetRenderState(const commands::SetRenderState& cmd)
         {
             const ScissorRect& src = state.scissorRects[i];
             D3D11_RECT& dst = scissorRects[i];
-            dst.left = LONG(src.minX);
-            dst.top = LONG(src.minY);
-            dst.right = LONG(src.maxX);
-            dst.bottom = LONG(src.maxY);
+            dst.left = src.minX;
+            dst.top = src.minY;
+            dst.right = src.maxX;
+            dst.bottom = src.maxY;
         }
         m_immediateContext->RSSetScissorRects(state.scissorRectCount, scissorRects);
     }

--- a/src/d3d11/d3d11-texture.cpp
+++ b/src/d3d11/d3d11-texture.cpp
@@ -58,7 +58,7 @@ ID3D11RenderTargetView* TextureImpl::getRTV(Format format, const SubresourceRang
         rtvDesc.ViewDimension = D3D11_RTV_DIMENSION_TEXTURE3D;
         rtvDesc.Texture3D.MipSlice = range.mipLevel;
         rtvDesc.Texture3D.FirstWSlice = 0;
-        rtvDesc.Texture3D.WSize = max(m_desc.size.depth >> range.mipLevel, 1);
+        rtvDesc.Texture3D.WSize = -1;
         break;
     case TextureType::TextureCube:
     case TextureType::TextureCubeArray:
@@ -243,7 +243,7 @@ ID3D11UnorderedAccessView* TextureImpl::getUAV(Format format, const SubresourceR
         uavDesc.ViewDimension = D3D11_UAV_DIMENSION_TEXTURE3D;
         uavDesc.Texture3D.MipSlice = range.mipLevel;
         uavDesc.Texture3D.FirstWSlice = 0;
-        uavDesc.Texture3D.WSize = max(m_desc.size.depth >> range.mipLevel, 1);
+        uavDesc.Texture3D.WSize = -1;
         break;
     case TextureType::TextureCube:
     case TextureType::TextureCubeArray:

--- a/src/d3d12/d3d12-command.cpp
+++ b/src/d3d12/d3d12-command.cpp
@@ -890,10 +890,10 @@ void CommandRecorder::cmdSetRenderState(const commands::SetRenderState& cmd)
         {
             const ScissorRect& src = state.scissorRects[i];
             D3D12_RECT& dst = scissorRects[i];
-            dst.left = LONG(src.minX);
-            dst.top = LONG(src.minY);
-            dst.right = LONG(src.maxX);
-            dst.bottom = LONG(src.maxY);
+            dst.left = src.minX;
+            dst.top = src.minY;
+            dst.right = src.maxX;
+            dst.bottom = src.maxY;
         }
         m_cmdList->RSSetScissorRects(state.scissorRectCount, scissorRects);
     }

--- a/src/d3d12/d3d12-command.cpp
+++ b/src/d3d12/d3d12-command.cpp
@@ -263,9 +263,6 @@ void CommandRecorder::cmdCopyTexture(const commands::CopyTexture& cmd)
                 }
 
                 // Validate source and destination parameters
-                SLANG_RHI_ASSERT(srcOffset.x >= 0 && srcOffset.y >= 0 && srcOffset.z >= 0);
-                SLANG_RHI_ASSERT(dstOffset.x >= 0 && dstOffset.y >= 0 && dstOffset.z >= 0);
-                SLANG_RHI_ASSERT(adjustedExtent.width > 0 && adjustedExtent.height > 0 && adjustedExtent.depth > 0);
                 SLANG_RHI_ASSERT(srcOffset.x + adjustedExtent.width <= srcMipSize.width);
                 SLANG_RHI_ASSERT(srcOffset.y + adjustedExtent.height <= srcMipSize.height);
                 SLANG_RHI_ASSERT(srcOffset.z + adjustedExtent.depth <= srcMipSize.depth);

--- a/src/d3d12/d3d12-command.cpp
+++ b/src/d3d12/d3d12-command.cpp
@@ -189,7 +189,7 @@ void CommandRecorder::cmdCopyTexture(const commands::CopyTexture& cmd)
     const Offset3D& dstOffset = cmd.dstOffset;
     SubresourceRange srcSubresource = cmd.srcSubresource;
     const Offset3D& srcOffset = cmd.srcOffset;
-    const Extents& extent = cmd.extent;
+    const Extent3D& extent = cmd.extent;
 
     // Fast path for copying whole resource.
     if (dstSubresource.layerCount == 0 && dstSubresource.mipLevelCount == 0 && srcSubresource.layerCount == 0 &&
@@ -226,7 +226,7 @@ void CommandRecorder::cmdCopyTexture(const commands::CopyTexture& cmd)
     requireTextureState(src, srcSubresource, ResourceState::CopySource);
     commitBarriers();
 
-    Extents srcTextureSize = src->m_desc.size;
+    Extent3D srcTextureSize = src->m_desc.size;
 
     uint32_t planeCount = D3DUtil::getPlaneSliceCount(dst->m_format);
     SLANG_RHI_ASSERT(planeCount == D3DUtil::getPlaneSliceCount(src->m_format));
@@ -244,8 +244,8 @@ void CommandRecorder::cmdCopyTexture(const commands::CopyTexture& cmd)
                 // Calculate adjusted extents. Note it is required and enforced
                 // by debug layer that if 'remaining texture' is used, src and
                 // dst offsets are the same.
-                Extents srcMipSize = calcMipSize(srcTextureSize, srcMipLevel);
-                Extents adjustedExtent = extent;
+                Extent3D srcMipSize = calcMipSize(srcTextureSize, srcMipLevel);
+                Extent3D adjustedExtent = extent;
                 if (adjustedExtent.width == kRemainingTextureSize)
                 {
                     SLANG_RHI_ASSERT(srcOffset.x == dstOffset.x);
@@ -321,7 +321,7 @@ void CommandRecorder::cmdCopyTextureToBuffer(const commands::CopyTextureToBuffer
     TextureImpl* src = checked_cast<TextureImpl*>(cmd.src);
 
     const TextureDesc& srcDesc = src->getDesc();
-    Extents textureSize = srcDesc.size;
+    Extent3D textureSize = srcDesc.size;
     const FormatInfo& formatInfo = getFormatInfo(srcDesc.format);
 
     const uint64_t dstOffset = cmd.dstOffset;
@@ -329,7 +329,7 @@ void CommandRecorder::cmdCopyTextureToBuffer(const commands::CopyTextureToBuffer
     uint32_t srcLayer = cmd.srcLayer;
     uint32_t srcMipLevel = cmd.srcMipLevel;
     const Offset3D& srcOffset = cmd.srcOffset;
-    const Extents& extent = cmd.extent;
+    const Extent3D& extent = cmd.extent;
 
     // Switch texture to copy src and buffer to copy dest.
     requireBufferState(dst, ResourceState::CopyDestination);
@@ -339,8 +339,8 @@ void CommandRecorder::cmdCopyTextureToBuffer(const commands::CopyTextureToBuffer
     // Calculate adjusted extents. Note it is required and enforced
     // by debug layer that if 'remaining texture' is used, src and
     // dst offsets are the same.
-    Extents srcMipSize = calcMipSize(textureSize, srcMipLevel);
-    Extents adjustedExtent = extent;
+    Extent3D srcMipSize = calcMipSize(textureSize, srcMipLevel);
+    Extent3D adjustedExtent = extent;
     if (adjustedExtent.width == kRemainingTextureSize)
     {
         SLANG_RHI_ASSERT(srcMipSize.width >= srcOffset.x);

--- a/src/d3d12/d3d12-device.cpp
+++ b/src/d3d12/d3d12-device.cpp
@@ -1062,7 +1062,7 @@ Result DeviceImpl::createTexture(const TextureDesc& desc_, const SubresourceData
             texture,
             range,
             {0, 0, 0},
-            Extents::kWholeTexture,
+            Extent3D::kWholeTexture,
             initData,
             range.layerCount * desc.mipLevelCount
         );

--- a/src/debug-layer/debug-command-encoder.cpp
+++ b/src/debug-layer/debug-command-encoder.cpp
@@ -331,7 +331,7 @@ void DebugCommandEncoder::copyTexture(
     ITexture* src,
     SubresourceRange srcSubresource,
     Offset3D srcOffset,
-    Extents extent
+    Extent3D extent
 )
 {
     SLANG_RHI_API_FUNC;
@@ -396,7 +396,7 @@ void DebugCommandEncoder::copyTexture(
 
         if (!extent.isWholeTexture())
         {
-            RHI_VALIDATION_ERROR("Copying multiple mip levels at once requires extent to be Extents::WholeTexture");
+            RHI_VALIDATION_ERROR("Copying multiple mip levels at once requires extent to be Extent3D::kWholeTexture");
             return;
         }
     }
@@ -445,7 +445,7 @@ Result DebugCommandEncoder::uploadTextureData(
     ITexture* dst,
     SubresourceRange subresourceRange,
     Offset3D offset,
-    Extents extent,
+    Extent3D extent,
     const SubresourceData* subresourceData,
     uint32_t subresourceDataCount
 )
@@ -465,7 +465,7 @@ Result DebugCommandEncoder::uploadTextureData(
         if (extent.width != kRemainingTextureSize || extent.height != kRemainingTextureSize ||
             extent.depth != kRemainingTextureSize)
         {
-            RHI_VALIDATION_ERROR("Uploading multiple mip levels at once requires extent to be Extents::WholeTexture");
+            RHI_VALIDATION_ERROR("Uploading multiple mip levels at once requires extent to be Extent3D::kWholeTexture");
             return SLANG_E_INVALID_ARG;
         }
     }
@@ -593,7 +593,7 @@ void DebugCommandEncoder::copyTextureToBuffer(
     uint32_t srcLayer,
     uint32_t srcMipLevel,
     Offset3D srcOffset,
-    Extents extent
+    Extent3D extent
 )
 {
     SLANG_RHI_API_FUNC;
@@ -626,7 +626,7 @@ void DebugCommandEncoder::copyBufferToTexture(
     Offset srcOffset,
     Size srcSize,
     Size srcRowPitch,
-    Extents extent
+    Extent3D extent
 )
 {
     SLANG_RHI_API_FUNC;

--- a/src/debug-layer/debug-command-encoder.h
+++ b/src/debug-layer/debug-command-encoder.h
@@ -118,7 +118,7 @@ public:
         ITexture* src,
         SubresourceRange srcSubresource,
         Offset3D srcOffset,
-        Extents extent
+        Extent3D extent
     ) override;
 
     virtual SLANG_NO_THROW void SLANG_MCALL copyTextureToBuffer(
@@ -130,7 +130,7 @@ public:
         uint32_t srcLayer,
         uint32_t srcMipLevel,
         Offset3D srcOffset,
-        Extents extent
+        Extent3D extent
     ) override;
 
     virtual SLANG_NO_THROW void SLANG_MCALL copyBufferToTexture(
@@ -142,14 +142,14 @@ public:
         Offset srcOffset,
         Size srcSize,
         Size srcRowPitch,
-        Extents extent
+        Extent3D extent
     ) override;
 
     virtual SLANG_NO_THROW Result SLANG_MCALL uploadTextureData(
         ITexture* dst,
         SubresourceRange subresourceRange,
         Offset3D offset,
-        Extents extent,
+        Extent3D extent,
         const SubresourceData* subresourceData,
         uint32_t subresourceDataCount
     ) override;

--- a/src/metal/metal-clear-engine.cpp
+++ b/src/metal/metal-clear-engine.cpp
@@ -134,7 +134,7 @@ void ClearEngine::clearTexture(
         {
             uint32_t mipLevel = subresourceRange.mipLevel + mipOffset;
             uint32_t layer = subresourceRange.baseArrayLayer + layerOffset;
-            Extents mipSize = calcMipSize(texture->m_desc.size, mipLevel);
+            Extent3D mipSize = calcMipSize(texture->m_desc.size, mipLevel);
             Params params = {};
             params.width = mipSize.width;
             params.height = mipSize.height;

--- a/src/metal/metal-command.cpp
+++ b/src/metal/metal-command.cpp
@@ -164,7 +164,7 @@ void CommandRecorder::cmdCopyTexture(const commands::CopyTexture& cmd)
     const SubresourceRange& dstSubresource = cmd.dstSubresource;
     const Offset3D& srcOffset = cmd.srcOffset;
     const Offset3D& dstOffset = cmd.dstOffset;
-    const Extents& extent = cmd.extent;
+    const Extent3D& extent = cmd.extent;
 
     auto encoder = getBlitCommandEncoder();
 
@@ -198,13 +198,13 @@ void CommandRecorder::cmdCopyTextureToBuffer(const commands::CopyTextureToBuffer
     BufferImpl* dst = checked_cast<BufferImpl*>(cmd.dst);
 
     const Offset3D& srcOffset = cmd.srcOffset;
-    const Extents& extent = cmd.extent;
+    const Extent3D& extent = cmd.extent;
 
     // Calculate adjusted extents. Note it is required and enforced
     // by debug layer that if 'remaining texture' is used, src and
     // dst offsets are the same.
-    Extents srcMipSize = calcMipSize(src->m_desc.size, cmd.srcMipLevel);
-    Extents adjustedExtent = extent;
+    Extent3D srcMipSize = calcMipSize(src->m_desc.size, cmd.srcMipLevel);
+    Extent3D adjustedExtent = extent;
     if (adjustedExtent.width == kRemainingTextureSize)
     {
         SLANG_RHI_ASSERT(srcMipSize.width >= srcOffset.x);

--- a/src/metal/metal-device.cpp
+++ b/src/metal/metal-device.cpp
@@ -216,9 +216,9 @@ Result DeviceImpl::getTextureAllocationInfo(const TextureDesc& desc_, Size* outS
         rowSize = alignTo(rowSize, alignment);
         Size sliceSize = rowSize * alignTo(extents.height, formatInfo.blockHeight);
         size += sliceSize * extents.depth;
-        extents.width = max(1, extents.width >> 1);
-        extents.height = max(1, extents.height >> 1);
-        extents.depth = max(1, extents.depth >> 1);
+        extents.width = max(1u, extents.width >> 1);
+        extents.height = max(1u, extents.height >> 1);
+        extents.depth = max(1u, extents.depth >> 1);
     }
     size *= desc.getLayerCount();
 

--- a/src/metal/metal-device.cpp
+++ b/src/metal/metal-device.cpp
@@ -207,18 +207,18 @@ Result DeviceImpl::getTextureAllocationInfo(const TextureDesc& desc_, Size* outS
     MTL::PixelFormat pixelFormat = MetalUtil::translatePixelFormat(desc.format);
     Size alignment = m_device->minimumLinearTextureAlignmentForPixelFormat(pixelFormat);
     Size size = 0;
-    Extents extents = desc.size;
+    Extent3D extent = desc.size;
 
     for (uint32_t i = 0; i < desc.mipLevelCount; ++i)
     {
         Size rowSize =
-            ((extents.width + formatInfo.blockWidth - 1) / formatInfo.blockWidth) * formatInfo.blockSizeInBytes;
+            ((extent.width + formatInfo.blockWidth - 1) / formatInfo.blockWidth) * formatInfo.blockSizeInBytes;
         rowSize = alignTo(rowSize, alignment);
-        Size sliceSize = rowSize * alignTo(extents.height, formatInfo.blockHeight);
-        size += sliceSize * extents.depth;
-        extents.width = max(1u, extents.width >> 1);
-        extents.height = max(1u, extents.height >> 1);
-        extents.depth = max(1u, extents.depth >> 1);
+        Size sliceSize = rowSize * alignTo(extent.height, formatInfo.blockHeight);
+        size += sliceSize * extent.depth;
+        extent.width = max(1u, extent.width >> 1);
+        extent.height = max(1u, extent.height >> 1);
+        extent.depth = max(1u, extent.depth >> 1);
     }
     size *= desc.getLayerCount();
 

--- a/src/resource-desc-utils.h
+++ b/src/resource-desc-utils.h
@@ -12,9 +12,9 @@ inline uint32_t calcMipSize(uint32_t size, uint32_t level)
     return size > 0 ? size : 1;
 }
 
-inline Extents calcMipSize(Extents size, uint32_t mipLevel)
+inline Extent3D calcMipSize(Extent3D size, uint32_t mipLevel)
 {
-    Extents rs;
+    Extent3D rs;
     rs.width = calcMipSize(size.width, mipLevel);
     rs.height = calcMipSize(size.height, mipLevel);
     rs.depth = calcMipSize(size.depth, mipLevel);
@@ -22,7 +22,7 @@ inline Extents calcMipSize(Extents size, uint32_t mipLevel)
 }
 
 /// Given the type works out the maximum dimension size
-inline uint32_t calcMaxDimension(Extents size, TextureType type)
+inline uint32_t calcMaxDimension(Extent3D size, TextureType type)
 {
     switch (type)
     {
@@ -44,7 +44,7 @@ inline uint32_t calcMaxDimension(Extents size, TextureType type)
 }
 
 /// Given the type, calculates the number of mip maps. 0 on error
-inline uint32_t calcMipLevelCount(TextureType type, Extents size)
+inline uint32_t calcMipLevelCount(TextureType type, Extent3D size)
 {
     uint32_t maxDimensionSize = calcMaxDimension(size, type);
     return (maxDimensionSize > 0) ? (math::log2Floor(maxDimensionSize) + 1) : 0;

--- a/src/rhi-shared.cpp
+++ b/src/rhi-shared.cpp
@@ -85,21 +85,21 @@ Result calcSubresourceRegionLayout(
 
     if (extents.width == kRemainingTextureSize)
     {
-        extents.width = max(1, (textureSize.width >> mipLevel));
+        extents.width = max(1u, (textureSize.width >> mipLevel));
         if (offset.x >= extents.width)
             return SLANG_E_INVALID_ARG;
         extents.width -= offset.x;
     }
     if (extents.height == kRemainingTextureSize)
     {
-        extents.height = max(1, (textureSize.height >> mipLevel));
+        extents.height = max(1u, (textureSize.height >> mipLevel));
         if (offset.y >= extents.height)
             return SLANG_E_INVALID_ARG;
         extents.height -= offset.y;
     }
     if (extents.depth == kRemainingTextureSize)
     {
-        extents.depth = max(1, (textureSize.depth >> mipLevel));
+        extents.depth = max(1u, (textureSize.depth >> mipLevel));
         if (offset.z >= extents.depth)
             return SLANG_E_INVALID_ARG;
         extents.depth -= offset.z;

--- a/src/rhi-shared.cpp
+++ b/src/rhi-shared.cpp
@@ -15,10 +15,10 @@
 namespace rhi {
 
 // ----------------------------------------------------------------------------
-// Extents
+// Extent3D
 // ----------------------------------------------------------------------------
 
-Extents Extents::kWholeTexture = {kRemainingTextureSize, kRemainingTextureSize, kRemainingTextureSize};
+Extent3D Extent3D::kWholeTexture = {kRemainingTextureSize, kRemainingTextureSize, kRemainingTextureSize};
 
 // ----------------------------------------------------------------------------
 // Fence
@@ -75,46 +75,46 @@ Result calcSubresourceRegionLayout(
     const TextureDesc& desc,
     uint32_t mipLevel,
     Offset3D offset,
-    Extents extents,
+    Extent3D extent,
     Size rowAlignment,
     SubresourceLayout* outLayout
 )
 {
-    Extents textureSize = desc.size;
+    Extent3D textureSize = desc.size;
     const FormatInfo& formatInfo = getFormatInfo(desc.format);
 
-    if (extents.width == kRemainingTextureSize)
+    if (extent.width == kRemainingTextureSize)
     {
-        extents.width = max(1u, (textureSize.width >> mipLevel));
-        if (offset.x >= extents.width)
+        extent.width = max(1u, (textureSize.width >> mipLevel));
+        if (offset.x >= extent.width)
             return SLANG_E_INVALID_ARG;
-        extents.width -= offset.x;
+        extent.width -= offset.x;
     }
-    if (extents.height == kRemainingTextureSize)
+    if (extent.height == kRemainingTextureSize)
     {
-        extents.height = max(1u, (textureSize.height >> mipLevel));
-        if (offset.y >= extents.height)
+        extent.height = max(1u, (textureSize.height >> mipLevel));
+        if (offset.y >= extent.height)
             return SLANG_E_INVALID_ARG;
-        extents.height -= offset.y;
+        extent.height -= offset.y;
     }
-    if (extents.depth == kRemainingTextureSize)
+    if (extent.depth == kRemainingTextureSize)
     {
-        extents.depth = max(1u, (textureSize.depth >> mipLevel));
-        if (offset.z >= extents.depth)
+        extent.depth = max(1u, (textureSize.depth >> mipLevel));
+        if (offset.z >= extent.depth)
             return SLANG_E_INVALID_ARG;
-        extents.depth -= offset.z;
+        extent.depth -= offset.z;
     }
 
-    size_t rowSize = math::divideRoundedUp(extents.width, formatInfo.blockWidth) * formatInfo.blockSizeInBytes;
-    size_t rowCount = math::divideRoundedUp(extents.height, formatInfo.blockHeight);
+    size_t rowSize = math::divideRoundedUp(extent.width, formatInfo.blockWidth) * formatInfo.blockSizeInBytes;
+    size_t rowCount = math::divideRoundedUp(extent.height, formatInfo.blockHeight);
     size_t rowPitch = math::calcAligned2(rowSize, rowAlignment);
     size_t layerPitch = rowPitch * rowCount;
 
-    outLayout->size = extents;
+    outLayout->size = extent;
     outLayout->colPitch = formatInfo.blockSizeInBytes;
     outLayout->rowPitch = rowPitch;
     outLayout->slicePitch = layerPitch;
-    outLayout->sizeInBytes = layerPitch * extents.depth;
+    outLayout->sizeInBytes = layerPitch * extent.depth;
     outLayout->rowCount = rowCount;
     outLayout->blockWidth = formatInfo.blockWidth;
     outLayout->blockHeight = formatInfo.blockHeight;
@@ -177,7 +177,7 @@ Result Texture::getSharedHandle(NativeHandle* outHandle)
 Result Texture::getSubresourceRegionLayout(
     uint32_t mipLevel,
     Offset3D offset,
-    Extents extents,
+    Extent3D extent,
     size_t rowAlignment,
     SubresourceLayout* outLayout
 )
@@ -186,7 +186,7 @@ Result Texture::getSubresourceRegionLayout(
     {
         SLANG_RETURN_ON_FAIL(m_device->getTextureRowAlignment(m_desc.format, &rowAlignment));
     }
-    return calcSubresourceRegionLayout(m_desc, mipLevel, offset, extents, rowAlignment, outLayout);
+    return calcSubresourceRegionLayout(m_desc, mipLevel, offset, extent, rowAlignment, outLayout);
 }
 
 Result Texture::createView(const TextureViewDesc& desc, ITextureView** outTextureView)

--- a/src/rhi-shared.h
+++ b/src/rhi-shared.h
@@ -150,7 +150,7 @@ public:
     virtual SLANG_NO_THROW Result SLANG_MCALL
     getSubresourceLayout(uint32_t mipLevel, size_t rowAlignment, SubresourceLayout* outLayout) override
     {
-        return getSubresourceRegionLayout(mipLevel, Offset3D(), Extents::kWholeTexture, rowAlignment, outLayout);
+        return getSubresourceRegionLayout(mipLevel, {0, 0, 0}, Extents::kWholeTexture, rowAlignment, outLayout);
     }
 
 public:

--- a/src/rhi-shared.h
+++ b/src/rhi-shared.h
@@ -96,7 +96,7 @@ public:
 
 struct SubResourceLayout
 {
-    Extents size;
+    Extent3D size;
     Size strideY;
     Size strideZ;
 };
@@ -107,7 +107,7 @@ Result calcSubresourceRegionLayout(
     const TextureDesc& desc,
     uint32_t mipLevel,
     Offset3D offset,
-    Extents extents,
+    Extent3D extent,
     Size rowAlignment,
     SubresourceLayout* outLayout
 );
@@ -130,12 +130,12 @@ public:
     bool isEntireTexture(const SubresourceRange& range);
 
     // Get layout the target requires for a given region within a given sub resource
-    // of this texture. Supply offset==0 and extents==kRemainingTextureSize to indicate whole sub resource.
+    // of this texture. Supply offset==0 and extent==kRemainingTextureSize to indicate whole sub resource.
     // If rowAlignment is kDefaultAlignment, implementation uses Device::getTextureRowAlignment for alignment.
     virtual Result getSubresourceRegionLayout(
         uint32_t mipLevel,
         Offset3D offset,
-        Extents extents,
+        Extent3D extent,
         size_t rowAlignment,
         SubresourceLayout* outLayout
     );
@@ -150,7 +150,7 @@ public:
     virtual SLANG_NO_THROW Result SLANG_MCALL
     getSubresourceLayout(uint32_t mipLevel, size_t rowAlignment, SubresourceLayout* outLayout) override
     {
-        return getSubresourceRegionLayout(mipLevel, {0, 0, 0}, Extents::kWholeTexture, rowAlignment, outLayout);
+        return getSubresourceRegionLayout(mipLevel, {0, 0, 0}, Extent3D::kWholeTexture, rowAlignment, outLayout);
     }
 
 public:

--- a/src/vulkan/vk-command.cpp
+++ b/src/vulkan/vk-command.cpp
@@ -277,8 +277,7 @@ void CommandRecorder::cmdCopyTexture(const commands::CopyTexture& cmd)
             region.dstSubresource.mipLevel = dstMipLevel;
             region.dstSubresource.layerCount = 1;
             region.dstOffset = {(int32_t)dstOffset.x, (int32_t)dstOffset.y, (int32_t)dstOffset.z};
-            region.extent =
-                {(uint32_t)adjustedExtent.width, (uint32_t)adjustedExtent.height, (uint32_t)adjustedExtent.depth};
+            region.extent = {adjustedExtent.width, adjustedExtent.height, adjustedExtent.depth};
 
             m_api.vkCmdCopyImage(m_cmdBuffer, src->m_image, srcImageLayout, dst->m_image, dstImageLayout, 1, &region);
         }
@@ -346,8 +345,7 @@ void CommandRecorder::cmdCopyTextureToBuffer(const commands::CopyTextureToBuffer
     region.imageSubresource.baseArrayLayer = srcLayer;
     region.imageSubresource.layerCount = 1;
     region.imageOffset = {(int32_t)srcOffset.x, (int32_t)srcOffset.y, (int32_t)srcOffset.z};
-    region.imageExtent =
-        {(uint32_t)adjustedExtent.width, (uint32_t)adjustedExtent.height, (uint32_t)adjustedExtent.depth};
+    region.imageExtent = {adjustedExtent.width, adjustedExtent.height, adjustedExtent.depth};
 
     m_api.vkCmdCopyImageToBuffer(
         m_cmdBuffer,
@@ -511,9 +509,8 @@ void CommandRecorder::cmdUploadTextureData(const commands::UploadTextureData& cm
             region.imageSubresource.mipLevel = mipLevel;
             region.imageSubresource.baseArrayLayer = layerIndex;
             region.imageSubresource.layerCount = 1;
-            region.imageOffset = {cmd.offset.x, cmd.offset.y, cmd.offset.z};
-            region.imageExtent =
-                {uint32_t(srLayout->size.width), uint32_t(srLayout->size.height), uint32_t(srLayout->size.depth)};
+            region.imageOffset = {int32_t(cmd.offset.x), int32_t(cmd.offset.y), int32_t(cmd.offset.z)};
+            region.imageExtent = {srLayout->size.width, srLayout->size.height, srLayout->size.depth};
 
             m_api.vkCmdCopyBufferToImage(
                 m_cmdBuffer,

--- a/src/vulkan/vk-command.cpp
+++ b/src/vulkan/vk-command.cpp
@@ -215,7 +215,7 @@ void CommandRecorder::cmdCopyTexture(const commands::CopyTexture& cmd)
     Offset3D dstOffset = cmd.dstOffset;
     SubresourceRange srcSubresource = cmd.srcSubresource;
     Offset3D srcOffset = cmd.srcOffset;
-    Extents extent = cmd.extent;
+    Extent3D extent = cmd.extent;
 
     // Fix up sub resource ranges.
     if (dstSubresource.mipLevelCount == 0)
@@ -234,7 +234,7 @@ void CommandRecorder::cmdCopyTexture(const commands::CopyTexture& cmd)
     // TODO: Could probably optimize this to do:
     //  - A single copy of the extents are fixed
     //  - Batching copies at the same mip level if extents aren't fixed.
-    Extents srcTextureSize = src->m_desc.size;
+    Extent3D srcTextureSize = src->m_desc.size;
     for (uint32_t layer = 0; layer < dstSubresource.layerCount; layer++)
     {
         for (uint32_t mipOffset = 0; mipOffset < dstSubresource.mipLevelCount; mipOffset++)
@@ -245,8 +245,8 @@ void CommandRecorder::cmdCopyTexture(const commands::CopyTexture& cmd)
             // Calculate adjusted extents. Note it is required and enforced
             // by debug layer that if 'remaining texture' is used, src and
             // dst offsets are the same.
-            Extents srcMipSize = calcMipSize(srcTextureSize, srcMipLevel);
-            Extents adjustedExtent = extent;
+            Extent3D srcMipSize = calcMipSize(srcTextureSize, srcMipLevel);
+            Extent3D adjustedExtent = extent;
             if (adjustedExtent.width == kRemainingTextureSize)
             {
                 SLANG_RHI_ASSERT(srcOffset.x == dstOffset.x);
@@ -290,7 +290,7 @@ void CommandRecorder::cmdCopyTextureToBuffer(const commands::CopyTextureToBuffer
     TextureImpl* src = checked_cast<TextureImpl*>(cmd.src);
 
     const TextureDesc& srcDesc = src->getDesc();
-    Extents textureSize = srcDesc.size;
+    Extent3D textureSize = srcDesc.size;
     const FormatInfo& formatInfo = getFormatInfo(srcDesc.format);
 
     const uint64_t dstOffset = cmd.dstOffset;
@@ -298,7 +298,7 @@ void CommandRecorder::cmdCopyTextureToBuffer(const commands::CopyTextureToBuffer
     uint32_t srcLayer = cmd.srcLayer;
     uint32_t srcMipLevel = cmd.srcMipLevel;
     const Offset3D& srcOffset = cmd.srcOffset;
-    const Extents& extent = cmd.extent;
+    const Extent3D& extent = cmd.extent;
 
     // Switch texture to copy src and buffer to copy dest.
     requireBufferState(dst, ResourceState::CopyDestination);
@@ -308,8 +308,8 @@ void CommandRecorder::cmdCopyTextureToBuffer(const commands::CopyTextureToBuffer
     // Calculate adjusted extents. Note it is required and enforced
     // by debug layer that if 'remaining texture' is used, src and
     // dst offsets are the same.
-    Extents srcMipSize = calcMipSize(textureSize, srcMipLevel);
-    Extents adjustedExtent = extent;
+    Extent3D srcMipSize = calcMipSize(textureSize, srcMipLevel);
+    Extent3D adjustedExtent = extent;
     if (adjustedExtent.width == kRemainingTextureSize)
     {
         SLANG_RHI_ASSERT(srcMipSize.width >= srcOffset.x);

--- a/src/vulkan/vk-command.cpp
+++ b/src/vulkan/vk-command.cpp
@@ -841,8 +841,8 @@ void CommandRecorder::cmdSetRenderState(const commands::SetRenderState& cmd)
             VkRect2D& dst = scissorRects[i];
             dst.offset.x = src.minX;
             dst.offset.y = src.minY;
-            dst.extent.width = uint32_t(src.maxX - src.minX);
-            dst.extent.height = uint32_t(src.maxY - src.minY);
+            dst.extent.width = src.maxX - src.minX;
+            dst.extent.height = src.maxY - src.minY;
         }
         api.vkCmdSetScissor(m_cmdBuffer, 0, state.scissorRectCount, scissorRects);
     }

--- a/src/vulkan/vk-device.cpp
+++ b/src/vulkan/vk-device.cpp
@@ -1427,7 +1427,7 @@ Result DeviceImpl::getTextureAllocationInfo(const TextureDesc& desc_, Size* outS
     case TextureType::Texture1DArray:
     {
         imageInfo.imageType = VK_IMAGE_TYPE_1D;
-        imageInfo.extent = VkExtent3D{uint32_t(desc.size.width), 1, 1};
+        imageInfo.extent = VkExtent3D{desc.size.width, 1, 1};
         break;
     }
     case TextureType::Texture2D:
@@ -1436,7 +1436,7 @@ Result DeviceImpl::getTextureAllocationInfo(const TextureDesc& desc_, Size* outS
     case TextureType::Texture2DMSArray:
     {
         imageInfo.imageType = VK_IMAGE_TYPE_2D;
-        imageInfo.extent = VkExtent3D{uint32_t(desc.size.width), uint32_t(desc.size.height), 1};
+        imageInfo.extent = VkExtent3D{desc.size.width, desc.size.height, 1};
         break;
     }
     case TextureType::Texture3D:
@@ -1444,14 +1444,14 @@ Result DeviceImpl::getTextureAllocationInfo(const TextureDesc& desc_, Size* outS
         // Can't have an array and 3d texture
         SLANG_RHI_ASSERT(desc.arrayLength <= 1);
         imageInfo.imageType = VK_IMAGE_TYPE_3D;
-        imageInfo.extent = VkExtent3D{uint32_t(desc.size.width), uint32_t(desc.size.height), uint32_t(desc.size.depth)};
+        imageInfo.extent = VkExtent3D{desc.size.width, desc.size.height, desc.size.depth};
         break;
     }
     case TextureType::TextureCube:
     case TextureType::TextureCubeArray:
     {
         imageInfo.imageType = VK_IMAGE_TYPE_2D;
-        imageInfo.extent = VkExtent3D{uint32_t(desc.size.width), uint32_t(desc.size.height), 1};
+        imageInfo.extent = VkExtent3D{desc.size.width, desc.size.height, 1};
         imageInfo.flags = VK_IMAGE_CREATE_CUBE_COMPATIBLE_BIT;
         break;
     }

--- a/src/vulkan/vk-texture.cpp
+++ b/src/vulkan/vk-texture.cpp
@@ -189,7 +189,7 @@ Result DeviceImpl::createTexture(const TextureDesc& desc_, const SubresourceData
     case TextureType::Texture1DArray:
     {
         imageInfo.imageType = VK_IMAGE_TYPE_1D;
-        imageInfo.extent = VkExtent3D{uint32_t(desc.size.width), 1, 1};
+        imageInfo.extent = VkExtent3D{desc.size.width, 1, 1};
         break;
     }
     case TextureType::Texture2D:
@@ -198,20 +198,20 @@ Result DeviceImpl::createTexture(const TextureDesc& desc_, const SubresourceData
     case TextureType::Texture2DMSArray:
     {
         imageInfo.imageType = VK_IMAGE_TYPE_2D;
-        imageInfo.extent = VkExtent3D{uint32_t(desc.size.width), uint32_t(desc.size.height), 1};
+        imageInfo.extent = VkExtent3D{desc.size.width, desc.size.height, 1};
         break;
     }
     case TextureType::Texture3D:
     {
         imageInfo.imageType = VK_IMAGE_TYPE_3D;
-        imageInfo.extent = VkExtent3D{uint32_t(desc.size.width), uint32_t(desc.size.height), uint32_t(desc.size.depth)};
+        imageInfo.extent = VkExtent3D{desc.size.width, desc.size.height, desc.size.depth};
         break;
     }
     case TextureType::TextureCube:
     case TextureType::TextureCubeArray:
     {
         imageInfo.imageType = VK_IMAGE_TYPE_2D;
-        imageInfo.extent = VkExtent3D{uint32_t(desc.size.width), uint32_t(desc.size.height), 1};
+        imageInfo.extent = VkExtent3D{desc.size.width, desc.size.height, 1};
         imageInfo.flags = VK_IMAGE_CREATE_CUBE_COMPATIBLE_BIT;
         break;
     }

--- a/src/vulkan/vk-texture.cpp
+++ b/src/vulkan/vk-texture.cpp
@@ -317,7 +317,7 @@ Result DeviceImpl::createTexture(const TextureDesc& desc_, const SubresourceData
             texture,
             range,
             {0, 0, 0},
-            Extents::kWholeTexture,
+            Extent3D::kWholeTexture,
             initData,
             layerCount * desc.mipLevelCount
         );

--- a/src/wgpu/wgpu-command.cpp
+++ b/src/wgpu/wgpu-command.cpp
@@ -172,7 +172,7 @@ void CommandRecorder::cmdCopyTexture(const commands::CopyTexture& cmd)
     const Offset3D& dstOffset = cmd.dstOffset;
     SubresourceRange srcSubresource = cmd.srcSubresource;
     const Offset3D& srcOffset = cmd.srcOffset;
-    const Extents& extent = cmd.extent;
+    const Extent3D& extent = cmd.extent;
 
     // Fix up sub resource ranges.
     if (dstSubresource.mipLevelCount == 0)
@@ -194,7 +194,7 @@ void CommandRecorder::cmdCopyTexture(const commands::CopyTexture& cmd)
     SLANG_RHI_ASSERT(srcSubresource.mipLevelCount == dstSubresource.mipLevelCount);
     SLANG_RHI_ASSERT(srcSubresource.layerCount == dstSubresource.layerCount);
 
-    Extents srcTextureSize = src->m_desc.size;
+    Extent3D srcTextureSize = src->m_desc.size;
     const FormatInfo& srcFormatInfo = getFormatInfo(src->m_desc.format);
     const FormatInfo& dstFormatInfo = getFormatInfo(dst->m_desc.format);
 
@@ -208,8 +208,8 @@ void CommandRecorder::cmdCopyTexture(const commands::CopyTexture& cmd)
             // Calculate adjusted extents. Note it is required and enforced
             // by debug layer that if 'remaining texture' is used, src and
             // dst offsets are the same.
-            Extents srcMipSize = calcMipSize(srcTextureSize, srcMipLevel);
-            Extents adjustedExtent = extent;
+            Extent3D srcMipSize = calcMipSize(srcTextureSize, srcMipLevel);
+            Extent3D adjustedExtent = extent;
             if (adjustedExtent.width == kRemainingTextureSize)
             {
                 SLANG_RHI_ASSERT(srcOffset.x == dstOffset.x);
@@ -268,7 +268,7 @@ void CommandRecorder::cmdCopyTextureToBuffer(const commands::CopyTextureToBuffer
     TextureImpl* src = checked_cast<TextureImpl*>(cmd.src);
 
     const TextureDesc& srcDesc = src->getDesc();
-    Extents textureSize = srcDesc.size;
+    Extent3D textureSize = srcDesc.size;
     const FormatInfo& formatInfo = getFormatInfo(srcDesc.format);
 
     const uint64_t dstOffset = cmd.dstOffset;
@@ -276,13 +276,13 @@ void CommandRecorder::cmdCopyTextureToBuffer(const commands::CopyTextureToBuffer
     uint32_t srcLayer = cmd.srcLayer;
     uint32_t srcMipLevel = cmd.srcMipLevel;
     const Offset3D& srcOffset = cmd.srcOffset;
-    const Extents& extent = cmd.extent;
+    const Extent3D& extent = cmd.extent;
 
     // Calculate adjusted extents. Note it is required and enforced
     // by debug layer that if 'remaining texture' is used, src and
     // dst offsets are the same.
-    Extents srcMipSize = calcMipSize(textureSize, srcMipLevel);
-    Extents adjustedExtent = extent;
+    Extent3D srcMipSize = calcMipSize(textureSize, srcMipLevel);
+    Extent3D adjustedExtent = extent;
     if (adjustedExtent.width == kRemainingTextureSize)
     {
         SLANG_RHI_ASSERT(srcMipSize.width >= srcOffset.x);

--- a/src/wgpu/wgpu-command.cpp
+++ b/src/wgpu/wgpu-command.cpp
@@ -227,9 +227,6 @@ void CommandRecorder::cmdCopyTexture(const commands::CopyTexture& cmd)
             }
 
             // Validate source and destination parameters
-            SLANG_RHI_ASSERT(srcOffset.x >= 0 && srcOffset.y >= 0 && srcOffset.z >= 0);
-            SLANG_RHI_ASSERT(dstOffset.x >= 0 && dstOffset.y >= 0 && dstOffset.z >= 0);
-            SLANG_RHI_ASSERT(adjustedExtent.width > 0 && adjustedExtent.height > 0 && adjustedExtent.depth > 0);
             SLANG_RHI_ASSERT(srcOffset.x + adjustedExtent.width <= srcMipSize.width);
             SLANG_RHI_ASSERT(srcOffset.y + adjustedExtent.height <= srcMipSize.height);
             SLANG_RHI_ASSERT(srcOffset.z + adjustedExtent.depth <= srcMipSize.depth);
@@ -242,18 +239,17 @@ void CommandRecorder::cmdCopyTexture(const commands::CopyTexture& cmd)
 
             WGPUImageCopyTexture source = {};
             source.texture = src->m_texture;
-            source.origin = {(uint32_t)cmd.srcOffset.x, (uint32_t)cmd.srcOffset.y, srcZ};
+            source.origin = {cmd.srcOffset.x, cmd.srcOffset.y, srcZ};
             source.mipLevel = srcMipLevel;
             source.aspect = WGPUTextureAspect_All;
 
             WGPUImageCopyTexture destination = {};
             destination.texture = dst->m_texture;
-            destination.origin = {(uint32_t)cmd.dstOffset.x, (uint32_t)cmd.dstOffset.y, dstZ};
+            destination.origin = {cmd.dstOffset.x, cmd.dstOffset.y, dstZ};
             destination.mipLevel = dstMipLevel;
             destination.aspect = WGPUTextureAspect_All;
 
-            WGPUExtent3D copySize =
-                {(uint32_t)adjustedExtent.width, (uint32_t)adjustedExtent.height, (uint32_t)adjustedExtent.depth};
+            WGPUExtent3D copySize = {adjustedExtent.width, adjustedExtent.height, adjustedExtent.depth};
 
             // Align copy sizes to format block dimensions
             copySize.width = math::calcAligned2(copySize.width, srcFormatInfo.blockWidth);
@@ -313,7 +309,7 @@ void CommandRecorder::cmdCopyTextureToBuffer(const commands::CopyTextureToBuffer
 
     WGPUImageCopyTexture source = {};
     source.texture = src->m_texture;
-    source.origin = {(uint32_t)srcOffset.x, (uint32_t)srcOffset.y, z};
+    source.origin = {srcOffset.x, srcOffset.y, z};
     source.mipLevel = srcMipLevel;
     source.aspect = WGPUTextureAspect_All;
 
@@ -327,8 +323,7 @@ void CommandRecorder::cmdCopyTextureToBuffer(const commands::CopyTextureToBuffer
     destination.layout.rowsPerImage = math::divideRoundedUp(adjustedExtent.height, formatInfo.blockHeight);
 
     // Store copy size.
-    WGPUExtent3D copySize =
-        {(uint32_t)adjustedExtent.width, (uint32_t)adjustedExtent.height, (uint32_t)adjustedExtent.depth};
+    WGPUExtent3D copySize = {adjustedExtent.width, adjustedExtent.height, adjustedExtent.depth};
 
     m_ctx.api.wgpuCommandEncoderCopyTextureToBuffer(m_commandEncoder, &source, &destination, &copySize);
 }

--- a/src/wgpu/wgpu-texture.cpp
+++ b/src/wgpu/wgpu-texture.cpp
@@ -118,7 +118,7 @@ Result DeviceImpl::createTexture(const TextureDesc& desc_, const SubresourceData
             texture,
             range,
             {0, 0, 0},
-            Extents::kWholeTexture,
+            Extent3D::kWholeTexture,
             initData,
             range.layerCount * desc.mipLevelCount
         );

--- a/tests/test-cmd-copy-texture-to-buffer.cpp
+++ b/tests/test-cmd-copy-texture-to-buffer.cpp
@@ -278,7 +278,7 @@ GPU_TEST_CASE("cmd-copy-texture-to-buffer-offset", D3D12 | Vulkan | Metal | WGPU
             commandEncoder->copyBuffer(buffer, 0, zeroBuffer, 0, totalSize);
 
             // Pick offset for the extra copy.
-            Extents size = data.desc.size;
+            Extent3D size = data.desc.size;
             Offset3D offset = {size.width / 4, size.height / 4, size.depth / 4};
             offset.x = math::calcAligned2(offset.x, data.formatInfo.blockWidth);
             offset.y = math::calcAligned2(offset.y, data.formatInfo.blockHeight);
@@ -299,7 +299,7 @@ GPU_TEST_CASE("cmd-copy-texture-to-buffer-offset", D3D12 | Vulkan | Metal | WGPU
                     layer,
                     0,
                     offset,
-                    Extents::kWholeTexture
+                    Extent3D::kWholeTexture
                 );
 
                 bufferOffset += textureLayout.sizeInBytes;
@@ -313,7 +313,7 @@ GPU_TEST_CASE("cmd-copy-texture-to-buffer-offset", D3D12 | Vulkan | Metal | WGPU
             REQUIRE_CALL(device->mapBuffer(buffer, CpuAccessMode::Read, &bufferData_));
             uint8_t* bufferData = (uint8_t*)bufferData_;
 
-            Extents checkExtents = {size.width - offset.x, size.height - offset.y, size.depth - offset.z};
+            Extent3D checkExtents = {size.width - offset.x, size.height - offset.y, size.depth - offset.z};
 
             for (uint32_t layer = 0; layer < data.desc.getLayerCount(); layer++)
             {
@@ -383,12 +383,12 @@ GPU_TEST_CASE("cmd-copy-texture-to-buffer-sizeoffset", D3D12 | Vulkan | Metal | 
             commandEncoder->copyBuffer(buffer, 0, zeroBuffer, 0, totalSize);
 
             // Pick offset for the extra copy.
-            Extents size = data.desc.size;
+            Extent3D size = data.desc.size;
             Offset3D offset = {size.width / 4, size.height / 4, size.depth / 4};
             offset.x = math::calcAligned2(offset.x, data.formatInfo.blockWidth);
             offset.y = math::calcAligned2(offset.y, data.formatInfo.blockHeight);
 
-            Extents copySize = {max(size.width / 2, 1u), max(size.height / 2, 1u), max(size.depth / 2, 1u)};
+            Extent3D copySize = {max(size.width / 2, 1u), max(size.height / 2, 1u), max(size.depth / 2, 1u)};
             copySize.width = math::calcAligned2(copySize.width, data.formatInfo.blockWidth);
             copySize.height = math::calcAligned2(copySize.height, data.formatInfo.blockHeight);
 
@@ -491,7 +491,7 @@ GPU_TEST_CASE("cmd-copy-texture-to-buffer-offset-mip1", D3D12 | Vulkan | Metal |
             commandEncoder->copyBuffer(buffer, 0, zeroBuffer, 0, totalSize);
 
             // Pick offset for the extra copy.
-            Extents size = calcMipSize(data.desc.size, 1);
+            Extent3D size = calcMipSize(data.desc.size, 1);
             Offset3D offset = {size.width / 4, size.height / 4, size.depth / 4};
             offset.x = math::calcAligned2(offset.x, data.formatInfo.blockWidth);
             offset.y = math::calcAligned2(offset.y, data.formatInfo.blockHeight);
@@ -512,7 +512,7 @@ GPU_TEST_CASE("cmd-copy-texture-to-buffer-offset-mip1", D3D12 | Vulkan | Metal |
                     layer,
                     1,
                     offset,
-                    Extents::kWholeTexture
+                    Extent3D::kWholeTexture
                 );
 
                 bufferOffset += textureLayout.sizeInBytes;
@@ -526,7 +526,7 @@ GPU_TEST_CASE("cmd-copy-texture-to-buffer-offset-mip1", D3D12 | Vulkan | Metal |
             REQUIRE_CALL(device->mapBuffer(buffer, CpuAccessMode::Read, &bufferData_));
             uint8_t* bufferData = (uint8_t*)bufferData_;
 
-            Extents checkExtents = {size.width - offset.x, size.height - offset.y, size.depth - offset.z};
+            Extent3D checkExtents = {size.width - offset.x, size.height - offset.y, size.depth - offset.z};
 
             for (uint32_t layer = 0; layer < data.desc.getLayerCount(); layer++)
             {
@@ -597,12 +597,12 @@ GPU_TEST_CASE("cmd-copy-texture-to-buffer-sizeoffset-mip1", D3D12 | Vulkan | Met
             commandEncoder->copyBuffer(buffer, 0, zeroBuffer, 0, totalSize);
 
             // Pick offset for the extra copy.
-            Extents size = calcMipSize(data.desc.size, 1);
+            Extent3D size = calcMipSize(data.desc.size, 1);
             Offset3D offset = {size.width / 4, size.height / 4, size.depth / 4};
             offset.x = math::calcAligned2(offset.x, data.formatInfo.blockWidth);
             offset.y = math::calcAligned2(offset.y, data.formatInfo.blockHeight);
 
-            Extents copySize = {max(size.width / 2, 1u), max(size.height / 2, 1u), max(size.depth / 2, 1u)};
+            Extent3D copySize = {max(size.width / 2, 1u), max(size.height / 2, 1u), max(size.depth / 2, 1u)};
             copySize.width = math::calcAligned2(copySize.width, data.formatInfo.blockWidth);
             copySize.height = math::calcAligned2(copySize.height, data.formatInfo.blockHeight);
 

--- a/tests/test-cmd-copy-texture-to-buffer.cpp
+++ b/tests/test-cmd-copy-texture-to-buffer.cpp
@@ -388,7 +388,7 @@ GPU_TEST_CASE("cmd-copy-texture-to-buffer-sizeoffset", D3D12 | Vulkan | Metal | 
             offset.x = math::calcAligned2(offset.x, data.formatInfo.blockWidth);
             offset.y = math::calcAligned2(offset.y, data.formatInfo.blockHeight);
 
-            Extents copySize = {max(size.width / 2, 1), max(size.height / 2, 1), max(size.depth / 2, 1)};
+            Extents copySize = {max(size.width / 2, 1u), max(size.height / 2, 1u), max(size.depth / 2, 1u)};
             copySize.width = math::calcAligned2(copySize.width, data.formatInfo.blockWidth);
             copySize.height = math::calcAligned2(copySize.height, data.formatInfo.blockHeight);
 
@@ -602,7 +602,7 @@ GPU_TEST_CASE("cmd-copy-texture-to-buffer-sizeoffset-mip1", D3D12 | Vulkan | Met
             offset.x = math::calcAligned2(offset.x, data.formatInfo.blockWidth);
             offset.y = math::calcAligned2(offset.y, data.formatInfo.blockHeight);
 
-            Extents copySize = {max(size.width / 2, 1), max(size.height / 2, 1), max(size.depth / 2, 1)};
+            Extents copySize = {max(size.width / 2, 1u), max(size.height / 2, 1u), max(size.depth / 2, 1u)};
             copySize.width = math::calcAligned2(copySize.width, data.formatInfo.blockWidth);
             copySize.height = math::calcAligned2(copySize.height, data.formatInfo.blockHeight);
 

--- a/tests/test-cmd-copy-texture.cpp
+++ b/tests/test-cmd-copy-texture.cpp
@@ -48,7 +48,7 @@ GPU_TEST_CASE("cmd-copy-texture-full", D3D12 | Vulkan | WGPU | CUDA)
                 c->getTexture(),
                 {0, 0, 0, 0},
                 {0, 0, 0},
-                Extents::kWholeTexture
+                Extent3D::kWholeTexture
             );
             queue->submit(commandEncoder->finish());
 
@@ -100,7 +100,7 @@ GPU_TEST_CASE("cmd-copy-texture-arrayrange", D3D12 | Vulkan | WGPU | CUDA)
                 c->getTexture(),
                 {0, 0, halfLayerCount, halfLayerCount},
                 {0, 0, 0},
-                Extents::kWholeTexture
+                Extent3D::kWholeTexture
             );
             queue->submit(commandEncoder->finish());
 
@@ -152,7 +152,7 @@ GPU_TEST_CASE("cmd-copy-texture-miprange", D3D12 | Vulkan | WGPU | CUDA)
                 c->getTexture(),
                 {0, halfMipCount, 0, 0},
                 {0, 0, 0},
-                Extents::kWholeTexture
+                Extent3D::kWholeTexture
             );
             queue->submit(commandEncoder->finish());
 
@@ -211,7 +211,7 @@ GPU_TEST_CASE("cmd-copy-texture-fromarray", D3D12 | Vulkan | WGPU | CUDA)
                 c->getTexture(),
                 {0, 0, 2, 1},
                 {0, 0, 0},
-                Extents::kWholeTexture
+                Extent3D::kWholeTexture
             );
             queue->submit(commandEncoder->finish());
 
@@ -262,7 +262,7 @@ GPU_TEST_CASE("cmd-copy-texture-toarray", D3D12 | Vulkan | WGPU | CUDA)
                 newTexture,
                 {0, 0, 0, 1},
                 {0, 0, 0},
-                Extents::kWholeTexture
+                Extent3D::kWholeTexture
             );
             queue->submit(commandEncoder->finish());
 
@@ -467,7 +467,7 @@ GPU_TEST_CASE("cmd-copy-texture-offset-nomip", D3D12 | Vulkan | WGPU | CUDA)
             ComPtr<ITexture> newTexture;
             REQUIRE_CALL(newData.createTexture(newTexture.writeRef()));
 
-            Extents size = data.desc.size;
+            Extent3D size = data.desc.size;
             Offset3D offset = {size.width / 4, size.height / 4, size.depth / 4};
             offset.x = math::calcAligned2(offset.x, data.formatInfo.blockWidth);
             offset.y = math::calcAligned2(offset.y, data.formatInfo.blockHeight);
@@ -484,15 +484,15 @@ GPU_TEST_CASE("cmd-copy-texture-offset-nomip", D3D12 | Vulkan | WGPU | CUDA)
                 c->getTexture(),
                 {0, 1, 0, 0},
                 offset,
-                Extents::kWholeTexture
+                Extent3D::kWholeTexture
             );
             queue->submit(commandEncoder->finish());
 
             // Verify it uploaded correctly
             // The original texture data should have stomped over the new texture data
             // at offset.
-            data.checkEqual(newTexture, offset, Extents::kWholeTexture, false);
-            newData.checkEqual(newTexture, offset, Extents::kWholeTexture, true);
+            data.checkEqual(newTexture, offset, Extent3D::kWholeTexture, false);
+            newData.checkEqual(newTexture, offset, Extent3D::kWholeTexture, true);
         }
     );
 }
@@ -517,14 +517,14 @@ GPU_TEST_CASE("cmd-copy-texture-sizeoffset-nomip", D3D12 | Vulkan | WGPU | CUDA)
             ComPtr<ITexture> newTexture;
             REQUIRE_CALL(newData.createTexture(newTexture.writeRef()));
 
-            Extents size = data.desc.size;
+            Extent3D size = data.desc.size;
             Offset3D offset = {size.width / 4, size.height / 4, size.depth / 4};
             offset.x = math::calcAligned2(offset.x, data.formatInfo.blockWidth);
             offset.y = math::calcAligned2(offset.y, data.formatInfo.blockHeight);
 
-            Extents extents = {max(size.width / 4, 1u), max(size.height / 4, 1u), max(size.depth / 4, 1u)};
-            extents.width = math::calcAligned2(extents.width, data.formatInfo.blockWidth);
-            extents.height = math::calcAligned2(extents.height, data.formatInfo.blockHeight);
+            Extent3D extent = {max(size.width / 4, 1u), max(size.height / 4, 1u), max(size.depth / 4, 1u)};
+            extent.width = math::calcAligned2(extent.width, data.formatInfo.blockWidth);
+            extent.height = math::calcAligned2(extent.height, data.formatInfo.blockHeight);
 
             // fprintf(stderr, "Copy:\n  %s\n  %s\n", newTexture->getDesc().label, c->getTexture()->getDesc().label);
 
@@ -534,15 +534,15 @@ GPU_TEST_CASE("cmd-copy-texture-sizeoffset-nomip", D3D12 | Vulkan | WGPU | CUDA)
 
             // Copy at the offset, using kWholeTexture to express 'the rest of the texture'
             commandEncoder
-                ->copyTexture(newTexture, {0, 1, 0, 0}, offset, c->getTexture(), {0, 1, 0, 0}, offset, extents);
+                ->copyTexture(newTexture, {0, 1, 0, 0}, offset, c->getTexture(), {0, 1, 0, 0}, offset, extent);
 
             queue->submit(commandEncoder->finish());
 
             // Verify it uploaded correctly
             // The original texture data should have stomped over the new texture data
-            // at offset with given extents.
-            data.checkEqual(newTexture, offset, extents, false);
-            newData.checkEqual(newTexture, offset, extents, true);
+            // at offset with given extent.
+            data.checkEqual(newTexture, offset, extent, false);
+            newData.checkEqual(newTexture, offset, extent, true);
         }
     );
 }
@@ -574,7 +574,7 @@ GPU_TEST_CASE("cmd-copy-texture-smalltolarge", D3D12 | Vulkan | WGPU | CUDA)
             ComPtr<ITexture> largerTexture;
             REQUIRE_CALL(largerData.createTexture(largerTexture.writeRef()));
 
-            Extents extents = smallerData.desc.size;
+            Extent3D extent = smallerData.desc.size;
             Offset3D offset = {0, 0, 0};
 
             // Create command encoder
@@ -583,14 +583,14 @@ GPU_TEST_CASE("cmd-copy-texture-smalltolarge", D3D12 | Vulkan | WGPU | CUDA)
 
             // Copy at the offset, using kWholeTexture to express 'the rest of the texture'
             commandEncoder
-                ->copyTexture(largerTexture, {0, 1, 0, 0}, offset, smallerTexture, {0, 1, 0, 0}, offset, extents);
+                ->copyTexture(largerTexture, {0, 1, 0, 0}, offset, smallerTexture, {0, 1, 0, 0}, offset, extent);
             queue->submit(commandEncoder->finish());
 
             // Verify it uploaded correctly
             // The smaller texture should have overwritten the corner of
             // the larger texture.
-            smallerData.checkEqual({0, 0, 0}, largerTexture, offset, extents, false);
-            largerData.checkEqual(largerTexture, offset, extents, true);
+            smallerData.checkEqual({0, 0, 0}, largerTexture, offset, extent, false);
+            largerData.checkEqual(largerTexture, offset, extent, true);
         }
     );
 }
@@ -624,7 +624,7 @@ GPU_TEST_CASE("cmd-copy-texture-largetosmall", D3D12 | Vulkan | WGPU | CUDA)
 
             // Going to copy an extent that is the size of the smaller texture,
             // with an offset based on its size (accounting for 1D/2D/3D dimensions)
-            Extents extents = smallerData.desc.size;
+            Extent3D extent = smallerData.desc.size;
             Offset3D offset;
             offset.x = smallerData.desc.size.width;
             if (smallerData.desc.size.height != 1)
@@ -638,12 +638,12 @@ GPU_TEST_CASE("cmd-copy-texture-largetosmall", D3D12 | Vulkan | WGPU | CUDA)
 
             // Copy at the offset, using kWholeTexture to express 'the rest of the texture'
             commandEncoder
-                ->copyTexture(smallerTexture, {0, 1, 0, 0}, {0, 0, 0}, largerTexture, {0, 1, 0, 0}, offset, extents);
+                ->copyTexture(smallerTexture, {0, 1, 0, 0}, {0, 0, 0}, largerTexture, {0, 1, 0, 0}, offset, extent);
             queue->submit(commandEncoder->finish());
 
             // Verify it uploaded correctly
             // The chunk of the larger texture we copied from should have overwritten the smaller texture
-            largerData.checkEqual(offset, smallerTexture, {0, 0, 0}, extents, false);
+            largerData.checkEqual(offset, smallerTexture, {0, 0, 0}, extent, false);
         }
     );
 }
@@ -678,7 +678,7 @@ GPU_TEST_CASE("cmd-copy-texture-acrossmips", D3D12 | Vulkan | WGPU | CUDA)
             // Going to copy an extent that is the size of mip1 from mip0
             SubresourceLayout srcMip1Layout;
             srcTexture->getSubresourceLayout(1, &srcMip1Layout);
-            Extents extents = srcMip1Layout.size;
+            Extent3D extent = srcMip1Layout.size;
 
             // Create command encoder
             auto queue = device->getQueue(QueueType::Graphics);
@@ -686,13 +686,13 @@ GPU_TEST_CASE("cmd-copy-texture-acrossmips", D3D12 | Vulkan | WGPU | CUDA)
 
             // Copy from mip 1 to mip 0
             commandEncoder
-                ->copyTexture(dstTexture, {0, 1, 0, 0}, {0, 0, 0}, srcTexture, {1, 1, 0, 0}, {0, 0, 0}, extents);
+                ->copyTexture(dstTexture, {0, 1, 0, 0}, {0, 0, 0}, srcTexture, {1, 1, 0, 0}, {0, 0, 0}, extent);
             queue->submit(commandEncoder->finish());
 
             // Verify it uploaded correctly
             // The corner of mip 0 of the dst texture should have been overwritten by mip 1 of the src texture
-            srcData.checkMipLevelsEqual(0, 1, {0, 0, 0}, dstTexture, 0, 0, {0, 0, 0}, extents, false);
-            dstData.checkMipLevelsEqual(dstTexture, 0, 0, {0, 0, 0}, extents, true);
+            srcData.checkMipLevelsEqual(0, 1, {0, 0, 0}, dstTexture, 0, 0, {0, 0, 0}, extent, false);
+            dstData.checkMipLevelsEqual(dstTexture, 0, 0, {0, 0, 0}, extent, true);
         }
     );
 }
@@ -724,7 +724,7 @@ GPU_TEST_CASE("cmd-copy-texture-offset-mip1", D3D12 | Vulkan | WGPU | CUDA)
             // Get the size of mip level 1
             SubresourceLayout mip1Layout;
             c->getTexture()->getSubresourceLayout(1, &mip1Layout);
-            Extents mip1Size = mip1Layout.size;
+            Extent3D mip1Size = mip1Layout.size;
 
             // Calculate offset for mip level 1 (quarter of mip1 size)
             Offset3D offset = {mip1Size.width / 4, mip1Size.height / 4, mip1Size.depth / 4};
@@ -743,15 +743,15 @@ GPU_TEST_CASE("cmd-copy-texture-offset-mip1", D3D12 | Vulkan | WGPU | CUDA)
                 c->getTexture(),
                 {1, 1, 0, 0}, // Source from mip level 1
                 offset,
-                Extents::kWholeTexture
+                Extent3D::kWholeTexture
             );
             queue->submit(commandEncoder->finish());
 
             // Verify it uploaded correctly at mip level 1
             // The original texture data should have stomped over the new texture data
             // at offset in mip level 1.
-            data.checkMipLevelsEqual(newTexture, 0, 1, offset, Extents::kWholeTexture, false);
-            newData.checkMipLevelsEqual(newTexture, 0, 1, offset, Extents::kWholeTexture, true);
+            data.checkMipLevelsEqual(newTexture, 0, 1, offset, Extent3D::kWholeTexture, false);
+            newData.checkMipLevelsEqual(newTexture, 0, 1, offset, Extent3D::kWholeTexture, true);
         }
     );
 }
@@ -783,7 +783,7 @@ GPU_TEST_CASE("cmd-copy-texture-offset-mip1", D3D12 | Vulkan | WGPU | CUDA)
             // Get the size of mip level 1
             SubresourceLayout mip1Layout;
             c->getTexture()->getSubresourceLayout(1, &mip1Layout);
-            Extents mip1Size = mip1Layout.size;
+            Extent3D mip1Size = mip1Layout.size;
 
             // Calculate offset for mip level 1 (quarter of mip1 size)
             Offset3D offset = {mip1Size.width / 4, mip1Size.height / 4, mip1Size.depth / 4};
@@ -802,15 +802,15 @@ GPU_TEST_CASE("cmd-copy-texture-offset-mip1", D3D12 | Vulkan | WGPU | CUDA)
                 c->getTexture(),
                 {1, 1, 0, 0}, // Source from mip level 1
                 offset,
-                Extents::kWholeTexture
+                Extent3D::kWholeTexture
             );
             queue->submit(commandEncoder->finish());
 
             // Verify it uploaded correctly at mip level 1
             // The original texture data should have stomped over the new texture data
             // at offset in mip level 1.
-            data.checkMipLevelsEqual(newTexture, 0, 1, offset, Extents::kWholeTexture, false);
-            newData.checkMipLevelsEqual(newTexture, 0, 1, offset, Extents::kWholeTexture, true);
+            data.checkMipLevelsEqual(newTexture, 0, 1, offset, Extent3D::kWholeTexture, false);
+            newData.checkMipLevelsEqual(newTexture, 0, 1, offset, Extent3D::kWholeTexture, true);
         }
     );
 }

--- a/tests/test-cmd-copy-texture.cpp
+++ b/tests/test-cmd-copy-texture.cpp
@@ -522,7 +522,7 @@ GPU_TEST_CASE("cmd-copy-texture-sizeoffset-nomip", D3D12 | Vulkan | WGPU | CUDA)
             offset.x = math::calcAligned2(offset.x, data.formatInfo.blockWidth);
             offset.y = math::calcAligned2(offset.y, data.formatInfo.blockHeight);
 
-            Extents extents = {max(size.width / 4, 1), max(size.height / 4, 1), max(size.depth / 4, 1)};
+            Extents extents = {max(size.width / 4, 1u), max(size.height / 4, 1u), max(size.depth / 4, 1u)};
             extents.width = math::calcAligned2(extents.width, data.formatInfo.blockWidth);
             extents.height = math::calcAligned2(extents.height, data.formatInfo.blockHeight);
 

--- a/tests/test-cmd-upload-texture.cpp
+++ b/tests/test-cmd-upload-texture.cpp
@@ -33,7 +33,7 @@ GPU_TEST_CASE("cmd-upload-texture-simple", D3D12 | Vulkan | Metal | CUDA | WGPU)
                 c->getTexture(),
                 {0, data.desc.mipLevelCount, 0, data.desc.getLayerCount()},
                 {0, 0, 0},
-                Extents::kWholeTexture,
+                Extent3D::kWholeTexture,
                 data.subresourceData.data(),
                 data.subresourceData.size()
             );
@@ -78,7 +78,7 @@ GPU_TEST_CASE("cmd-upload-texture-single-layer", D3D12 | Vulkan | Metal | CUDA |
                         c->getTexture(),
                         {0, newData.desc.mipLevelCount, layer, 1},
                         {0, 0, 0},
-                        Extents::kWholeTexture,
+                        Extent3D::kWholeTexture,
                         srdata,
                         currentData.desc.mipLevelCount
                     );
@@ -135,7 +135,7 @@ GPU_TEST_CASE("cmd-upload-texture-single-mip", D3D12 | Vulkan | Metal | CUDA | W
                             c->getTexture(),
                             {mipLevel, 1, layerIdx, 1},
                             {0, 0, 0},
-                            Extents::kWholeTexture,
+                            Extent3D::kWholeTexture,
                             srdata,
                             1
                         );
@@ -195,7 +195,7 @@ GPU_TEST_CASE("cmd-upload-texture-multisubmit", D3D12 | Vulkan | Metal | CUDA | 
                         c->getTexture(),
                         {mipLevel, 1, layerIdx, 1},
                         {0, 0, 0},
-                        Extents::kWholeTexture,
+                        Extent3D::kWholeTexture,
                         srdata,
                         1
                     );
@@ -228,7 +228,7 @@ GPU_TEST_CASE("cmd-upload-texture-offset", D3D12 | Vulkan | Metal | CUDA | WGPU)
         {
             // Get / re-init cpu side data with random data.
             const TextureData& currentData = c->getTextureData();
-            Extents size = currentData.desc.size;
+            Extent3D size = currentData.desc.size;
 
             Offset3D offset = {size.width / 2, size.height / 2, size.depth / 2};
             offset.x = math::calcAligned2(offset.x, currentData.formatInfo.blockWidth);
@@ -255,7 +255,7 @@ GPU_TEST_CASE("cmd-upload-texture-offset", D3D12 | Vulkan | Metal | CUDA | WGPU)
                     c->getTexture(),
                     {0, 1, layer, 1},
                     offset,
-                    Extents::kWholeTexture,
+                    Extent3D::kWholeTexture,
                     newData.getLayerFirstSubresourceData(layer),
                     1
                 );
@@ -266,8 +266,8 @@ GPU_TEST_CASE("cmd-upload-texture-offset", D3D12 | Vulkan | Metal | CUDA | WGPU)
 
             // Verify region. The inverse region should be the same as the original data,
             // and the interior of the region should match the new data.
-            currentData.checkEqual(c->getTexture(), offset, Extents::kWholeTexture, true);
-            newData.checkEqual({0, 0, 0}, c->getTexture(), offset, Extents::kWholeTexture, false);
+            currentData.checkEqual(c->getTexture(), offset, Extent3D::kWholeTexture, true);
+            newData.checkEqual({0, 0, 0}, c->getTexture(), offset, Extent3D::kWholeTexture, false);
         }
     );
 }
@@ -283,20 +283,20 @@ GPU_TEST_CASE("cmd-upload-texture-sizeoffset", D3D12 | Vulkan | Metal | CUDA | W
         {
             // Get / re-init cpu side data with random data.
             const TextureData& currentData = c->getTextureData();
-            Extents size = currentData.desc.size;
+            Extent3D size = currentData.desc.size;
 
             Offset3D offset = {size.width / 4, size.height / 4, size.depth / 4};
             offset.x = math::calcAligned2(offset.x, currentData.formatInfo.blockWidth);
             offset.y = math::calcAligned2(offset.y, currentData.formatInfo.blockHeight);
 
-            Extents extents = {max(size.width / 4, 1u), max(size.height / 4, 1u), max(size.depth / 4, 1u)};
-            extents.width = math::calcAligned2(extents.width, currentData.formatInfo.blockWidth);
-            extents.height = math::calcAligned2(extents.height, currentData.formatInfo.blockHeight);
+            Extent3D extent = {max(size.width / 4, 1u), max(size.height / 4, 1u), max(size.depth / 4, 1u)};
+            extent.width = math::calcAligned2(extent.width, currentData.formatInfo.blockWidth);
+            extent.height = math::calcAligned2(extent.height, currentData.formatInfo.blockHeight);
 
             TextureDesc newDesc = currentData.desc;
-            newDesc.size.width = extents.width;
-            newDesc.size.height = extents.height;
-            newDesc.size.depth = extents.depth;
+            newDesc.size.width = extent.width;
+            newDesc.size.height = extent.height;
+            newDesc.size.depth = extent.depth;
 
             TextureData newData;
             newData.init(currentData.device, newDesc, TextureInitMode::Random, 1000);
@@ -313,7 +313,7 @@ GPU_TEST_CASE("cmd-upload-texture-sizeoffset", D3D12 | Vulkan | Metal | CUDA | W
                     c->getTexture(),
                     {0, 1, layer, 1},
                     offset,
-                    extents,
+                    extent,
                     newData.getLayerFirstSubresourceData(layer),
                     1
                 );
@@ -324,8 +324,8 @@ GPU_TEST_CASE("cmd-upload-texture-sizeoffset", D3D12 | Vulkan | Metal | CUDA | W
 
             // Verify region. The inverse region should be the same as the original data,
             // and the interior of the region should match the new data.
-            currentData.checkEqual(c->getTexture(), offset, extents, true);
-            newData.checkEqual({0, 0, 0}, c->getTexture(), offset, extents, false);
+            currentData.checkEqual(c->getTexture(), offset, extent, true);
+            newData.checkEqual({0, 0, 0}, c->getTexture(), offset, extent, false);
         }
     );
 }
@@ -348,22 +348,22 @@ GPU_TEST_CASE("cmd-upload-texture-mipsizeoffset", D3D12 | Vulkan | Metal | CUDA 
         {
             // Get / re-init cpu side data with random data.
             const TextureData& currentData = c->getTextureData();
-            Extents size = currentData.desc.size;
+            Extent3D size = currentData.desc.size;
 
             Offset3D offset = {size.width / 4, size.height / 4, size.depth / 4};
-            Extents extents = {max(size.width / 4, 1u), max(size.height / 4, 1u), max(size.depth / 4, 1u)};
+            Extent3D extent = {max(size.width / 4, 1u), max(size.height / 4, 1u), max(size.depth / 4, 1u)};
 
             offset.x >>= 1;
             offset.y >>= 1;
             offset.z >>= 1;
-            extents.width = max(extents.width >> 1, 1u);
-            extents.height = max(extents.height >> 1, 1u);
-            extents.depth = max(extents.depth >> 1, 1u);
+            extent.width = max(extent.width >> 1, 1u);
+            extent.height = max(extent.height >> 1, 1u);
+            extent.depth = max(extent.depth >> 1, 1u);
 
             TextureDesc newDesc = currentData.desc;
-            newDesc.size.width = extents.width;
-            newDesc.size.height = extents.height;
-            newDesc.size.depth = extents.depth;
+            newDesc.size.width = extent.width;
+            newDesc.size.height = extent.height;
+            newDesc.size.depth = extent.depth;
 
             TextureData newData;
             newData.init(currentData.device, newDesc, TextureInitMode::Random, 1000);
@@ -378,7 +378,7 @@ GPU_TEST_CASE("cmd-upload-texture-mipsizeoffset", D3D12 | Vulkan | Metal | CUDA 
                 c->getTexture(),
                 {1, 1, 0, 1},
                 offset,
-                extents,
+                extent,
                 newData.getLayerFirstSubresourceData(0),
                 1
             );
@@ -391,7 +391,7 @@ GPU_TEST_CASE("cmd-upload-texture-mipsizeoffset", D3D12 | Vulkan | Metal | CUDA 
 
             // Verify region. Mip 0 should be untouched and the chunk of mip 1 should match the new data
             currentData.checkMipLevelsEqual(c->getTexture(), 0, 0);
-            newData.checkMipLevelsEqual(0, 0, {0, 0, 0}, c->getTexture(), 0, 1, offset, extents, false);
+            newData.checkMipLevelsEqual(0, 0, {0, 0, 0}, c->getTexture(), 0, 1, offset, extent, false);
         }
     );
 }

--- a/tests/test-cmd-upload-texture.cpp
+++ b/tests/test-cmd-upload-texture.cpp
@@ -289,7 +289,7 @@ GPU_TEST_CASE("cmd-upload-texture-sizeoffset", D3D12 | Vulkan | Metal | CUDA | W
             offset.x = math::calcAligned2(offset.x, currentData.formatInfo.blockWidth);
             offset.y = math::calcAligned2(offset.y, currentData.formatInfo.blockHeight);
 
-            Extents extents = {max(size.width / 4, 1), max(size.height / 4, 1), max(size.depth / 4, 1)};
+            Extents extents = {max(size.width / 4, 1u), max(size.height / 4, 1u), max(size.depth / 4, 1u)};
             extents.width = math::calcAligned2(extents.width, currentData.formatInfo.blockWidth);
             extents.height = math::calcAligned2(extents.height, currentData.formatInfo.blockHeight);
 
@@ -351,14 +351,14 @@ GPU_TEST_CASE("cmd-upload-texture-mipsizeoffset", D3D12 | Vulkan | Metal | CUDA 
             Extents size = currentData.desc.size;
 
             Offset3D offset = {size.width / 4, size.height / 4, size.depth / 4};
-            Extents extents = {max(size.width / 4, 1), max(size.height / 4, 1), max(size.depth / 4, 1)};
+            Extents extents = {max(size.width / 4, 1u), max(size.height / 4, 1u), max(size.depth / 4, 1u)};
 
             offset.x >>= 1;
             offset.y >>= 1;
             offset.z >>= 1;
-            extents.width = max(extents.width >> 1, 1);
-            extents.height = max(extents.height >> 1, 1);
-            extents.depth = max(extents.depth >> 1, 1);
+            extents.width = max(extents.width >> 1, 1u);
+            extents.height = max(extents.height >> 1, 1u);
+            extents.depth = max(extents.depth >> 1, 1u);
 
             TextureDesc newDesc = currentData.desc;
             newDesc.size.width = extents.width;

--- a/tests/test-formats.cpp
+++ b/tests/test-formats.cpp
@@ -44,7 +44,7 @@ struct TestFormats
         return true;
     }
 
-    ComPtr<ITextureView> createTextureView(Format format, Extents size, SubresourceData* data, int mips = 1)
+    ComPtr<ITextureView> createTextureView(Format format, Extent3D size, SubresourceData* data, int mips = 1)
     {
         TextureDesc texDesc = {};
         texDesc.type = TextureType::Texture2D;
@@ -109,7 +109,7 @@ struct TestFormats
     template<typename T, size_t Count>
     void testFormat(
         Format format,
-        Extents textureSize,
+        Extent3D textureSize,
         SubresourceData* textureData,
         const std::array<T, Count>& expected
     )
@@ -147,12 +147,12 @@ struct TestFormats
 
     void run()
     {
-        Extents size = {};
+        Extent3D size = {};
         size.width = 2;
         size.height = 2;
         size.depth = 1;
 
-        Extents bcSize = {};
+        Extent3D bcSize = {};
         bcSize.width = 4;
         bcSize.height = 4;
         bcSize.depth = 1;

--- a/tests/test-resolve-resource-tests.cpp
+++ b/tests/test-resolve-resource-tests.cpp
@@ -66,7 +66,7 @@ struct BaseResolveResourceTest
 
     struct TextureInfo
     {
-        Extents extent;
+        Extent3D extent;
         int mipLevelCount;
         int arrayLength;
         const SubresourceData* initData;
@@ -149,7 +149,7 @@ struct BaseResolveResourceTest
         REQUIRE_CALL(device->createTextureView(dstTexture, textureViewDesc, dstTextureView.writeRef()));
     }
 
-    void submitGPUWork(SubresourceRange msaaSubresource, SubresourceRange dstSubresource, Extents extent)
+    void submitGPUWork(SubresourceRange msaaSubresource, SubresourceRange dstSubresource, Extent3D extent)
     {
         auto queue = device->getQueue(QueueType::Graphics);
         auto commandEncoder = queue->createCommandEncoder();
@@ -227,7 +227,7 @@ struct ResolveResourceSimple : BaseResolveResourceTest
 {
     void run()
     {
-        Extents extent = {};
+        Extent3D extent = {};
         extent.width = kWidth;
         extent.height = kHeight;
         extent.depth = 1;

--- a/tests/test-resource-states.cpp
+++ b/tests/test-resource-states.cpp
@@ -118,7 +118,7 @@ GPU_TEST_CASE("texture-resource-states", D3D12 | Vulkan)
         TextureDesc texDesc = {};
         texDesc.type = TextureType::Texture2D;
         texDesc.format = format;
-        texDesc.size = Extents{4, 4, 1};
+        texDesc.size = Extent3D{4, 4, 1};
         texDesc.mipLevelCount = 1;
         texDesc.usage = textureUsage;
         texDesc.memoryType = MemoryType::DeviceLocal;

--- a/tests/test-surface.cpp
+++ b/tests/test-surface.cpp
@@ -268,7 +268,7 @@ struct ComputeSurfaceTest : SurfaceTest
                 renderTexture,
                 {0, 0, 0, 0},
                 offset,
-                Extents::kWholeTexture
+                Extent3D::kWholeTexture
             );
         }
         queue->submit(commandEncoder->finish());

--- a/tests/test-texture-layout.cpp
+++ b/tests/test-texture-layout.cpp
@@ -37,13 +37,13 @@ void testTextureLayout2(
     uint32_t layer,
     uint32_t mipLevel,
     Offset3D offset,
-    Extents extents,
+    Extent3D extent,
     SubresourceLayout expectedLayout
 )
 {
     SubresourceLayout layout;
     REQUIRE_CALL(
-        ((Texture*)texture.get())->getSubresourceRegionLayout(mipLevel, offset, extents, kDefaultAlignment, &layout)
+        ((Texture*)texture.get())->getSubresourceRegionLayout(mipLevel, offset, extent, kDefaultAlignment, &layout)
     );
 
     CHECK_EQ(layout.size.width, expectedLayout.size.width);

--- a/tests/test-texture-shared.cpp
+++ b/tests/test-texture-shared.cpp
@@ -45,12 +45,12 @@ static void setUpAndRunShader(
     }
 }
 
-static ComPtr<ITexture> createTexture(IDevice* device, Extents extents, Format format, SubresourceData* initialData)
+static ComPtr<ITexture> createTexture(IDevice* device, Extent3D extent, Format format, SubresourceData* initialData)
 {
     TextureDesc texDesc = {};
     texDesc.type = TextureType::Texture2D;
     texDesc.mipLevelCount = 1;
-    texDesc.size = extents;
+    texDesc.size = extent;
     texDesc.usage = TextureUsage::ShaderResource | TextureUsage::UnorderedAccess | TextureUsage::CopyDestination |
                     TextureUsage::CopySource | TextureUsage::Shared;
     texDesc.defaultState = ResourceState::UnorderedAccess;
@@ -96,12 +96,12 @@ void testSharedTexture(GpuTestContext* ctx, DeviceType deviceType)
     int32_t initIntData[16] = {0};
     auto intResults = createBuffer<uint32_t>(dstDevice, 16, initIntData);
 
-    Extents size = {};
+    Extent3D size = {};
     size.width = 2;
     size.height = 2;
     size.depth = 1;
 
-    Extents bcSize = {};
+    Extent3D bcSize = {};
     bcSize.width = 4;
     bcSize.height = 4;
     bcSize.depth = 1;

--- a/tests/test-texture-view.cpp
+++ b/tests/test-texture-view.cpp
@@ -44,7 +44,7 @@ struct TestTextureViews
         TextureType textureType,
         TextureUsage usage,
         uint32_t mipLevelCount,
-        Extents textureSize,
+        Extent3D textureSize,
         SubresourceRange textureViewRange,
         SubresourceData* data
     )
@@ -73,7 +73,7 @@ struct TestTextureViews
     void testTextureViewUnorderedAccess(
         TextureType textureType,
         uint32_t mipLevelCount,
-        Extents textureSize,
+        Extent3D textureSize,
         SubresourceRange textureViewRange,
         SubresourceData* textureData
     )
@@ -88,7 +88,7 @@ struct TestTextureViews
         );
 
         // Create result buffer
-        Extents textureViewSize = {
+        Extent3D textureViewSize = {
             std::max(textureSize.width >> textureViewRange.mipLevel, 1u),
             std::max(textureSize.height >> textureViewRange.mipLevel, 1u),
             std::max(textureSize.depth >> textureViewRange.mipLevel, 1u)
@@ -185,7 +185,7 @@ struct TestTextureViews
 
             TextureType type = TextureType::Texture3D;
             // Texture size
-            Extents size = {16 /*width*/, 16 /*height*/, 16 /*depth*/};
+            Extent3D size = {16 /*width*/, 16 /*height*/, 16 /*depth*/};
             // This subrange/textureView will give a 8x8x8 texture and verifies a fix for issue #220
             // We use 3 for baseArrayLayer as this was previously used for FirstWSlice and we want
             // to verify that selecting a subset of depth slices is not currently supported.

--- a/tests/test-texture-view.cpp
+++ b/tests/test-texture-view.cpp
@@ -89,9 +89,9 @@ struct TestTextureViews
 
         // Create result buffer
         Extents textureViewSize = {
-            std::max(textureSize.width >> textureViewRange.mipLevel, 1),
-            std::max(textureSize.height >> textureViewRange.mipLevel, 1),
-            std::max(textureSize.depth >> textureViewRange.mipLevel, 1)
+            std::max(textureSize.width >> textureViewRange.mipLevel, 1u),
+            std::max(textureSize.height >> textureViewRange.mipLevel, 1u),
+            std::max(textureSize.depth >> textureViewRange.mipLevel, 1u)
         };
         // In bytes
         int dataLength =

--- a/tests/texture-test.cpp
+++ b/tests/texture-test.cpp
@@ -270,7 +270,7 @@ void checkRegionsEqual(
     /*
     fprintf(
         stderr,
-        "    Oa: [%d,%d,%d], Ob: [%d,%d,%d], Ex: [%d,%d,%d]\n",
+        "    Oa: [%u,%u,%u], Ob: [%u,%u,%u], Ex: [%u,%u,%u]\n",
         offsetA.x,
         offsetA.y,
         offsetA.z,
@@ -438,11 +438,11 @@ void TextureData::checkMipLevelsEqual(
 
     // Adjust extents if 'whole texture' specified.
     if (textureExtents.width == Extents::kWholeTexture.width)
-        textureExtents.width = max(textureLayout.size.width - textureOffset.x, 1);
+        textureExtents.width = max(textureLayout.size.width - textureOffset.x, 1u);
     if (textureExtents.height == Extents::kWholeTexture.height)
-        textureExtents.height = max(textureLayout.size.height - textureOffset.y, 1);
+        textureExtents.height = max(textureLayout.size.height - textureOffset.y, 1u);
     if (textureExtents.depth == Extents::kWholeTexture.depth)
-        textureExtents.depth = max(textureLayout.size.depth - textureOffset.z, 1);
+        textureExtents.depth = max(textureLayout.size.depth - textureOffset.z, 1u);
 
     if (!compareOutsideRegion)
     {
@@ -471,28 +471,28 @@ void TextureData::checkMipLevelsEqual(
         // For simplicity, the (potentially 3D) texture is divided into 3x3x3
         // regions, with the central region being the region to exclude.
         // The surrounding regions are then compared.
-        int zSizes[] =
+        uint32_t zSizes[] =
             {textureOffset.z, textureExtents.depth, textureLayout.size.depth - textureExtents.depth - textureOffset.z};
-        int ySizes[] = {
+        uint32_t ySizes[] = {
             textureOffset.y,
             textureExtents.height,
             textureLayout.size.height - textureExtents.height - textureOffset.y
         };
-        int xSizes[] =
+        uint32_t xSizes[] =
             {textureOffset.x, textureExtents.width, textureLayout.size.width - textureExtents.width - textureOffset.x};
 
-        int offsetZ = 0;
+        uint32_t offsetZ = 0;
         for (uint32_t regionZ = 0; regionZ < 3; regionZ++)
         {
-            int sizeZ = zSizes[regionZ];
-            int offsetY = 0;
+            uint32_t sizeZ = zSizes[regionZ];
+            uint32_t offsetY = 0;
             for (uint32_t regionY = 0; regionY < 3; regionY++)
             {
-                int sizeY = ySizes[regionY];
-                int offsetX = 0;
+                uint32_t sizeY = ySizes[regionY];
+                uint32_t offsetX = 0;
                 for (uint32_t regionX = 0; regionX < 3; regionX++)
                 {
-                    int sizeX = xSizes[regionX];
+                    uint32_t sizeX = xSizes[regionX];
                     if (regionX != 1 || regionY != 1 || regionZ != 1)
                     {
                         checkRegionsEqual(

--- a/tests/texture-test.cpp
+++ b/tests/texture-test.cpp
@@ -166,7 +166,7 @@ void TextureData::initData(TextureInitMode initMode_, int initSeed_, int initRow
         for (uint32_t mipLevel = 0; mipLevel < desc.mipLevelCount; ++mipLevel)
         {
             SubresourceLayout layout;
-            calcSubresourceRegionLayout(desc, mipLevel, {0, 0, 0}, Extents::kWholeTexture, initRowAlignment, &layout);
+            calcSubresourceRegionLayout(desc, mipLevel, {0, 0, 0}, Extent3D::kWholeTexture, initRowAlignment, &layout);
 
             Subresource sr;
             sr.layer = layer;
@@ -214,7 +214,7 @@ void TextureData::checkEqual(
     Offset3D thisOffset,
     ITexture* texture,
     Offset3D textureOffset,
-    Extents textureExtents,
+    Extent3D textureExtent,
     bool compareOutsideRegion
 ) const
 {
@@ -224,7 +224,7 @@ void TextureData::checkEqual(
 
     for (uint32_t layer = 0; layer < desc.getLayerCount(); ++layer)
     {
-        checkLayersEqual(layer, thisOffset, texture, layer, textureOffset, textureExtents, compareOutsideRegion);
+        checkLayersEqual(layer, thisOffset, texture, layer, textureOffset, textureExtent, compareOutsideRegion);
     }
 }
 
@@ -234,7 +234,7 @@ void TextureData::checkLayersEqual(
     ITexture* texture,
     int textureLayer,
     Offset3D textureOffset,
-    Extents textureExtents,
+    Extent3D textureExtent,
     bool compareOutsideRegion
 ) const
 {
@@ -251,7 +251,7 @@ void TextureData::checkLayersEqual(
             textureLayer,
             mipLevel,
             textureOffset,
-            textureExtents,
+            textureExtent,
             compareOutsideRegion
         );
     }
@@ -264,7 +264,7 @@ void checkRegionsEqual(
     const void* dataB_,
     const SubresourceLayout& layoutB,
     Offset3D offsetB,
-    Extents extents
+    Extent3D extent
 )
 {
     /*
@@ -277,9 +277,9 @@ void checkRegionsEqual(
         offsetB.x,
         offsetB.y,
         offsetB.z,
-        extents.width,
-        extents.height,
-        extents.depth
+        extent.width,
+        extent.height,
+        extent.depth
     );
     */
 
@@ -292,14 +292,14 @@ void checkRegionsEqual(
     CHECK_EQ(layoutA.colPitch, layoutB.colPitch);
 
     // Check region is valid for A
-    CHECK_GE(layoutA.size.width, offsetA.x + extents.width);
-    CHECK_GE(layoutA.size.height, offsetA.y + extents.height);
-    CHECK_GE(layoutA.size.depth, offsetA.z + extents.depth);
+    CHECK_GE(layoutA.size.width, offsetA.x + extent.width);
+    CHECK_GE(layoutA.size.height, offsetA.y + extent.height);
+    CHECK_GE(layoutA.size.depth, offsetA.z + extent.depth);
 
     // Check region is valid for B
-    CHECK_GE(layoutB.size.width, offsetB.x + extents.width);
-    CHECK_GE(layoutB.size.height, offsetB.y + extents.height);
-    CHECK_GE(layoutB.size.depth, offsetB.z + extents.depth);
+    CHECK_GE(layoutB.size.width, offsetB.x + extent.width);
+    CHECK_GE(layoutB.size.height, offsetB.y + extent.height);
+    CHECK_GE(layoutB.size.depth, offsetB.z + extent.depth);
 
     // Calculate overall dimensions in blocks rather than pixels to handle compressed textures.
     uint32_t sliceOffsetA = offsetA.z;
@@ -308,9 +308,9 @@ void checkRegionsEqual(
     uint32_t sliceOffsetB = offsetB.z;
     uint32_t rowOffsetB = math::divideRoundedUp(offsetB.y, layoutB.blockHeight);
     uint32_t colOffsetB = math::divideRoundedUp(offsetB.x, layoutB.blockWidth);
-    uint32_t sliceCount = extents.depth;
-    uint32_t rowCount = math::divideRoundedUp(extents.height, layoutA.blockHeight);
-    uint32_t colCount = math::divideRoundedUp(extents.width, layoutA.blockWidth);
+    uint32_t sliceCount = extent.depth;
+    uint32_t rowCount = math::divideRoundedUp(extent.height, layoutA.blockHeight);
+    uint32_t colCount = math::divideRoundedUp(extent.width, layoutA.blockWidth);
 
     // Iterate over whole texture, checking each block.
     for (uint32_t slice = 0; slice < sliceCount; slice++)
@@ -340,14 +340,14 @@ void checkRegionsEqual(
     }
 }
 
-void checkInverseRegionZero(const void* dataA_, const SubresourceLayout& layoutA, Offset3D offsetA, Extents extents)
+void checkInverseRegionZero(const void* dataA_, const SubresourceLayout& layoutA, Offset3D offsetA, Extent3D extent)
 {
     const uint8_t* dataA = (const uint8_t*)dataA_;
 
     // Check region is valid for A
-    CHECK_GE(layoutA.size.width, offsetA.x + extents.width);
-    CHECK_GE(layoutA.size.height, offsetA.y + extents.height);
-    CHECK_GE(layoutA.size.depth, offsetA.z + extents.depth);
+    CHECK_GE(layoutA.size.width, offsetA.x + extent.width);
+    CHECK_GE(layoutA.size.height, offsetA.y + extent.height);
+    CHECK_GE(layoutA.size.depth, offsetA.z + extent.depth);
 
     uint32_t textureSliceCount = layoutA.size.depth;
     uint32_t textureRowCount = math::divideRoundedUp(layoutA.size.height, layoutA.blockHeight);
@@ -357,9 +357,9 @@ void checkInverseRegionZero(const void* dataA_, const SubresourceLayout& layoutA
     uint32_t sliceBegin = offsetA.z;
     uint32_t rowBegin = math::divideRoundedUp(offsetA.y, layoutA.blockHeight);
     uint32_t colBegin = math::divideRoundedUp(offsetA.x, layoutA.blockWidth);
-    uint32_t sliceEnd = sliceBegin + extents.depth;
-    uint32_t rowEnd = rowBegin + math::divideRoundedUp(extents.height, layoutA.blockHeight);
-    uint32_t colEnd = colBegin + math::divideRoundedUp(extents.width, layoutA.blockWidth);
+    uint32_t sliceEnd = sliceBegin + extent.depth;
+    uint32_t rowEnd = rowBegin + math::divideRoundedUp(extent.height, layoutA.blockHeight);
+    uint32_t colEnd = colBegin + math::divideRoundedUp(extent.width, layoutA.blockWidth);
 
     // Iterate over whole texture, checking each block.
     for (uint32_t textureSlice = 0; textureSlice < textureSliceCount; textureSlice++)
@@ -400,7 +400,7 @@ void TextureData::checkMipLevelsEqual(
     int textureLayer,
     int textureMipLevel,
     Offset3D textureOffset,
-    Extents textureExtents,
+    Extent3D textureExtent,
     bool compareOutsideRegion
 ) const
 {
@@ -426,23 +426,23 @@ void TextureData::checkMipLevelsEqual(
     if (formatInfo.blockWidth > 1)
     {
         CHECK_EQ(textureOffset.x % formatInfo.blockWidth, 0);
-        if (textureExtents.width != Extents::kWholeTexture.width)
-            CHECK_EQ(textureExtents.width % formatInfo.blockWidth, 0);
+        if (textureExtent.width != Extent3D::kWholeTexture.width)
+            CHECK_EQ(textureExtent.width % formatInfo.blockWidth, 0);
     }
     if (formatInfo.blockHeight > 1)
     {
         CHECK_EQ(textureOffset.y % formatInfo.blockHeight, 0);
-        if (textureExtents.height != Extents::kWholeTexture.height)
-            CHECK_EQ(textureExtents.height % formatInfo.blockHeight, 0);
+        if (textureExtent.height != Extent3D::kWholeTexture.height)
+            CHECK_EQ(textureExtent.height % formatInfo.blockHeight, 0);
     }
 
     // Adjust extents if 'whole texture' specified.
-    if (textureExtents.width == Extents::kWholeTexture.width)
-        textureExtents.width = max(textureLayout.size.width - textureOffset.x, 1u);
-    if (textureExtents.height == Extents::kWholeTexture.height)
-        textureExtents.height = max(textureLayout.size.height - textureOffset.y, 1u);
-    if (textureExtents.depth == Extents::kWholeTexture.depth)
-        textureExtents.depth = max(textureLayout.size.depth - textureOffset.z, 1u);
+    if (textureExtent.width == Extent3D::kWholeTexture.width)
+        textureExtent.width = max(textureLayout.size.width - textureOffset.x, 1u);
+    if (textureExtent.height == Extent3D::kWholeTexture.height)
+        textureExtent.height = max(textureLayout.size.height - textureOffset.y, 1u);
+    if (textureExtent.depth == Extent3D::kWholeTexture.depth)
+        textureExtent.depth = max(textureLayout.size.depth - textureOffset.z, 1u);
 
     if (!compareOutsideRegion)
     {
@@ -456,7 +456,7 @@ void TextureData::checkMipLevelsEqual(
             blob->getBufferPointer(),
             textureLayout,
             textureOffset,
-            textureExtents
+            textureExtent
         );
     }
     else
@@ -472,14 +472,11 @@ void TextureData::checkMipLevelsEqual(
         // regions, with the central region being the region to exclude.
         // The surrounding regions are then compared.
         uint32_t zSizes[] =
-            {textureOffset.z, textureExtents.depth, textureLayout.size.depth - textureExtents.depth - textureOffset.z};
-        uint32_t ySizes[] = {
-            textureOffset.y,
-            textureExtents.height,
-            textureLayout.size.height - textureExtents.height - textureOffset.y
-        };
+            {textureOffset.z, textureExtent.depth, textureLayout.size.depth - textureExtent.depth - textureOffset.z};
+        uint32_t ySizes[] =
+            {textureOffset.y, textureExtent.height, textureLayout.size.height - textureExtent.height - textureOffset.y};
         uint32_t xSizes[] =
-            {textureOffset.x, textureExtents.width, textureLayout.size.width - textureExtents.width - textureOffset.x};
+            {textureOffset.x, textureExtent.width, textureLayout.size.width - textureExtent.width - textureOffset.x};
 
         uint32_t offsetZ = 0;
         for (uint32_t regionZ = 0; regionZ < 3; regionZ++)

--- a/tests/texture-test.h
+++ b/tests/texture-test.h
@@ -71,7 +71,7 @@ struct TextureData
         Offset3D thisOffset,
         ITexture* texture,
         Offset3D textureOffset = {0, 0, 0},
-        Extents textureExtents = Extents::kWholeTexture,
+        Extent3D textureExtent = Extent3D::kWholeTexture,
         bool compareOutsideRegion = false
     ) const;
 
@@ -79,9 +79,9 @@ struct TextureData
     inline void checkEqual(ITexture* texture) const { checkEqual({0, 0, 0}, texture); }
 
     /// Helper for checkEqual that tests the same offsets/extents
-    inline void checkEqual(ITexture* texture, Offset3D offset, Extents extents, bool compareOutsideRegion = false) const
+    inline void checkEqual(ITexture* texture, Offset3D offset, Extent3D extent, bool compareOutsideRegion = false) const
     {
-        checkEqual(offset, texture, offset, extents, compareOutsideRegion);
+        checkEqual(offset, texture, offset, extent, compareOutsideRegion);
     }
 
     /// Compare cpu data for a layer in this TextureData against a layer
@@ -92,14 +92,14 @@ struct TextureData
         ITexture* texture,
         int textureLayer,
         Offset3D textureOffset,
-        Extents textureExtents,
+        Extent3D textureExtent,
         bool compareOutsideRegion = false
     ) const;
 
     /// Helper for checkLayersEqual that requires no offsets/extents
     inline void checkLayersEqual(int thisLayer, ITexture* texture, int textureLayer) const
     {
-        checkLayersEqual(thisLayer, {0, 0, 0}, texture, textureLayer, {0, 0, 0}, Extents::kWholeTexture);
+        checkLayersEqual(thisLayer, {0, 0, 0}, texture, textureLayer, {0, 0, 0}, Extent3D::kWholeTexture);
     }
 
     /// Helper for checkLayersEqual that tests the same layers, offsets and extents in each texture
@@ -107,17 +107,17 @@ struct TextureData
         ITexture* texture,
         int layer,
         Offset3D offset,
-        Extents extents,
+        Extent3D extent,
         bool compareOutsideRegion = false
     ) const
     {
-        checkLayersEqual(layer, offset, texture, layer, offset, extents, compareOutsideRegion);
+        checkLayersEqual(layer, offset, texture, layer, offset, extent, compareOutsideRegion);
     }
 
     /// Helper for checkLayersEqual that tests the same layers of the whole of each texture
     inline void checkLayersEqual(ITexture* texture, int layer) const
     {
-        checkLayersEqual(layer, {0, 0, 0}, texture, layer, {0, 0, 0}, Extents::kWholeTexture);
+        checkLayersEqual(layer, {0, 0, 0}, texture, layer, {0, 0, 0}, Extent3D::kWholeTexture);
     }
 
     /// Compare mip levels for a layer in this TextureData against a layer
@@ -130,7 +130,7 @@ struct TextureData
         int textureLayer,
         int textureMipLevel,
         Offset3D textureOffset,
-        Extents textureExtents,
+        Extent3D textureExtent,
         bool compareOutsideRegion = false
     ) const;
 
@@ -151,7 +151,7 @@ struct TextureData
             textureLayer,
             textureMipLevel,
             {0, 0, 0},
-            Extents::kWholeTexture
+            Extent3D::kWholeTexture
         );
     }
 
@@ -161,17 +161,17 @@ struct TextureData
         int layer,
         int mipLevel,
         Offset3D offset,
-        Extents extents,
+        Extent3D extent,
         bool compareOutsideRegion = false
     ) const
     {
-        checkMipLevelsEqual(layer, mipLevel, offset, texture, layer, mipLevel, offset, extents, compareOutsideRegion);
+        checkMipLevelsEqual(layer, mipLevel, offset, texture, layer, mipLevel, offset, extent, compareOutsideRegion);
     }
 
     /// Helper for checkMipLevelsEqual that tests the same layers and mip levels of the whole of each texture
     inline void checkMipLevelsEqual(ITexture* texture, int layer, int mipLevel) const
     {
-        checkMipLevelsEqual(layer, mipLevel, {0, 0, 0}, texture, layer, mipLevel, {0, 0, 0}, Extents::kWholeTexture);
+        checkMipLevelsEqual(layer, mipLevel, {0, 0, 0}, texture, layer, mipLevel, {0, 0, 0}, Extent3D::kWholeTexture);
     }
 
     /// Compare a slice of this TextureData (must be 3D) against a 2D
@@ -214,10 +214,10 @@ void checkRegionsEqual(
     const void* dataB_,
     const SubresourceLayout& layoutB,
     Offset3D offsetB,
-    Extents extents
+    Extent3D extent
 );
 
-void checkInverseRegionZero(const void* dataA_, const SubresourceLayout& layoutA, Offset3D offsetA, Extents extents);
+void checkInverseRegionZero(const void* dataA_, const SubresourceLayout& layoutA, Offset3D offsetA, Extent3D extent);
 
 /// Description of a given texture in a variant (texture descriptor + how to init)
 struct TestTextureDesc

--- a/tests/texture-utils.cpp
+++ b/tests/texture-utils.cpp
@@ -189,7 +189,7 @@ RefPtr<ValidationTextureFormatBase> getValidationTextureFormat(Format format)
 
 void generateTextureData(RefPtr<TextureInfo> texture, ValidationTextureFormatBase* validationFormat)
 {
-    Extents extents = texture->extents;
+    Extent3D extent = texture->extent;
     uint32_t arrayLayers = texture->arrayLength;
     if (texture->textureType == TextureType::TextureCube)
         arrayLayers *= 6;
@@ -202,16 +202,16 @@ void generateTextureData(RefPtr<TextureInfo> texture, ValidationTextureFormatBas
         {
             RefPtr<ValidationTextureData> subresource = new ValidationTextureData();
 
-            uint32_t mipWidth = std::max(extents.width >> mip, 1u);
-            uint32_t mipHeight = std::max(extents.height >> mip, 1u);
-            uint32_t mipDepth = std::max(extents.depth >> mip, 1u);
+            uint32_t mipWidth = std::max(extent.width >> mip, 1u);
+            uint32_t mipHeight = std::max(extent.height >> mip, 1u);
+            uint32_t mipDepth = std::max(extent.depth >> mip, 1u);
             uint32_t mipSize = mipWidth * mipHeight * mipDepth * texelSize;
             subresource->textureData = ::malloc(mipSize);
             REQUIRE(subresource->textureData != nullptr);
 
-            subresource->extents.width = mipWidth;
-            subresource->extents.height = mipHeight;
-            subresource->extents.depth = mipDepth;
+            subresource->extent.width = mipWidth;
+            subresource->extent.height = mipHeight;
+            subresource->extent.depth = mipDepth;
             subresource->pitches.x = texelSize;
             subresource->pitches.y = mipWidth * texelSize;
             subresource->pitches.z = mipHeight * subresource->pitches.y;

--- a/tests/texture-utils.cpp
+++ b/tests/texture-utils.cpp
@@ -189,12 +189,12 @@ RefPtr<ValidationTextureFormatBase> getValidationTextureFormat(Format format)
 
 void generateTextureData(RefPtr<TextureInfo> texture, ValidationTextureFormatBase* validationFormat)
 {
-    auto extents = texture->extents;
-    auto arrayLayers = texture->arrayLength;
+    Extents extents = texture->extents;
+    uint32_t arrayLayers = texture->arrayLength;
     if (texture->textureType == TextureType::TextureCube)
         arrayLayers *= 6;
-    auto mipLevels = texture->mipLevelCount;
-    auto texelSize = getTexelSize(texture->format);
+    uint32_t mipLevels = texture->mipLevelCount;
+    Size texelSize = getTexelSize(texture->format);
 
     for (uint32_t layer = 0; layer < arrayLayers; ++layer)
     {
@@ -202,10 +202,10 @@ void generateTextureData(RefPtr<TextureInfo> texture, ValidationTextureFormatBas
         {
             RefPtr<ValidationTextureData> subresource = new ValidationTextureData();
 
-            auto mipWidth = std::max(extents.width >> mip, 1);
-            auto mipHeight = std::max(extents.height >> mip, 1);
-            auto mipDepth = std::max(extents.depth >> mip, 1);
-            auto mipSize = mipWidth * mipHeight * mipDepth * texelSize;
+            uint32_t mipWidth = std::max(extents.width >> mip, 1u);
+            uint32_t mipHeight = std::max(extents.height >> mip, 1u);
+            uint32_t mipDepth = std::max(extents.depth >> mip, 1u);
+            uint32_t mipSize = mipWidth * mipHeight * mipDepth * texelSize;
             subresource->textureData = ::malloc(mipSize);
             REQUIRE(subresource->textureData != nullptr);
 

--- a/tests/texture-utils.h
+++ b/tests/texture-utils.h
@@ -164,14 +164,14 @@ struct PackedValidationTextureFormat : ValidationTextureFormatBase
 struct ValidationTextureData : RefObject
 {
     const void* textureData;
-    Extents extents;
+    Extent3D extent;
     Strides pitches;
 
     void* getBlockAt(uint32_t x, uint32_t y, uint32_t z)
     {
-        SLANG_RHI_ASSERT(x < extents.width);
-        SLANG_RHI_ASSERT(y < extents.height);
-        SLANG_RHI_ASSERT(z < extents.depth);
+        SLANG_RHI_ASSERT(x < extent.width);
+        SLANG_RHI_ASSERT(y < extent.height);
+        SLANG_RHI_ASSERT(z < extent.depth);
 
         char* layerData = (char*)textureData + z * pitches.z;
         char* rowData = layerData + y * pitches.y;
@@ -186,7 +186,7 @@ struct TextureInfo : RefObject
     Format format;
     TextureType textureType;
 
-    Extents extents;
+    Extent3D extent;
     uint32_t mipLevelCount;
     uint32_t arrayLength;
 


### PR DESCRIPTION
- use `uint32_t` for `Offset3D`, `Extent3D` and `ScissorRect`
- rename `Extents` to `Extent3D`
- rename various `extents` arguments to `extent`