### PR TITLE
readTexture to client memory

### DIFF
--- a/include/slang-rhi.h
+++ b/include/slang-rhi.h
@@ -2800,6 +2800,14 @@ public:
         return pipeline;
     }
 
+    /// Read back texture resource and stores the result in `outData`.
+    /// `layout` is the layout to store the data in. It is the caller's responsibility to
+    /// ensure that the layout is compatible with the texture format and mip level.
+    /// This can be achieved by using `getTextureLayout()` to get the layout for the texture.
+    /// The `outData` pointer must be large enough to hold the data (i.e. `layout.sizeInBytes`).
+    virtual SLANG_NO_THROW Result SLANG_MCALL
+    readTexture(ITexture* texture, uint32_t layer, uint32_t mip, const SubresourceLayout& layout, void* outData) = 0;
+
     /// Read back texture resource and stores the result in `outBlob`.
     virtual SLANG_NO_THROW Result SLANG_MCALL readTexture(
         ITexture* texture,

--- a/include/slang-rhi.h
+++ b/include/slang-rhi.h
@@ -2817,41 +2817,6 @@ public:
         SubresourceLayout* outLayout
     ) = 0;
 
-
-    /// Helper that just outputs row pitch and (optionally) pixel size
-    /// instead of whole texture layout.
-    inline SLANG_NO_THROW Result SLANG_MCALL readTexture(
-        ITexture* texture,
-        uint32_t layer,
-        uint32_t mip,
-        ISlangBlob** outBlob,
-        Size* outRowPitch,
-        Size* outPixelSize = nullptr
-    )
-    {
-        SubresourceLayout layout;
-        SLANG_RETURN_ON_FAIL(readTexture(texture, layer, mip, outBlob, &layout));
-        if (outRowPitch)
-            *outRowPitch = layout.rowPitch;
-        if (outPixelSize)
-            *outPixelSize = layout.colPitch;
-        return SLANG_OK;
-    };
-
-    /// Helper overload that reads the entire texture (layer 0, mip level 0)
-    inline SLANG_NO_THROW Result SLANG_MCALL
-    readTexture(ITexture* texture, ISlangBlob** outBlob, SubresourceLayout* outLayout)
-    {
-        return readTexture(texture, 0, 0, outBlob, outLayout);
-    };
-
-    /// Helper overload that reads the entire texture (layer 0, mip level 0)
-    inline SLANG_NO_THROW Result SLANG_MCALL
-    readTexture(ITexture* texture, ISlangBlob** outBlob, Size* outRowPitch, Size* outPixelSize = nullptr)
-    {
-        return readTexture(texture, 0, 0, outBlob, outRowPitch, outPixelSize);
-    };
-
     virtual SLANG_NO_THROW Result SLANG_MCALL readBuffer(IBuffer* buffer, Offset offset, Size size, void* outData) = 0;
 
     virtual SLANG_NO_THROW Result SLANG_MCALL

--- a/src/cpu/cpu-device.h
+++ b/src/cpu/cpu-device.h
@@ -31,7 +31,7 @@ public:
     virtual SLANG_NO_THROW Result SLANG_MCALL unmapBuffer(IBuffer* buffer) override;
 
     virtual SLANG_NO_THROW Result SLANG_MCALL
-    readTexture(ITexture* texture, uint32_t layer, uint32_t mip, ISlangBlob** outBlob, SubresourceLayout* outLayout)
+    readTexture(ITexture* texture, uint32_t layer, uint32_t mip, const SubresourceLayout& layout, void* outData)
         override;
 
     virtual SLANG_NO_THROW Result SLANG_MCALL

--- a/src/cpu/cpu-texture.cpp
+++ b/src/cpu/cpu-texture.cpp
@@ -403,22 +403,15 @@ Result DeviceImpl::readTexture(
     ITexture* texture,
     uint32_t layer,
     uint32_t mip,
-    ISlangBlob** outBlob,
-    SubresourceLayout* outLayout
+    const SubresourceLayout& layout,
+    void* outData
 )
 {
     auto textureImpl = checked_cast<TextureImpl*>(texture);
 
-    // Calculate layout info.
-    SubresourceLayout layout;
-    SLANG_RETURN_ON_FAIL(texture->getSubresourceLayout(mip, &layout));
-
-    // Create blob for result.
-    auto blob = OwnedBlob::create(layout.sizeInBytes);
-
     // Get src + dest buffers.
     uint8_t* srcBuffer = (uint8_t*)textureImpl->m_data;
-    uint8_t* dstBuffer = (uint8_t*)blob->getBufferPointer();
+    uint8_t* dstBuffer = (uint8_t*)outData;
 
     // Should be able to make assumption that subresource layout info
     // matches those stored in the mip. If they don't match, this is a bug.
@@ -447,10 +440,6 @@ Result DeviceImpl::readTexture(
         dstBuffer += layout.slicePitch;
     }
 
-    // Return data.
-    returnComPtr(outBlob, blob);
-    if (outLayout)
-        *outLayout = layout;
     return SLANG_OK;
 }
 

