### PR TITLE
Pipeline cache

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -746,6 +746,7 @@ if(SLANG_RHI_BUILD_TESTS)
         tests/test-null-views.cpp
         tests/test-nvrtc.cpp
         tests/test-offset-allocator.cpp
+        tests/test-pipeline-cache.cpp
         # tests/test-precompiled-module-cache.cpp
         tests/test-precompiled-module.cpp
         tests/test-ray-tracing.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -714,6 +714,7 @@ if(SLANG_RHI_BUILD_TESTS)
         tests/test-arena-allocator.cpp
         tests/test-benchmark-command.cpp
         tests/test-bindless-descriptor-handles.cpp
+        tests/test-blob.cpp
         tests/test-buffer-barrier.cpp
         tests/test-buffer-from-handle.cpp
         tests/test-buffer-shared.cpp

--- a/include/slang-rhi.h
+++ b/include/slang-rhi.h
@@ -2595,8 +2595,6 @@ struct DeviceDesc
     uint32_t requiredFeatureCount = 0;
     // Array of required feature names, whose size is `requiredFeatureCount`.
     const char** requiredFeatures = nullptr;
-    // A command dispatcher object that intercepts and handles actual low-level API call.
-    ISlangUnknown* apiCommandDispatcher = nullptr;
     // Configurations for Slang compiler.
     SlangDesc slang = {};
 
@@ -3019,35 +3017,6 @@ class IPersistentCache : public ISlangUnknown
 public:
     virtual SLANG_NO_THROW Result SLANG_MCALL writeCache(ISlangBlob* key, ISlangBlob* data) = 0;
     virtual SLANG_NO_THROW Result SLANG_MCALL queryCache(ISlangBlob* key, ISlangBlob** outData) = 0;
-};
-
-class IPipelineCreationAPIDispatcher : public ISlangUnknown
-{
-    SLANG_COM_INTERFACE(0x8d7aa89d, 0x07f1, 0x4e21, {0xbc, 0xd2, 0x9a, 0x71, 0xc7, 0x95, 0xba, 0x91});
-
-public:
-    virtual SLANG_NO_THROW Result SLANG_MCALL createComputePipeline(
-        IDevice* device,
-        slang::IComponentType* program,
-        void* pipelineDesc,
-        void** outPipelineState
-    ) = 0;
-    virtual SLANG_NO_THROW Result SLANG_MCALL createRenderPipeline(
-        IDevice* device,
-        slang::IComponentType* program,
-        void* pipelineDesc,
-        void** outPipelineState
-    ) = 0;
-    virtual SLANG_NO_THROW Result SLANG_MCALL createMeshPipeline(
-        IDevice* device,
-        slang::IComponentType* program,
-        void* pipelineDesc,
-        void** outPipelineState
-    ) = 0;
-    virtual SLANG_NO_THROW Result SLANG_MCALL
-    beforeCreateRayTracingState(IDevice* device, slang::IComponentType* program) = 0;
-    virtual SLANG_NO_THROW Result SLANG_MCALL
-    afterCreateRayTracingState(IDevice* device, slang::IComponentType* program) = 0;
 };
 
 class IRHI

--- a/include/slang-rhi.h
+++ b/include/slang-rhi.h
@@ -3086,6 +3086,16 @@ public:
         return device;
     }
 
+    /// Create a blob. If `data` is non-null, then it must point to a buffer of size `size`.
+    virtual SLANG_NO_THROW Result SLANG_MCALL createBlob(const void* data, size_t size, ISlangBlob** outBlob) = 0;
+
+    ComPtr<ISlangBlob> createBlob(const void* data, size_t size)
+    {
+        ComPtr<ISlangBlob> blob;
+        SLANG_RETURN_NULL_ON_FAIL(createBlob(data, size, blob.writeRef()));
+        return blob;
+    }
+
     /// Reports current set of live objects.
     /// Currently this just calls D3D's ReportLiveObjects.
     virtual SLANG_NO_THROW Result SLANG_MCALL reportLiveObjects() = 0;

--- a/include/slang-rhi.h
+++ b/include/slang-rhi.h
@@ -2961,9 +2961,6 @@ public:
 
     virtual SLANG_NO_THROW Result SLANG_MCALL
     convertCooperativeVectorMatrix(const ConvertCooperativeVectorMatrixDesc* descs, uint32_t descCount) = 0;
-
-    virtual SLANG_NO_THROW Result SLANG_MCALL
-    getShaderCacheStats(size_t* outCacheHitCount, size_t* outCacheMissCount, size_t* outCacheSize) = 0;
 };
 
 class ITaskPool : public ISlangUnknown

--- a/include/slang-rhi.h
+++ b/include/slang-rhi.h
@@ -107,6 +107,7 @@ enum class DeviceType
     x(ParameterBlock,                           "parameter-block"                               ) \
     x(Bindless,                                 "bindless"                                      ) \
     x(Surface,                                  "surface"                                       ) \
+    x(PipelineCache,                            "pipeline-cache"                                ) \
     /* Rasterization features */                                                                  \
     x(Rasterization,                            "rasterization"                                 ) \
     x(Barycentrics,                             "barycentrics"                                  ) \

--- a/include/slang-rhi.h
+++ b/include/slang-rhi.h
@@ -2601,6 +2601,8 @@ struct DeviceDesc
 
     // Interface to persistent shader cache.
     IPersistentCache* persistentShaderCache = nullptr;
+    // Interface to persistent pipeline cache.
+    IPersistentCache* persistentPipelineCache = nullptr;
 
     /// NVAPI shader extension uav slot (-1 disables the extension).
     uint32_t nvapiExtUavSlot = uint32_t(-1);

--- a/include/slang-rhi.h
+++ b/include/slang-rhi.h
@@ -178,7 +178,7 @@ enum class AccessFlag
     Write,
 };
 
-class IPersistentShaderCache;
+class IPersistentCache;
 
 /// Defines how linking should be performed for a shader program.
 enum class LinkingStyle
@@ -2600,7 +2600,7 @@ struct DeviceDesc
     SlangDesc slang = {};
 
     // Interface to persistent shader cache.
-    IPersistentShaderCache* persistentShaderCache = nullptr;
+    IPersistentCache* persistentShaderCache = nullptr;
 
     /// NVAPI shader extension uav slot (-1 disables the extension).
     uint32_t nvapiExtUavSlot = uint32_t(-1);
@@ -3009,7 +3009,7 @@ public:
     virtual SLANG_NO_THROW void SLANG_MCALL waitAll() = 0;
 };
 
