### PR TITLE
Fix several VVL violations detected in slang-test

### DIFF
--- a/include/slang-rhi.h
+++ b/include/slang-rhi.h
@@ -125,7 +125,7 @@ enum class DeviceType
     x(RayQuery,                                 "ray-query"                                     ) \
     x(ShaderExecutionReordering,                "shader-execution-reordering"                   ) \
     x(RayTracingValidation,                     "ray-tracing-validation"                        ) \
-    /* Other features */                                                                           \
+    /* Other features */                                                                          \
     x(TimestampQuery,                           "timestamp-query"                               ) \
     x(RealtimeClock,                            "realtime-clock"                                ) \
     x(CooperativeVector,                        "cooperative-vector"                            ) \

--- a/src/vulkan/vk-api.h
+++ b/src/vulkan/vk-api.h
@@ -330,6 +330,9 @@ struct VulkanExtendedFeatureProperties
     // Vulkan 1.3 features.
     VkPhysicalDeviceVulkan13Features vulkan13Features = {VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_3_FEATURES};
 
+    // Vulkan 1.4 features.
+    VkPhysicalDeviceVulkan14Features vulkan14Features = {VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_4_FEATURES};
+
     // Dynamic rendering features
     VkPhysicalDeviceDynamicRenderingFeaturesKHR dynamicRenderingFeatures = {
         VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DYNAMIC_RENDERING_FEATURES_KHR
@@ -395,6 +398,11 @@ struct VulkanExtendedFeatureProperties
     // Pipeline binary features
     VkPhysicalDevicePipelineBinaryFeaturesKHR pipelineBinaryFeatures = {
         VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PIPELINE_BINARY_FEATURES_KHR
+    };
+
+    // Shader subgroup rotate features
+    VkPhysicalDeviceShaderSubgroupRotateFeatures shaderSubgroupRotateFeatures = {
+       VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_SUBGROUP_ROTATE_FEATURES_KHR
     };
 };
 

--- a/src/vulkan/vk-command.cpp
+++ b/src/vulkan/vk-command.cpp
@@ -1519,13 +1519,23 @@ void CommandRecorder::accelerationStructureBarrier(
         memBarriers[i].offset = 0;
         memBarriers[i].size = asImpl->m_buffer->m_desc.size;
     }
