### PR TITLE
Fix CUDA_PATH on NixOS

### DIFF
--- a/src/cuda/cuda-nvrtc.cpp
+++ b/src/cuda/cuda-nvrtc.cpp
@@ -73,6 +73,7 @@ inline void findNVRTCPaths(std::vector<std::filesystem::path>& outPaths)
         if (path)
         {
             outPaths.push_back(std::filesystem::path(path) / "lib64");
+            outPaths.push_back(std::filesystem::path(path) / "lib");
         }
     }
     // Next, check default installation paths.


### PR DESCRIPTION
The current implementation of `findNVRTCPaths` on Linux only searched "lib64" under `CUDA_PATH` this caused create device failure on NixOS as nixpkgs stores libnvrtc under `${pkgs.cudatoolkit}/lib`:

```
~/personal/slangpy (feat-flake-and-uv-support ✔) echo $CUDA_PATH 
/nix/store/z9zaxg2bghjc76v8lif7sj882d2m3p45-cuda-merged-12.4
~/personal/slangpy (feat-flake-and-uv-support ✔) ls $CUDA_PATH 
bin  compute-sanitizer  extras  include  lib  LICENSE  nix-support  nvml  nvvm  share  src
~/personal/slangpy (feat-flake-and-uv-support ✔) ls -la $CUDA_PATH/lib | grep nvrtc
lrwxrwxrwx  1 root root   25 Dec 31  1969 libnvrtc-builtins.so -> libnvrtc-builtins.so.12.4
lrwxrwxrwx  1 root root   28 Dec 31  1969 libnvrtc-builtins.so.12.4 -> libnvrtc-builtins.so.12.4.99
lrwxrwxrwx  1 root root   99 Dec 31  1969 libnvrtc-builtins.so.12.4.99 -> /nix/store/7ybyvq8dpv68ifnryilmp5dy5c1p2zi9-cuda_nvrtc-12.4.99-lib/lib/libnvrtc-builtins.so.12.4.99
lrwxrwxrwx  1 root root   14 Dec 31  1969 libnvrtc.so -> libnvrtc.so.12
lrwxrwxrwx  1 root root   19 Dec 31  1969 libnvrtc.so.12 -> libnvrtc.so.12.4.99
lrwxrwxrwx  1 root root   90 Dec 31  1969 libnvrtc.so.12.4.99 -> /nix/store/7ybyvq8dpv68ifnryilmp5dy5c1p2zi9-cuda_nvrtc-12.4.99-lib/lib/libnvrtc.so.12.4.99
```

Adding `lib` to the search path should solve this issue,