### PR TITLE
Improve CUDA error reporting

### DIFF
--- a/src/cpu/cpu-command.cpp
+++ b/src/cpu/cpu-command.cpp
@@ -91,7 +91,7 @@ Result CommandExecutor::execute(CommandBufferImpl* commandBuffer)
     return SLANG_OK;
 }
 
-#define NOT_SUPPORTED(x) m_device->warning(x " command is not supported!")
+#define NOT_SUPPORTED(x) m_device->printWarning(x " command is not supported!")
 
 void CommandExecutor::cmdCopyBuffer(const commands::CopyBuffer& cmd)
 {

--- a/src/cuda/cuda-clear-engine.cpp
+++ b/src/cuda/cuda-clear-engine.cpp
@@ -25,7 +25,7 @@ Result ClearEngine::initialize(IDebugCallback* debugCallback)
     }
 
     // Load PTX module
-    SLANG_CUDA_RETURN_ON_FAIL(cuModuleLoadData(&m_module, compileResult.ptx.data()));
+    SLANG_CUDA_RETURN_ON_FAIL_REPORT(cuModuleLoadData(&m_module, compileResult.ptx.data()), debugCallback);
 
     // Get clear kernel functions
     for (size_t dim = 0; dim < size_t(Dimension::Count); ++dim)
@@ -51,7 +51,10 @@ Result ClearEngine::initialize(IDebugCallback* debugCallback)
                     sizeNames[size],
                     layeredNames[layered]
                 );
-                SLANG_CUDA_RETURN_ON_FAIL(cuModuleGetFunction(&m_clearFunction[dim][size][layered], m_module, name));
+                SLANG_CUDA_RETURN_ON_FAIL_REPORT(
+                    cuModuleGetFunction(&m_clearFunction[dim][size][layered], m_module, name),
+                    debugCallback
+                );
             }
         }
     }

--- a/src/cuda/cuda-command.cpp
+++ b/src/cuda/cuda-command.cpp
@@ -113,7 +113,7 @@ Result CommandExecutor::execute(CommandBufferImpl* commandBuffer)
     return SLANG_OK;
 }
 
-#define NOT_SUPPORTED(x) m_device->warning(x " command is not supported!")
+#define NOT_SUPPORTED(x) m_device->printWarning(x " command is not supported!")
 
 void CommandExecutor::cmdCopyBuffer(const commands::CopyBuffer& cmd)
 {

--- a/src/cuda/cuda-command.cpp
+++ b/src/cuda/cuda-command.cpp
@@ -773,8 +773,8 @@ Result CommandQueueImpl::waitOnHost()
 {
     SLANG_CUDA_CTX_SCOPE(getDevice<DeviceImpl>());
 
-    SLANG_CUDA_RETURN_ON_FAIL(cuStreamSynchronize(m_stream));
-    SLANG_CUDA_RETURN_ON_FAIL(cuCtxSynchronize());
+    SLANG_CUDA_RETURN_ON_FAIL_REPORT(cuStreamSynchronize(m_stream), this);
+    SLANG_CUDA_RETURN_ON_FAIL_REPORT(cuCtxSynchronize(), this);
     return SLANG_OK;
 }
 

--- a/src/cuda/cuda-constant-buffer-pool.cpp
+++ b/src/cuda/cuda-constant-buffer-pool.cpp
@@ -98,7 +98,7 @@ Result ConstantBufferPool::createPage(size_t size, Page& outPage)
     {
         return SLANG_FAIL;
     }
-    SLANG_CUDA_RETURN_ON_FAIL(cuMemAlloc(&outPage.deviceData, size));
+    SLANG_CUDA_RETURN_ON_FAIL_REPORT(cuMemAlloc(&outPage.deviceData, size), m_device);
     outPage.size = size;
     return SLANG_OK;
 }

--- a/src/cuda/cuda-device.cpp
+++ b/src/cuda/cuda-device.cpp
@@ -224,13 +224,10 @@ Result DeviceImpl::initialize(const DeviceDesc& desc)
 
     // Query device limits
     {
-        CUresult lastResult = CUDA_SUCCESS;
         auto getAttribute = [&](CUdevice_attribute attribute) -> int
         {
-            int value;
-            CUresult result = cuDeviceGetAttribute(&value, attribute, m_ctx.device);
-            if (result != CUDA_SUCCESS)
-                lastResult = result;
+            int value = 0;
+            cuDeviceGetAttribute(&value, attribute, m_ctx.device);
             return value;
         };
 
@@ -252,11 +249,6 @@ Result DeviceImpl::initialize(const DeviceDesc& desc)
             getAttribute(CU_DEVICE_ATTRIBUTE_MAXIMUM_SURFACE2D_LAYERED_LAYERS),
         });
 