--- a/src/cuda/cuda-device.h
+++ b/src/cuda/cuda-device.h
@@ -116,7 +116,7 @@ public:
     createInputLayout(const InputLayoutDesc& desc, IInputLayout** outLayout) override;
 
     virtual SLANG_NO_THROW Result SLANG_MCALL
-    readTexture(ITexture* texture, uint32_t layer, uint32_t mip, ISlangBlob** outBlob, SubresourceLayout* outLayout)
+    readTexture(ITexture* texture, uint32_t layer, uint32_t mip, const SubresourceLayout& layout, void* outData)
         override;
 
     virtual SLANG_NO_THROW Result SLANG_MCALL

--- a/src/d3d11/d3d11-device.h
+++ b/src/d3d11/d3d11-device.h
@@ -57,7 +57,7 @@ public:
     createComputePipeline2(const ComputePipelineDesc& desc, IComputePipeline** outPipeline) override;
 
     virtual SLANG_NO_THROW Result SLANG_MCALL
-    readTexture(ITexture* texture, uint32_t layer, uint32_t mip, ISlangBlob** outBlob, SubresourceLayout* outLayout)
+    readTexture(ITexture* texture, uint32_t layer, uint32_t mip, const SubresourceLayout& layout, void* outData)
         override;
 
     virtual SLANG_NO_THROW Result SLANG_MCALL

--- a/src/debug-layer/debug-device.cpp
+++ b/src/debug-layer/debug-device.cpp
@@ -523,6 +523,40 @@ Result DebugDevice::readTexture(
     ITexture* texture,
     uint32_t layer,
     uint32_t mip,
+    const SubresourceLayout& layout,
+    void* outData
+)
+{
+    const TextureDesc& desc = texture->getDesc();
+
+    if (layer > desc.getLayerCount())
+    {
+        RHI_VALIDATION_ERROR("Layer out of bounds");
+        return SLANG_E_INVALID_ARG;
+    }
+    if (mip > desc.mipCount)
+    {
+        RHI_VALIDATION_ERROR("Mip out of bounds");
+        return SLANG_E_INVALID_ARG;
+    }
+
+    switch (desc.type)
+    {
+    case TextureType::Texture2DMS:
+    case TextureType::Texture2DMSArray:
+        RHI_VALIDATION_ERROR("Multisample textures cannot be read");
+        return SLANG_E_INVALID_ARG;
+    default:
+        break;
+    }
+
+    return baseObject->readTexture(texture, layer, mip, layout, outData);
+}
+
+Result DebugDevice::readTexture(
+    ITexture* texture,
+    uint32_t layer,
+    uint32_t mip,
     ISlangBlob** outBlob,
     SubresourceLayout* outLayout
 )

--- a/src/debug-layer/debug-device.cpp
+++ b/src/debug-layer/debug-device.cpp
@@ -550,6 +550,14 @@ Result DebugDevice::readTexture(
         break;
     }
 
+    SubresourceLayout expectedLayout;
+    SLANG_RETURN_ON_FAIL(texture->getSubresourceLayout(mip, &expectedLayout));
+    if (std::memcmp(&layout, &expectedLayout, sizeof(SubresourceLayout)) != 0)
+    {
+        RHI_VALIDATION_ERROR("Layout does not match the expected layout");
+        return SLANG_E_INVALID_ARG;
+    }
+
     return baseObject->readTexture(texture, layer, mip, layout, outData);
 }
 

--- a/src/debug-layer/debug-device.h
+++ b/src/debug-layer/debug-device.h
@@ -74,6 +74,9 @@ public:
     virtual SLANG_NO_THROW Result SLANG_MCALL
     createRayTracingPipeline(const RayTracingPipelineDesc& desc, IRayTracingPipeline** outPipeline) override;
     virtual SLANG_NO_THROW Result SLANG_MCALL
