### PR TITLE
Fix clang compiler flag

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -440,6 +440,7 @@ target_compile_options(slang-rhi PRIVATE
         -Wno-unused-parameter
         -Wno-missing-field-initializers
         -Wno-sign-compare
+        -Wno-gnu-anonymous-struct
         -Wno-gnu-zero-variadic-macro-arguments
         -Wno-nested-anon-types
         -Wno-cast-function-type-mismatch


### PR DESCRIPTION
Add `-Wno-gnu-anonymous-struct` flag to all Clang targets. This should resolve https://github.com/shader-slang/slangpy/issues/190