-        // limits.maxVertexInputElements
-        // limits.maxVertexInputElementOffset
-        // limits.maxVertexStreams
-        // limits.maxVertexStreamStride
-
         limits.maxComputeThreadsPerGroup = getAttribute(CU_DEVICE_ATTRIBUTE_MAX_THREADS_PER_BLOCK);
         limits.maxComputeThreadGroupSize[0] = getAttribute(CU_DEVICE_ATTRIBUTE_MAX_BLOCK_DIM_X);
         limits.maxComputeThreadGroupSize[1] = getAttribute(CU_DEVICE_ATTRIBUTE_MAX_BLOCK_DIM_Y);
@@ -265,15 +257,7 @@ Result DeviceImpl::initialize(const DeviceDesc& desc)
         limits.maxComputeDispatchThreadGroups[1] = getAttribute(CU_DEVICE_ATTRIBUTE_MAX_GRID_DIM_Y);
         limits.maxComputeDispatchThreadGroups[2] = getAttribute(CU_DEVICE_ATTRIBUTE_MAX_GRID_DIM_Z);
 
-        // limits.maxViewports
-        // limits.maxViewportDimensions
-        // limits.maxFramebufferDimensions
-
-        // limits.maxShaderVisibleSamplers
-
         m_info.limits = limits;
-
-        SLANG_CUDA_RETURN_ON_FAIL(lastResult);
     }
 
     // Initialize features & capabilities

--- a/src/cuda/cuda-device.cpp
+++ b/src/cuda/cuda-device.cpp
@@ -63,17 +63,26 @@ Result DeviceImpl::_findMaxFlopsDeviceIndex(int* outDeviceIndex)
     int deviceCount = 0;
 
     uint64_t maxComputePerf = 0;
-    SLANG_CUDA_RETURN_ON_FAIL(cuDeviceGetCount(&deviceCount));
+    SLANG_CUDA_RETURN_ON_FAIL_REPORT(cuDeviceGetCount(&deviceCount), this);
 
     // Find the best CUDA capable GPU device
     for (int currentDevice = 0; currentDevice < deviceCount; ++currentDevice)
     {
         CUdevice device;
-        SLANG_CUDA_RETURN_ON_FAIL(cuDeviceGet(&device, currentDevice));
+        SLANG_CUDA_RETURN_ON_FAIL_REPORT(cuDeviceGet(&device, currentDevice), this);
         int computeMode = -1, major = 0, minor = 0;
-        SLANG_CUDA_RETURN_ON_FAIL(cuDeviceGetAttribute(&computeMode, CU_DEVICE_ATTRIBUTE_COMPUTE_MODE, device));
-        SLANG_CUDA_RETURN_ON_FAIL(cuDeviceGetAttribute(&major, CU_DEVICE_ATTRIBUTE_COMPUTE_CAPABILITY_MAJOR, device));
-        SLANG_CUDA_RETURN_ON_FAIL(cuDeviceGetAttribute(&minor, CU_DEVICE_ATTRIBUTE_COMPUTE_CAPABILITY_MINOR, device));
+        SLANG_CUDA_RETURN_ON_FAIL_REPORT(
+            cuDeviceGetAttribute(&computeMode, CU_DEVICE_ATTRIBUTE_COMPUTE_MODE, device),
+            this
+        );
+        SLANG_CUDA_RETURN_ON_FAIL_REPORT(
+            cuDeviceGetAttribute(&major, CU_DEVICE_ATTRIBUTE_COMPUTE_CAPABILITY_MAJOR, device),
+            this
+        );
+        SLANG_CUDA_RETURN_ON_FAIL_REPORT(
+            cuDeviceGetAttribute(&minor, CU_DEVICE_ATTRIBUTE_COMPUTE_CAPABILITY_MINOR, device),
+            this
+        );
 
         // If this GPU is not running on Compute Mode prohibited,
         // then we can add it to the list
@@ -89,10 +98,14 @@ Result DeviceImpl::_findMaxFlopsDeviceIndex(int* outDeviceIndex)
             }
 
             int multiProcessorCount = 0, clockRate = 0;
-            SLANG_CUDA_RETURN_ON_FAIL(
-                cuDeviceGetAttribute(&multiProcessorCount, CU_DEVICE_ATTRIBUTE_MULTIPROCESSOR_COUNT, device)
+            SLANG_CUDA_RETURN_ON_FAIL_REPORT(
+                cuDeviceGetAttribute(&multiProcessorCount, CU_DEVICE_ATTRIBUTE_MULTIPROCESSOR_COUNT, device),
+                this
             );
-            SLANG_CUDA_RETURN_ON_FAIL(cuDeviceGetAttribute(&clockRate, CU_DEVICE_ATTRIBUTE_CLOCK_RATE, device));
+            SLANG_CUDA_RETURN_ON_FAIL_REPORT(
+                cuDeviceGetAttribute(&clockRate, CU_DEVICE_ATTRIBUTE_CLOCK_RATE, device),
+                this
+            );
             uint64_t compute_perf = uint64_t(multiProcessorCount) * smPerMultiproc * clockRate;
 
             if (compute_perf > maxComputePerf)
@@ -112,14 +125,14 @@ Result DeviceImpl::_findMaxFlopsDeviceIndex(int* outDeviceIndex)
     return SLANG_OK;
 }
 