+    readTexture(ITexture* texture, uint32_t layer, uint32_t mip, const SubresourceLayout& layout, void* outData)
+        override;
+    virtual SLANG_NO_THROW Result SLANG_MCALL
     readTexture(ITexture* texture, uint32_t layer, uint32_t mip, ISlangBlob** outBlob, SubresourceLayout* outLayout)
         override;
     virtual SLANG_NO_THROW Result SLANG_MCALL

--- a/src/device.h
+++ b/src/device.h
@@ -213,6 +213,10 @@ public:
 
     // Default implementation uses encoder.copyTextureToBuffer to copy to the read-back heap
     virtual SLANG_NO_THROW Result SLANG_MCALL
+    readTexture(ITexture* texture, uint32_t layer, uint32_t mip, const SubresourceLayout& layout, void* outData)
+        override;
+
+    virtual SLANG_NO_THROW Result SLANG_MCALL
     readTexture(ITexture* texture, uint32_t layer, uint32_t mip, ISlangBlob** outBlob, SubresourceLayout* outLayout)
         override;
 

--- a/tests/test-cmd-draw.cpp
+++ b/tests/test-cmd-draw.cpp
@@ -171,9 +171,8 @@ public:
         // and compare against expected values (because testing every single pixel will be too long and tedious
         // and requires maintaining reference images).
         ComPtr<ISlangBlob> resultBlob;
-        size_t rowPitch = 0;
-        size_t pixelSize = 0;
-        REQUIRE_CALL(device->readTexture(colorBuffer, 0, 0, resultBlob.writeRef(), &rowPitch, &pixelSize));
+        SubresourceLayout layout;
+        REQUIRE_CALL(device->readTexture(colorBuffer, 0, 0, resultBlob.writeRef(), &layout));
         auto result = (float*)resultBlob->getBufferPointer();
 
         int cursor = 0;