-class IPersistentShaderCache : public ISlangUnknown
+class IPersistentCache : public ISlangUnknown
 {
     SLANG_COM_INTERFACE(0x68981742, 0x7fd6, 0x4700, {0x8a, 0x71, 0xe8, 0xea, 0x42, 0x91, 0x3b, 0x28});
 

--- a/src/core.natvis
+++ b/src/core.natvis
@@ -22,10 +22,10 @@
     </Expand>
 </Type>
 
-<Type Name="rhi::short_vector&lt;*,*,*&gt;">
-    <DisplayString>{{ size={m_count} }}</DisplayString>
+<Type Name="rhi::short_vector&lt;*,*&gt;">
+    <DisplayString>{{ size={m_size} }}</DisplayString>
     <Expand>
-        <Item Name="[size]">m_count</Item>
+        <Item Name="[size]">m_size</Item>
         <Item Name="[capacity]">m_capacity</Item>
         <ArrayItems>
             <Size>m_size</Size>

--- a/src/d3d12/d3d12-device.cpp
+++ b/src/d3d12/d3d12-device.cpp
@@ -590,6 +590,7 @@ Result DeviceImpl::initialize(const DeviceDesc& desc)
     addFeature(m_deviceInfo.m_isSoftware ? Feature::SoftwareDevice : Feature::HardwareDevice);
     addFeature(Feature::ParameterBlock);
     addFeature(Feature::Surface);
+    addFeature(Feature::PipelineCache);
     addFeature(Feature::Rasterization);
     addFeature(Feature::CustomBorderColor);
     addFeature(Feature::TimestampQuery);

--- a/src/d3d12/d3d12-pipeline.cpp
+++ b/src/d3d12/d3d12-pipeline.cpp
@@ -100,7 +100,7 @@ inline void hashPipelineDesc(SHA1& sha1, const D3D12_COMPUTE_PIPELINE_STATE_DESC
     hashValue(sha1, desc->Flags);
 }
 
-inline Result getPipelineCacheKey(
+inline void getPipelineCacheKey(
     DeviceImpl* device,
     const D3D12_GRAPHICS_PIPELINE_STATE_DESC* desc,
     ISlangBlob** outBlob
@@ -112,7 +112,6 @@ inline Result getPipelineCacheKey(
     SHA1::Digest digest = sha1.getDigest();
     ComPtr<ISlangBlob> blob = OwnedBlob::create(digest.data(), digest.size());
     returnComPtr(outBlob, blob);
-    return SLANG_OK;
 }
 
 inline void getPipelineCacheKey(DeviceImpl* device, const D3D12_COMPUTE_PIPELINE_STATE_DESC* desc, ISlangBlob** outBlob)

--- a/src/d3d12/d3d12-pipeline.cpp
+++ b/src/d3d12/d3d12-pipeline.cpp
@@ -109,7 +109,7 @@ inline Result getPipelineCacheKey(
     SHA1 sha1;
     hashDevice(sha1, device);
     hashPipelineDesc(sha1, desc);
-    SHA1::Digest digest = sha1.digest();
+    SHA1::Digest digest = sha1.getDigest();
     ComPtr<ISlangBlob> blob = OwnedBlob::create(digest.data(), digest.size());
     returnComPtr(outBlob, blob);
     return SLANG_OK;
@@ -120,7 +120,7 @@ inline void getPipelineCacheKey(DeviceImpl* device, const D3D12_COMPUTE_PIPELINE
     SHA1 sha1;
     hashDevice(sha1, device);
     hashPipelineDesc(sha1, desc);
-    SHA1::Digest digest = sha1.digest();
+    SHA1::Digest digest = sha1.getDigest();
     ComPtr<ISlangBlob> blob = OwnedBlob::create(digest.data(), digest.size());
     returnComPtr(outBlob, blob);
 }

--- a/src/d3d12/d3d12-pipeline.cpp
+++ b/src/d3d12/d3d12-pipeline.cpp
@@ -7,12 +7,190 @@
 
 #include "core/stable_vector.h"
 #include "core/string.h"
+#include "core/sha1.h"
 
 #include <climits>
 
 #include <string>
 
 namespace rhi::d3d12 {
+
+void hashShader(SHA1& sha1, const D3D12_SHADER_BYTECODE& shaderBytecode)
+{
+    if (shaderBytecode.pShaderBytecode && shaderBytecode.BytecodeLength)
+    {
+        sha1.update(shaderBytecode.pShaderBytecode, shaderBytecode.BytecodeLength);
+    }
+}
+
+template<typename T>
+void hashValue(SHA1& sha1, const T& value)
+{
+    sha1.update(&value, sizeof(value));
+}
+
+void hashString(SHA1& sha1, const char* str)
+{
+    if (str)
+    {
+        sha1.update(str, strlen(str));
+    }
+}
+
+inline void hashDevice(SHA1& sha1, DeviceImpl* device)
+{
+    const AdapterLUID& luid = device->getInfo().adapterLUID;
+    sha1.update(luid.luid, sizeof(luid.luid));
+}
+
+inline void hashPipelineDesc(SHA1& sha1, const D3D12_GRAPHICS_PIPELINE_STATE_DESC* desc)
+{
+    hashShader(sha1, desc->VS);
+    hashShader(sha1, desc->PS);
+    hashShader(sha1, desc->DS);
+    hashShader(sha1, desc->HS);
+    hashShader(sha1, desc->GS);
+    for (uint32_t i = 0; i < desc->StreamOutput.NumEntries; ++i)
+    {
+        const D3D12_SO_DECLARATION_ENTRY& entry = desc->StreamOutput.pSODeclaration[i];
+        hashValue(sha1, entry.Stream);
+        hashString(sha1, entry.SemanticName);
+        hashValue(sha1, entry.SemanticIndex);
+        hashValue(sha1, entry.StartComponent);
+        hashValue(sha1, entry.ComponentCount);
+        hashValue(sha1, entry.OutputSlot);
+    }
+    for (uint32_t i = 0; i < desc->StreamOutput.NumStrides; ++i)
+    {
+        hashValue(sha1, desc->StreamOutput.pBufferStrides[i]);
+    }
+    hashValue(sha1, desc->StreamOutput.RasterizedStream);
+    hashValue(sha1, desc->BlendState);
+    hashValue(sha1, desc->SampleMask);
+    hashValue(sha1, desc->RasterizerState);
+    hashValue(sha1, desc->DepthStencilState);
+    for (uint32_t i = 0; i < desc->InputLayout.NumElements; ++i)
+    {
+        const D3D12_INPUT_ELEMENT_DESC& element = desc->InputLayout.pInputElementDescs[i];
+        hashString(sha1, element.SemanticName);
+        hashValue(sha1, element.SemanticIndex);
+        hashValue(sha1, element.Format);
+        hashValue(sha1, element.InputSlot);
+        hashValue(sha1, element.AlignedByteOffset);
+        hashValue(sha1, element.InputSlotClass);
+        hashValue(sha1, element.InstanceDataStepRate);
+    }
+    hashValue(sha1, desc->IBStripCutValue);
+    hashValue(sha1, desc->PrimitiveTopologyType);
+    hashValue(sha1, desc->NumRenderTargets);
+    for (uint32_t i = 0; i < desc->NumRenderTargets; i++)
+    {
+        hashValue(sha1, desc->RTVFormats[i]);
+    }
+    hashValue(sha1, desc->DSVFormat);
+    hashValue(sha1, desc->SampleDesc);
+    hashValue(sha1, desc->NodeMask);
+    hashValue(sha1, desc->Flags);
+}
+
+inline void hashPipelineDesc(SHA1& sha1, const D3D12_COMPUTE_PIPELINE_STATE_DESC* desc)
+{
+    hashShader(sha1, desc->CS);
+    hashValue(sha1, desc->NodeMask);
+    hashValue(sha1, desc->Flags);
+}
+
+inline Result getPipelineCacheKey(
+    DeviceImpl* device,
+    const D3D12_GRAPHICS_PIPELINE_STATE_DESC* desc,
+    ISlangBlob** outBlob
+)
+{
+    SHA1 sha1;
+    hashDevice(sha1, device);
+    hashPipelineDesc(sha1, desc);
+    SHA1::Digest digest = sha1.digest();
+    ComPtr<ISlangBlob> blob = OwnedBlob::create(digest.data(), digest.size());
+    returnComPtr(outBlob, blob);
+    return SLANG_OK;
+}
+
+inline void getPipelineCacheKey(DeviceImpl* device, const D3D12_COMPUTE_PIPELINE_STATE_DESC* desc, ISlangBlob** outBlob)
+{
+    SHA1 sha1;
+    hashDevice(sha1, device);
+    hashPipelineDesc(sha1, desc);
+    SHA1::Digest digest = sha1.digest();
+    ComPtr<ISlangBlob> blob = OwnedBlob::create(digest.data(), digest.size());
+    returnComPtr(outBlob, blob);
+}
+
+template<typename PipelineDesc, typename PipelineState>
+Result createPipelineWithCache(
+    DeviceImpl* device,
+    PipelineDesc* desc,
+    Result (*createPipelineFunc)(DeviceImpl* device, PipelineDesc* desc, PipelineState** outPipeline),
+    PipelineState** outPipeline
+)
+{
+    // Early out if cache is not enabled.
+    if (!device->m_persistentPipelineCache)
+    {
+        return createPipelineFunc(device, desc, outPipeline);
+    }
+
+    bool writeCache = true;
+    ComPtr<ISlangBlob> pipelineCacheKey;
+    ComPtr<ISlangBlob> pipelineCacheData;
+    PipelineState* pipeline = nullptr;
+
+    // Create pipeline cache key.
+    getPipelineCacheKey(device, desc, pipelineCacheKey.writeRef());
+
+    // Query pipeline cache.
+    if (SLANG_FAILED(device->m_persistentPipelineCache->queryCache(pipelineCacheKey, pipelineCacheData.writeRef())))
+    {
+        pipelineCacheData = nullptr;
+    }
+
+    // Try create pipeline from cache.
+    if (pipelineCacheData)
+    {
+        desc->CachedPSO.pCachedBlob = pipelineCacheData->getBufferPointer();
+        desc->CachedPSO.CachedBlobSizeInBytes = pipelineCacheData->getBufferSize();
+        if (createPipelineFunc(device, desc, &pipeline) == SLANG_OK)
+        {
+            writeCache = false;
+        }
+        else
+        {
+            desc->CachedPSO.pCachedBlob = nullptr;
+            desc->CachedPSO.CachedBlobSizeInBytes = 0;
+            pipeline = nullptr;
+        }
+    }
+
+    // Create pipeline if not found in cache.
+    if (!pipeline)
+    {
+        SLANG_RETURN_ON_FAIL(createPipelineFunc(device, desc, &pipeline));
+    }
+
+    // Write to the cache.
+    if (writeCache)
+    {
+        ComPtr<ID3DBlob> cachedBlob;
+        if (SLANG_SUCCEEDED(pipeline->GetCachedBlob(cachedBlob.writeRef())) && cachedBlob)
+        {
+            pipelineCacheData = UnownedBlob::create(cachedBlob->GetBufferPointer(), cachedBlob->GetBufferSize());
+            device->m_persistentPipelineCache->writeCache(pipelineCacheKey, pipelineCacheData);
+        }
+    }
+
+    *outPipeline = pipeline;
+    return SLANG_OK;
+}
+
 
 RenderPipelineImpl::RenderPipelineImpl(Device* device)
     : RenderPipeline(device)
@@ -159,22 +337,9 @@ Result DeviceImpl::createRenderPipeline2(const RenderPipelineDesc& desc, IRender
             }
         }
         fillCommonGraphicsState(meshDesc);
-        if (m_pipelineCreationAPIDispatcher)
-        {
-            SLANG_RETURN_ON_FAIL(m_pipelineCreationAPIDispatcher->createMeshPipeline(
-                this,
-                program->linkedProgram.get(),
-                &meshDesc,
-                (void**)pipelineState.writeRef()
-            ));
-        }
-        else
-        {
-            CD3DX12_PIPELINE_STATE_STREAM2 meshStateStream{meshDesc};
-            D3D12_PIPELINE_STATE_STREAM_DESC streamDesc{sizeof(meshStateStream), &meshStateStream};
-
-            SLANG_RETURN_ON_FAIL(m_device5->CreatePipelineState(&streamDesc, IID_PPV_ARGS(pipelineState.writeRef())));
-        }
+        CD3DX12_PIPELINE_STATE_STREAM2 meshStateStream{meshDesc};
+        D3D12_PIPELINE_STATE_STREAM_DESC streamDesc{sizeof(meshStateStream), &meshStateStream};
+        SLANG_RETURN_ON_FAIL(m_device5->CreatePipelineState(&streamDesc, IID_PPV_ARGS(pipelineState.writeRef())));
     }
     else
     {
@@ -211,46 +376,43 @@ Result DeviceImpl::createRenderPipeline2(const RenderPipelineDesc& desc, IRender
 
         fillCommonGraphicsState(graphicsDesc);
 
-        if (m_pipelineCreationAPIDispatcher)
-        {
-            SLANG_RETURN_ON_FAIL(m_pipelineCreationAPIDispatcher->createRenderPipeline(
-                this,
-                program->linkedProgram.get(),
-                &graphicsDesc,
-                (void**)pipelineState.writeRef()
-            ));
-        }
-        else
-        {
+        Result result = createPipelineWithCache<D3D12_GRAPHICS_PIPELINE_STATE_DESC, ID3D12PipelineState>(
+            this,
+            &graphicsDesc,
+            [](DeviceImpl* device, D3D12_GRAPHICS_PIPELINE_STATE_DESC* desc, ID3D12PipelineState** outPipeline
+            ) -> Result
+            {
 #if SLANG_RHI_ENABLE_NVAPI
-            if (m_nvapiShaderExtension)
-            {
-                NVAPI_D3D12_PSO_SET_SHADER_EXTENSION_SLOT_DESC extensionDesc;
-                extensionDesc.baseVersion = NV_PSO_EXTENSION_DESC_VER;
-                extensionDesc.psoExtension = NV_PSO_SET_SHADER_EXTENSION_SLOT_AND_SPACE;
-                extensionDesc.version = NV_SET_SHADER_EXTENSION_SLOT_DESC_VER;
-                extensionDesc.uavSlot = m_nvapiShaderExtension.uavSlot;
-                extensionDesc.registerSpace = m_nvapiShaderExtension.registerSpace;
+                if (device->m_nvapiShaderExtension)
+                {
+                    NVAPI_D3D12_PSO_SET_SHADER_EXTENSION_SLOT_DESC extensionDesc;
+                    extensionDesc.baseVersion = NV_PSO_EXTENSION_DESC_VER;
+                    extensionDesc.psoExtension = NV_PSO_SET_SHADER_EXTENSION_SLOT_AND_SPACE;
+                    extensionDesc.version = NV_SET_SHADER_EXTENSION_SLOT_DESC_VER;
+                    extensionDesc.uavSlot = device->m_nvapiShaderExtension.uavSlot;
+                    extensionDesc.registerSpace = device->m_nvapiShaderExtension.registerSpace;
 
-                const NVAPI_D3D12_PSO_EXTENSION_DESC* extensions[] = {&extensionDesc};
+                    const NVAPI_D3D12_PSO_EXTENSION_DESC* extensions[] = {&extensionDesc};
 
-                // Now create the PSO.
-                SLANG_RHI_NVAPI_RETURN_ON_FAIL(NvAPI_D3D12_CreateGraphicsPipelineState(
-                    m_device,
-                    &graphicsDesc,
-                    SLANG_COUNT_OF(extensions),
-                    extensions,
-                    pipelineState.writeRef()
-                ));
-            }
-            else
+                    NvAPI_Status status = NvAPI_D3D12_CreateGraphicsPipelineState(
+                        device->m_device,
+                        desc,
+                        SLANG_COUNT_OF(extensions),
+                        extensions,
+                        outPipeline
+                    );
+                    return status == NVAPI_OK ? SLANG_OK : SLANG_FAIL;
+                }
+                else
 #endif // SLANG_RHI_ENABLE_NVAPI
-            {
-                SLANG_RETURN_ON_FAIL(
-                    m_device->CreateGraphicsPipelineState(&graphicsDesc, IID_PPV_ARGS(pipelineState.writeRef()))
-                );
-            }
-        }
+                {
+                    HRESULT hr = device->m_device->CreateGraphicsPipelineState(desc, IID_PPV_ARGS(outPipeline));
+                    return hr == S_OK ? SLANG_OK : SLANG_FAIL;
+                }
+            },
+            pipelineState.writeRef()
+        );
+        SLANG_RETURN_ON_FAIL(result);
     }
 
     RefPtr<RenderPipelineImpl> pipeline = new RenderPipelineImpl(this);
@@ -280,8 +442,6 @@ Result DeviceImpl::createComputePipeline2(const ComputePipelineDesc& desc, IComp
     ShaderProgramImpl* program = checked_cast<ShaderProgramImpl*>(desc.program);
     SLANG_RHI_ASSERT(!program->m_shaders.empty());
 
-    ComPtr<ID3D12PipelineState> pipelineState;
-
     // Describe and create the compute pipeline state object
     D3D12_COMPUTE_PIPELINE_STATE_DESC computeDesc = {};
     computeDesc.pRootSignature = desc.d3d12RootSignatureOverride
@@ -289,46 +449,43 @@ Result DeviceImpl::createComputePipeline2(const ComputePipelineDesc& desc, IComp
                                      : program->m_rootObjectLayout->m_rootSignature;
     computeDesc.CS = {program->m_shaders[0].code.data(), SIZE_T(program->m_shaders[0].code.size())};
 
-    if (m_pipelineCreationAPIDispatcher)
-    {
-        SLANG_RETURN_ON_FAIL(m_pipelineCreationAPIDispatcher->createComputePipeline(
-            this,
-            program->linkedProgram.get(),
-            &computeDesc,
-            (void**)pipelineState.writeRef()
-        ));
-    }
-    else
-    {
+    ComPtr<ID3D12PipelineState> pipelineState;
+    Result result = createPipelineWithCache<D3D12_COMPUTE_PIPELINE_STATE_DESC, ID3D12PipelineState>(
+        this,
+        &computeDesc,
+        [](DeviceImpl* device, D3D12_COMPUTE_PIPELINE_STATE_DESC* desc, ID3D12PipelineState** outPipeline) -> Result
+        {
 #if SLANG_RHI_ENABLE_NVAPI
-        if (m_nvapiShaderExtension)
-        {
-            NVAPI_D3D12_PSO_SET_SHADER_EXTENSION_SLOT_DESC extensionDesc;
-            extensionDesc.baseVersion = NV_PSO_EXTENSION_DESC_VER;
-            extensionDesc.psoExtension = NV_PSO_SET_SHADER_EXTENSION_SLOT_AND_SPACE;
-            extensionDesc.version = NV_SET_SHADER_EXTENSION_SLOT_DESC_VER;
-            extensionDesc.uavSlot = m_nvapiShaderExtension.uavSlot;
-            extensionDesc.registerSpace = m_nvapiShaderExtension.registerSpace;
+            if (device->m_nvapiShaderExtension)
+            {
+                NVAPI_D3D12_PSO_SET_SHADER_EXTENSION_SLOT_DESC extensionDesc;
+                extensionDesc.baseVersion = NV_PSO_EXTENSION_DESC_VER;
+                extensionDesc.psoExtension = NV_PSO_SET_SHADER_EXTENSION_SLOT_AND_SPACE;
+                extensionDesc.version = NV_SET_SHADER_EXTENSION_SLOT_DESC_VER;
+                extensionDesc.uavSlot = device->m_nvapiShaderExtension.uavSlot;
+                extensionDesc.registerSpace = device->m_nvapiShaderExtension.registerSpace;
 
-            const NVAPI_D3D12_PSO_EXTENSION_DESC* extensions[] = {&extensionDesc};
+                const NVAPI_D3D12_PSO_EXTENSION_DESC* extensions[] = {&extensionDesc};
 
-            // Now create the PSO.
-            SLANG_RHI_NVAPI_RETURN_ON_FAIL(NvAPI_D3D12_CreateComputePipelineState(
-                m_device,
-                &computeDesc,
-                SLANG_COUNT_OF(extensions),
-                extensions,
-                pipelineState.writeRef()
-            ));
-        }
-        else
+                NvAPI_Status status = NvAPI_D3D12_CreateComputePipelineState(
+                    device->m_device,
+                    desc,
+                    SLANG_COUNT_OF(extensions),
+                    extensions,
+                    outPipeline
+                );
+                return status == NVAPI_OK ? SLANG_OK : SLANG_FAIL;
+            }
+            else
 #endif // SLANG_RHI_ENABLE_NVAPI
-        {
-            SLANG_RETURN_ON_FAIL(
-                m_device->CreateComputePipelineState(&computeDesc, IID_PPV_ARGS(pipelineState.writeRef()))
-            );
-        }
-    }
+            {
+                HRESULT hr = device->m_device->CreateComputePipelineState(desc, IID_PPV_ARGS(outPipeline));
+                return hr == S_OK ? SLANG_OK : SLANG_FAIL;
+            }
+        },
+        pipelineState.writeRef()
+    );
+    SLANG_RETURN_ON_FAIL(result);
 
     RefPtr<ComputePipelineImpl> pipeline = new ComputePipelineImpl(this);
     pipeline->m_program = program;
@@ -494,23 +651,16 @@ Result DeviceImpl::createRayTracingPipeline2(const RayTracingPipelineDesc& desc,
     globalSignatureSubobject.pDesc = &globalSignatureDesc;
     subObjects.push_back(globalSignatureSubobject);
 
-    if (m_pipelineCreationAPIDispatcher)
-    {
-        SLANG_RETURN_ON_FAIL(m_pipelineCreationAPIDispatcher->beforeCreateRayTracingState(this, slangGlobalScope));
-    }
-    else
-    {
 #if SLANG_RHI_ENABLE_NVAPI
-        if (m_nvapiShaderExtension)
-        {
-            SLANG_RHI_NVAPI_RETURN_ON_FAIL(NvAPI_D3D12_SetNvShaderExtnSlotSpace(
-                m_device,
-                m_nvapiShaderExtension.uavSlot,
-                m_nvapiShaderExtension.registerSpace
-            ));
-        }
-#endif // SLANG_RHI_ENABLE_NVAPI
+    if (m_nvapiShaderExtension)
+    {
+        SLANG_RHI_NVAPI_RETURN_ON_FAIL(NvAPI_D3D12_SetNvShaderExtnSlotSpace(
+            m_device,
+            m_nvapiShaderExtension.uavSlot,
+            m_nvapiShaderExtension.registerSpace
+        ));
     }
+#endif // SLANG_RHI_ENABLE_NVAPI
 
     D3D12_STATE_OBJECT_DESC rtpsoDesc = {};
     rtpsoDesc.Type = D3D12_STATE_OBJECT_TYPE_RAYTRACING_PIPELINE;
@@ -518,19 +668,12 @@ Result DeviceImpl::createRayTracingPipeline2(const RayTracingPipelineDesc& desc,
     rtpsoDesc.pSubobjects = subObjects.data();
     SLANG_RETURN_ON_FAIL(m_device5->CreateStateObject(&rtpsoDesc, IID_PPV_ARGS(stateObject.writeRef())));
 
-    if (m_pipelineCreationAPIDispatcher)
-    {
-        SLANG_RETURN_ON_FAIL(m_pipelineCreationAPIDispatcher->afterCreateRayTracingState(this, slangGlobalScope));
-    }
-    else
-    {
 #if SLANG_RHI_ENABLE_NVAPI
-        if (m_nvapiShaderExtension)
-        {
-            SLANG_RHI_NVAPI_RETURN_ON_FAIL(NvAPI_D3D12_SetNvShaderExtnSlotSpace(m_device, 0xffffffff, 0));
-        }
-#endif // SLANG_RHI_ENABLE_NVAPI
+    if (m_nvapiShaderExtension)
+    {
+        SLANG_RHI_NVAPI_RETURN_ON_FAIL(NvAPI_D3D12_SetNvShaderExtnSlotSpace(m_device, 0xffffffff, 0));
     }
+#endif // SLANG_RHI_ENABLE_NVAPI
 
     RefPtr<RayTracingPipelineImpl> pipeline = new RayTracingPipelineImpl(this);
     pipeline->m_program = program;

--- a/src/debug-layer/debug-device.cpp
+++ b/src/debug-layer/debug-device.cpp
@@ -734,10 +734,4 @@ Result DebugDevice::createShaderTable(const ShaderTableDesc& desc, IShaderTable*
     return baseObject->createShaderTable(desc, outTable);
 }
 
-Result DebugDevice::getShaderCacheStats(size_t* outCacheHitCount, size_t* outCacheMissCount, size_t* outCacheSize)
-{
-    SLANG_RHI_API_FUNC;
-    return baseObject->getShaderCacheStats(outCacheHitCount, outCacheMissCount, outCacheSize);
-}
-
 } // namespace rhi::debug

--- a/src/debug-layer/debug-device.h
+++ b/src/debug-layer/debug-device.h
@@ -101,8 +101,6 @@ public:
     convertCooperativeVectorMatrix(const ConvertCooperativeVectorMatrixDesc* descs, uint32_t descCount) override;
     virtual SLANG_NO_THROW Result SLANG_MCALL
     createShaderTable(const ShaderTableDesc& desc, IShaderTable** outTable) override;
-    virtual SLANG_NO_THROW Result SLANG_MCALL
-    getShaderCacheStats(size_t* outCacheHitCount, size_t* outCacheMissCount, size_t* outCacheSize) override;
 
 private:
     DebugContext m_ctx;

--- a/src/device.cpp
+++ b/src/device.cpp
@@ -358,13 +358,6 @@ Result Device::initialize(const DeviceDesc& desc)
     m_uploadHeap.initialize(this, desc.stagingHeapPageSize, MemoryType::Upload);
     m_readbackHeap.initialize(this, desc.stagingHeapPageSize, MemoryType::ReadBack);
 
-    if (desc.apiCommandDispatcher)
-    {
-        desc.apiCommandDispatcher->queryInterface(
-            IPipelineCreationAPIDispatcher::getTypeGuid(),
-            (void**)m_pipelineCreationAPIDispatcher.writeRef()
-        );
-    }
     return SLANG_OK;
 }
 

--- a/src/device.cpp
+++ b/src/device.cpp
@@ -322,11 +322,6 @@ Result Device::getEntryPointCodeFromShaderCache(
             program->getEntryPointCode(entryPointIndex, targetIndex, codeBlob.writeRef(), outDiagnostics)
         );
         m_persistentShaderCache->writeCache(hashBlob, codeBlob);
-        m_shaderCacheMisses++;
-    }
-    else
-    {
-        m_shaderCacheHits++;
     }
 
     *outCode = codeBlob.detach();
@@ -824,18 +819,6 @@ Result Device::convertCooperativeVectorMatrix(const ConvertCooperativeVectorMatr
     SLANG_UNUSED(descs);
     SLANG_UNUSED(descCount);
     return SLANG_E_NOT_AVAILABLE;
-}
-
-
-Result Device::getShaderCacheStats(size_t* outCacheHitCount, size_t* outCacheMissCount, size_t* outCacheSize)
-{
-    if (outCacheHitCount)
-        *outCacheHitCount = m_shaderCacheHits;
-    if (outCacheMissCount)
-        *outCacheMissCount = m_shaderCacheMisses;
-    if (outCacheSize)
-        *outCacheSize = m_shaderCache.getSize();
-    return SLANG_OK;
 }
 
 Result Device::getShaderObjectLayout(

--- a/src/device.cpp
+++ b/src/device.cpp
@@ -353,6 +353,7 @@ Result Device::initialize(const DeviceDesc& desc)
     m_debugCallback = desc.debugCallback ? desc.debugCallback : NullDebugCallback::getInstance();
 
     m_persistentShaderCache = desc.persistentShaderCache;
+    m_persistentPipelineCache = desc.persistentPipelineCache;
 
     m_uploadHeap.initialize(this, desc.stagingHeapPageSize, MemoryType::Upload);
     m_readbackHeap.initialize(this, desc.stagingHeapPageSize, MemoryType::ReadBack);

--- a/src/device.h
+++ b/src/device.h
@@ -338,7 +338,6 @@ public:
     ComPtr<IPersistentCache> m_persistentPipelineCache;
 
     std::map<slang::TypeLayoutReflection*, RefPtr<ShaderObjectLayout>> m_shaderObjectLayoutCache;
-    ComPtr<IPipelineCreationAPIDispatcher> m_pipelineCreationAPIDispatcher;
 
     IDebugCallback* m_debugCallback = nullptr;
 };

--- a/src/device.h
+++ b/src/device.h
@@ -334,9 +334,7 @@ public:
     StagingHeap m_uploadHeap;
     StagingHeap m_readbackHeap;
 
-    ComPtr<IPersistentShaderCache> m_persistentShaderCache;
-    size_t m_shaderCacheHits = 0;
-    size_t m_shaderCacheMisses = 0;
+    ComPtr<IPersistentCache> m_persistentShaderCache;
 
     std::map<slang::TypeLayoutReflection*, RefPtr<ShaderObjectLayout>> m_shaderObjectLayoutCache;
     ComPtr<IPipelineCreationAPIDispatcher> m_pipelineCreationAPIDispatcher;

--- a/src/device.h
+++ b/src/device.h
@@ -93,8 +93,6 @@ public:
         specializedPipelines = decltype(specializedPipelines)();
     }
 
-    size_t getSize() const { return specializedPipelines.size(); }
-
 protected:
     struct ComponentKeyHasher
     {
@@ -244,9 +242,6 @@ public:
     // Provides a default implementation that returns SLANG_E_NOT_AVAILABLE.
     virtual SLANG_NO_THROW Result SLANG_MCALL
     convertCooperativeVectorMatrix(const ConvertCooperativeVectorMatrixDesc* descs, uint32_t descCount) override;
-
-    virtual SLANG_NO_THROW Result SLANG_MCALL
-    getShaderCacheStats(size_t* outCacheHitCount, size_t* outCacheMissCount, size_t* outCacheSize) override;
 
     Result getEntryPointCodeFromShaderCache(
         slang::IComponentType* program,

--- a/src/device.h
+++ b/src/device.h
@@ -335,6 +335,7 @@ public:
     StagingHeap m_readbackHeap;
 
     ComPtr<IPersistentCache> m_persistentShaderCache;
+    ComPtr<IPersistentCache> m_persistentPipelineCache;
 
     std::map<slang::TypeLayoutReflection*, RefPtr<ShaderObjectLayout>> m_shaderObjectLayoutCache;
     ComPtr<IPipelineCreationAPIDispatcher> m_pipelineCreationAPIDispatcher;

--- a/src/rhi.cpp
+++ b/src/rhi.cpp
@@ -143,8 +143,11 @@ public:
     virtual const char* getCapabilityName(Capability capability) override;
 
     Result getAdapters(DeviceType type, ISlangBlob** outAdaptersBlob) override;
-    Result createDevice(const DeviceDesc& desc, IDevice** outDevice) override;
     void enableDebugLayers() override;
+    Result createDevice(const DeviceDesc& desc, IDevice** outDevice) override;
+
+    Result createBlob(const void* data, size_t size, ISlangBlob** outBlob) override;
+
     Result reportLiveObjects() override;
     Result setTaskPool(ITaskPool* scheduler) override;
 
@@ -365,6 +368,25 @@ Result RHI::createDevice(const DeviceDesc& desc, IDevice** outDevice)
     debugDevice->baseObject = innerDevice;
     returnComPtr(outDevice, debugDevice);
     return resultCode;
+}
+
+Result RHI::createBlob(const void* data, size_t size, ISlangBlob** outBlob)
+{
+    ComPtr<ISlangBlob> blob;
+    if (data)
+    {
+        blob = OwnedBlob::create(data, size);
+    }
+    else
+    {
+        blob = OwnedBlob::create(size);
+    }
+    if (!blob)
+    {
+        return SLANG_FAIL;
+    }
+    returnComPtr(outBlob, blob);
+    return SLANG_OK;
 }
 
 Result RHI::reportLiveObjects()

--- a/src/vulkan/vk-api.h
+++ b/src/vulkan/vk-api.h
@@ -224,6 +224,11 @@ namespace rhi::vk {
     x(vkConvertCooperativeVectorMatrixNV) \
     x(vkCmdConvertCooperativeVectorMatrixNV) \
     x(vkGetDescriptorSetLayoutSupport) \
+    x(vkCreatePipelineBinariesKHR) \
+    x(vkDestroyPipelineBinaryKHR) \
+    x(vkGetPipelineBinaryDataKHR) \
+    x(vkGetPipelineKeyKHR) \
+    x(vkReleaseCapturedPipelineDataKHR) \
     /* */
 
 #define VK_API_ALL_GLOBAL_PROCS(x) \
@@ -385,6 +390,11 @@ struct VulkanExtendedFeatureProperties
     // Mutable descriptor type features
     VkPhysicalDeviceMutableDescriptorTypeFeaturesEXT mutableDescriptorTypeFeatures = {
         VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MUTABLE_DESCRIPTOR_TYPE_FEATURES_EXT
+    };
+
+    // Pipeline binary features
+    VkPhysicalDevicePipelineBinaryFeaturesKHR pipelineBinaryFeatures = {
+        VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PIPELINE_BINARY_FEATURES_KHR
     };
 };
 

--- a/src/vulkan/vk-device.cpp
+++ b/src/vulkan/vk-device.cpp
@@ -255,7 +255,13 @@ Result DeviceImpl::initVulkanInstanceAndDevice(
                 }
             }
         }
-        uint32_t apiVersionsToTry[] = {VK_API_VERSION_1_3, VK_API_VERSION_1_2, VK_API_VERSION_1_1, VK_API_VERSION_1_0};
+        uint32_t apiVersionsToTry[] = {
+            // VK_API_VERSION_1_4,
+            VK_API_VERSION_1_3,
+            VK_API_VERSION_1_2,
+            VK_API_VERSION_1_1,
+            VK_API_VERSION_1_0,
+        };
         for (auto apiVersion : apiVersionsToTry)
         {
             applicationInfo.apiVersion = apiVersion;
@@ -530,6 +536,9 @@ Result DeviceImpl::initVulkanInstanceAndDevice(
 
         extendedFeatures.mutableDescriptorTypeFeatures.pNext = deviceFeatures2.pNext;
         deviceFeatures2.pNext = &extendedFeatures.mutableDescriptorTypeFeatures;
+
+        extendedFeatures.pipelineBinaryFeatures.pNext = deviceFeatures2.pNext;
+        deviceFeatures2.pNext = &extendedFeatures.pipelineBinaryFeatures;
 
         if (VK_MAKE_VERSION(majorVersion, minorVersion, 0) >= VK_API_VERSION_1_2)
         {
@@ -807,6 +816,16 @@ Result DeviceImpl::initVulkanInstanceAndDevice(
             mutableDescriptorType,
             VK_EXT_MUTABLE_DESCRIPTOR_TYPE_EXTENSION_NAME,
             {}
+        );
+
+        SIMPLE_EXTENSION_FEATURE(
+            extendedFeatures.pipelineBinaryFeatures,
+            pipelineBinaries,
+            VK_KHR_PIPELINE_BINARY_EXTENSION_NAME,
+            {
+                deviceExtensions.push_back(VK_KHR_MAINTENANCE_5_EXTENSION_NAME);
+                availableFeatures.push_back(Feature::PipelineCache);
+            }
         );
 
 #undef SIMPLE_EXTENSION_FEATURE

--- a/src/vulkan/vk-pipeline.cpp
+++ b/src/vulkan/vk-pipeline.cpp
@@ -6,12 +6,324 @@
 #include "vk-input-layout.h"
 
 #include "core/static_vector.h"
+#include "core/sha1.h"
 
 #include <map>
 #include <string>
 #include <vector>
 
 namespace rhi::vk {
+
+// For pipeline caching, we use the VK_KHR_pipeline_binary extension.
+// We serialize the pipeline binaries into a custom format that stores a number of pipeline binaries,
+// each with a key and data size, along with the binary data itself.
+// The format is layed out as follows:
+// Header [PipelineCacheHeader] (12 bytes):
+// - Magic number (4 bytes)
+// - Version (4 bytes)
+// - Number of binaries (4 bytes)
+// Binary headers [PipelineCacheBinaryHeader] (44 bytes each):
+// - Key size (4 bytes)
+// - Key (32 bytes (VK_MAX_PIPELINE_BINARY_KEY_SIZE_KHR))
+// - Data size (4 bytes)
+// - Data offset (4 bytes, relative to the start of the blob)
+// Binary data (variable size)
+
+struct PipelineCacheHeader
+{
+    static constexpr uint32_t kMagic = 0x12345678;
+    static constexpr uint32_t kVersion = 1;
+
+    uint32_t magic;
+    uint32_t version;
+    uint32_t binaryCount;
+};
+
+struct PipelineCacheBinaryHeader
+{
+    uint32_t keySize;
+    uint8_t key[VK_MAX_PIPELINE_BINARY_KEY_SIZE_KHR];
+    uint32_t dataSize;
+    uint32_t dataOffset;
+};
+
+// Create a pipeline cache key based on the device and pipeline create info.
+// The key is a SHA1 hash that includes the adapter LUID, global pipeline key, and the pipeline create info key.
+Result getPipelineCacheKey(DeviceImpl* device, void* createInfo, ISlangBlob** outBlob)
+{
+    auto& api = device->m_api;
+
+    SHA1 sha1;
+    // Hash adapter LUID.
+    {
+        const AdapterLUID& luid = device->getInfo().adapterLUID;
+        sha1.update(luid.luid, sizeof(luid.luid));
+    }
+    // Hash global key.
+    {
+        VkPipelineBinaryKeyKHR pipelineKey = {VK_STRUCTURE_TYPE_PIPELINE_BINARY_KEY_KHR};
+        SLANG_VK_RETURN_ON_FAIL(api.vkGetPipelineKeyKHR(device->m_device, nullptr, &pipelineKey));
+        sha1.update(pipelineKey.key, pipelineKey.keySize);
+    }
+    // Hash pipeline key.
+    {
+        VkPipelineCreateInfoKHR pipelineCreateInfo = {VK_STRUCTURE_TYPE_PIPELINE_CREATE_INFO_KHR};
+        pipelineCreateInfo.pNext = createInfo;
+        VkPipelineBinaryKeyKHR pipelineKey = {VK_STRUCTURE_TYPE_PIPELINE_BINARY_KEY_KHR};
+        SLANG_VK_RETURN_ON_FAIL(api.vkGetPipelineKeyKHR(device->m_device, &pipelineCreateInfo, &pipelineKey));
+        sha1.update(pipelineKey.key, pipelineKey.keySize);
+    }
+    SHA1::Digest digest = sha1.digest();
+    ComPtr<ISlangBlob> blob = OwnedBlob::create(digest.data(), digest.size());
+    returnComPtr(outBlob, blob);
+    return SLANG_OK;
+}
+
+// Serialize a vulkan pipeline into a blob containing the pipeline binaries.
+Result serializePipelineBinaries(DeviceImpl* device, VkPipeline pipeline, ISlangBlob** outBlob)
+{
+    auto& api = device->m_api;
+
+    VkPipelineBinaryCreateInfoKHR binaryCreateInfo = {VK_STRUCTURE_TYPE_PIPELINE_BINARY_CREATE_INFO_KHR};
+    binaryCreateInfo.pipeline = pipeline;
+
+    VkPipelineBinaryHandlesInfoKHR binaryHandlesInfo = {VK_STRUCTURE_TYPE_PIPELINE_BINARY_HANDLES_INFO_KHR};
+
+    SLANG_VK_RETURN_ON_FAIL(
+        api.vkCreatePipelineBinariesKHR(device->m_device, &binaryCreateInfo, nullptr, &binaryHandlesInfo)
+    );
+
+    short_vector<VkPipelineBinaryKHR> pipelineBinaries(binaryHandlesInfo.pipelineBinaryCount, VK_NULL_HANDLE);
+    binaryHandlesInfo.pPipelineBinaries = pipelineBinaries.data();
+    SLANG_VK_RETURN_ON_FAIL(
+        api.vkCreatePipelineBinariesKHR(device->m_device, &binaryCreateInfo, nullptr, &binaryHandlesInfo)
+    );
+
+    // Compute total size of the cache data blob.
+    size_t dataSize = sizeof(PipelineCacheHeader);
+    dataSize += binaryHandlesInfo.pipelineBinaryCount * sizeof(PipelineCacheBinaryHeader);
+    for (uint32_t i = 0; i < binaryHandlesInfo.pipelineBinaryCount; ++i)
+    {
+        VkPipelineBinaryDataInfoKHR binaryInfo = {VK_STRUCTURE_TYPE_PIPELINE_BINARY_DATA_INFO_KHR};
+        binaryInfo.pipelineBinary = pipelineBinaries[i];
+        VkPipelineBinaryKeyKHR binaryKey = {VK_STRUCTURE_TYPE_PIPELINE_BINARY_KEY_KHR};
+        size_t binaryDataSize = 0;
+        SLANG_VK_RETURN_ON_FAIL(
+            api.vkGetPipelineBinaryDataKHR(device->m_device, &binaryInfo, &binaryKey, &binaryDataSize, nullptr)
+        );
+        dataSize += binaryDataSize;
+    }
+
+    ComPtr<ISlangBlob> blob = OwnedBlob::create(dataSize);
+    uint8_t* data = (uint8_t*)blob->getBufferPointer();
+    uint8_t* dataPtr = data;
+
+    // Write cache data header.
+    PipelineCacheHeader* header = (PipelineCacheHeader*)dataPtr;
+    header->magic = PipelineCacheHeader::kMagic;
+    header->version = PipelineCacheHeader::kVersion;
+    header->binaryCount = binaryHandlesInfo.pipelineBinaryCount;
+    dataPtr += sizeof(PipelineCacheHeader);
+
+    // Write binary data.
+    uint32_t binaryDataOffset =
+        sizeof(PipelineCacheHeader) + binaryHandlesInfo.pipelineBinaryCount * sizeof(PipelineCacheBinaryHeader);
+    for (uint32_t i = 0; i < binaryHandlesInfo.pipelineBinaryCount; ++i)
+    {
+        VkPipelineBinaryDataInfoKHR binaryInfo = {VK_STRUCTURE_TYPE_PIPELINE_BINARY_DATA_INFO_KHR};
+        binaryInfo.pipelineBinary = pipelineBinaries[i];
+
+        VkPipelineBinaryKeyKHR binaryKey = {VK_STRUCTURE_TYPE_PIPELINE_BINARY_KEY_KHR};
+        size_t binaryDataSize = 0;
+        SLANG_VK_RETURN_ON_FAIL(
+            api.vkGetPipelineBinaryDataKHR(device->m_device, &binaryInfo, &binaryKey, &binaryDataSize, nullptr)
+        );
+
+        SLANG_VK_RETURN_ON_FAIL(api.vkGetPipelineBinaryDataKHR(
+            device->m_device,
+            &binaryInfo,
+            &binaryKey,
+            &binaryDataSize,
+            data + binaryDataOffset
+        ));
+
+        PipelineCacheBinaryHeader* binaryHeader = (PipelineCacheBinaryHeader*)dataPtr;
+        std::memset(binaryHeader->key, 0, sizeof(PipelineCacheBinaryHeader::key));
+        std::memcpy(binaryHeader->key, binaryKey.key, binaryKey.keySize);
+        binaryHeader->keySize = binaryKey.keySize;
+        binaryHeader->dataSize = (uint32_t)binaryDataSize;
+        binaryHeader->dataOffset = binaryDataOffset;
+        dataPtr += sizeof(PipelineCacheBinaryHeader);
+
+        binaryDataOffset += binaryDataSize;
+
+        api.vkDestroyPipelineBinaryKHR(device->m_device, pipelineBinaries[i], nullptr);
+    }
+
+    returnComPtr(outBlob, blob);
+    return SLANG_OK;
+}
+
+// Deserialize a blob containing pipeline binaries into a vector of VkPipelineBinaryKHR handles.
+// The caller is responsible for destroying the VkPipelineBinaryKHR handles after use.
+Result deserializePipelineBinaries(DeviceImpl* device, ISlangBlob* blob, short_vector<VkPipelineBinaryKHR>& outBinaries)
+{
+    auto& api = device->m_api;
+
+    size_t dataSize = blob->getBufferSize();
+    const uint8_t* data = (const uint8_t*)blob->getBufferPointer();
+    const uint8_t* dataPtr = data;
+    if (dataSize < sizeof(PipelineCacheHeader))
+    {
+        return SLANG_FAIL;
+    }
+
+    const PipelineCacheHeader* header = (const PipelineCacheHeader*)dataPtr;
+    if (header->magic != PipelineCacheHeader::kMagic || header->version != PipelineCacheHeader::kVersion ||
+        header->binaryCount == 0)
+    {
+        return SLANG_FAIL;
+    }
+    dataPtr += sizeof(PipelineCacheHeader);
+
+    short_vector<VkPipelineBinaryKeyKHR> binaryKeys(header->binaryCount, {VK_STRUCTURE_TYPE_PIPELINE_BINARY_KEY_KHR});
+    short_vector<VkPipelineBinaryDataKHR> pipelineData(header->binaryCount, {});
+
+    for (uint32_t i = 0; i < header->binaryCount; ++i)
+    {
+        const PipelineCacheBinaryHeader* binaryHeader = (const PipelineCacheBinaryHeader*)dataPtr;
+        dataPtr += sizeof(PipelineCacheBinaryHeader);
+
+        binaryKeys[i].keySize = binaryHeader->keySize;
+        std::memcpy(binaryKeys[i].key, binaryHeader->key, binaryHeader->keySize);
+
+        pipelineData[i].dataSize = binaryHeader->dataSize;
+        pipelineData[i].pData = (void*)(data + binaryHeader->dataOffset);
+    }
+
+    VkPipelineBinaryKeysAndDataKHR binaryKeysAndData;
+    binaryKeysAndData.binaryCount = header->binaryCount;
+    binaryKeysAndData.pPipelineBinaryKeys = binaryKeys.data();
+    binaryKeysAndData.pPipelineBinaryData = pipelineData.data();
+
+    VkPipelineBinaryCreateInfoKHR createInfo = {VK_STRUCTURE_TYPE_PIPELINE_BINARY_CREATE_INFO_KHR};
+    createInfo.pKeysAndDataInfo = &binaryKeysAndData;
+
+    short_vector<VkPipelineBinaryKHR> binaries(header->binaryCount, VK_NULL_HANDLE);
+
+    VkPipelineBinaryHandlesInfoKHR handlesInfo = {VK_STRUCTURE_TYPE_PIPELINE_BINARY_HANDLES_INFO_KHR};
+    handlesInfo.pipelineBinaryCount = binaries.size();
+    handlesInfo.pPipelineBinaries = binaries.data();
+
+    SLANG_VK_RETURN_ON_FAIL(api.vkCreatePipelineBinariesKHR(device->m_device, &createInfo, nullptr, &handlesInfo));
+
+    outBinaries = binaries;
+    return SLANG_OK;
+}
+
+template<typename VkPipelineCreateInfo>
+Result createPipelineWithCache(
+    DeviceImpl* device,
+    VkPipelineCreateInfo* createInfo,
+    VkResult (*createPipelineFunc)(DeviceImpl* device, VkPipelineCreateInfo* createInfo, VkPipeline* outPipeline),
+    VkPipeline* outPipeline
+)
+{
+    auto& api = device->m_api;
+
+    // Early out if cache is not enabled or the feature is not supported.
+    if (!device->m_persistentPipelineCache || !api.m_extendedFeatures.pipelineBinaryFeatures.pipelineBinaries)
+    {
+        return createPipelineFunc(device, createInfo, outPipeline);
+    }
+
+    bool writeCache = true;
+    ComPtr<ISlangBlob> pipelineCacheKey;
+    ComPtr<ISlangBlob> pipelineCacheData;
+    VkPipeline pipeline = VK_NULL_HANDLE;
+
+    // Create pipeline cache key.
+    if (SLANG_FAILED(getPipelineCacheKey(device, createInfo, pipelineCacheKey.writeRef())))
+    {
+        device->printWarning("Failed to get pipeline cache key, disabling pipeline cache.");
+        return createPipelineFunc(device, createInfo, outPipeline);
+    }
+
+    // Query pipeline cache.
+    if (SLANG_FAILED(device->m_persistentPipelineCache->queryCache(pipelineCacheKey, pipelineCacheData.writeRef())))
+    {
+        pipelineCacheData = nullptr;
+    }
+
+    // Try create pipeline from cache.
+    if (pipelineCacheData)
+    {
+        short_vector<VkPipelineBinaryKHR> pipelineBinaries;
+        if (SLANG_SUCCEEDED(deserializePipelineBinaries(device, pipelineCacheData, pipelineBinaries)))
+        {
+            VkPipelineBinaryInfoKHR binaryInfo = {VK_STRUCTURE_TYPE_PIPELINE_BINARY_INFO_KHR};
+            binaryInfo.binaryCount = (uint32_t)pipelineBinaries.size();
+            binaryInfo.pPipelineBinaries = pipelineBinaries.data();
+            binaryInfo.pNext = createInfo->pNext;
+            createInfo->pNext = &binaryInfo;
+            if (createPipelineFunc(device, createInfo, &pipeline) == VK_SUCCESS)
+            {
+                writeCache = false;
+            }
+            else
+            {
+                createInfo->pNext = binaryInfo.pNext;
+                pipeline = VK_NULL_HANDLE;
+            }
+            for (auto& binary : pipelineBinaries)
+            {
+                api.vkDestroyPipelineBinaryKHR(device->m_device, binary, nullptr);
+            }
+        }
+        else
+        {
+            device->printWarning("Failed to deserialize pipeline binaries from cache, creating new pipeline.");
+        }
+    }
+
+    // Create pipeline if not found in cache.
+    if (!pipeline)
+    {
+        // Enable capturing of pipeline data if we plan to write to the pipeline cache.
+        VkPipelineCreateFlags2CreateInfoKHR createFlags = {VK_STRUCTURE_TYPE_PIPELINE_CREATE_FLAGS_2_CREATE_INFO_KHR};
+        createFlags.flags = VK_PIPELINE_CREATE_2_CAPTURE_DATA_BIT_KHR;
+        if (writeCache)
+        {
+            createFlags.pNext = createInfo->pNext;
+            createInfo->pNext = &createFlags;
+        }
+        SLANG_VK_RETURN_ON_FAIL(createPipelineFunc(device, createInfo, &pipeline));
+    }
+
+    // Write to the cache.
+    if (writeCache)
+    {
+        if (SLANG_SUCCEEDED(serializePipelineBinaries(device, pipeline, pipelineCacheData.writeRef())))
+        {
+            device->m_persistentPipelineCache->writeCache(pipelineCacheKey, pipelineCacheData);
+        }
+        else
+        {
+            device->printWarning("Failed to serialize pipeline binaries, cache write skipped.");
+        }
+    }
+
+    // Release captured pipeline data.
+    if (writeCache)
+    {
+        VkReleaseCapturedPipelineDataInfoKHR releaseInfo = {VK_STRUCTURE_TYPE_RELEASE_CAPTURED_PIPELINE_DATA_INFO_KHR};
+        releaseInfo.pipeline = pipeline;
+        SLANG_VK_RETURN_ON_FAIL(api.vkReleaseCapturedPipelineDataKHR(device->m_device, &releaseInfo, nullptr));
+    }
+
+    *outPipeline = pipeline;
+    return SLANG_OK;
+}
 
 RenderPipelineImpl::RenderPipelineImpl(Device* device)
     : RenderPipeline(device)
@@ -226,21 +538,15 @@ Result DeviceImpl::createRenderPipeline2(const RenderPipelineDesc& desc, IRender
     createInfo.pDynamicState = &dynamicStateInfo;
 
     VkPipeline vkPipeline = VK_NULL_HANDLE;
-
-    if (m_pipelineCreationAPIDispatcher)
-    {
-        SLANG_RETURN_ON_FAIL(
-            m_pipelineCreationAPIDispatcher
-                ->createRenderPipeline(this, program->linkedProgram.get(), &createInfo, (void**)&vkPipeline)
-        );
-    }
-    else
-    {
-        VkPipelineCache pipelineCache = VK_NULL_HANDLE;
-        SLANG_VK_RETURN_ON_FAIL(
-            m_api.vkCreateGraphicsPipelines(m_device, pipelineCache, 1, &createInfo, nullptr, &vkPipeline)
-        );
-    }
+    SLANG_RETURN_ON_FAIL(createPipelineWithCache<VkGraphicsPipelineCreateInfo>(
+        this,
+        &createInfo,
+        [](DeviceImpl* device, VkGraphicsPipelineCreateInfo* createInfo, VkPipeline* pipeline) -> VkResult {
+            return device->m_api
+                .vkCreateGraphicsPipelines(device->m_device, VK_NULL_HANDLE, 1, createInfo, nullptr, pipeline);
+        },
+        &vkPipeline
+    ));
 
     RefPtr<RenderPipelineImpl> pipeline = new RenderPipelineImpl(this);
     pipeline->m_program = program;
@@ -276,26 +582,21 @@ Result DeviceImpl::createComputePipeline2(const ComputePipelineDesc& desc, IComp
 {
     ShaderProgramImpl* program = checked_cast<ShaderProgramImpl*>(desc.program);
     SLANG_RHI_ASSERT(!program->m_modules.empty());
-    VkPipeline vkPipeline = VK_NULL_HANDLE;
 
     VkComputePipelineCreateInfo createInfo = {VK_STRUCTURE_TYPE_COMPUTE_PIPELINE_CREATE_INFO};
     createInfo.stage = program->m_stageCreateInfos[0];
     createInfo.layout = program->m_rootShaderObjectLayout->m_pipelineLayout;
 
-    if (m_pipelineCreationAPIDispatcher)
-    {
-        SLANG_RETURN_ON_FAIL(
-            m_pipelineCreationAPIDispatcher
-                ->createComputePipeline(this, program->linkedProgram.get(), &createInfo, (void**)&vkPipeline)
-        );
-    }
-    else
-    {
-        VkPipelineCache pipelineCache = VK_NULL_HANDLE;
-        SLANG_VK_RETURN_ON_FAIL(
-            m_api.vkCreateComputePipelines(m_device, pipelineCache, 1, &createInfo, nullptr, &vkPipeline)
-        );
-    }
+    VkPipeline vkPipeline = VK_NULL_HANDLE;
+    SLANG_RETURN_ON_FAIL(createPipelineWithCache<VkComputePipelineCreateInfo>(
+        this,
+        &createInfo,
+        [](DeviceImpl* device, VkComputePipelineCreateInfo* createInfo, VkPipeline* pipeline) -> VkResult {
+            return device->m_api
+                .vkCreateComputePipelines(device->m_device, VK_NULL_HANDLE, 1, createInfo, nullptr, pipeline);
+        },
+        &vkPipeline
+    ));
 
     RefPtr<ComputePipelineImpl> pipeline = new ComputePipelineImpl(this);
     pipeline->m_program = program;
@@ -427,27 +728,24 @@ Result DeviceImpl::createRayTracingPipeline2(const RayTracingPipelineDesc& desc,
     createInfo.basePipelineHandle = VK_NULL_HANDLE;
     createInfo.basePipelineIndex = 0;
 
-    if (m_pipelineCreationAPIDispatcher)
-    {
-        m_pipelineCreationAPIDispatcher->beforeCreateRayTracingState(this, program->linkedProgram.get());
-    }
-
     VkPipeline vkPipeline = VK_NULL_HANDLE;
-    VkPipelineCache pipelineCache = VK_NULL_HANDLE;
-    SLANG_VK_RETURN_ON_FAIL(m_api.vkCreateRayTracingPipelinesKHR(
-        m_device,
-        VK_NULL_HANDLE,
-        pipelineCache,
-        1,
+    SLANG_RETURN_ON_FAIL(createPipelineWithCache<VkRayTracingPipelineCreateInfoKHR>(
+        this,
         &createInfo,
-        nullptr,
+        [](DeviceImpl* device, VkRayTracingPipelineCreateInfoKHR* createInfo, VkPipeline* pipeline) -> VkResult
+        {
+            return device->m_api.vkCreateRayTracingPipelinesKHR(
+                device->m_device,
+                VK_NULL_HANDLE,
+                VK_NULL_HANDLE,
+                1,
+                createInfo,
+                nullptr,
+                pipeline
+            );
+        },
         &vkPipeline
     ));
-
-    if (m_pipelineCreationAPIDispatcher)
-    {
-        m_pipelineCreationAPIDispatcher->afterCreateRayTracingState(this, program->linkedProgram.get());
-    }
 
     RefPtr<RayTracingPipelineImpl> pipeline = new RayTracingPipelineImpl(this);
     pipeline->m_program = program;

--- a/src/vulkan/vk-pipeline.cpp
+++ b/src/vulkan/vk-pipeline.cpp
@@ -73,7 +73,7 @@ Result getPipelineCacheKey(DeviceImpl* device, void* createInfo, ISlangBlob** ou
         SLANG_VK_RETURN_ON_FAIL(api.vkGetPipelineKeyKHR(device->m_device, &pipelineCreateInfo, &pipelineKey));
         sha1.update(pipelineKey.key, pipelineKey.keySize);
     }
-    SHA1::Digest digest = sha1.digest();
+    SHA1::Digest digest = sha1.getDigest();
     ComPtr<ISlangBlob> blob = OwnedBlob::create(digest.data(), digest.size());
     returnComPtr(outBlob, blob);
     return SLANG_OK;

--- a/src/vulkan/vk-pipeline.cpp
+++ b/src/vulkan/vk-pipeline.cpp
@@ -17,7 +17,7 @@ namespace rhi::vk {
 // For pipeline caching, we use the VK_KHR_pipeline_binary extension.
 // We serialize the pipeline binaries into a custom format that stores a number of pipeline binaries,
 // each with a key and data size, along with the binary data itself.
-// The format is layed out as follows:
+// The format is laid out as follows:
 // Header [PipelineCacheHeader] (12 bytes):
 // - Magic number (4 bytes)
 // - Version (4 bytes)

--- a/src/vulkan/vk-pipeline.cpp
+++ b/src/vulkan/vk-pipeline.cpp
@@ -541,9 +541,10 @@ Result DeviceImpl::createRenderPipeline2(const RenderPipelineDesc& desc, IRender
     SLANG_RETURN_ON_FAIL(createPipelineWithCache<VkGraphicsPipelineCreateInfo>(
         this,
         &createInfo,
-        [](DeviceImpl* device, VkGraphicsPipelineCreateInfo* createInfo, VkPipeline* pipeline) -> VkResult {
+        [](DeviceImpl* device, VkGraphicsPipelineCreateInfo* createInfo2, VkPipeline* pipeline) -> VkResult
+        {
             return device->m_api
-                .vkCreateGraphicsPipelines(device->m_device, VK_NULL_HANDLE, 1, createInfo, nullptr, pipeline);
+                .vkCreateGraphicsPipelines(device->m_device, VK_NULL_HANDLE, 1, createInfo2, nullptr, pipeline);
         },
         &vkPipeline
     ));
@@ -591,9 +592,9 @@ Result DeviceImpl::createComputePipeline2(const ComputePipelineDesc& desc, IComp
     SLANG_RETURN_ON_FAIL(createPipelineWithCache<VkComputePipelineCreateInfo>(
         this,
         &createInfo,
-        [](DeviceImpl* device, VkComputePipelineCreateInfo* createInfo, VkPipeline* pipeline) -> VkResult {
+        [](DeviceImpl* device, VkComputePipelineCreateInfo* createInfo2, VkPipeline* pipeline) -> VkResult {
             return device->m_api
-                .vkCreateComputePipelines(device->m_device, VK_NULL_HANDLE, 1, createInfo, nullptr, pipeline);
+                .vkCreateComputePipelines(device->m_device, VK_NULL_HANDLE, 1, createInfo2, nullptr, pipeline);
         },
         &vkPipeline
     ));

--- a/src/vulkan/vk-pipeline.cpp
+++ b/src/vulkan/vk-pipeline.cpp
@@ -733,14 +733,14 @@ Result DeviceImpl::createRayTracingPipeline2(const RayTracingPipelineDesc& desc,
     SLANG_RETURN_ON_FAIL(createPipelineWithCache<VkRayTracingPipelineCreateInfoKHR>(
         this,
         &createInfo,
-        [](DeviceImpl* device, VkRayTracingPipelineCreateInfoKHR* createInfo, VkPipeline* pipeline) -> VkResult
+        [](DeviceImpl* device, VkRayTracingPipelineCreateInfoKHR* createInfo2, VkPipeline* pipeline) -> VkResult
         {
             return device->m_api.vkCreateRayTracingPipelinesKHR(
                 device->m_device,
                 VK_NULL_HANDLE,
                 VK_NULL_HANDLE,
                 1,
-                createInfo,
+                createInfo2,
                 nullptr,
                 pipeline
             );

--- a/tests/shader-cache.h
+++ b/tests/shader-cache.h
@@ -10,7 +10,7 @@
 
 namespace rhi::testing {
 
-class ShaderCache : public IPersistentShaderCache
+class ShaderCache : public IPersistentCache
 {
 public:
     using Key = std::vector<uint8_t>;
@@ -50,9 +50,9 @@ public:
 
     virtual SLANG_NO_THROW Result SLANG_MCALL queryInterface(const SlangUUID& uuid, void** outObject) override
     {
-        if (uuid == IPersistentShaderCache::getTypeGuid())
+        if (uuid == IPersistentCache::getTypeGuid())
         {
-            *outObject = static_cast<IPersistentShaderCache*>(this);
+            *outObject = static_cast<IPersistentCache*>(this);
             return SLANG_OK;
         }
         return SLANG_E_NO_INTERFACE;

--- a/tests/test-blob.cpp
+++ b/tests/test-blob.cpp
@@ -1,0 +1,26 @@
+#include "testing.h"
+
+using namespace rhi;
+using namespace rhi::testing;
+
+TEST_CASE("blob")
+{
+    SUBCASE("without data")
+    {
+        ComPtr<ISlangBlob> blob;
+        REQUIRE_CALL(getRHI()->createBlob(nullptr, 64, blob.writeRef()));
+        CHECK(blob != nullptr);
+        CHECK(blob->getBufferSize() == 64);
+        CHECK(blob->getBufferPointer() != nullptr);
+    }
+    SUBCASE("with data")
+    {
+        ComPtr<ISlangBlob> blob;
+        const char* data = "Hello, World!";
+        REQUIRE_CALL(getRHI()->createBlob(data, 14, blob.writeRef()));
+        CHECK(blob != nullptr);
+        CHECK(blob->getBufferSize() == 14);
+        CHECK(blob->getBufferPointer() != nullptr);
+        CHECK(std::memcmp(blob->getBufferPointer(), data, 14) == 0);
+    }
+}

--- a/tests/test-pipeline-cache.cpp
+++ b/tests/test-pipeline-cache.cpp
@@ -338,7 +338,11 @@ struct PipelineCacheTestRender : PipelineCacheTest
         ComPtr<ISlangBlob> textureBlob;
         SubresourceLayout layout;
         REQUIRE_CALL(device->readTexture(texture, 0, 0, textureBlob.writeRef(), &layout));
-        return ::memcmp(textureBlob->getBufferPointer(), expectedOutput.data(), expectedOutput.size() * sizeof(float)) == 0;
+        return ::memcmp(
+                   textureBlob->getBufferPointer(),
+                   expectedOutput.data(),
+                   expectedOutput.size() * sizeof(float)
+               ) == 0;
     }
 
     void runRenderPipeline(std::string_view shaderSource, const std::vector<float>& expectedOutput)

--- a/tests/test-pipeline-cache.cpp
+++ b/tests/test-pipeline-cache.cpp
@@ -1,0 +1,415 @@
+#include "testing.h"
+
+#include <filesystem>
+#include <fstream>
+#include <map>
+#include <algorithm>
+
+using namespace rhi;
+using namespace rhi::testing;
+
+class VirtualCache : public IPersistentCache
+{
+public:
+    struct Stats
+    {
+        uint32_t writeCount = 0;
+        uint32_t queryCount = 0;
+        uint32_t missCount = 0;
+        uint32_t hitCount = 0;
+        uint32_t entryCount = 0;
+    };
+
+    using Key = std::vector<uint8_t>;
+    using Data = std::vector<uint8_t>;
+
+    std::map<Key, Data> entries;
+    Stats stats;
+
+    void clear()
+    {
+        entries.clear();
+        stats = {};
+    }
+
+    void corrupt()
+    {
+        for (auto& entry : entries)
+        {
+            // Corrupt the data.
+            if (!entry.second.empty())
+            {
+                for (size_t i = 0; i < entry.second.size(); i += 100)
+                {
+                    entry.second[i] ^= 0xff; // Flip all bits in the byte.
+                }
+            }
+        }
+    }
+
+    virtual SLANG_NO_THROW Result SLANG_MCALL writeCache(ISlangBlob* key_, ISlangBlob* data_) override
+    {
+        stats.writeCount++;
+        Key key(
+            static_cast<const uint8_t*>(key_->getBufferPointer()),
+            static_cast<const uint8_t*>(key_->getBufferPointer()) + key_->getBufferSize()
+        );
+        Data data(
+            static_cast<const uint8_t*>(data_->getBufferPointer()),
+            static_cast<const uint8_t*>(data_->getBufferPointer()) + data_->getBufferSize()
+        );
+        entries[key] = data;
+        stats.entryCount = entries.size();
+        return SLANG_OK;
+    }
+
+    virtual SLANG_NO_THROW Result SLANG_MCALL queryCache(ISlangBlob* key_, ISlangBlob** outData) override
+    {
+        stats.queryCount++;
+        Key key(
+            static_cast<const uint8_t*>(key_->getBufferPointer()),
+            static_cast<const uint8_t*>(key_->getBufferPointer()) + key_->getBufferSize()
+        );
+        auto it = entries.find(key);
+        if (it == entries.end())
+        {
+            stats.missCount++;
+            *outData = nullptr;
+            return SLANG_E_NOT_FOUND;
+        }
+        stats.hitCount++;
+        *outData = UnownedBlob::create(it->second.data(), it->second.size()).detach();
+        return SLANG_OK;
+    }
+
+    virtual SLANG_NO_THROW Result SLANG_MCALL queryInterface(const SlangUUID& uuid, void** outObject) override
+    {
+        if (uuid == IPersistentCache::getTypeGuid())
+        {
+            *outObject = static_cast<IPersistentCache*>(this);
+            return SLANG_OK;
+        }
+        return SLANG_E_NO_INTERFACE;
+    }
+
+    virtual SLANG_NO_THROW uint32_t SLANG_MCALL addRef() override
+    {
+        // The lifetime of this object is tied to the test.
+        // Do not perform any reference counting.
+        return 2;
+    }
+
+    virtual SLANG_NO_THROW uint32_t SLANG_MCALL release() override
+    {
+        // Returning 2 is important here, because when releasing a COM pointer, it checks
+        // if the ref count **was 1 before releasing** in order to free the object.
+        return 2;
+    }
+};
+
+
+// Base class for pipeline cache tests.
+struct PipelineCacheTest
+{
+    GpuTestContext* ctx;
+    DeviceType deviceType;
+    std::filesystem::path tempDirectory;
+    VirtualCache pipelineCache;
+    ComPtr<IDevice> device;
+
+    void createDevice()
+    {
+        DeviceExtraOptions extraOptions;
+        extraOptions.persistentPipelineCache = &pipelineCache;
+        device = createTestingDevice(ctx, deviceType, false, &extraOptions);
+    }
+
+    VirtualCache::Stats getStats() { return pipelineCache.stats; }
+
+    void run(GpuTestContext* ctx_, DeviceType deviceType_, std::string tempDirectory_)
+    {
+        ctx = ctx_;
+        deviceType = deviceType_;
+        tempDirectory = tempDirectory_;
+
+        pipelineCache.clear();
+        remove_all(tempDirectory);
+        create_directories(tempDirectory);
+
+        runTests();
+
+        remove_all(tempDirectory);
+    }
+
+    virtual void runTests() = 0;
+};
+
+template<bool Corrupt>
+struct PipelineCacheTestCompute : PipelineCacheTest
+{
+    ComPtr<IComputePipeline> computePipeline;
+    ComPtr<IBuffer> buffer;
+
+    std::string computeShader = std::string(
+        R"(
+        [shader("compute")]
+        [numthreads(4, 1, 1)]
+        void main(
+            uint3 sv_dispatchThreadID : SV_DispatchThreadID,
+            uniform RWStructuredBuffer<float> buffer)
+        {
+            var input = buffer[sv_dispatchThreadID.x];
+            buffer[sv_dispatchThreadID.x] = input + 1.0f;
+        }
+        )"
+    );
+
+    void createResources()
+    {
+        const int numberCount = 4;
+        float initialData[] = {0.0f, 1.0f, 2.0f, 3.0f};
+        BufferDesc bufferDesc = {};
+        bufferDesc.size = numberCount * sizeof(float);
+        bufferDesc.usage = BufferUsage::ShaderResource | BufferUsage::UnorderedAccess | BufferUsage::CopyDestination |
+                           BufferUsage::CopySource;
+        REQUIRE_CALL(device->createBuffer(bufferDesc, initialData, buffer.writeRef()));
+    }
+
+    void freeResources()
+    {
+        buffer = nullptr;
+        computePipeline = nullptr;
+    }
+
+    void createComputePipeline(std::string_view shaderSource)
+    {
+        ComPtr<IShaderProgram> shaderProgram;
+        REQUIRE_CALL(loadComputeProgramFromSource(device, shaderProgram, shaderSource));
+
+        ComputePipelineDesc pipelineDesc = {};
+        pipelineDesc.program = shaderProgram.get();
+        REQUIRE_CALL(device->createComputePipeline(pipelineDesc, computePipeline.writeRef()));
+    }
+
+    void dispatchComputePipeline()
+    {
+        auto queue = device->getQueue(QueueType::Graphics);
+        auto commandEncoder = queue->createCommandEncoder();
+        auto passEncoder = commandEncoder->beginComputePass();
+        auto rootObject = passEncoder->bindPipeline(computePipeline);
+        ShaderCursor entryPointCursor(rootObject->getEntryPoint(0));
+        entryPointCursor["buffer"].setBinding(buffer);
+        passEncoder->dispatchCompute(4, 1, 1);
+        passEncoder->end();
+        queue->submit(commandEncoder->finish());
+        queue->waitOnHost();
+    }
+
+    bool checkOutput(const std::vector<float>& expectedOutput)
+    {
+        ComPtr<ISlangBlob> bufferBlob;
+        device->readBuffer(buffer, 0, 4 * sizeof(float), bufferBlob.writeRef());
+        REQUIRE(bufferBlob);
+        REQUIRE(bufferBlob->getBufferSize() == expectedOutput.size() * sizeof(float));
+        return ::memcmp(bufferBlob->getBufferPointer(), expectedOutput.data(), bufferBlob->getBufferSize()) == 0;
+    }
+
+    void runComputePipeline(std::string_view shaderSource, const std::vector<float>& expectedOutput)
+    {
+        createResources();
+        createComputePipeline(shaderSource);
+        dispatchComputePipeline();
+        CHECK(checkOutput(expectedOutput));
+        freeResources();
+    }
+
+    void runTests()
+    {
+        // Cache is cold and we expect 1 miss.
+        createDevice();
+        if (!device->hasFeature(Feature::PipelineCache))
+            SKIP("Pipeline cache is not supported on this device type.");
+        runComputePipeline(computeShader, {1.f, 2.f, 3.f, 4.f});
+        CHECK_EQ(getStats().writeCount, 1);
+        CHECK_EQ(getStats().queryCount, 1);
+        CHECK_EQ(getStats().missCount, 1);
+        CHECK_EQ(getStats().hitCount, 0);
+        CHECK_EQ(getStats().entryCount, 1);
+
+        // Corrupt the cache.
+        if constexpr (Corrupt)
+        {
+            pipelineCache.corrupt();
+        }
+
+        // Cache is hot and we expect 1 hit.
+        createDevice();
+        runComputePipeline(computeShader, {1.f, 2.f, 3.f, 4.f});
+        CHECK_EQ(getStats().writeCount, Corrupt ? 2 : 1);
+        CHECK_EQ(getStats().queryCount, 2);
+        CHECK_EQ(getStats().missCount, 1);
+        CHECK_EQ(getStats().hitCount, 1);
+        CHECK_EQ(getStats().entryCount, 1);
+    }
+};
+
+template<bool Corrupt>
+struct PipelineCacheTestRender : PipelineCacheTest
+{
+    ComPtr<IRenderPipeline> renderPipeline;
+    ComPtr<ITexture> texture;
+
+    std::string renderShader = std::string(
+        R"(
+        [shader("vertex")]
+        float4 vertexMain(uint vid: SV_VertexID) : SV_Position
+        {
+            float2 uv = float2((vid << 1) & 2, vid & 2);
+            return float4(uv * float2(2, -2) + float2(-1, 1), 0, 1);
+        }
+
+        // Fragment Shader
+
+        [shader("fragment")]
+        float4 fragmentMain()
+            : SV_Target
+        {
+            return float4(1.0, 0.0, 1.0, 1.0);
+        }
+        )"
+    );
+
+    void createResources()
+    {
+        TextureDesc textureDesc = {};
+        textureDesc.format = Format::RGBA32Float;
+        textureDesc.size = {2, 2, 1};
+        textureDesc.usage = TextureUsage::CopySource | TextureUsage::RenderTarget;
+        REQUIRE_CALL(device->createTexture(textureDesc, nullptr, texture.writeRef()));
+    }
+
+    void freeResources()
+    {
+        texture = nullptr;
+        renderPipeline = nullptr;
+    }
+
+    void createRenderPipeline(std::string_view shaderSource)
+    {
+        ComPtr<IShaderProgram> shaderProgram;
+        REQUIRE_CALL(loadRenderProgramFromSource(device, shaderProgram, shaderSource, "vertexMain", "fragmentMain"));
+
+        RenderPipelineDesc pipelineDesc = {};
+        pipelineDesc.program = shaderProgram.get();
+        ColorTargetDesc colorTargetDesc = {};
+        colorTargetDesc.format = Format::RGBA32Float;
+        pipelineDesc.targetCount = 1;
+        pipelineDesc.targets = &colorTargetDesc;
+        REQUIRE_CALL(device->createRenderPipeline(pipelineDesc, renderPipeline.writeRef()));
+    }
+
+    void dispatchRenderPipeline()
+    {
+        auto queue = device->getQueue(QueueType::Graphics);
+        auto commandEncoder = queue->createCommandEncoder();
+        RenderPassDesc renderPass = {};
+        RenderPassColorAttachment colorAttachment = {};
+        colorAttachment.view = texture->getDefaultView();
+        renderPass.colorAttachments = &colorAttachment;
+        renderPass.colorAttachmentCount = 1;
+        auto passEncoder = commandEncoder->beginRenderPass(renderPass);
+        auto rootObject = passEncoder->bindPipeline(renderPipeline);
+        RenderState renderState = {};
+        renderState.viewports[0] = Viewport::fromSize(2, 2);
+        renderState.viewportCount = 1;
+        renderState.scissorRects[0] = ScissorRect::fromSize(2, 2);
+        renderState.scissorRectCount = 1;
+        passEncoder->setRenderState(renderState);
+        DrawArguments drawArgs = {};
+        drawArgs.vertexCount = 3;
+        passEncoder->draw(drawArgs);
+        passEncoder->end();
+        queue->submit(commandEncoder->finish());
+        queue->waitOnHost();
+    }
+
+    bool checkOutput(const std::vector<float>& expectedOutput)
+    {
+        ComPtr<ISlangBlob> textureBlob;
+        SubresourceLayout layout;
+        REQUIRE_CALL(device->readTexture(texture, 0, 0, textureBlob.writeRef(), &layout));
+        return ::memcmp(textureBlob->getBufferPointer(), expectedOutput.data(), expectedOutput.size() * sizeof(float)) == 0;
+    }
+
+    void runRenderPipeline(std::string_view shaderSource, const std::vector<float>& expectedOutput)
+    {
+        createResources();
+        createRenderPipeline(shaderSource);
+        dispatchRenderPipeline();
+        CHECK(checkOutput(expectedOutput));
+        freeResources();
+    }
+
+    void runTests()
+    {
+        // Cache is cold and we expect 1 miss.
+        createDevice();
+        if (!device->hasFeature(Feature::PipelineCache))
+            SKIP("Pipeline cache is not supported on this device type.");
+        runRenderPipeline(renderShader, {1.f, 0.f, 1.f, 1.f});
+        CHECK_EQ(getStats().writeCount, 1);
+        CHECK_EQ(getStats().queryCount, 1);
+        CHECK_EQ(getStats().missCount, 1);
+        CHECK_EQ(getStats().hitCount, 0);
+        CHECK_EQ(getStats().entryCount, 1);
+
+        // Corrupt the cache.
+        if constexpr (Corrupt)
+        {
+            pipelineCache.corrupt();
+        }
+
+        // Cache is hot and we expect 1 hit.
+        createDevice();
+        runRenderPipeline(renderShader, {1.f, 0.f, 1.f, 1.f});
+        CHECK_EQ(getStats().writeCount, Corrupt ? 2 : 1);
+        CHECK_EQ(getStats().queryCount, 2);
+        CHECK_EQ(getStats().missCount, 1);
+        CHECK_EQ(getStats().hitCount, 1);
+        CHECK_EQ(getStats().entryCount, 1);
+    }
+};
+
+template<typename T>
+void runTest(GpuTestContext* ctx, DeviceType deviceType)
+{
+    std::string tempDirectory = getCaseTempDirectory();
+    T test;
+    test.run(ctx, deviceType, tempDirectory);
+}
+
+TEST_CASE("pipeline-cache-compute")
+{
+    runGpuTests(runTest<PipelineCacheTestCompute<false>>, {DeviceType::D3D12, DeviceType::Vulkan});
+}
+
+#if 0
+// TODO: D3D12 does fail in debug layers and not return an error correctly.
+TEST_CASE("pipeline-cache-compute-corrupt")
+{
+    runGpuTests(runTest<PipelineCacheTestCompute<true>>, {DeviceType::Vulkan});
+}
+#endif
+
+TEST_CASE("pipeline-cache-render")
+{
+    runGpuTests(runTest<PipelineCacheTestRender<false>>, {DeviceType::D3D12, DeviceType::Vulkan});
+}
+
+#if 0
+// TODO: D3D12 does fail in debug layers and not return an error correctly.
+TEST_CASE("pipeline-cache-render-corrupt")
+{
+    runGpuTests(runTest<PipelineCacheTestRender<true>>, {DeviceType::Vulkan});
+}
+#endif

--- a/tests/test-shader-cache.cpp
+++ b/tests/test-shader-cache.cpp
@@ -8,7 +8,7 @@
 using namespace rhi;
 using namespace rhi::testing;
 
-class VirtualShaderCache : public IPersistentShaderCache
+class VirtualShaderCache : public IPersistentCache
 {
 public:
     struct Stats
@@ -85,9 +85,9 @@ public:
 
     virtual SLANG_NO_THROW Result SLANG_MCALL queryInterface(const SlangUUID& uuid, void** outObject) override
     {
-        if (uuid == IPersistentShaderCache::getTypeGuid())
+        if (uuid == IPersistentCache::getTypeGuid())
         {
-            *outObject = static_cast<IPersistentShaderCache*>(this);
+            *outObject = static_cast<IPersistentCache*>(this);
             return SLANG_OK;
         }
         return SLANG_E_NO_INTERFACE;

--- a/tests/testing.cpp
+++ b/tests/testing.cpp
@@ -327,9 +327,15 @@ ComPtr<IDevice> createTestingDevice(
     GpuTestContext* ctx,
     DeviceType deviceType,
     bool useCachedDevice,
-    std::vector<const char*> additionalSearchPaths
+    const DeviceExtraOptions* extraOptions
 )
 {
+    // Extra options can only be used when not using cached device.
+    if (useCachedDevice)
+    {
+        REQUIRE(extraOptions == nullptr);
+    }
+
     if (useCachedDevice)
     {
         auto it = gCachedDevices.find(deviceType);
@@ -347,8 +353,15 @@ ComPtr<IDevice> createTestingDevice(
 #endif
 
     std::vector<const char*> searchPaths = getSlangSearchPaths();
-    for (const char* path : additionalSearchPaths)
-        searchPaths.push_back(path);
+    if (extraOptions)
+    {
+        for (const char* path : extraOptions->searchPaths)
+            searchPaths.push_back(path);
+        if (extraOptions->persistentShaderCache)
+            deviceDesc.persistentShaderCache = extraOptions->persistentShaderCache;
+        if (extraOptions->persistentPipelineCache)
+            deviceDesc.persistentPipelineCache = extraOptions->persistentPipelineCache;
+    }
 
     std::vector<slang::PreprocessorMacroDesc> preprocessorMacros;
     std::vector<slang::CompilerOptionEntry> compilerOptions;

--- a/tests/testing.cpp
+++ b/tests/testing.cpp
@@ -323,6 +323,53 @@ Result loadGraphicsProgram(
     return outShaderProgram ? SLANG_OK : SLANG_FAIL;
 }
 
+Result loadRenderProgramFromSource(
+    IDevice* device,
+    ComPtr<IShaderProgram>& outShaderProgram,
+    std::string_view source,
+    const char* vertexEntryPointName,
+    const char* fragmentEntryPointName
+)
+{
+    auto slangSession = device->getSlangSession();
+    slang::IModule* module = nullptr;
+    ComPtr<slang::IBlob> diagnosticsBlob;
+    size_t hash = std::hash<std::string_view>()(source);
+    std::string moduleName = "source_module_" + std::to_string(hash);
+    auto srcBlob = UnownedBlob::create(source.data(), source.size());
+    module =
+        slangSession->loadModuleFromSource(moduleName.data(), moduleName.data(), srcBlob, diagnosticsBlob.writeRef());
+    if (!module)
+        return SLANG_FAIL;
+
+    std::vector<ComPtr<slang::IComponentType>> componentTypes;
+    componentTypes.push_back(ComPtr<slang::IComponentType>(module));
+
+    ComPtr<slang::IEntryPoint> vertexEntryPoint;
+    SLANG_RETURN_ON_FAIL(module->findEntryPointByName(vertexEntryPointName, vertexEntryPoint.writeRef()));
+    componentTypes.push_back(ComPtr<slang::IComponentType>(vertexEntryPoint.get()));
+
+    ComPtr<slang::IEntryPoint> fragmentEntryPoint;
+    SLANG_RETURN_ON_FAIL(module->findEntryPointByName(fragmentEntryPointName, fragmentEntryPoint.writeRef()));
+    componentTypes.push_back(ComPtr<slang::IComponentType>(fragmentEntryPoint.get()));
+
+    std::vector<slang::IComponentType*> rawComponentTypes;
+    for (auto& compType : componentTypes)
+        rawComponentTypes.push_back(compType.get());
+
+    ComPtr<slang::IComponentType> linkedProgram;
+    Result result = slangSession->createCompositeComponentType(
+        rawComponentTypes.data(),
+        rawComponentTypes.size(),
+        linkedProgram.writeRef(),
+        diagnosticsBlob.writeRef()
+    );
+    SLANG_RETURN_ON_FAIL(result);
+
+    outShaderProgram = device->createShaderProgram(linkedProgram);
+    return outShaderProgram ? SLANG_OK : SLANG_FAIL;
+}
+
 ComPtr<IDevice> createTestingDevice(
     GpuTestContext* ctx,
     DeviceType deviceType,

--- a/tests/testing.h
+++ b/tests/testing.h
@@ -167,11 +167,18 @@ void compareComputeResult(
     compareComputeResult(device, texture, layer, mip, span<T>(expectedResult.data(), Count));
 }
 
+struct DeviceExtraOptions
+{
+    std::vector<const char*> searchPaths;
+    IPersistentCache* persistentShaderCache = nullptr;
+    IPersistentCache* persistentPipelineCache = nullptr;
+};
+
 ComPtr<IDevice> createTestingDevice(
     GpuTestContext* ctx,
     DeviceType deviceType,
     bool useCachedDevice = true,
-    std::vector<const char*> additionalSearchPaths = {}
+    const DeviceExtraOptions* extraOptions = nullptr
 );
 
 void releaseCachedDevices();

--- a/tests/testing.h
+++ b/tests/testing.h
@@ -77,6 +77,14 @@ Result loadGraphicsProgram(
     slang::ProgramLayout*& slangReflection
 );
 
+Result loadRenderProgramFromSource(
+    IDevice* device,
+    ComPtr<IShaderProgram>& outShaderProgram,
+    std::string_view source,
+    const char* vertexEntryPointName,
+    const char* fragmentEntryPointName
+);
+
 template<typename T>
 void compareResult(const T* result, const T* expectedResult, size_t count)
 {


### PR DESCRIPTION
- add pipeline caching for D3D12 and Vulkan
- cache is hooked up through `DeviceDesc::persistentPipelineCache`
- add `Feature::PipelineCache` to allow detecting support
- rename `IPersistentShaderCache` to `IPersistentCache`
- remove `Device::getShaderCacheStats()`
- remove `IPipelineCreationAPIDispatcher` interface
- add `IRHI::createBlob` utility to allow creating binary blobs
- fix natvis rule for `short_vector`
- add `loadRenderProgramFromSource` to testing helpers
- introduce `DeviceExtraOptions` to testing helpers