-Result DeviceImpl::_initCuda(CUDAReportStyle reportType)
+Result DeviceImpl::_initCuda()
 {
     if (!rhiCudaDriverApiInit())
     {
+        error("Failed to initialize CUDA driver API.");
         return SLANG_FAIL;
     }
-    CUresult res = cuInit(0);
-    SLANG_CUDA_RETURN_WITH_REPORT_ON_FAIL(res, reportType);
+    SLANG_CUDA_RETURN_ON_FAIL_REPORT(cuInit(0), this);
     return SLANG_OK;
 }
 
@@ -170,7 +183,7 @@ Result DeviceImpl::initialize(const DeviceDesc& desc)
 {
     SLANG_RETURN_ON_FAIL(Device::initialize(desc));
 
-    SLANG_RETURN_ON_FAIL(_initCuda(kReportType));
+    SLANG_RETURN_ON_FAIL(_initCuda());
 
     int selectedDeviceIndex = -1;
     if (desc.adapterLUID)
@@ -191,9 +204,9 @@ Result DeviceImpl::initialize(const DeviceDesc& desc)
         SLANG_RETURN_ON_FAIL(_findMaxFlopsDeviceIndex(&selectedDeviceIndex));
     }
 
-    SLANG_CUDA_RETURN_ON_FAIL(cuDeviceGet(&m_ctx.device, selectedDeviceIndex));
+    SLANG_CUDA_RETURN_ON_FAIL_REPORT(cuDeviceGet(&m_ctx.device, selectedDeviceIndex), this);
 
-    SLANG_CUDA_RETURN_WITH_REPORT_ON_FAIL(cuCtxCreate(&m_ctx.context, 0, m_ctx.device), kReportType);
+    SLANG_CUDA_RETURN_ON_FAIL_REPORT(cuCtxCreate(&m_ctx.context, 0, m_ctx.device), this);
 
     SLANG_CUDA_CTX_SCOPE(this);
 
@@ -323,7 +336,10 @@ Result DeviceImpl::initialize(const DeviceDesc& desc)
             options.validationMode = desc.enableRayTracingValidation ? OPTIX_DEVICE_CONTEXT_VALIDATION_MODE_ALL
                                                                      : OPTIX_DEVICE_CONTEXT_VALIDATION_MODE_OFF;
 
-            SLANG_OPTIX_RETURN_ON_FAIL(optixDeviceContextCreate(m_ctx.context, &options, &m_ctx.optixContext));
+            SLANG_OPTIX_RETURN_ON_FAIL_REPORT(
+                optixDeviceContextCreate(m_ctx.context, &options, &m_ctx.optixContext),
+                this
+            );
 
             addFeature(Feature::AccelerationStructure);
             addFeature(Feature::AccelerationStructureSpheres);
@@ -331,7 +347,8 @@ Result DeviceImpl::initialize(const DeviceDesc& desc)
         }
         else
         {
-            SLANG_OPTIX_HANDLE_ERROR(result);
+            // TODO print error code
+            warning("Failed to initialize OptiX");
         }
     }
 #endif