@@ -181,7 +180,7 @@ public:
         {
             auto x = testXCoords[i];
             auto y = testYCoords[i];
-            auto pixelPtr = result + x * channelCount + y * rowPitch / sizeof(float);
+            auto pixelPtr = result + x * channelCount + y * layout.rowPitch / sizeof(float);
             for (int j = 0; j < channelCount; ++j)
             {
                 testResults[cursor] = pixelPtr[j];

--- a/tests/test-ray-tracing.cpp
+++ b/tests/test-ray-tracing.cpp
@@ -311,13 +311,12 @@ struct BaseRayTracingTest
     void checkTestResults(float* expectedResult, uint32_t count)
     {
         ComPtr<ISlangBlob> resultBlob;
-        size_t rowPitch = 0;
-        size_t pixelSize = 0;
-        REQUIRE_CALL(device->readTexture(resultTexture, 0, 0, resultBlob.writeRef(), &rowPitch, &pixelSize));
+        SubresourceLayout layout;
+        REQUIRE_CALL(device->readTexture(resultTexture, 0, 0, resultBlob.writeRef(), &layout));
 #if 0 // for debugging only
-        writeImage("test.hdr", resultBlob, width, height, (uint32_t)rowPitch, (uint32_t)pixelSize);
+        writeImage("test.hdr", resultBlob, width, height, (uint32_t)layout.rowPitch, (uint32_t)layout.colPitch);
 #endif
-        auto buffer = removePadding(resultBlob, width, height, rowPitch, pixelSize);
+        auto buffer = removePadding(resultBlob, width, height, layout.rowPitch, layout.colPitch);
         auto actualData = (float*)buffer.data();
         CHECK(memcmp(actualData, expectedResult, count * sizeof(float)) == 0);
     }

--- a/tests/test-resolve-resource-tests.cpp
+++ b/tests/test-resolve-resource-tests.cpp
@@ -196,9 +196,8 @@ struct BaseResolveResourceTest
         // and compare against expected values (because testing every single pixel will be too long and tedious
         // and requires maintaining reference images).
         ComPtr<ISlangBlob> resultBlob;
-        size_t rowPitch = 0;
-        size_t pixelSize = 0;
-        REQUIRE_CALL(device->readTexture(dstTexture, 0, 0, resultBlob.writeRef(), &rowPitch, &pixelSize));
+        SubresourceLayout layout;
+        REQUIRE_CALL(device->readTexture(dstTexture, 0, 0, resultBlob.writeRef(), &layout));
         auto result = (float*)resultBlob->getBufferPointer();
 
         int cursor = 0;
@@ -206,7 +205,7 @@ struct BaseResolveResourceTest
         {
             auto x = testXCoords[i];
             auto y = testYCoords[i];
-            auto pixelPtr = result + x * channelCount + y * rowPitch / sizeof(float);
+            auto pixelPtr = result + x * channelCount + y * layout.rowPitch / sizeof(float);
             for (int j = 0; j < channelCount; ++j)
             {
                 testResults[cursor] = pixelPtr[j];

--- a/tests/test-texture-types.cpp
+++ b/tests/test-texture-types.cpp
@@ -175,22 +175,21 @@ struct TextureAccessTest : TextureTest
         if (readWrite)
         {
             ComPtr<ISlangBlob> textureBlob;
-            size_t rowPitch;
-            size_t pixelSize;
-            REQUIRE_CALL(device->readTexture(texture, 0, 0, textureBlob.writeRef(), &rowPitch, &pixelSize));
+            SubresourceLayout layout;
+            REQUIRE_CALL(device->readTexture(texture, 0, 0, textureBlob.writeRef(), &layout));
             auto textureValues = (uint8_t*)textureBlob->getBufferPointer();
 
             ValidationTextureData textureResults;
             textureResults.extent = textureInfo->extent;
             textureResults.textureData = textureValues;
-            textureResults.pitches.x = (uint32_t)pixelSize;
-            textureResults.pitches.y = (uint32_t)rowPitch;
+            textureResults.pitches.x = (uint32_t)layout.colPitch;
+            textureResults.pitches.y = (uint32_t)layout.rowPitch;
             textureResults.pitches.z = textureResults.extent.height * textureResults.pitches.y;
 
             ValidationTextureData originalData;
             originalData.extent = textureInfo->extent;
             originalData.textureData = textureInfo->subresourceDatas.data();
-            originalData.pitches.x = (uint32_t)pixelSize;
+            originalData.pitches.x = (uint32_t)layout.colPitch;
             originalData.pitches.y = textureInfo->extent.width * originalData.pitches.x;
             originalData.pitches.z = textureInfo->extent.height * originalData.pitches.y;
 
@@ -430,23 +429,22 @@ struct RenderTargetTests : TextureTest
     void checkTestResults()
     {
         ComPtr<ISlangBlob> textureBlob;
-        size_t rowPitch;
-        size_t pixelSize;
+        SubresourceLayout layout;
         if (sampleCount > 1)
         {
-            REQUIRE_CALL(device->readTexture(texture, 0, 0, textureBlob.writeRef(), &rowPitch, &pixelSize));
+            REQUIRE_CALL(device->readTexture(texture, 0, 0, textureBlob.writeRef(), &layout));
         }
         else
         {
-            REQUIRE_CALL(device->readTexture(renderTexture, 0, 0, textureBlob.writeRef(), &rowPitch, &pixelSize));
+            REQUIRE_CALL(device->readTexture(renderTexture, 0, 0, textureBlob.writeRef(), &layout));
         }
         auto textureValues = (float*)textureBlob->getBufferPointer();
 
         ValidationTextureData textureResults;
         textureResults.extent = textureInfo->extent;
         textureResults.textureData = textureValues;
-        textureResults.pitches.x = (uint32_t)pixelSize;
-        textureResults.pitches.y = (uint32_t)rowPitch;
+        textureResults.pitches.x = (uint32_t)layout.colPitch;
+        textureResults.pitches.y = (uint32_t)layout.rowPitch;
         textureResults.pitches.z = textureResults.extent.height * textureResults.pitches.y;
 
         validateTextureValues(textureResults);

--- a/tests/testing.cpp
+++ b/tests/testing.cpp
@@ -330,15 +330,14 @@ void compareComputeResult(
 {
     // Read back the results.
     ComPtr<ISlangBlob> resultBlob;
-    size_t rowPitch = 0;
-    size_t pixelSize = 0;
-    REQUIRE_CALL(device->readTexture(texture, 0, 0, resultBlob.writeRef(), &rowPitch, &pixelSize));
+    SubresourceLayout layout;
+    REQUIRE_CALL(device->readTexture(texture, 0, 0, resultBlob.writeRef(), &layout));
     // Compare results.
     for (size_t row = 0; row < rowCount; row++)
     {
         CHECK(
             memcmp(
-                (uint8_t*)resultBlob->getBufferPointer() + rowPitch * row,
+                (uint8_t*)resultBlob->getBufferPointer() + layout.rowPitch * row,
                 (uint8_t*)expectedResult + expectedResultRowPitch * row,
                 expectedResultRowPitch
             ) == 0


### PR DESCRIPTION
- add `Device::readTexture` that writes to user provided buffer
- remove various `readTexture` variants that are now obsolete