### PR TITLE
SubresourceRange cleanup

### DIFF
--- a/include/slang-rhi.h
+++ b/include/slang-rhi.h
@@ -653,7 +653,7 @@ struct SubresourceRange
 {
     // TODO: Check this comment - many areas explicitly specify a 3D offset / extents,
     // and this is expected to be 0 for 3D texture.
-    uint32_t baseArrayLayer;
+    uint32_t layer;
     uint32_t layerCount; // For cube maps, this is a multiple of 6.
 
     uint32_t mipLevel;
@@ -661,7 +661,7 @@ struct SubresourceRange
 
     bool operator==(const SubresourceRange& other) const
     {
-        return baseArrayLayer == other.baseArrayLayer && layerCount == other.layerCount && mipLevel == other.mipLevel &&
+        return layer == other.layer && layerCount == other.layerCount && mipLevel == other.mipLevel &&
                mipLevelCount == other.mipLevelCount;
     }
     bool operator!=(const SubresourceRange& other) const { return !(*this == other); }

--- a/include/slang-rhi.h
+++ b/include/slang-rhi.h
@@ -651,19 +651,18 @@ enum class TextureAspect : uint32_t
 
 struct SubresourceRange
 {
-    uint32_t mipLevel;
-    uint32_t mipLevelCount;
-
     // TODO: Check this comment - many areas explicitly specify a 3D offset / extents,
     // and this is expected to be 0 for 3D texture.
     uint32_t baseArrayLayer;
-
     uint32_t layerCount; // For cube maps, this is a multiple of 6.
+
+    uint32_t mipLevel;
+    uint32_t mipLevelCount;
 
     bool operator==(const SubresourceRange& other) const
     {
-        return mipLevel == other.mipLevel && mipLevelCount == other.mipLevelCount &&
-               baseArrayLayer == other.baseArrayLayer && layerCount == other.layerCount;
+        return baseArrayLayer == other.baseArrayLayer && layerCount == other.layerCount && mipLevel == other.mipLevel &&
+               mipLevelCount == other.mipLevelCount;
     }
     bool operator!=(const SubresourceRange& other) const { return !(*this == other); }
 };
@@ -787,7 +786,7 @@ struct SubresourceLayout
 
 static const uint32_t kAllLayers = 0xffffffff;
 static const uint32_t kAllMipLevels = 0xffffffff;
-static const SubresourceRange kAllSubresources = {0, kAllMipLevels, 0, kAllLayers};
+static const SubresourceRange kAllSubresources = {0, kAllLayers, 0, kAllMipLevels};
 
 struct TextureDesc
 {

--- a/src/command-buffer.cpp
+++ b/src/command-buffer.cpp
@@ -543,7 +543,7 @@ void CommandEncoder::copyBufferToTexture(
     // Add texture upload command for just this layer/mip
     commands::UploadTextureData cmd;
     cmd.dst = dst;
-    cmd.subresourceRange = {dstMipLevel, 1, dstLayer, 1};
+    cmd.subresourceRange = {dstLayer, 1, dstMipLevel, 1};
     cmd.offset = dstOffset;
     cmd.extent = extent;
     cmd.layouts = layout;

--- a/src/cuda/cuda-clear-engine.cpp
+++ b/src/cuda/cuda-clear-engine.cpp
@@ -184,7 +184,7 @@ void ClearEngine::clearTexture(
         for (uint32_t layerOffset = 0; layerOffset < subresourceRange.layerCount; ++layerOffset)
         {
             uint32_t layer = subresourceRange.baseArrayLayer + layerOffset;
-            SubresourceRange sr = {mipLevel, 1, layer, 1};
+            SubresourceRange sr = {layer, 1, mipLevel, 1};
             CUsurfObject surface = texture->getSurfObject(sr);
             uint32_t sizeAndLayer[4] = {mipSize.width, mipSize.height, mipSize.depth, layer};
             launch(stream, function, blockDim, surface, sizeAndLayer, reinterpret_cast<const uint32_t*>(clearValue));

--- a/src/cuda/cuda-clear-engine.cpp
+++ b/src/cuda/cuda-clear-engine.cpp
@@ -183,7 +183,7 @@ void ClearEngine::clearTexture(
         Extent3D mipSize = calcMipSize(texture->m_desc.size, mipLevel);
         for (uint32_t layerOffset = 0; layerOffset < subresourceRange.layerCount; ++layerOffset)
         {
-            uint32_t layer = subresourceRange.baseArrayLayer + layerOffset;
+            uint32_t layer = subresourceRange.layer + layerOffset;
             SubresourceRange sr = {layer, 1, mipLevel, 1};
             CUsurfObject surface = texture->getSurfObject(sr);
             uint32_t sizeAndLayer[4] = {mipSize.width, mipSize.height, mipSize.depth, layer};

--- a/src/cuda/cuda-command.cpp
+++ b/src/cuda/cuda-command.cpp
@@ -153,8 +153,8 @@ void CommandExecutor::cmdCopyTexture(const commands::CopyTexture& cmd)
     // Copy each layer and mip level
     for (uint32_t layerOffset = 0; layerOffset < srcSubresource.layerCount; layerOffset++)
     {
-        uint32_t srcLayer = srcSubresource.baseArrayLayer + layerOffset;
-        uint32_t dstLayer = dstSubresource.baseArrayLayer + layerOffset;
+        uint32_t srcLayer = srcSubresource.layer + layerOffset;
+        uint32_t dstLayer = dstSubresource.layer + layerOffset;
 
         for (uint32_t mipOffset = 0; mipOffset < srcSubresource.mipLevelCount; mipOffset++)
         {
@@ -325,7 +325,7 @@ void CommandExecutor::cmdUploadTextureData(const commands::UploadTextureData& cm
 
     for (uint32_t layerOffset = 0; layerOffset < subresourceRange.layerCount; layerOffset++)
     {
-        uint32_t layer = subresourceRange.baseArrayLayer + layerOffset;
+        uint32_t layer = subresourceRange.layer + layerOffset;
         for (uint32_t mipOffset = 0; mipOffset < subresourceRange.mipLevelCount; mipOffset++)
         {
             uint32_t mipLevel = subresourceRange.mipLevel + mipOffset;

--- a/src/cuda/cuda-command.cpp
+++ b/src/cuda/cuda-command.cpp
@@ -138,14 +138,14 @@ void CommandExecutor::cmdCopyTexture(const commands::CopyTexture& cmd)
     const Extent3D& extent = cmd.extent;
 
     // Fix up sub resource ranges if they are 0 (meaning use entire range)
-    if (dstSubresource.mipLevelCount == 0)
-        dstSubresource.mipLevelCount = dst->m_desc.mipLevelCount;
     if (dstSubresource.layerCount == 0)
         dstSubresource.layerCount = dst->m_desc.getLayerCount();
-    if (srcSubresource.mipLevelCount == 0)
-        srcSubresource.mipLevelCount = src->m_desc.mipLevelCount;
+    if (dstSubresource.mipLevelCount == 0)
+        dstSubresource.mipLevelCount = dst->m_desc.mipLevelCount;
     if (srcSubresource.layerCount == 0)
         srcSubresource.layerCount = src->m_desc.getLayerCount();
+    if (srcSubresource.mipLevelCount == 0)
+        srcSubresource.mipLevelCount = src->m_desc.mipLevelCount;
 
     const FormatInfo& formatInfo = getFormatInfo(src->m_desc.format);
     Extent3D srcTextureSize = src->m_desc.size;

--- a/src/cuda/cuda-texture.cpp
+++ b/src/cuda/cuda-texture.cpp
@@ -190,8 +190,8 @@ CUtexObject TextureImpl::getTexObject(Format format, const SubresourceRange& ran
     viewDesc.depth = m_desc.size.depth;
     viewDesc.firstMipmapLevel = range.mipLevel;
     viewDesc.lastMipmapLevel = range.mipLevel + range.mipLevelCount - 1;
-    viewDesc.firstLayer = range.baseArrayLayer;
-    viewDesc.lastLayer = range.baseArrayLayer + range.layerCount - 1;
+    viewDesc.firstLayer = range.layer;
+    viewDesc.lastLayer = range.layer + range.layerCount - 1;
 
     SLANG_CUDA_ASSERT_ON_FAIL(
         cuTexObjectCreate(&texObject, &resDesc, &texDesc, isEntireTexture(range) ? nullptr : &viewDesc)

--- a/src/cuda/cuda-texture.h
+++ b/src/cuda/cuda-texture.h
@@ -32,7 +32,7 @@ public:
         {
             size_t hash = 0;
             hash_combine(hash, key.format);
-            hash_combine(hash, key.range.baseArrayLayer);
+            hash_combine(hash, key.range.layer);
             hash_combine(hash, key.range.layerCount);
             hash_combine(hash, key.range.mipLevel);
             hash_combine(hash, key.range.mipLevelCount);
@@ -45,7 +45,7 @@ public:
         size_t operator()(const SubresourceRange& key) const
         {
             size_t hash = 0;
-            hash_combine(hash, key.baseArrayLayer);
+            hash_combine(hash, key.layer);
             hash_combine(hash, key.layerCount);
             hash_combine(hash, key.mipLevel);
             hash_combine(hash, key.mipLevelCount);

--- a/src/d3d11/d3d11-texture.cpp
+++ b/src/d3d11/d3d11-texture.cpp
@@ -33,7 +33,7 @@ ID3D11RenderTargetView* TextureImpl::getRTV(Format format, const SubresourceRang
     case TextureType::Texture1DArray:
         rtvDesc.ViewDimension = D3D11_RTV_DIMENSION_TEXTURE1DARRAY;
         rtvDesc.Texture1DArray.MipSlice = range.mipLevel;
-        rtvDesc.Texture1DArray.FirstArraySlice = range.baseArrayLayer;
+        rtvDesc.Texture1DArray.FirstArraySlice = range.layer;
         rtvDesc.Texture1DArray.ArraySize = range.layerCount;
         break;
     case TextureType::Texture2D:
@@ -43,7 +43,7 @@ ID3D11RenderTargetView* TextureImpl::getRTV(Format format, const SubresourceRang
     case TextureType::Texture2DArray:
         rtvDesc.ViewDimension = D3D11_RTV_DIMENSION_TEXTURE2DARRAY;
         rtvDesc.Texture2DArray.MipSlice = range.mipLevel;
-        rtvDesc.Texture2DArray.FirstArraySlice = range.baseArrayLayer;
+        rtvDesc.Texture2DArray.FirstArraySlice = range.layer;
         rtvDesc.Texture2DArray.ArraySize = range.layerCount;
         break;
     case TextureType::Texture2DMS:
@@ -51,7 +51,7 @@ ID3D11RenderTargetView* TextureImpl::getRTV(Format format, const SubresourceRang
         break;
     case TextureType::Texture2DMSArray:
         rtvDesc.ViewDimension = D3D11_RTV_DIMENSION_TEXTURE2DMSARRAY;
-        rtvDesc.Texture2DMSArray.FirstArraySlice = range.baseArrayLayer;
+        rtvDesc.Texture2DMSArray.FirstArraySlice = range.layer;
         rtvDesc.Texture2DMSArray.ArraySize = range.layerCount;
         break;
     case TextureType::Texture3D:
@@ -94,7 +94,7 @@ ID3D11DepthStencilView* TextureImpl::getDSV(Format format, const SubresourceRang
     case TextureType::Texture1DArray:
         dsvDesc.ViewDimension = D3D11_DSV_DIMENSION_TEXTURE1DARRAY;
         dsvDesc.Texture1DArray.MipSlice = range.mipLevel;
-        dsvDesc.Texture1DArray.FirstArraySlice = range.baseArrayLayer;
+        dsvDesc.Texture1DArray.FirstArraySlice = range.layer;
         dsvDesc.Texture1DArray.ArraySize = range.layerCount;
         break;
     case TextureType::Texture2D:
@@ -104,7 +104,7 @@ ID3D11DepthStencilView* TextureImpl::getDSV(Format format, const SubresourceRang
     case TextureType::Texture2DArray:
         dsvDesc.ViewDimension = D3D11_DSV_DIMENSION_TEXTURE2DARRAY;
         dsvDesc.Texture2DArray.MipSlice = range.mipLevel;
-        dsvDesc.Texture2DArray.FirstArraySlice = range.baseArrayLayer;
+        dsvDesc.Texture2DArray.FirstArraySlice = range.layer;
         dsvDesc.Texture2DArray.ArraySize = range.layerCount;
         break;
     case TextureType::Texture2DMS:
@@ -112,7 +112,7 @@ ID3D11DepthStencilView* TextureImpl::getDSV(Format format, const SubresourceRang
         break;
     case TextureType::Texture2DMSArray:
         dsvDesc.ViewDimension = D3D11_DSV_DIMENSION_TEXTURE2DMSARRAY;
-        dsvDesc.Texture2DMSArray.FirstArraySlice = range.baseArrayLayer;
+        dsvDesc.Texture2DMSArray.FirstArraySlice = range.layer;
         dsvDesc.Texture2DMSArray.ArraySize = range.layerCount;
         break;
     case TextureType::Texture3D:
@@ -152,7 +152,7 @@ ID3D11ShaderResourceView* TextureImpl::getSRV(Format format, const SubresourceRa
         srvDesc.ViewDimension = D3D11_SRV_DIMENSION_TEXTURE1DARRAY;
         srvDesc.Texture1DArray.MostDetailedMip = range.mipLevel;
         srvDesc.Texture1DArray.MipLevels = range.mipLevelCount;
-        srvDesc.Texture1DArray.FirstArraySlice = range.baseArrayLayer;
+        srvDesc.Texture1DArray.FirstArraySlice = range.layer;
         srvDesc.Texture1DArray.ArraySize = range.layerCount;
         break;
     case TextureType::Texture2D:
@@ -164,7 +164,7 @@ ID3D11ShaderResourceView* TextureImpl::getSRV(Format format, const SubresourceRa
         srvDesc.ViewDimension = D3D11_SRV_DIMENSION_TEXTURE2DARRAY;
         srvDesc.Texture2DArray.MostDetailedMip = range.mipLevel;
         srvDesc.Texture2DArray.MipLevels = range.mipLevelCount;
-        srvDesc.Texture2DArray.FirstArraySlice = range.baseArrayLayer;
+        srvDesc.Texture2DArray.FirstArraySlice = range.layer;
         srvDesc.Texture2DArray.ArraySize = range.layerCount;
         break;
     case TextureType::Texture2DMS:
@@ -172,7 +172,7 @@ ID3D11ShaderResourceView* TextureImpl::getSRV(Format format, const SubresourceRa
         break;
     case TextureType::Texture2DMSArray:
         srvDesc.ViewDimension = D3D11_SRV_DIMENSION_TEXTURE2DMSARRAY;
-        srvDesc.Texture2DMSArray.FirstArraySlice = range.baseArrayLayer;
+        srvDesc.Texture2DMSArray.FirstArraySlice = range.layer;
         srvDesc.Texture2DMSArray.ArraySize = range.layerCount;
         break;
     case TextureType::Texture3D:
@@ -189,7 +189,7 @@ ID3D11ShaderResourceView* TextureImpl::getSRV(Format format, const SubresourceRa
         srvDesc.ViewDimension = D3D11_SRV_DIMENSION_TEXTURECUBEARRAY;
         srvDesc.TextureCubeArray.MostDetailedMip = range.mipLevel;
         srvDesc.TextureCubeArray.MipLevels = range.mipLevelCount;
-        srvDesc.TextureCubeArray.First2DArrayFace = range.baseArrayLayer;
+        srvDesc.TextureCubeArray.First2DArrayFace = range.layer;
         srvDesc.TextureCubeArray.NumCubes = range.layerCount / 6;
         break;
     }
@@ -223,7 +223,7 @@ ID3D11UnorderedAccessView* TextureImpl::getUAV(Format format, const SubresourceR
     case TextureType::Texture1DArray:
         uavDesc.ViewDimension = D3D11_UAV_DIMENSION_TEXTURE1DARRAY;
         uavDesc.Texture1DArray.MipSlice = range.mipLevel;
-        uavDesc.Texture1DArray.FirstArraySlice = range.baseArrayLayer;
+        uavDesc.Texture1DArray.FirstArraySlice = range.layer;
         uavDesc.Texture1DArray.ArraySize = range.layerCount;
         break;
     case TextureType::Texture2D:
@@ -233,7 +233,7 @@ ID3D11UnorderedAccessView* TextureImpl::getUAV(Format format, const SubresourceR
     case TextureType::Texture2DArray:
         uavDesc.ViewDimension = D3D11_UAV_DIMENSION_TEXTURE2DARRAY;
         uavDesc.Texture2DArray.MipSlice = range.mipLevel;
-        uavDesc.Texture2DArray.FirstArraySlice = range.baseArrayLayer;
+        uavDesc.Texture2DArray.FirstArraySlice = range.layer;
         uavDesc.Texture2DArray.ArraySize = range.layerCount;
         break;
     case TextureType::Texture2DMS:

--- a/src/d3d11/d3d11-texture.h
+++ b/src/d3d11/d3d11-texture.h
@@ -26,7 +26,7 @@ public:
         {
             size_t hash = 0;
             hash_combine(hash, key.format);
-            hash_combine(hash, key.range.baseArrayLayer);
+            hash_combine(hash, key.range.layer);
             hash_combine(hash, key.range.layerCount);
             hash_combine(hash, key.range.mipLevel);
             hash_combine(hash, key.range.mipLevelCount);

--- a/src/d3d12/d3d12-command.cpp
+++ b/src/d3d12/d3d12-command.cpp
@@ -213,8 +213,8 @@ void CommandRecorder::cmdCopyTexture(const commands::CopyTexture& cmd)
         srcSubresource.mipLevelCount = src->m_desc.mipLevelCount;
 
     // Validate subresource ranges
-    SLANG_RHI_ASSERT(srcSubresource.baseArrayLayer + srcSubresource.layerCount <= src->m_desc.getLayerCount());
-    SLANG_RHI_ASSERT(dstSubresource.baseArrayLayer + dstSubresource.layerCount <= dst->m_desc.getLayerCount());
+    SLANG_RHI_ASSERT(srcSubresource.layer + srcSubresource.layerCount <= src->m_desc.getLayerCount());
+    SLANG_RHI_ASSERT(dstSubresource.layer + dstSubresource.layerCount <= dst->m_desc.getLayerCount());
     SLANG_RHI_ASSERT(srcSubresource.mipLevel + srcSubresource.mipLevelCount <= src->m_desc.mipLevelCount);
     SLANG_RHI_ASSERT(dstSubresource.mipLevel + dstSubresource.mipLevelCount <= dst->m_desc.mipLevelCount);
 
@@ -274,7 +274,7 @@ void CommandRecorder::cmdCopyTexture(const commands::CopyTexture& cmd)
                 dstRegion.pResource = dst->m_resource.getResource();
                 dstRegion.SubresourceIndex = D3DUtil::getSubresourceIndex(
                     dstMipLevel,
-                    dstSubresource.baseArrayLayer + layer,
+                    dstSubresource.layer + layer,
                     planeIndex,
                     dst->m_desc.mipLevelCount,
                     dst->m_desc.getLayerCount()
@@ -285,7 +285,7 @@ void CommandRecorder::cmdCopyTexture(const commands::CopyTexture& cmd)
                 srcRegion.pResource = src->m_resource.getResource();
                 srcRegion.SubresourceIndex = D3DUtil::getSubresourceIndex(
                     srcMipLevel,
-                    srcSubresource.baseArrayLayer + layer,
+                    srcSubresource.layer + layer,
                     planeIndex,
                     src->m_desc.mipLevelCount,
                     src->m_desc.getLayerCount()
@@ -538,7 +538,7 @@ void CommandRecorder::cmdUploadTextureData(const commands::UploadTextureData& cm
 
     for (uint32_t layerOffset = 0; layerOffset < subresourceRange.layerCount; layerOffset++)
     {
-        uint32_t layerIndex = subresourceRange.baseArrayLayer + layerOffset;
+        uint32_t layer = subresourceRange.layer + layerOffset;
         for (uint32_t mipOffset = 0; mipOffset < subresourceRange.mipLevelCount; mipOffset++)
         {
             uint32_t mipLevel = subresourceRange.mipLevel + mipOffset;
@@ -549,13 +549,8 @@ void CommandRecorder::cmdUploadTextureData(const commands::UploadTextureData& cm
             dstRegion.Type = D3D12_TEXTURE_COPY_TYPE_SUBRESOURCE_INDEX;
             dstRegion.pResource = dst->m_resource.getResource();
 
-            dstRegion.SubresourceIndex = D3DUtil::getSubresourceIndex(
-                mipLevel,
-                layerIndex,
-                0,
-                dst->m_desc.mipLevelCount,
-                dst->m_desc.arrayLength
-            );
+            dstRegion.SubresourceIndex =
+                D3DUtil::getSubresourceIndex(mipLevel, layer, 0, dst->m_desc.mipLevelCount, dst->m_desc.arrayLength);
 
             D3D12_TEXTURE_COPY_LOCATION srcRegion = {};
             srcRegion.Type = D3D12_TEXTURE_COPY_TYPE_PLACED_FOOTPRINT;

--- a/src/d3d12/d3d12-command.cpp
+++ b/src/d3d12/d3d12-command.cpp
@@ -203,24 +203,24 @@ void CommandRecorder::cmdCopyTexture(const commands::CopyTexture& cmd)
     }
 
     // If we couldn't use the fast CopyResource path, need to ensure that the subresource ranges are valid.
-    if (dstSubresource.mipLevelCount == 0)
-        dstSubresource.mipLevelCount = dst->m_desc.mipLevelCount;
     if (dstSubresource.layerCount == 0)
         dstSubresource.layerCount = dst->m_desc.getLayerCount();
-    if (srcSubresource.mipLevelCount == 0)
-        srcSubresource.mipLevelCount = src->m_desc.mipLevelCount;
+    if (dstSubresource.mipLevelCount == 0)
+        dstSubresource.mipLevelCount = dst->m_desc.mipLevelCount;
     if (srcSubresource.layerCount == 0)
         srcSubresource.layerCount = src->m_desc.getLayerCount();
+    if (srcSubresource.mipLevelCount == 0)
+        srcSubresource.mipLevelCount = src->m_desc.mipLevelCount;
 
     // Validate subresource ranges
-    SLANG_RHI_ASSERT(srcSubresource.mipLevel + srcSubresource.mipLevelCount <= src->m_desc.mipLevelCount);
-    SLANG_RHI_ASSERT(dstSubresource.mipLevel + dstSubresource.mipLevelCount <= dst->m_desc.mipLevelCount);
     SLANG_RHI_ASSERT(srcSubresource.baseArrayLayer + srcSubresource.layerCount <= src->m_desc.getLayerCount());
     SLANG_RHI_ASSERT(dstSubresource.baseArrayLayer + dstSubresource.layerCount <= dst->m_desc.getLayerCount());
+    SLANG_RHI_ASSERT(srcSubresource.mipLevel + srcSubresource.mipLevelCount <= src->m_desc.mipLevelCount);
+    SLANG_RHI_ASSERT(dstSubresource.mipLevel + dstSubresource.mipLevelCount <= dst->m_desc.mipLevelCount);
 
     // Validate matching dimensions between source and destination
-    SLANG_RHI_ASSERT(srcSubresource.mipLevelCount == dstSubresource.mipLevelCount);
     SLANG_RHI_ASSERT(srcSubresource.layerCount == dstSubresource.layerCount);
+    SLANG_RHI_ASSERT(srcSubresource.mipLevelCount == dstSubresource.mipLevelCount);
 
     requireTextureState(dst, dstSubresource, ResourceState::CopyDestination);
     requireTextureState(src, srcSubresource, ResourceState::CopySource);
@@ -333,7 +333,7 @@ void CommandRecorder::cmdCopyTextureToBuffer(const commands::CopyTextureToBuffer
 
     // Switch texture to copy src and buffer to copy dest.
     requireBufferState(dst, ResourceState::CopyDestination);
-    requireTextureState(src, {srcMipLevel, 1, srcLayer, 1}, ResourceState::CopySource);
+    requireTextureState(src, {srcLayer, 1, srcMipLevel, 1}, ResourceState::CopySource);
     commitBarriers();
 
     // Calculate adjusted extents. Note it is required and enforced

--- a/src/d3d12/d3d12-device.cpp
+++ b/src/d3d12/d3d12-device.cpp
@@ -1053,10 +1053,10 @@ Result DeviceImpl::createTexture(const TextureDesc& desc_, const SubresourceData
         SLANG_RETURN_ON_FAIL(queue->createCommandEncoder(commandEncoder.writeRef()));
 
         SubresourceRange range;
-        range.mipLevel = 0;
-        range.mipLevelCount = desc.mipLevelCount;
         range.baseArrayLayer = 0;
         range.layerCount = desc.getLayerCount();
+        range.mipLevel = 0;
+        range.mipLevelCount = desc.mipLevelCount;
 
         commandEncoder->uploadTextureData(
             texture,

--- a/src/d3d12/d3d12-device.cpp
+++ b/src/d3d12/d3d12-device.cpp
@@ -1053,7 +1053,7 @@ Result DeviceImpl::createTexture(const TextureDesc& desc_, const SubresourceData
         SLANG_RETURN_ON_FAIL(queue->createCommandEncoder(commandEncoder.writeRef()));
 
         SubresourceRange range;
-        range.baseArrayLayer = 0;
+        range.layer = 0;
         range.layerCount = desc.getLayerCount();
         range.mipLevel = 0;
         range.mipLevelCount = desc.mipLevelCount;

--- a/src/d3d12/d3d12-texture.cpp
+++ b/src/d3d12/d3d12-texture.cpp
@@ -106,7 +106,7 @@ TextureImpl::getSRV(Format format, TextureType type, TextureAspect aspect, const
         viewDesc.ViewDimension = D3D12_SRV_DIMENSION_TEXTURE1DARRAY;
         viewDesc.Texture1DArray.MostDetailedMip = range.mipLevel;
         viewDesc.Texture1DArray.MipLevels = range.mipLevelCount;
-        viewDesc.Texture1DArray.FirstArraySlice = range.baseArrayLayer;
+        viewDesc.Texture1DArray.FirstArraySlice = range.layer;
         viewDesc.Texture1DArray.ArraySize = range.layerCount;
         break;
     case TextureType::Texture2D:
@@ -119,7 +119,7 @@ TextureImpl::getSRV(Format format, TextureType type, TextureAspect aspect, const
         viewDesc.ViewDimension = D3D12_SRV_DIMENSION_TEXTURE2DARRAY;
         viewDesc.Texture2DArray.MostDetailedMip = range.mipLevel;
         viewDesc.Texture2DArray.MipLevels = range.mipLevelCount;
-        viewDesc.Texture2DArray.FirstArraySlice = range.baseArrayLayer;
+        viewDesc.Texture2DArray.FirstArraySlice = range.layer;
         viewDesc.Texture2DArray.ArraySize = range.layerCount;
         viewDesc.Texture2DArray.PlaneSlice = D3DUtil::getPlaneSlice(viewDesc.Format, aspect);
         break;
@@ -128,7 +128,7 @@ TextureImpl::getSRV(Format format, TextureType type, TextureAspect aspect, const
         break;
     case TextureType::Texture2DMSArray:
         viewDesc.ViewDimension = D3D12_SRV_DIMENSION_TEXTURE2DMSARRAY;
-        viewDesc.Texture2DMSArray.FirstArraySlice = range.baseArrayLayer;
+        viewDesc.Texture2DMSArray.FirstArraySlice = range.layer;
         viewDesc.Texture2DMSArray.ArraySize = range.layerCount;
         break;
     case TextureType::Texture3D:
@@ -145,7 +145,7 @@ TextureImpl::getSRV(Format format, TextureType type, TextureAspect aspect, const
         viewDesc.ViewDimension = D3D12_SRV_DIMENSION_TEXTURECUBEARRAY;
         viewDesc.TextureCubeArray.MostDetailedMip = range.mipLevel;
         viewDesc.TextureCubeArray.MipLevels = range.mipLevelCount;
-        viewDesc.TextureCubeArray.First2DArrayFace = range.baseArrayLayer;
+        viewDesc.TextureCubeArray.First2DArrayFace = range.layer;
         viewDesc.TextureCubeArray.NumCubes = range.layerCount / 6;
         break;
     }
@@ -182,7 +182,7 @@ D3D12_CPU_DESCRIPTOR_HANDLE TextureImpl::getUAV(
         viewDesc.ViewDimension = D3D12_UAV_DIMENSION_TEXTURE1DARRAY;
         viewDesc.Texture1DArray.MipSlice = range.mipLevel;
         viewDesc.Texture1DArray.ArraySize = range.layerCount;
-        viewDesc.Texture1DArray.FirstArraySlice = range.baseArrayLayer;
+        viewDesc.Texture1DArray.FirstArraySlice = range.layer;
         break;
     case TextureType::Texture2D:
         viewDesc.ViewDimension = D3D12_UAV_DIMENSION_TEXTURE2D;
@@ -195,7 +195,7 @@ D3D12_CPU_DESCRIPTOR_HANDLE TextureImpl::getUAV(
         viewDesc.ViewDimension = D3D12_UAV_DIMENSION_TEXTURE2DARRAY;
         viewDesc.Texture2DArray.MipSlice = range.mipLevel;
         viewDesc.Texture2DArray.ArraySize = range.layerCount;
-        viewDesc.Texture2DArray.FirstArraySlice = range.baseArrayLayer;
+        viewDesc.Texture2DArray.FirstArraySlice = range.layer;
         viewDesc.Texture2DArray.PlaneSlice = D3DUtil::getPlaneSlice(viewDesc.Format, aspect);
         break;
 #if SLANG_RHI_ENABLE_AGILITY_SDK
@@ -204,7 +204,7 @@ D3D12_CPU_DESCRIPTOR_HANDLE TextureImpl::getUAV(
         break;
     case TextureType::Texture2DMSArray:
         viewDesc.ViewDimension = D3D12_UAV_DIMENSION_TEXTURE2DMSARRAY;
-        viewDesc.Texture2DMSArray.FirstArraySlice = range.baseArrayLayer;
+        viewDesc.Texture2DMSArray.FirstArraySlice = range.layer;
         viewDesc.Texture2DMSArray.ArraySize = range.layerCount;
         break;
 #else  // SLANG_RHI_ENABLE_AGILITY_SDK
@@ -254,7 +254,7 @@ D3D12_CPU_DESCRIPTOR_HANDLE TextureImpl::getRTV(
     case TextureType::Texture1DArray:
         viewDesc.ViewDimension = D3D12_RTV_DIMENSION_TEXTURE1DARRAY;
         viewDesc.Texture1DArray.MipSlice = range.mipLevel;
-        viewDesc.Texture1DArray.FirstArraySlice = range.baseArrayLayer;
+        viewDesc.Texture1DArray.FirstArraySlice = range.layer;
         viewDesc.Texture1DArray.ArraySize = range.layerCount;
         break;
     case TextureType::Texture2D:
@@ -268,7 +268,7 @@ D3D12_CPU_DESCRIPTOR_HANDLE TextureImpl::getRTV(
         viewDesc.ViewDimension = D3D12_RTV_DIMENSION_TEXTURE2DARRAY;
         viewDesc.Texture2DArray.MipSlice = range.mipLevel;
         viewDesc.Texture2DArray.ArraySize = range.layerCount;
-        viewDesc.Texture2DArray.FirstArraySlice = range.baseArrayLayer;
+        viewDesc.Texture2DArray.FirstArraySlice = range.layer;
         viewDesc.Texture2DArray.PlaneSlice = D3DUtil::getPlaneSlice(viewDesc.Format, aspect);
         break;
     case TextureType::Texture2DMS:
@@ -277,7 +277,7 @@ D3D12_CPU_DESCRIPTOR_HANDLE TextureImpl::getRTV(
     case TextureType::Texture2DMSArray:
         viewDesc.ViewDimension = D3D12_RTV_DIMENSION_TEXTURE2DMSARRAY;
         viewDesc.Texture2DMSArray.ArraySize = range.layerCount;
-        viewDesc.Texture2DMSArray.FirstArraySlice = range.baseArrayLayer;
+        viewDesc.Texture2DMSArray.FirstArraySlice = range.layer;
         break;
     case TextureType::Texture3D:
         viewDesc.ViewDimension = D3D12_RTV_DIMENSION_TEXTURE3D;
@@ -322,7 +322,7 @@ D3D12_CPU_DESCRIPTOR_HANDLE TextureImpl::getDSV(
         viewDesc.ViewDimension = D3D12_DSV_DIMENSION_TEXTURE1DARRAY;
         viewDesc.Texture1DArray.MipSlice = range.mipLevel;
         viewDesc.Texture1DArray.ArraySize = range.layerCount;
-        viewDesc.Texture1DArray.FirstArraySlice = range.baseArrayLayer;
+        viewDesc.Texture1DArray.FirstArraySlice = range.layer;
         break;
     case TextureType::Texture2D:
         viewDesc.ViewDimension = D3D12_DSV_DIMENSION_TEXTURE2D;
@@ -332,7 +332,7 @@ D3D12_CPU_DESCRIPTOR_HANDLE TextureImpl::getDSV(
         viewDesc.ViewDimension = D3D12_DSV_DIMENSION_TEXTURE2DARRAY;
         viewDesc.Texture2DArray.MipSlice = range.mipLevel;
         viewDesc.Texture2DArray.ArraySize = range.layerCount;
-        viewDesc.Texture2DArray.FirstArraySlice = range.baseArrayLayer;
+        viewDesc.Texture2DArray.FirstArraySlice = range.layer;
         break;
     case TextureType::Texture2DMS:
         viewDesc.ViewDimension = D3D12_DSV_DIMENSION_TEXTURE2DMS;
@@ -340,7 +340,7 @@ D3D12_CPU_DESCRIPTOR_HANDLE TextureImpl::getDSV(
     case TextureType::Texture2DMSArray:
         viewDesc.ViewDimension = D3D12_DSV_DIMENSION_TEXTURE2DMSARRAY;
         viewDesc.Texture2DMSArray.ArraySize = range.layerCount;
-        viewDesc.Texture2DMSArray.FirstArraySlice = range.baseArrayLayer;
+        viewDesc.Texture2DMSArray.FirstArraySlice = range.layer;
         break;
     case TextureType::Texture3D:
         SLANG_RHI_ASSERT_FAILURE("Not supported");
@@ -350,7 +350,7 @@ D3D12_CPU_DESCRIPTOR_HANDLE TextureImpl::getDSV(
         viewDesc.ViewDimension = D3D12_DSV_DIMENSION_TEXTURE2DARRAY;
         viewDesc.Texture2DArray.MipSlice = range.mipLevel;
         viewDesc.Texture2DArray.ArraySize = range.layerCount;
-        viewDesc.Texture2DArray.FirstArraySlice = range.baseArrayLayer;
+        viewDesc.Texture2DArray.FirstArraySlice = range.layer;
         break;
     }
 

--- a/src/d3d12/d3d12-texture.h
+++ b/src/d3d12/d3d12-texture.h
@@ -40,7 +40,7 @@ public:
             hash_combine(hash, key.format);
             hash_combine(hash, key.type);
             hash_combine(hash, key.aspect);
-            hash_combine(hash, key.range.baseArrayLayer);
+            hash_combine(hash, key.range.layer);
             hash_combine(hash, key.range.layerCount);
             hash_combine(hash, key.range.mipLevel);
             hash_combine(hash, key.range.mipLevelCount);

--- a/src/debug-layer/debug-command-encoder.cpp
+++ b/src/debug-layer/debug-command-encoder.cpp
@@ -339,9 +339,9 @@ void DebugCommandEncoder::copyTexture(
     requireNoPass();
 
     const TextureDesc& srcDesc = src->getDesc();
-    if (srcSubresource.baseArrayLayer > srcDesc.getLayerCount())
+    if (srcSubresource.layer > srcDesc.getLayerCount())
     {
-        RHI_VALIDATION_ERROR("Src base array layer is out of bounds.");
+        RHI_VALIDATION_ERROR("Src layer is out of bounds.");
         return;
     }
     if (srcSubresource.mipLevel > srcDesc.mipLevelCount)
@@ -351,9 +351,9 @@ void DebugCommandEncoder::copyTexture(
     }
 
     const TextureDesc& dstDesc = dst->getDesc();
-    if (dstSubresource.baseArrayLayer > dstDesc.getLayerCount())
+    if (dstSubresource.layer > dstDesc.getLayerCount())
     {
-        RHI_VALIDATION_ERROR("Dest base array layer is out of bounds.");
+        RHI_VALIDATION_ERROR("Dest layer is out of bounds.");
         return;
     }
     if (dstSubresource.mipLevel > dstDesc.mipLevelCount)

--- a/src/debug-layer/debug-helper-functions.cpp
+++ b/src/debug-layer/debug-helper-functions.cpp
@@ -36,11 +36,11 @@ std::string _rhiGetFuncName(const char* input)
 std::string subresourceRangeToString(const SubresourceRange& range)
 {
     return string::format(
-        "(mipLevel=%u, mipLevelCount=%u, baseArrayLayer=%u, layerCount=%u)",
-        range.mipLevel,
-        range.mipLevelCount,
+        "(baseArrayLayer=%u, layerCount=%u, mipLevel=%u, mipLevelCount=%u)",
         range.baseArrayLayer,
-        range.layerCount
+        range.layerCount,
+        range.mipLevel,
+        range.mipLevelCount
     );
 }
 

--- a/src/debug-layer/debug-helper-functions.cpp
+++ b/src/debug-layer/debug-helper-functions.cpp
@@ -36,8 +36,8 @@ std::string _rhiGetFuncName(const char* input)
 std::string subresourceRangeToString(const SubresourceRange& range)
 {
     return string::format(
-        "(baseArrayLayer=%u, layerCount=%u, mipLevel=%u, mipLevelCount=%u)",
-        range.baseArrayLayer,
+        "(layer=%u, layerCount=%u, mipLevel=%u, mipLevelCount=%u)",
+        range.layer,
         range.layerCount,
         range.mipLevel,
         range.mipLevelCount

--- a/src/metal/metal-clear-engine.cpp
+++ b/src/metal/metal-clear-engine.cpp
@@ -133,7 +133,7 @@ void ClearEngine::clearTexture(
         for (uint32_t layerOffset = 0; layerOffset < subresourceRange.layerCount; ++layerOffset)
         {
             uint32_t mipLevel = subresourceRange.mipLevel + mipOffset;
-            uint32_t layer = subresourceRange.baseArrayLayer + layerOffset;
+            uint32_t layer = subresourceRange.layer + layerOffset;
             Extent3D mipSize = calcMipSize(texture->m_desc.size, mipLevel);
             Params params = {};
             params.width = mipSize.width;

--- a/src/metal/metal-command.cpp
+++ b/src/metal/metal-command.cpp
@@ -179,12 +179,12 @@ void CommandRecorder::cmdCopyTexture(const commands::CopyTexture& cmd)
         {
             encoder->copyFromTexture(
                 src->m_texture.get(),
-                srcSubresource.baseArrayLayer + layer,
+                srcSubresource.layer + layer,
                 srcSubresource.mipLevel,
                 MTL::Origin(srcOffset.x, srcOffset.y, srcOffset.z),
                 MTL::Size(extent.width, extent.height, extent.depth),
                 dst->m_texture.get(),
-                dstSubresource.baseArrayLayer + layer,
+                dstSubresource.layer + layer,
                 dstSubresource.mipLevel,
                 MTL::Origin(dstOffset.x, dstOffset.y, dstOffset.z)
             );
@@ -276,7 +276,7 @@ void CommandRecorder::cmdUploadTextureData(const commands::UploadTextureData& cm
     auto encoder = getBlitCommandEncoder();
     for (uint32_t layerOffset = 0; layerOffset < subresourceRange.layerCount; layerOffset++)
     {
-        uint32_t layerIndex = subresourceRange.baseArrayLayer + layerOffset;
+        uint32_t layer = subresourceRange.layer + layerOffset;
         for (uint32_t mipOffset = 0; mipOffset < subresourceRange.mipLevelCount; mipOffset++)
         {
             uint32_t mipLevel = subresourceRange.mipLevel + mipOffset;
@@ -288,7 +288,7 @@ void CommandRecorder::cmdUploadTextureData(const commands::UploadTextureData& cm
                 srLayout->slicePitch,
                 MTL::Size(srLayout->size.width, srLayout->size.height, srLayout->size.depth),
                 dst->m_texture.get(),
-                layerIndex,
+                layer,
                 mipLevel,
                 MTL::Origin(cmd.offset.x, cmd.offset.y, cmd.offset.z)
             );
@@ -362,7 +362,7 @@ void CommandRecorder::cmdBeginRenderPass(const commands::BeginRenderPass& cmd)
                                      : nullptr
         );
         colorAttachment->setLevel(view->m_desc.subresourceRange.mipLevel);
-        colorAttachment->setSlice(view->m_desc.subresourceRange.baseArrayLayer);
+        colorAttachment->setSlice(view->m_desc.subresourceRange.layer);
     }
 
     // Setup depth stencil attachment.
@@ -386,7 +386,7 @@ void CommandRecorder::cmdBeginRenderPass(const commands::BeginRenderPass& cmd)
             }
             depthAttachment->setTexture(view->m_textureView.get());
             depthAttachment->setLevel(view->m_desc.subresourceRange.mipLevel);
-            depthAttachment->setSlice(view->m_desc.subresourceRange.baseArrayLayer);
+            depthAttachment->setSlice(view->m_desc.subresourceRange.layer);
         }
         if (MetalUtil::isStencilFormat(pixelFormat))
         {
@@ -399,7 +399,7 @@ void CommandRecorder::cmdBeginRenderPass(const commands::BeginRenderPass& cmd)
             }
             stencilAttachment->setTexture(view->m_textureView.get());
             stencilAttachment->setLevel(view->m_desc.subresourceRange.mipLevel);
-            stencilAttachment->setSlice(view->m_desc.subresourceRange.baseArrayLayer);
+            stencilAttachment->setSlice(view->m_desc.subresourceRange.layer);
         }
     }
 

--- a/src/metal/metal-texture.cpp
+++ b/src/metal/metal-texture.cpp
@@ -193,7 +193,7 @@ Result DeviceImpl::createTextureView(ITexture* texture, const TextureViewDesc& d
     const TextureDesc& textureDesc = textureImpl->m_desc;
     uint32_t layerCount = textureDesc.arrayLength * (textureDesc.type == TextureType::TextureCube ? 6 : 1);
     SubresourceRange sr = viewImpl->m_desc.subresourceRange;
-    if (sr.baseArrayLayer == 0 && sr.layerCount == layerCount && sr.mipLevel == 0 &&
+    if (sr.layer == 0 && sr.layerCount == layerCount && sr.mipLevel == 0 &&
         sr.mipLevelCount == textureDesc.mipLevelCount)
     {
         viewImpl->m_textureView = textureImpl->m_texture;
@@ -203,7 +203,7 @@ Result DeviceImpl::createTextureView(ITexture* texture, const TextureViewDesc& d
 
     MTL::PixelFormat pixelFormat =
         desc.format == Format::Undefined ? textureImpl->m_pixelFormat : MetalUtil::translatePixelFormat(desc.format);
-    NS::Range sliceRange(sr.baseArrayLayer, sr.layerCount);
+    NS::Range sliceRange(sr.layer, sr.layerCount);
     NS::Range levelRange(sr.mipLevel, sr.mipLevelCount);
 
     viewImpl->m_textureView = NS::TransferPtr(

--- a/src/metal/metal-texture.cpp
+++ b/src/metal/metal-texture.cpp
@@ -193,8 +193,8 @@ Result DeviceImpl::createTextureView(ITexture* texture, const TextureViewDesc& d
     const TextureDesc& textureDesc = textureImpl->m_desc;
     uint32_t layerCount = textureDesc.arrayLength * (textureDesc.type == TextureType::TextureCube ? 6 : 1);
     SubresourceRange sr = viewImpl->m_desc.subresourceRange;
-    if (sr.mipLevel == 0 && sr.mipLevelCount == textureDesc.mipLevelCount && sr.baseArrayLayer == 0 &&
-        sr.layerCount == layerCount)
+    if (sr.baseArrayLayer == 0 && sr.layerCount == layerCount && sr.mipLevel == 0 &&
+        sr.mipLevelCount == textureDesc.mipLevelCount)
     {
         viewImpl->m_textureView = textureImpl->m_texture;
         returnComPtr(outView, viewImpl);
@@ -203,8 +203,8 @@ Result DeviceImpl::createTextureView(ITexture* texture, const TextureViewDesc& d
 
     MTL::PixelFormat pixelFormat =
         desc.format == Format::Undefined ? textureImpl->m_pixelFormat : MetalUtil::translatePixelFormat(desc.format);
-    NS::Range levelRange(sr.mipLevel, sr.mipLevelCount);
     NS::Range sliceRange(sr.baseArrayLayer, sr.layerCount);
+    NS::Range levelRange(sr.mipLevel, sr.mipLevelCount);
 
     viewImpl->m_textureView = NS::TransferPtr(
         textureImpl->m_texture->newTextureView(pixelFormat, textureImpl->m_textureType, levelRange, sliceRange)

--- a/src/rhi-shared.cpp
+++ b/src/rhi-shared.cpp
@@ -137,20 +137,20 @@ IResource* Texture::getInterface(const Guid& guid)
 SubresourceRange Texture::resolveSubresourceRange(const SubresourceRange& range)
 {
     SubresourceRange resolved = range;
-    resolved.mipLevel = min(resolved.mipLevel, m_desc.mipLevelCount);
-    resolved.mipLevelCount = min(resolved.mipLevelCount, m_desc.mipLevelCount - resolved.mipLevel);
     resolved.baseArrayLayer = min(resolved.baseArrayLayer, (m_desc.getLayerCount() - 1));
     resolved.layerCount = min(resolved.layerCount, m_desc.getLayerCount() - resolved.baseArrayLayer);
+    resolved.mipLevel = min(resolved.mipLevel, m_desc.mipLevelCount - 1);
+    resolved.mipLevelCount = min(resolved.mipLevelCount, m_desc.mipLevelCount - resolved.mipLevel);
     return resolved;
 }
 
 bool Texture::isEntireTexture(const SubresourceRange& range)
 {
-    if (range.mipLevel > 0 || range.mipLevelCount < m_desc.mipLevelCount)
+    if (range.baseArrayLayer > 0 || range.layerCount < m_desc.getLayerCount())
     {
         return false;
     }
-    if (range.baseArrayLayer > 0 || range.layerCount < m_desc.getLayerCount())
+    if (range.mipLevel > 0 || range.mipLevelCount < m_desc.mipLevelCount)
     {
         return false;
     }

--- a/src/rhi-shared.cpp
+++ b/src/rhi-shared.cpp
@@ -137,8 +137,8 @@ IResource* Texture::getInterface(const Guid& guid)
 SubresourceRange Texture::resolveSubresourceRange(const SubresourceRange& range)
 {
     SubresourceRange resolved = range;
-    resolved.baseArrayLayer = min(resolved.baseArrayLayer, (m_desc.getLayerCount() - 1));
-    resolved.layerCount = min(resolved.layerCount, m_desc.getLayerCount() - resolved.baseArrayLayer);
+    resolved.layer = min(resolved.layer, (m_desc.getLayerCount() - 1));
+    resolved.layerCount = min(resolved.layerCount, m_desc.getLayerCount() - resolved.layer);
     resolved.mipLevel = min(resolved.mipLevel, m_desc.mipLevelCount - 1);
     resolved.mipLevelCount = min(resolved.mipLevelCount, m_desc.mipLevelCount - resolved.mipLevel);
     return resolved;
@@ -146,7 +146,7 @@ SubresourceRange Texture::resolveSubresourceRange(const SubresourceRange& range)
 
 bool Texture::isEntireTexture(const SubresourceRange& range)
 {
-    if (range.baseArrayLayer > 0 || range.layerCount < m_desc.getLayerCount())
+    if (range.layer > 0 || range.layerCount < m_desc.getLayerCount())
     {
         return false;
     }

--- a/src/state-tracking.h
+++ b/src/state-tracking.h
@@ -84,7 +84,7 @@ public:
                 textureState->state = ResourceState::Undefined;
             }
             uint32_t layerCount = texture->m_desc.getLayerCount();
-            for (uint32_t layer = subresourceRange.baseArrayLayer; layer < layerCount; layer++)
+            for (uint32_t layer = subresourceRange.layer; layer < layerCount; layer++)
             {
                 for (uint32_t mipLevel = subresourceRange.mipLevel;
                      mipLevel < subresourceRange.mipLevel + subresourceRange.mipLevelCount;

--- a/src/vulkan/vk-command.cpp
+++ b/src/vulkan/vk-command.cpp
@@ -268,12 +268,12 @@ void CommandRecorder::cmdCopyTexture(const commands::CopyTexture& cmd)
 
             VkImageCopy region = {};
             region.srcSubresource.aspectMask = VulkanUtil::getAspectMask(TextureAspect::All, src->m_vkformat);
-            region.srcSubresource.baseArrayLayer = srcSubresource.baseArrayLayer + layer;
+            region.srcSubresource.baseArrayLayer = srcSubresource.layer + layer;
             region.srcSubresource.mipLevel = srcMipLevel;
             region.srcSubresource.layerCount = 1;
             region.srcOffset = {(int32_t)srcOffset.x, (int32_t)srcOffset.y, (int32_t)srcOffset.z};
             region.dstSubresource.aspectMask = VulkanUtil::getAspectMask(TextureAspect::All, dst->m_vkformat);
-            region.dstSubresource.baseArrayLayer = dstSubresource.baseArrayLayer + layer;
+            region.dstSubresource.baseArrayLayer = dstSubresource.layer + layer;
             region.dstSubresource.mipLevel = dstMipLevel;
             region.dstSubresource.layerCount = 1;
             region.dstOffset = {(int32_t)dstOffset.x, (int32_t)dstOffset.y, (int32_t)dstOffset.z};
@@ -390,7 +390,7 @@ void CommandRecorder::cmdClearTextureFloat(const commands::ClearTextureFloat& cm
     subresourceRange.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
     subresourceRange.baseMipLevel = cmd.subresourceRange.mipLevel;
     subresourceRange.levelCount = cmd.subresourceRange.mipLevelCount;
-    subresourceRange.baseArrayLayer = cmd.subresourceRange.baseArrayLayer;
+    subresourceRange.baseArrayLayer = cmd.subresourceRange.layer;
     subresourceRange.layerCount = cmd.subresourceRange.layerCount;
 
     VkClearColorValue vkClearColor = {};
@@ -417,7 +417,7 @@ void CommandRecorder::cmdClearTextureUint(const commands::ClearTextureUint& cmd)
     subresourceRange.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
     subresourceRange.baseMipLevel = cmd.subresourceRange.mipLevel;
     subresourceRange.levelCount = cmd.subresourceRange.mipLevelCount;
-    subresourceRange.baseArrayLayer = cmd.subresourceRange.baseArrayLayer;
+    subresourceRange.baseArrayLayer = cmd.subresourceRange.layer;
     subresourceRange.layerCount = cmd.subresourceRange.layerCount;
 
     VkClearColorValue vkClearColor = {};
@@ -445,7 +445,7 @@ void CommandRecorder::cmdClearTextureDepthStencil(const commands::ClearTextureDe
     subresourceRange.aspectMask = 0;
     subresourceRange.baseMipLevel = cmd.subresourceRange.mipLevel;
     subresourceRange.levelCount = cmd.subresourceRange.mipLevelCount;
-    subresourceRange.baseArrayLayer = cmd.subresourceRange.baseArrayLayer;
+    subresourceRange.baseArrayLayer = cmd.subresourceRange.layer;
     subresourceRange.layerCount = cmd.subresourceRange.layerCount;
 
     VkClearDepthStencilValue vkClearValue = {};
@@ -483,7 +483,7 @@ void CommandRecorder::cmdUploadTextureData(const commands::UploadTextureData& cm
 
     for (uint32_t layerOffset = 0; layerOffset < subresourceRange.layerCount; layerOffset++)
     {
-        uint32_t layerIndex = subresourceRange.baseArrayLayer + layerOffset;
+        uint32_t layer = subresourceRange.layer + layerOffset;
         for (uint32_t mipOffset = 0; mipOffset < subresourceRange.mipLevelCount; mipOffset++)
         {
             uint32_t mipLevel = subresourceRange.mipLevel + mipOffset;
@@ -507,7 +507,7 @@ void CommandRecorder::cmdUploadTextureData(const commands::UploadTextureData& cm
 
             region.imageSubresource.aspectMask = getAspectMaskFromFormat(dst->m_vkformat);
             region.imageSubresource.mipLevel = mipLevel;
-            region.imageSubresource.baseArrayLayer = layerIndex;
+            region.imageSubresource.baseArrayLayer = layer;
             region.imageSubresource.layerCount = 1;
             region.imageOffset = {int32_t(cmd.offset.x), int32_t(cmd.offset.y), int32_t(cmd.offset.z)};
             region.imageExtent = {srLayout->size.width, srLayout->size.height, srLayout->size.depth};

--- a/src/vulkan/vk-command.cpp
+++ b/src/vulkan/vk-command.cpp
@@ -218,14 +218,14 @@ void CommandRecorder::cmdCopyTexture(const commands::CopyTexture& cmd)
     Extent3D extent = cmd.extent;
 
     // Fix up sub resource ranges.
-    if (dstSubresource.mipLevelCount == 0)
-        dstSubresource.mipLevelCount = dst->m_desc.mipLevelCount;
     if (dstSubresource.layerCount == 0)
         dstSubresource.layerCount = dst->m_desc.getLayerCount();
-    if (srcSubresource.mipLevelCount == 0)
-        srcSubresource.mipLevelCount = src->m_desc.mipLevelCount;
+    if (dstSubresource.mipLevelCount == 0)
+        dstSubresource.mipLevelCount = dst->m_desc.mipLevelCount;
     if (srcSubresource.layerCount == 0)
         srcSubresource.layerCount = src->m_desc.getLayerCount();
+    if (srcSubresource.mipLevelCount == 0)
+        srcSubresource.mipLevelCount = src->m_desc.mipLevelCount;
 
     requireTextureState(dst, dstSubresource, ResourceState::CopyDestination);
     requireTextureState(src, srcSubresource, ResourceState::CopySource);
@@ -302,7 +302,7 @@ void CommandRecorder::cmdCopyTextureToBuffer(const commands::CopyTextureToBuffer
 
     // Switch texture to copy src and buffer to copy dest.
     requireBufferState(dst, ResourceState::CopyDestination);
-    requireTextureState(src, {srcMipLevel, 1, srcLayer, 1}, ResourceState::CopySource);
+    requireTextureState(src, {srcLayer, 1, srcMipLevel, 1}, ResourceState::CopySource);
     commitBarriers();
 
     // Calculate adjusted extents. Note it is required and enforced

--- a/src/vulkan/vk-texture.cpp
+++ b/src/vulkan/vk-texture.cpp
@@ -147,7 +147,7 @@ TextureSubresourceView TextureImpl::getView(Format format, TextureAspect aspect,
 
     createInfo.subresourceRange.aspectMask = getAspectMaskFromFormat(m_vkformat, aspect);
 
-    createInfo.subresourceRange.baseArrayLayer = range.baseArrayLayer;
+    createInfo.subresourceRange.baseArrayLayer = range.layer;
     createInfo.subresourceRange.baseMipLevel = range.mipLevel;
     createInfo.subresourceRange.layerCount = range.layerCount;
     createInfo.subresourceRange.levelCount = range.mipLevelCount;
@@ -308,7 +308,7 @@ Result DeviceImpl::createTexture(const TextureDesc& desc_, const SubresourceData
         SLANG_RETURN_ON_FAIL(queue->createCommandEncoder(commandEncoder.writeRef()));
 
         SubresourceRange range;
-        range.baseArrayLayer = 0;
+        range.layer = 0;
         range.layerCount = layerCount;
         range.mipLevel = 0;
         range.mipLevelCount = desc.mipLevelCount;

--- a/src/vulkan/vk-texture.cpp
+++ b/src/vulkan/vk-texture.cpp
@@ -308,10 +308,10 @@ Result DeviceImpl::createTexture(const TextureDesc& desc_, const SubresourceData
         SLANG_RETURN_ON_FAIL(queue->createCommandEncoder(commandEncoder.writeRef()));
 
         SubresourceRange range;
-        range.mipLevel = 0;
-        range.mipLevelCount = desc.mipLevelCount;
         range.baseArrayLayer = 0;
         range.layerCount = layerCount;
+        range.mipLevel = 0;
+        range.mipLevelCount = desc.mipLevelCount;
 
         commandEncoder->uploadTextureData(
             texture,

--- a/src/vulkan/vk-texture.h
+++ b/src/vulkan/vk-texture.h
@@ -45,7 +45,7 @@ public:
             size_t hash = 0;
             hash_combine(hash, key.format);
             hash_combine(hash, key.aspect);
-            hash_combine(hash, key.range.baseArrayLayer);
+            hash_combine(hash, key.range.layer);
             hash_combine(hash, key.range.layerCount);
             hash_combine(hash, key.range.mipLevel);
             hash_combine(hash, key.range.mipLevelCount);

--- a/src/wgpu/wgpu-command.cpp
+++ b/src/wgpu/wgpu-command.cpp
@@ -185,8 +185,8 @@ void CommandRecorder::cmdCopyTexture(const commands::CopyTexture& cmd)
         srcSubresource.mipLevelCount = src->m_desc.mipLevelCount;
 
     // Validate subresource ranges
-    SLANG_RHI_ASSERT(srcSubresource.baseArrayLayer + srcSubresource.layerCount <= src->m_desc.getLayerCount());
-    SLANG_RHI_ASSERT(dstSubresource.baseArrayLayer + dstSubresource.layerCount <= dst->m_desc.getLayerCount());
+    SLANG_RHI_ASSERT(srcSubresource.layer + srcSubresource.layerCount <= src->m_desc.getLayerCount());
+    SLANG_RHI_ASSERT(dstSubresource.layer + dstSubresource.layerCount <= dst->m_desc.getLayerCount());
     SLANG_RHI_ASSERT(srcSubresource.mipLevel + srcSubresource.mipLevelCount <= src->m_desc.mipLevelCount);
     SLANG_RHI_ASSERT(dstSubresource.mipLevel + dstSubresource.mipLevelCount <= dst->m_desc.mipLevelCount);
 
@@ -232,10 +232,10 @@ void CommandRecorder::cmdCopyTexture(const commands::CopyTexture& cmd)
             SLANG_RHI_ASSERT(srcOffset.z + adjustedExtent.depth <= srcMipSize.depth);
 
             // z is either base array layer or z offset depending on whether this is 3D or array texture
-            SLANG_RHI_ASSERT(cmd.srcSubresource.baseArrayLayer == 0 || cmd.srcOffset.z == 0);
-            SLANG_RHI_ASSERT(cmd.dstSubresource.baseArrayLayer == 0 || cmd.dstOffset.z == 0);
-            uint32_t srcZ = cmd.srcOffset.z + cmd.srcSubresource.baseArrayLayer + layer;
-            uint32_t dstZ = cmd.dstOffset.z + cmd.dstSubresource.baseArrayLayer + layer;
+            SLANG_RHI_ASSERT(cmd.srcSubresource.layer == 0 || cmd.srcOffset.z == 0);
+            SLANG_RHI_ASSERT(cmd.dstSubresource.layer == 0 || cmd.dstOffset.z == 0);
+            uint32_t srcZ = cmd.srcOffset.z + cmd.srcSubresource.layer + layer;
+            uint32_t dstZ = cmd.dstOffset.z + cmd.dstSubresource.layer + layer;
 
             WGPUImageCopyTexture source = {};
             source.texture = src->m_texture;
@@ -360,7 +360,7 @@ void CommandRecorder::cmdUploadTextureData(const commands::UploadTextureData& cm
 
     for (uint32_t layerOffset = 0; layerOffset < subresourceRange.layerCount; layerOffset++)
     {
-        uint32_t layerIndex = subresourceRange.baseArrayLayer + layerOffset;
+        uint32_t layer = subresourceRange.layer + layerOffset;
         for (uint32_t mipOffset = 0; mipOffset < subresourceRange.mipLevelCount; mipOffset++)
         {
             uint32_t mipLevel = subresourceRange.mipLevel + mipOffset;
@@ -373,8 +373,8 @@ void CommandRecorder::cmdUploadTextureData(const commands::UploadTextureData& cm
             srcRegion.layout.offset = bufferOffset;
 
             // Can't be copying multiple layers from a volume texture
-            SLANG_RHI_ASSERT(layerIndex == 0 || cmd.offset.z == 0);
-            uint32_t z = cmd.offset.z + layerIndex;
+            SLANG_RHI_ASSERT(layer == 0 || cmd.offset.z == 0);
+            uint32_t z = cmd.offset.z + layer;
 
             WGPUImageCopyTexture dstRegion;
             dstRegion.aspect = WGPUTextureAspect_All;

--- a/src/wgpu/wgpu-command.cpp
+++ b/src/wgpu/wgpu-command.cpp
@@ -175,24 +175,24 @@ void CommandRecorder::cmdCopyTexture(const commands::CopyTexture& cmd)
     const Extent3D& extent = cmd.extent;
 
     // Fix up sub resource ranges.
-    if (dstSubresource.mipLevelCount == 0)
-        dstSubresource.mipLevelCount = dst->m_desc.mipLevelCount;
     if (dstSubresource.layerCount == 0)
         dstSubresource.layerCount = dst->m_desc.getLayerCount();
-    if (srcSubresource.mipLevelCount == 0)
-        srcSubresource.mipLevelCount = src->m_desc.mipLevelCount;
+    if (dstSubresource.mipLevelCount == 0)
+        dstSubresource.mipLevelCount = dst->m_desc.mipLevelCount;
     if (srcSubresource.layerCount == 0)
         srcSubresource.layerCount = src->m_desc.getLayerCount();
+    if (srcSubresource.mipLevelCount == 0)
+        srcSubresource.mipLevelCount = src->m_desc.mipLevelCount;
 
     // Validate subresource ranges
-    SLANG_RHI_ASSERT(srcSubresource.mipLevel + srcSubresource.mipLevelCount <= src->m_desc.mipLevelCount);
-    SLANG_RHI_ASSERT(dstSubresource.mipLevel + dstSubresource.mipLevelCount <= dst->m_desc.mipLevelCount);
     SLANG_RHI_ASSERT(srcSubresource.baseArrayLayer + srcSubresource.layerCount <= src->m_desc.getLayerCount());
     SLANG_RHI_ASSERT(dstSubresource.baseArrayLayer + dstSubresource.layerCount <= dst->m_desc.getLayerCount());
+    SLANG_RHI_ASSERT(srcSubresource.mipLevel + srcSubresource.mipLevelCount <= src->m_desc.mipLevelCount);
+    SLANG_RHI_ASSERT(dstSubresource.mipLevel + dstSubresource.mipLevelCount <= dst->m_desc.mipLevelCount);
 
     // Validate matching dimensions between source and destination
-    SLANG_RHI_ASSERT(srcSubresource.mipLevelCount == dstSubresource.mipLevelCount);
     SLANG_RHI_ASSERT(srcSubresource.layerCount == dstSubresource.layerCount);
+    SLANG_RHI_ASSERT(srcSubresource.mipLevelCount == dstSubresource.mipLevelCount);
 
     Extent3D srcTextureSize = src->m_desc.size;
     const FormatInfo& srcFormatInfo = getFormatInfo(src->m_desc.format);
@@ -353,7 +353,6 @@ void CommandRecorder::cmdUploadTextureData(const commands::UploadTextureData& cm
 {
     auto dst = checked_cast<TextureImpl*>(cmd.dst);
     SubresourceRange subresourceRange = cmd.subresourceRange;
-
 
     SubresourceLayout* srLayout = cmd.layouts;
     Offset bufferOffset = cmd.srcOffset;

--- a/src/wgpu/wgpu-texture.cpp
+++ b/src/wgpu/wgpu-texture.cpp
@@ -109,7 +109,7 @@ Result DeviceImpl::createTexture(const TextureDesc& desc_, const SubresourceData
         SLANG_RETURN_ON_FAIL(queue->createCommandEncoder(commandEncoder.writeRef()));
 
         SubresourceRange range;
-        range.baseArrayLayer = 0;
+        range.layer = 0;
         range.layerCount = desc.getLayerCount();
         range.mipLevel = 0;
         range.mipLevelCount = desc.mipLevelCount;
@@ -164,7 +164,7 @@ Result DeviceImpl::createTextureView(ITexture* texture, const TextureViewDesc& d
     viewDesc.dimension = translateTextureViewDimension(textureImpl->m_desc.type, textureImpl->m_desc.arrayLength > 1);
     viewDesc.baseMipLevel = view->m_desc.subresourceRange.mipLevel;
     viewDesc.mipLevelCount = view->m_desc.subresourceRange.mipLevelCount;
-    viewDesc.baseArrayLayer = view->m_desc.subresourceRange.baseArrayLayer;
+    viewDesc.baseArrayLayer = view->m_desc.subresourceRange.layer;
     viewDesc.arrayLayerCount = view->m_desc.subresourceRange.layerCount;
     viewDesc.aspect = translateTextureAspect(desc.aspect);
     viewDesc.label = desc.label;

--- a/src/wgpu/wgpu-texture.cpp
+++ b/src/wgpu/wgpu-texture.cpp
@@ -109,10 +109,10 @@ Result DeviceImpl::createTexture(const TextureDesc& desc_, const SubresourceData
         SLANG_RETURN_ON_FAIL(queue->createCommandEncoder(commandEncoder.writeRef()));
 
         SubresourceRange range;
-        range.mipLevel = 0;
-        range.mipLevelCount = desc.mipLevelCount;
         range.baseArrayLayer = 0;
         range.layerCount = desc.getLayerCount();
+        range.mipLevel = 0;
+        range.mipLevelCount = desc.mipLevelCount;
 
         commandEncoder->uploadTextureData(
             texture,

--- a/tests/test-cmd-copy-texture.cpp
+++ b/tests/test-cmd-copy-texture.cpp
@@ -95,10 +95,10 @@ GPU_TEST_CASE("cmd-copy-texture-arrayrange", D3D12 | Vulkan | WGPU | CUDA)
             // Copy the 1st half of the layers to the 2nd half
             commandEncoder->copyTexture(
                 newTexture,
-                {0, 0, 0, halfLayerCount},
+                {0, halfLayerCount, 0, 0},
                 {0, 0, 0},
                 c->getTexture(),
-                {0, 0, halfLayerCount, halfLayerCount},
+                {halfLayerCount, halfLayerCount, 0, 0},
                 {0, 0, 0},
                 Extent3D::kWholeTexture
             );
@@ -147,10 +147,10 @@ GPU_TEST_CASE("cmd-copy-texture-miprange", D3D12 | Vulkan | WGPU | CUDA)
             // Copy the 1st half of the mips for all layers
             commandEncoder->copyTexture(
                 newTexture,
-                {0, halfMipCount, 0, 0},
+                {0, 0, 0, halfMipCount},
                 {0, 0, 0},
                 c->getTexture(),
-                {0, halfMipCount, 0, 0},
+                {0, 0, 0, halfMipCount},
                 {0, 0, 0},
                 Extent3D::kWholeTexture
             );
@@ -206,10 +206,10 @@ GPU_TEST_CASE("cmd-copy-texture-fromarray", D3D12 | Vulkan | WGPU | CUDA)
             // Copy from layer 2 into layer 0
             commandEncoder->copyTexture(
                 newTexture,
-                {0, 0, 0, 1},
+                {0, 1, 0, 0},
                 {0, 0, 0},
                 c->getTexture(),
-                {0, 0, 2, 1},
+                {2, 1, 0, 0},
                 {0, 0, 0},
                 Extent3D::kWholeTexture
             );
@@ -257,10 +257,10 @@ GPU_TEST_CASE("cmd-copy-texture-toarray", D3D12 | Vulkan | WGPU | CUDA)
             // of the one allocated by the testing system.
             commandEncoder->copyTexture(
                 c->getTexture(),
-                {0, 0, 2, 1},
+                {2, 1, 0, 0},
                 {0, 0, 0},
                 newTexture,
-                {0, 0, 0, 1},
+                {0, 1, 0, 0},
                 {0, 0, 0},
                 Extent3D::kWholeTexture
             );
@@ -362,7 +362,7 @@ GPU_TEST_CASE("cmd-copy-texture-arrayfromslice", D3D12 | Vulkan | WGPU | CUDA)
             // Copy 1 slice with a depth offset
             commandEncoder->copyTexture(
                 newTexture,
-                {0, 1, 2, 1},
+                {2, 1, 0, 1},
                 {0, 0, 0},
                 c->getTexture(),
                 {0, 1, 0, 1},
@@ -479,10 +479,10 @@ GPU_TEST_CASE("cmd-copy-texture-offset-nomip", D3D12 | Vulkan | WGPU | CUDA)
             // Copy at the offset, using kWholeTexture to express 'the rest of the texture'
             commandEncoder->copyTexture(
                 newTexture,
-                {0, 1, 0, 0},
+                {0, 0, 0, 1},
                 offset,
                 c->getTexture(),
-                {0, 1, 0, 0},
+                {0, 0, 0, 1},
                 offset,
                 Extent3D::kWholeTexture
             );
@@ -534,7 +534,7 @@ GPU_TEST_CASE("cmd-copy-texture-sizeoffset-nomip", D3D12 | Vulkan | WGPU | CUDA)
 
             // Copy at the offset, using kWholeTexture to express 'the rest of the texture'
             commandEncoder
-                ->copyTexture(newTexture, {0, 1, 0, 0}, offset, c->getTexture(), {0, 1, 0, 0}, offset, extent);
+                ->copyTexture(newTexture, {0, 0, 0, 1}, offset, c->getTexture(), {0, 0, 0, 1}, offset, extent);
 
             queue->submit(commandEncoder->finish());
 
@@ -583,7 +583,7 @@ GPU_TEST_CASE("cmd-copy-texture-smalltolarge", D3D12 | Vulkan | WGPU | CUDA)
 
             // Copy at the offset, using kWholeTexture to express 'the rest of the texture'
             commandEncoder
-                ->copyTexture(largerTexture, {0, 1, 0, 0}, offset, smallerTexture, {0, 1, 0, 0}, offset, extent);
+                ->copyTexture(largerTexture, {0, 0, 0, 1}, offset, smallerTexture, {0, 0, 0, 1}, offset, extent);
             queue->submit(commandEncoder->finish());
 
             // Verify it uploaded correctly
@@ -638,7 +638,7 @@ GPU_TEST_CASE("cmd-copy-texture-largetosmall", D3D12 | Vulkan | WGPU | CUDA)
 
             // Copy at the offset, using kWholeTexture to express 'the rest of the texture'
             commandEncoder
-                ->copyTexture(smallerTexture, {0, 1, 0, 0}, {0, 0, 0}, largerTexture, {0, 1, 0, 0}, offset, extent);
+                ->copyTexture(smallerTexture, {0, 0, 0, 1}, {0, 0, 0}, largerTexture, {0, 0, 0, 1}, offset, extent);
             queue->submit(commandEncoder->finish());
 
             // Verify it uploaded correctly
@@ -686,7 +686,7 @@ GPU_TEST_CASE("cmd-copy-texture-acrossmips", D3D12 | Vulkan | WGPU | CUDA)
 
             // Copy from mip 1 to mip 0
             commandEncoder
-                ->copyTexture(dstTexture, {0, 1, 0, 0}, {0, 0, 0}, srcTexture, {1, 1, 0, 0}, {0, 0, 0}, extent);
+                ->copyTexture(dstTexture, {0, 0, 0, 1}, {0, 0, 0}, srcTexture, {0, 0, 1, 1}, {0, 0, 0}, extent);
             queue->submit(commandEncoder->finish());
 
             // Verify it uploaded correctly
@@ -738,10 +738,10 @@ GPU_TEST_CASE("cmd-copy-texture-offset-mip1", D3D12 | Vulkan | WGPU | CUDA)
             // Copy at the offset in mip level 1, using kWholeTexture to express 'the rest of the texture'
             commandEncoder->copyTexture(
                 newTexture,
-                {1, 1, 0, 0}, // Target mip level 1
+                {0, 0, 1, 1}, // Target mip level 1
                 offset,
                 c->getTexture(),
-                {1, 1, 0, 0}, // Source from mip level 1
+                {0, 0, 1, 1}, // Source from mip level 1
                 offset,
                 Extent3D::kWholeTexture
             );
@@ -797,10 +797,10 @@ GPU_TEST_CASE("cmd-copy-texture-offset-mip1", D3D12 | Vulkan | WGPU | CUDA)
             // Copy at the offset in mip level 1, using kWholeTexture to express 'the rest of the texture'
             commandEncoder->copyTexture(
                 newTexture,
-                {1, 1, 0, 0}, // Target mip level 1
+                {0, 0, 1, 1}, // Target mip level 1
                 offset,
                 c->getTexture(),
-                {1, 1, 0, 0}, // Source from mip level 1
+                {0, 0, 1, 1}, // Source from mip level 1
                 offset,
                 Extent3D::kWholeTexture
             );

--- a/tests/test-cmd-upload-texture.cpp
+++ b/tests/test-cmd-upload-texture.cpp
@@ -31,7 +31,7 @@ GPU_TEST_CASE("cmd-upload-texture-simple", D3D12 | Vulkan | Metal | CUDA | WGPU)
             // Upload new texture data + wait
             commandEncoder->uploadTextureData(
                 c->getTexture(),
-                {0, data.desc.mipLevelCount, 0, data.desc.getLayerCount()},
+                {0, data.desc.getLayerCount(), 0, data.desc.mipLevelCount},
                 {0, 0, 0},
                 Extent3D::kWholeTexture,
                 data.subresourceData.data(),
@@ -76,7 +76,7 @@ GPU_TEST_CASE("cmd-upload-texture-single-layer", D3D12 | Vulkan | Metal | CUDA |
                     auto srdata = newData.getLayerFirstSubresourceData(layer);
                     commandEncoder->uploadTextureData(
                         c->getTexture(),
-                        {0, newData.desc.mipLevelCount, layer, 1},
+                        {layer, 1, 0, newData.desc.mipLevelCount},
                         {0, 0, 0},
                         Extent3D::kWholeTexture,
                         srdata,
@@ -133,7 +133,7 @@ GPU_TEST_CASE("cmd-upload-texture-single-mip", D3D12 | Vulkan | Metal | CUDA | W
                         auto srdata = newData.getLayerFirstSubresourceData(layerIdx) + mipLevel;
                         commandEncoder->uploadTextureData(
                             c->getTexture(),
-                            {mipLevel, 1, layerIdx, 1},
+                            {layerIdx, 1, mipLevel, 1},
                             {0, 0, 0},
                             Extent3D::kWholeTexture,
                             srdata,
@@ -193,7 +193,7 @@ GPU_TEST_CASE("cmd-upload-texture-multisubmit", D3D12 | Vulkan | Metal | CUDA | 
                     auto srdata = newData.getLayerFirstSubresourceData(layerIdx) + mipLevel;
                     commandEncoder->uploadTextureData(
                         c->getTexture(),
-                        {mipLevel, 1, layerIdx, 1},
+                        {layerIdx, 1, mipLevel, 1},
                         {0, 0, 0},
                         Extent3D::kWholeTexture,
                         srdata,
@@ -253,7 +253,7 @@ GPU_TEST_CASE("cmd-upload-texture-offset", D3D12 | Vulkan | Metal | CUDA | WGPU)
             {
                 commandEncoder->uploadTextureData(
                     c->getTexture(),
-                    {0, 1, layer, 1},
+                    {layer, 1, 0, 1},
                     offset,
                     Extent3D::kWholeTexture,
                     newData.getLayerFirstSubresourceData(layer),
@@ -311,7 +311,7 @@ GPU_TEST_CASE("cmd-upload-texture-sizeoffset", D3D12 | Vulkan | Metal | CUDA | W
             {
                 commandEncoder->uploadTextureData(
                     c->getTexture(),
-                    {0, 1, layer, 1},
+                    {layer, 1, 0, 1},
                     offset,
                     extent,
                     newData.getLayerFirstSubresourceData(layer),
@@ -376,7 +376,7 @@ GPU_TEST_CASE("cmd-upload-texture-mipsizeoffset", D3D12 | Vulkan | Metal | CUDA 
             // Write an offset, still allowing remainder of texture to be written
             commandEncoder->uploadTextureData(
                 c->getTexture(),
-                {1, 1, 0, 1},
+                {0, 1, 1, 1},
                 offset,
                 extent,
                 newData.getLayerFirstSubresourceData(0),

--- a/tests/test-resolve-resource-tests.cpp
+++ b/tests/test-resolve-resource-tests.cpp
@@ -238,16 +238,16 @@ struct ResolveResourceSimple : BaseResolveResourceTest
         createRequiredResources(msaaTextureInfo, dstTextureInfo, kFormat);
 
         SubresourceRange msaaSubresource = {};
-        msaaSubresource.mipLevel = 0;
-        msaaSubresource.mipLevelCount = 1;
         msaaSubresource.baseArrayLayer = 0;
         msaaSubresource.layerCount = 1;
+        msaaSubresource.mipLevel = 0;
+        msaaSubresource.mipLevelCount = 1;
 
         SubresourceRange dstSubresource = {};
-        dstSubresource.mipLevel = 0;
-        dstSubresource.mipLevelCount = 1;
         dstSubresource.baseArrayLayer = 0;
         dstSubresource.layerCount = 1;
+        dstSubresource.mipLevel = 0;
+        dstSubresource.mipLevelCount = 1;
 
         submitGPUWork(msaaSubresource, dstSubresource, extent);
 

--- a/tests/test-resolve-resource-tests.cpp
+++ b/tests/test-resolve-resource-tests.cpp
@@ -238,13 +238,13 @@ struct ResolveResourceSimple : BaseResolveResourceTest
         createRequiredResources(msaaTextureInfo, dstTextureInfo, kFormat);
 
         SubresourceRange msaaSubresource = {};
-        msaaSubresource.baseArrayLayer = 0;
+        msaaSubresource.layer = 0;
         msaaSubresource.layerCount = 1;
         msaaSubresource.mipLevel = 0;
         msaaSubresource.mipLevelCount = 1;
 
         SubresourceRange dstSubresource = {};
-        dstSubresource.baseArrayLayer = 0;
+        dstSubresource.layer = 0;
         dstSubresource.layerCount = 1;
         dstSubresource.mipLevel = 0;
         dstSubresource.mipLevelCount = 1;

--- a/tests/test-texture-types.cpp
+++ b/tests/test-texture-types.cpp
@@ -225,7 +225,7 @@ struct TextureAccessTest : TextureTest
 
         // We need to save the pointer to the original texture data for results checking because the texture will be
         // overwritten during testing (if the texture can be written to).
-        expectedTextureData = textureInfo->subresourceDatas[getSubresourceIndex(0, 1, 0)].data;
+        expectedTextureData = textureInfo->subresourceDatas[0].data;
 
         createRequiredResources();
         auto entryPointName = getShaderEntryPoint();
@@ -467,7 +467,7 @@ struct RenderTargetTests : TextureTest
 
         // We need to save the pointer to the original texture data for results checking because the texture will be
         // overwritten during testing (if the texture can be written to).
-        expectedTextureData = textureInfo->subresourceDatas[getSubresourceIndex(0, 1, 0)].data;
+        expectedTextureData = textureInfo->subresourceDatas[0].data;
 
         createRequiredResources();
         submitShaderWork();

--- a/tests/test-texture-view.cpp
+++ b/tests/test-texture-view.cpp
@@ -187,9 +187,9 @@ struct TestTextureViews
             // Texture size
             Extent3D size = {16 /*width*/, 16 /*height*/, 16 /*depth*/};
             // This subrange/textureView will give a 8x8x8 texture and verifies a fix for issue #220
-            // We use 3 for baseArrayLayer as this was previously used for FirstWSlice and we want
+            // We use 3 for layer as this was previously used for FirstWSlice and we want
             // to verify that selecting a subset of depth slices is not currently supported.
-            SubresourceRange range = {3 /*baseArrayLayer*/, 1 /*layerCount*/, 1 /*mipLevel*/, 4 /*mipLevelCount*/};
+            SubresourceRange range = {3 /*layer*/, 1 /*layerCount*/, 1 /*mipLevel*/, 4 /*mipLevelCount*/};
             testTextureViewUnorderedAccess(type, 5 /*mipLevelCount*/, size, range, subData);
         }
     }

--- a/tests/test-texture-view.cpp
+++ b/tests/test-texture-view.cpp
@@ -189,7 +189,7 @@ struct TestTextureViews
             // This subrange/textureView will give a 8x8x8 texture and verifies a fix for issue #220
             // We use 3 for baseArrayLayer as this was previously used for FirstWSlice and we want
             // to verify that selecting a subset of depth slices is not currently supported.
-            SubresourceRange range = {1 /*mipLevel*/, 4 /*mipLevelCount*/, 3 /*baseArrayLayer*/, 1 /*layerCount*/};
+            SubresourceRange range = {3 /*baseArrayLayer*/, 1 /*layerCount*/, 1 /*mipLevel*/, 4 /*mipLevelCount*/};
             testTextureViewUnorderedAccess(type, 5 /*mipLevelCount*/, size, range, subData);
         }
     }

--- a/tests/texture-utils.cpp
+++ b/tests/texture-utils.cpp
@@ -31,9 +31,9 @@ Size getTexelSize(Format format)
     return info.blockSizeInBytes / info.pixelsPerBlock;
 }
 
-uint32_t getSubresourceIndex(uint32_t mipLevel, uint32_t mipLevelCount, uint32_t baseArrayLayer)
+uint32_t getSubresourceIndex(uint32_t mipLevel, uint32_t mipLevelCount, uint32_t layer)
 {
-    return baseArrayLayer * mipLevelCount + mipLevel;
+    return layer * mipLevelCount + mipLevel;
 }
 
 RefPtr<ValidationTextureFormatBase> getValidationTextureFormat(Format format)

--- a/tests/texture-utils.cpp
+++ b/tests/texture-utils.cpp
@@ -31,11 +31,6 @@ Size getTexelSize(Format format)
     return info.blockSizeInBytes / info.pixelsPerBlock;
 }
 
-uint32_t getSubresourceIndex(uint32_t mipLevel, uint32_t mipLevelCount, uint32_t layer)
-{
-    return layer * mipLevelCount + mipLevel;
-}
-
 RefPtr<ValidationTextureFormatBase> getValidationTextureFormat(Format format)
 {
     switch (format)

--- a/tests/texture-utils.h
+++ b/tests/texture-utils.h
@@ -214,7 +214,6 @@ inline TextureType toArrayType(TextureType type)
 }
 
 Size getTexelSize(Format format);
-uint32_t getSubresourceIndex(uint32_t mipLevel, uint32_t mipLevelCount, uint32_t layer);
 RefPtr<ValidationTextureFormatBase> getValidationTextureFormat(Format format);
 void generateTextureData(RefPtr<TextureInfo> texture, ValidationTextureFormatBase* validationFormat);
 

--- a/tests/texture-utils.h
+++ b/tests/texture-utils.h
@@ -214,7 +214,7 @@ inline TextureType toArrayType(TextureType type)
 }
 
 Size getTexelSize(Format format);
-uint32_t getSubresourceIndex(uint32_t mipLevel, uint32_t mipLevelCount, uint32_t baseArrayLayer);
+uint32_t getSubresourceIndex(uint32_t mipLevel, uint32_t mipLevelCount, uint32_t layer);
 RefPtr<ValidationTextureFormatBase> getValidationTextureFormat(Format format);
 void generateTextureData(RefPtr<TextureInfo> texture, ValidationTextureFormatBase* validationFormat);
 


### PR DESCRIPTION
- rename `baseArrayLayer` to `layer`
- move `layer/layerCount` before `mipLevel/mipLevelCount` to be consistent with rest of API