@@ -499,7 +516,10 @@ Result DeviceImpl::readTexture(
     CUarray srcArray = textureImpl->m_cudaArray;
     if (textureImpl->m_cudaMipMappedArray)
     {
-        SLANG_CUDA_RETURN_ON_FAIL(cuMipmappedArrayGetLevel(&srcArray, textureImpl->m_cudaMipMappedArray, mip));
+        SLANG_CUDA_RETURN_ON_FAIL_REPORT(
+            cuMipmappedArrayGetLevel(&srcArray, textureImpl->m_cudaMipMappedArray, mip),
+            this
+        );
     }
 
     CUDA_MEMCPY3D copyParam = {};
@@ -512,7 +532,7 @@ Result DeviceImpl::readTexture(
     copyParam.WidthInBytes = layout.rowPitch;
     copyParam.Height = (layout.size.height + layout.blockHeight - 1) / layout.blockHeight;
     copyParam.Depth = layout.size.depth;
-    SLANG_CUDA_RETURN_ON_FAIL(cuMemcpy3D(&copyParam));
+    SLANG_CUDA_RETURN_ON_FAIL_REPORT(cuMemcpy3D(&copyParam), this);
 
     return SLANG_OK;
 }
@@ -526,8 +546,9 @@ Result DeviceImpl::readBuffer(IBuffer* buffer, size_t offset, size_t size, void*
     {
         return SLANG_FAIL;
     }
-    SLANG_CUDA_RETURN_ON_FAIL(
-        cuMemcpy((CUdeviceptr)outData, (CUdeviceptr)((uint8_t*)bufferImpl->m_cudaMemory + offset), size)
+    SLANG_CUDA_RETURN_ON_FAIL_REPORT(
+        cuMemcpy((CUdeviceptr)outData, (CUdeviceptr)((uint8_t*)bufferImpl->m_cudaMemory + offset), size),
+        this
     );
     return SLANG_OK;
 }
@@ -547,13 +568,16 @@ Result DeviceImpl::getAccelerationStructureSizes(
     AccelerationStructureBuildDescConverter converter;
     SLANG_RETURN_ON_FAIL(converter.convert(desc, m_debugCallback));
     OptixAccelBufferSizes sizes;
-    SLANG_OPTIX_RETURN_ON_FAIL(optixAccelComputeMemoryUsage(
-        m_ctx.optixContext,
-        &converter.buildOptions,
-        converter.buildInputs.data(),
-        converter.buildInputs.size(),
-        &sizes
-    ));
+    SLANG_OPTIX_RETURN_ON_FAIL_REPORT(
+        optixAccelComputeMemoryUsage(
+            m_ctx.optixContext,
+            &converter.buildOptions,
+            converter.buildInputs.data(),
+            converter.buildInputs.size(),
+            &sizes
+        ),
+        this
+    );
     outSizes->accelerationStructureSize = sizes.outputSizeInBytes;
     outSizes->scratchSize = sizes.tempSizeInBytes;
     outSizes->updateScratchSize = sizes.tempUpdateSizeInBytes;
@@ -577,8 +601,8 @@ Result DeviceImpl::createAccelerationStructure(
         return SLANG_E_NOT_AVAILABLE;
     }
     RefPtr<AccelerationStructureImpl> result = new AccelerationStructureImpl(this, desc);
-    SLANG_CUDA_RETURN_ON_FAIL(cuMemAlloc(&result->m_buffer, desc.size));
-    SLANG_CUDA_RETURN_ON_FAIL(cuMemAlloc(&result->m_propertyBuffer, 8));
+    SLANG_CUDA_RETURN_ON_FAIL_REPORT(cuMemAlloc(&result->m_buffer, desc.size), this);
+    SLANG_CUDA_RETURN_ON_FAIL_REPORT(cuMemAlloc(&result->m_propertyBuffer, 8), this);
     returnComPtr(outAccelerationStructure, result);
     return SLANG_OK;
 #else

--- a/src/cuda/cuda-device.cpp
+++ b/src/cuda/cuda-device.cpp
@@ -129,7 +129,7 @@ Result DeviceImpl::_initCuda()
 {
     if (!rhiCudaDriverApiInit())
     {
-        error("Failed to initialize CUDA driver API.");
+        printError("Failed to initialize CUDA driver API.");
         return SLANG_FAIL;
     }
     SLANG_CUDA_RETURN_ON_FAIL_REPORT(cuInit(0), this);
@@ -347,8 +347,7 @@ Result DeviceImpl::initialize(const DeviceDesc& desc)
         }
         else
         {
-            // TODO print error code
-            warning("Failed to initialize OptiX");
+            printWarning("Failed to initialize OptiX: %s (%s)", optixGetErrorString(result), optixGetErrorName(result));
         }
     }
 #endif

--- a/src/cuda/cuda-device.h
+++ b/src/cuda/cuda-device.h
@@ -18,13 +18,11 @@ struct Context
 class DeviceImpl : public Device
 {
 private:
-    static const CUDAReportStyle kReportType = CUDAReportStyle::Normal;
-
     static int _calcSMCountPerMultiProcessor(int major, int minor);
 
-    static Result _findMaxFlopsDeviceIndex(int* outDeviceIndex);
+    Result _findMaxFlopsDeviceIndex(int* outDeviceIndex);
 
-    static Result _initCuda(CUDAReportStyle reportType = CUDAReportStyle::Normal);
+    Result _initCuda();
 
 public:
     Context m_ctx;

--- a/src/cuda/cuda-surface.cpp
+++ b/src/cuda/cuda-surface.cpp
@@ -570,7 +570,10 @@ Result SurfaceImpl::createFrameData(FrameData& frameData)
         externalSemaphoreHandleDesc.type = CU_EXTERNAL_SEMAPHORE_HANDLE_TYPE_TIMELINE_SEMAPHORE_FD;
         externalSemaphoreHandleDesc.handle.fd = (int)frameData.sharedSemaphoreHandle.value;
 #endif
-        SLANG_CUDA_RETURN_ON_FAIL(cuImportExternalSemaphore(&frameData.cudaSemaphore, &externalSemaphoreHandleDesc));
+        SLANG_CUDA_RETURN_ON_FAIL_REPORT(
+            cuImportExternalSemaphore(&frameData.cudaSemaphore, &externalSemaphoreHandleDesc),
+            m_deviceImpl->m_debugCallback
+        );
     }
 
     SLANG_RETURN_ON_FAIL(createSharedTexture(frameData.sharedTexture));

--- a/src/cuda/cuda-texture.cpp
+++ b/src/cuda/cuda-texture.cpp
@@ -259,7 +259,7 @@ Result DeviceImpl::createTexture(const TextureDesc& desc_, const SubresourceData
             arrayDesc.Width = desc.size.width;
             arrayDesc.Format = mapping.arrayFormat;
             arrayDesc.NumChannels = mapping.channelCount;
-            SLANG_CUDA_RETURN_ON_FAIL(cuArrayCreate(&tex->m_cudaArray, &arrayDesc));
+            SLANG_CUDA_RETURN_ON_FAIL_REPORT(cuArrayCreate(&tex->m_cudaArray, &arrayDesc), this);
         }
         else
         {
@@ -267,7 +267,10 @@ Result DeviceImpl::createTexture(const TextureDesc& desc_, const SubresourceData
             arrayDesc.Width = desc.size.width;
             arrayDesc.Format = mapping.arrayFormat;
             arrayDesc.NumChannels = mapping.channelCount;
-            SLANG_CUDA_RETURN_ON_FAIL(cuMipmappedArrayCreate(&tex->m_cudaMipMappedArray, &arrayDesc, desc.mipCount));
+            SLANG_CUDA_RETURN_ON_FAIL_REPORT(
+                cuMipmappedArrayCreate(&tex->m_cudaMipMappedArray, &arrayDesc, desc.mipCount),
+                this
+            );
         }
         break;
     case TextureType::Texture1DArray:
@@ -278,9 +281,10 @@ Result DeviceImpl::createTexture(const TextureDesc& desc_, const SubresourceData
         arrayDesc.Format = mapping.arrayFormat;
         arrayDesc.NumChannels = mapping.channelCount;
         arrayDesc.Flags = CUDA_ARRAY3D_LAYERED;
-        SLANG_CUDA_RETURN_ON_FAIL(
+        SLANG_CUDA_RETURN_ON_FAIL_REPORT(
             desc.mipCount == 1 ? cuArray3DCreate(&tex->m_cudaArray, &arrayDesc)
-                               : cuMipmappedArrayCreate(&tex->m_cudaMipMappedArray, &arrayDesc, desc.mipCount)
+                               : cuMipmappedArrayCreate(&tex->m_cudaMipMappedArray, &arrayDesc, desc.mipCount),
+            this
         );
         break;
     }
@@ -293,7 +297,7 @@ Result DeviceImpl::createTexture(const TextureDesc& desc_, const SubresourceData
             arrayDesc.Height = desc.size.height;
             arrayDesc.Format = mapping.arrayFormat;
             arrayDesc.NumChannels = mapping.channelCount;
-            SLANG_CUDA_RETURN_ON_FAIL(cuArrayCreate(&tex->m_cudaArray, &arrayDesc));
+            SLANG_CUDA_RETURN_ON_FAIL_REPORT(cuArrayCreate(&tex->m_cudaArray, &arrayDesc), this);
         }
         else
         {
@@ -302,7 +306,10 @@ Result DeviceImpl::createTexture(const TextureDesc& desc_, const SubresourceData
             arrayDesc.Height = desc.size.height;
             arrayDesc.Format = mapping.arrayFormat;
             arrayDesc.NumChannels = mapping.channelCount;
-            SLANG_CUDA_RETURN_ON_FAIL(cuMipmappedArrayCreate(&tex->m_cudaMipMappedArray, &arrayDesc, desc.mipCount));
+            SLANG_CUDA_RETURN_ON_FAIL_REPORT(
+                cuMipmappedArrayCreate(&tex->m_cudaMipMappedArray, &arrayDesc, desc.mipCount),
+                this
+            );
         }
         break;
     }
@@ -315,9 +322,10 @@ Result DeviceImpl::createTexture(const TextureDesc& desc_, const SubresourceData
         arrayDesc.Format = mapping.arrayFormat;
         arrayDesc.NumChannels = mapping.channelCount;
         arrayDesc.Flags = CUDA_ARRAY3D_LAYERED;
-        SLANG_CUDA_RETURN_ON_FAIL(
+        SLANG_CUDA_RETURN_ON_FAIL_REPORT(
             desc.mipCount == 1 ? cuArray3DCreate(&tex->m_cudaArray, &arrayDesc)
-                               : cuMipmappedArrayCreate(&tex->m_cudaMipMappedArray, &arrayDesc, desc.mipCount)
+                               : cuMipmappedArrayCreate(&tex->m_cudaMipMappedArray, &arrayDesc, desc.mipCount),
+            this
         );
         break;
     }
@@ -332,9 +340,10 @@ Result DeviceImpl::createTexture(const TextureDesc& desc_, const SubresourceData
         arrayDesc.Depth = desc.size.depth;
         arrayDesc.Format = mapping.arrayFormat;
         arrayDesc.NumChannels = mapping.channelCount;
-        SLANG_CUDA_RETURN_ON_FAIL(
+        SLANG_CUDA_RETURN_ON_FAIL_REPORT(
             desc.mipCount == 1 ? cuArray3DCreate(&tex->m_cudaArray, &arrayDesc)
-                               : cuMipmappedArrayCreate(&tex->m_cudaMipMappedArray, &arrayDesc, desc.mipCount)
+                               : cuMipmappedArrayCreate(&tex->m_cudaMipMappedArray, &arrayDesc, desc.mipCount),
+            this
         );
         break;
     }
@@ -347,9 +356,10 @@ Result DeviceImpl::createTexture(const TextureDesc& desc_, const SubresourceData
         arrayDesc.Format = mapping.arrayFormat;
         arrayDesc.NumChannels = mapping.channelCount;
         arrayDesc.Flags = CUDA_ARRAY3D_CUBEMAP;
-        SLANG_CUDA_RETURN_ON_FAIL(
+        SLANG_CUDA_RETURN_ON_FAIL_REPORT(
             desc.mipCount == 1 ? cuArray3DCreate(&tex->m_cudaArray, &arrayDesc)
-                               : cuMipmappedArrayCreate(&tex->m_cudaMipMappedArray, &arrayDesc, desc.mipCount)
+                               : cuMipmappedArrayCreate(&tex->m_cudaMipMappedArray, &arrayDesc, desc.mipCount),
+            this
         );
         break;
     }
@@ -362,9 +372,10 @@ Result DeviceImpl::createTexture(const TextureDesc& desc_, const SubresourceData
         arrayDesc.Format = mapping.arrayFormat;
         arrayDesc.NumChannels = mapping.channelCount;
         arrayDesc.Flags = CUDA_ARRAY3D_CUBEMAP | CUDA_ARRAY3D_LAYERED;
-        SLANG_CUDA_RETURN_ON_FAIL(
+        SLANG_CUDA_RETURN_ON_FAIL_REPORT(
             desc.mipCount == 1 ? cuArray3DCreate(&tex->m_cudaArray, &arrayDesc)
-                               : cuMipmappedArrayCreate(&tex->m_cudaMipMappedArray, &arrayDesc, desc.mipCount)
+                               : cuMipmappedArrayCreate(&tex->m_cudaMipMappedArray, &arrayDesc, desc.mipCount),
+            this
         );
         break;
     }
@@ -387,7 +398,10 @@ Result DeviceImpl::createTexture(const TextureDesc& desc_, const SubresourceData
                 CUarray dstArray = tex->m_cudaArray;
                 if (tex->m_cudaMipMappedArray)
                 {
-                    SLANG_CUDA_RETURN_ON_FAIL(cuMipmappedArrayGetLevel(&dstArray, tex->m_cudaMipMappedArray, mip));
+                    SLANG_CUDA_RETURN_ON_FAIL_REPORT(
+                        cuMipmappedArrayGetLevel(&dstArray, tex->m_cudaMipMappedArray, mip),
+                        this
+                    );
                 }
 
                 CUDA_MEMCPY3D copyParam = {};
@@ -401,7 +415,7 @@ Result DeviceImpl::createTexture(const TextureDesc& desc_, const SubresourceData
                 copyParam.WidthInBytes = widthInBlocks(formatInfo, mipSize.width) * mapping.elementSize;
                 copyParam.Height = heightInBlocks(formatInfo, mipSize.height);
                 copyParam.Depth = mipSize.depth;
-                SLANG_CUDA_RETURN_ON_FAIL(cuMemcpy3D(&copyParam));
+                SLANG_CUDA_RETURN_ON_FAIL_REPORT(cuMemcpy3D(&copyParam), this);
             }
         }
     }
@@ -447,7 +461,7 @@ Result DeviceImpl::createTextureFromSharedHandle(
     externalMemoryHandleDesc.flags = 0; // CUDA_EXTERNAL_MEMORY_DEDICATED;
 
     CUexternalMemory externalMemory;
-    SLANG_CUDA_RETURN_ON_FAIL(cuImportExternalMemory(&externalMemory, &externalMemoryHandleDesc));
+    SLANG_CUDA_RETURN_ON_FAIL_REPORT(cuImportExternalMemory(&externalMemory, &externalMemoryHandleDesc), this);
     texture->m_cudaExternalMemory = externalMemory;
 
     const FormatMapping& mapping = getFormatMapping(desc.format);
@@ -471,7 +485,9 @@ Result DeviceImpl::createTextureFromSharedHandle(
     externalMemoryMipDesc.numLevels = desc.mipCount;
 
     CUmipmappedArray mipArray;
-    SLANG_CUDA_RETURN_ON_FAIL(cuExternalMemoryGetMappedMipmappedArray(&mipArray, externalMemory, &externalMemoryMipDesc)
+    SLANG_CUDA_RETURN_ON_FAIL_REPORT(
+        cuExternalMemoryGetMappedMipmappedArray(&mipArray, externalMemory, &externalMemoryMipDesc),
+        this
     );
     texture->m_cudaMipMappedArray = mipArray;
 

--- a/src/d3d11/d3d11-command.cpp
+++ b/src/d3d11/d3d11-command.cpp
@@ -125,7 +125,7 @@ Result CommandExecutor::execute(CommandBufferImpl* commandBuffer)
     return SLANG_OK;
 }
 
-#define NOT_SUPPORTED(x) m_device->warning(x " command is not supported!")
+#define NOT_SUPPORTED(x) m_device->printWarning(x " command is not supported!")
 
 void CommandExecutor::cmdCopyBuffer(const commands::CopyBuffer& cmd)
 {
@@ -552,7 +552,7 @@ void CommandExecutor::cmdDrawIndirect(const commands::DrawIndirect& cmd)
     // D3D11 does not support sourcing the count from a buffer.
     if (cmd.countBuffer)
     {
-        m_device->warning(S_RenderPassEncoder_drawIndirect " with countBuffer not supported");
+        m_device->printWarning(S_RenderPassEncoder_drawIndirect " with countBuffer not supported");
         return;
     }
 
@@ -569,7 +569,7 @@ void CommandExecutor::cmdDrawIndexedIndirect(const commands::DrawIndexedIndirect
     // D3D11 does not support sourcing the count from a buffer.
     if (cmd.countBuffer)
     {
-        m_device->warning(S_RenderPassEncoder_drawIndirect " with countBuffer not supported");
+        m_device->printWarning(S_RenderPassEncoder_drawIndirect " with countBuffer not supported");
         return;
     }
 

--- a/src/d3d12/d3d12-command.cpp
+++ b/src/d3d12/d3d12-command.cpp
@@ -160,7 +160,7 @@ Result CommandRecorder::record(CommandBufferImpl* commandBuffer)
     return SLANG_OK;
 }
 
-#define NOT_SUPPORTED(x) m_device->warning(S_CommandEncoder_##x " command is not supported!")
+#define NOT_SUPPORTED(x) m_device->printWarning(S_CommandEncoder_##x " command is not supported!")
 
 void CommandRecorder::cmdCopyBuffer(const commands::CopyBuffer& cmd)
 {

--- a/src/device.cpp
+++ b/src/device.cpp
@@ -3,6 +3,7 @@
 #include "rhi-shared.h"
 
 #include <algorithm>
+#include <cstdarg>
 
 namespace rhi {
 
@@ -77,6 +78,36 @@ void ShaderCache::addSpecializedPipeline(PipelineKey key, RefPtr<Pipeline> speci
 // ----------------------------------------------------------------------------
 // Device
 // ----------------------------------------------------------------------------
+
+void Device::printMessage(DebugMessageType type, DebugMessageSource source, const char* message, ...)
+{
+    va_list args;
+    va_start(args, message);
+    char buffer[4096];
+    vsnprintf(buffer, sizeof(buffer), message, args);
+    va_end(args);
+    handleMessage(type, source, buffer);
+}
+
+void Device::printWarning(const char* message, ...)
+{
+    va_list args;
+    va_start(args, message);
+    char buffer[4096];
+    vsnprintf(buffer, sizeof(buffer), message, args);
+    va_end(args);
+    handleMessage(DebugMessageType::Warning, DebugMessageSource::Layer, buffer);
+}
+
+void Device::printError(const char* message, ...)
+{
+    va_list args;
+    va_start(args, message);
+    char buffer[4096];
+    vsnprintf(buffer, sizeof(buffer), message, args);
+    va_end(args);
+    handleMessage(DebugMessageType::Error, DebugMessageSource::Layer, buffer);
+}
 
 Result Device::createShaderObject(ShaderObjectLayout* layout, ShaderObject** outObject)
 {

--- a/src/device.h
+++ b/src/device.h
@@ -276,15 +276,9 @@ public:
         m_debugCallback->handleMessage(type, source, message);
     }
 
-    inline void warning(const char* message)
-    {
-        handleMessage(DebugMessageType::Warning, DebugMessageSource::Layer, message);
-    }
-
-    inline void error(const char* message)
-    {
-        handleMessage(DebugMessageType::Error, DebugMessageSource::Layer, message);
-    }
+    void printMessage(DebugMessageType type, DebugMessageSource source, const char* message, ...);
+    void printWarning(const char* message, ...);
+    void printError(const char* message, ...);
 
     Result createShaderObject(ShaderObjectLayout* layout, ShaderObject** outObject);
     Result createRootShaderObject(ShaderProgram* program, RootShaderObject** outObject);

--- a/src/device.h
+++ b/src/device.h
@@ -281,6 +281,11 @@ public:
         handleMessage(DebugMessageType::Warning, DebugMessageSource::Layer, message);
     }
 
+    inline void error(const char* message)
+    {
+        handleMessage(DebugMessageType::Error, DebugMessageSource::Layer, message);
+    }
+
     Result createShaderObject(ShaderObjectLayout* layout, ShaderObject** outObject);
     Result createRootShaderObject(ShaderProgram* program, RootShaderObject** outObject);
 

--- a/src/metal/metal-command.cpp
+++ b/src/metal/metal-command.cpp
@@ -144,7 +144,7 @@ Result CommandRecorder::record(CommandBufferImpl* commandBuffer)
     return SLANG_OK;
 }
 
-#define NOT_SUPPORTED(x) m_device->warning(x " command is not supported!")
+#define NOT_SUPPORTED(x) m_device->printWarning(x " command is not supported!")
 
 void CommandRecorder::cmdCopyBuffer(const commands::CopyBuffer& cmd)
 {

--- a/src/rhi-shared.h
+++ b/src/rhi-shared.h
@@ -309,6 +309,29 @@ public:
     StructHolder m_configHolder;
 };
 
+struct DebugCallbackAdapter
+{
+    IDebugCallback* callback;
+    DebugCallbackAdapter(IDebugCallback* callback)
+        : callback(callback)
+    {
+    }
+    DebugCallbackAdapter(Device* device)
+        : callback(device ? device->m_debugCallback : nullptr)
+    {
+    }
+    DebugCallbackAdapter(DeviceChild* deviceChild)
+        : callback(deviceChild && deviceChild->getDevice() ? deviceChild->getDevice()->m_debugCallback : nullptr)
+    {
+    }
+    DebugCallbackAdapter(const BreakableReference<Device>& device)
+        : callback(device ? device->m_debugCallback : nullptr)
+    {
+    }
+    explicit operator bool() const { return callback != nullptr; }
+    IDebugCallback* operator->() const { return callback; }
+};
+
 bool isDepthFormat(Format format);
 bool isStencilFormat(Format format);
 

--- a/src/vulkan/vk-command.cpp
+++ b/src/vulkan/vk-command.cpp
@@ -188,7 +188,7 @@ Result CommandRecorder::record(CommandBufferImpl* commandBuffer)
     return SLANG_OK;
 }
 
-#define NOT_SUPPORTED(x) m_device->warning(x " command is not supported!")
+#define NOT_SUPPORTED(x) m_device->printWarning(x " command is not supported!")
 
 void CommandRecorder::cmdCopyBuffer(const commands::CopyBuffer& cmd)
 {

--- a/src/wgpu/wgpu-command.cpp
+++ b/src/wgpu/wgpu-command.cpp
@@ -99,7 +99,7 @@ Result CommandRecorder::record(CommandBufferImpl* commandBuffer)
 {
     auto existingError = m_device->getAndClearLastError();
     if (existingError != WGPUErrorType_NoError)
-        m_device->warning("Web GPU device had reported error before command record.");
+        m_device->printWarning("Web GPU device had reported error before command record.");
 
     m_commandEncoder = m_ctx.api.wgpuDeviceCreateCommandEncoder(m_ctx.device, nullptr);
     SLANG_RHI_DEFERRED({ m_ctx.api.wgpuCommandEncoderRelease(m_commandEncoder); });
@@ -147,7 +147,7 @@ Result CommandRecorder::record(CommandBufferImpl* commandBuffer)
     return SLANG_OK;
 }
 
-#define NOT_SUPPORTED(x) m_device->warning(x " command is not supported!")
+#define NOT_SUPPORTED(x) m_device->printWarning(x " command is not supported!")
 
 void CommandRecorder::cmdCopyBuffer(const commands::CopyBuffer& cmd)
 {

--- a/src/wgpu/wgpu-shader-program.cpp
+++ b/src/wgpu/wgpu-shader-program.cpp
@@ -26,7 +26,7 @@ Result ShaderProgramImpl::createShaderModule(slang::EntryPointReflection* entryP
 {
     auto existingError = m_device->getAndClearLastError();
     if (existingError != WGPUErrorType_NoError)
-        m_device->warning("Web GPU device had reported error before shader compilation.");
+        m_device->printWarning("Web GPU device had reported error before shader compilation.");
 
     Module module;
     module.stage = entryPointInfo->getStage();


### PR DESCRIPTION
- report CUDA/OptiX errors through the debug callback
- add `Device::printMessage`, `Device::printError` and `Device::printWarning` for formatted messages
- make OptiX initialization optional, not aborting device creation (OptiX support is optional)