+
+    VkPipelineStageFlagBits dstStageMask = VK_PIPELINE_STAGE_RAY_TRACING_SHADER_BIT_KHR;
+    if (m_device->m_api.m_extendedFeatures.rayQueryFeatures.rayQuery)
+    {
+        // for VUID-vkCmdPipelineBarrier-dstAccessMask-06257
+        // If the rayQuery feature is not enabled and a memory barrier dstAccessMask includes VK_ACCESS_ACCELERATION_STRUCTURE_READ_BIT_KHR,
+        // dstStageMask must not include any of the VK_PIPELINE_STAGE_*_SHADER_BIT stages except VK_PIPELINE_STAGE_RAY_TRACING_SHADER_BIT_KHR
+        dstStageMask = (VkPipelineStageFlagBits)(VK_PIPELINE_STAGE_ACCELERATION_STRUCTURE_BUILD_BIT_KHR |
+            VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT |
+            VK_PIPELINE_STAGE_TRANSFER_BIT | VK_PIPELINE_STAGE_VERTEX_SHADER_BIT |
+            VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT | VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT |
+            VK_PIPELINE_STAGE_RAY_TRACING_SHADER_BIT_KHR);
+    }
     m_device->m_api.vkCmdPipelineBarrier(
         m_cmdBuffer,
         VK_PIPELINE_STAGE_ACCELERATION_STRUCTURE_BUILD_BIT_KHR | VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT,
-        VK_PIPELINE_STAGE_ACCELERATION_STRUCTURE_BUILD_BIT_KHR | VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT |
-            VK_PIPELINE_STAGE_TRANSFER_BIT | VK_PIPELINE_STAGE_VERTEX_SHADER_BIT |
-            VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT | VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT |
-            VK_PIPELINE_STAGE_RAY_TRACING_SHADER_BIT_KHR,
+        dstStageMask,
         0,
         0,
         nullptr,

--- a/src/vulkan/vk-device.cpp
+++ b/src/vulkan/vk-device.cpp
@@ -546,11 +546,17 @@ Result DeviceImpl::initVulkanInstanceAndDevice(
             deviceFeatures2.pNext = &extendedFeatures.vulkan12Features;
         }
 
-        // if (VK_MAKE_VERSION(majorVersion, minorVersion, 0) >= VK_API_VERSION_1_3)
-        // {
-        //     extendedFeatures.vulkan13Features.pNext = deviceFeatures2.pNext;
-        //     deviceFeatures2.pNext = &extendedFeatures.vulkan13Features;
-        // }
+        if (VK_MAKE_VERSION(majorVersion, minorVersion, 0) >= VK_API_VERSION_1_3)
+        {
+            extendedFeatures.vulkan13Features.pNext = deviceFeatures2.pNext;
+            deviceFeatures2.pNext = &extendedFeatures.vulkan13Features;
+        }
+
+        if (VK_MAKE_VERSION(majorVersion, minorVersion, 0) >= VK_API_VERSION_1_4)
+        {
+            extendedFeatures.vulkan14Features.pNext = deviceFeatures2.pNext;
+            deviceFeatures2.pNext = &extendedFeatures.vulkan14Features;
+        }
 
         m_api.vkGetPhysicalDeviceFeatures2(m_api.m_physicalDevice, &deviceFeatures2);
 
@@ -666,6 +672,17 @@ Result DeviceImpl::initVulkanInstanceAndDevice(
             VK_EXT_CUSTOM_BORDER_COLOR_EXTENSION_NAME,
             { availableFeatures.push_back(Feature::CustomBorderColor); }
         );
+
+        if (extendedFeatures.vulkan14Features.shaderSubgroupRotate &&
+            extendedFeatures.vulkan14Features.shaderSubgroupRotateClustered &&
+            extensionNames.count(VK_KHR_SHADER_SUBGROUP_ROTATE_EXTENSION_NAME))
+        {
+            extendedFeatures.shaderSubgroupRotateFeatures.shaderSubgroupRotate = VK_TRUE;
+            extendedFeatures.shaderSubgroupRotateFeatures.shaderSubgroupRotateClustered  = VK_TRUE;
+            extendedFeatures.shaderSubgroupRotateFeatures.pNext = (void*)deviceCreateInfo.pNext;
+            deviceCreateInfo.pNext = &extendedFeatures.shaderSubgroupRotateFeatures;
+            deviceExtensions.push_back(VK_KHR_SHADER_SUBGROUP_ROTATE_EXTENSION_NAME);
+        }
 
         if (extendedFeatures.accelerationStructureFeatures.accelerationStructure &&
             extensionNames.count(VK_KHR_ACCELERATION_STRUCTURE_EXTENSION_NAME) &&

--- a/src/vulkan/vk-helper-functions.cpp
+++ b/src/vulkan/vk-helper-functions.cpp
@@ -196,7 +196,7 @@ VkAccessFlags translateAccelerationStructureAccessFlag(AccessFlag access)
     VkAccessFlags result = 0;
     if ((uint32_t)access & (uint32_t)AccessFlag::Read)
         result |=
-            VK_ACCESS_ACCELERATION_STRUCTURE_READ_BIT_KHR | VK_ACCESS_SHADER_READ_BIT | VK_ACCESS_TRANSFER_READ_BIT;
+            VK_ACCESS_ACCELERATION_STRUCTURE_READ_BIT_KHR | VK_ACCESS_SHADER_READ_BIT;
     if ((uint32_t)access & (uint32_t)AccessFlag::Write)
         result |= VK_ACCESS_ACCELERATION_STRUCTURE_WRITE_BIT_KHR;
     return result;


### PR DESCRIPTION
1. `VUID-vkCmdPipelineBarrier-pBufferMemoryBarriers-02818` Removed VK_ACCESS_TRANSFER_READ_BIT as it's not supported in ray tracing stage
2. `VUID-vkCmdPipelineBarrier-dstAccessMask-06257` Check rayquery feature first before setting stages to the AS barriers
3. `VUID-RuntimeSpirv-shaderSubgroupRotateClustered-09566` Query 1.4 features and turn on ShaderSubgroupRotate* if available

Fixes part of https://github.com/shader-slang/slang/issues/4798