### PR TITLE
Fix uninitialized memory in D3D12 TextureImpl

### DIFF
--- a/src/d3d12/d3d12-texture.h
+++ b/src/d3d12/d3d12-texture.h
@@ -11,9 +11,9 @@ public:
     ~TextureImpl();
 
     D3D12Resource m_resource;
-    DXGI_FORMAT m_format;
-    bool m_isTypeless;
-    D3D12_RESOURCE_STATES m_defaultState;
+    DXGI_FORMAT m_format = DXGI_FORMAT_UNKNOWN;
+    bool m_isTypeless = false;
+    D3D12_RESOURCE_STATES m_defaultState = D3D12_RESOURCE_STATE_COMMON;
 
     virtual SLANG_NO_THROW Result SLANG_MCALL getNativeHandle(NativeHandle* outHandle) override;
     virtual SLANG_NO_THROW Result SLANG_MCALL getSharedHandle(NativeHandle* outHandle) override;

--- a/src/d3d12/d3d12-texture.h
+++ b/src/d3d12/d3d12-texture.h
@@ -12,7 +12,7 @@ public:
 
     D3D12Resource m_resource;
     DXGI_FORMAT m_format = DXGI_FORMAT_UNKNOWN;
-    bool m_isTypeless = false;
+    bool m_isTypeless = true;
     D3D12_RESOURCE_STATES m_defaultState = D3D12_RESOURCE_STATE_COMMON;
 
     virtual SLANG_NO_THROW Result SLANG_MCALL getNativeHandle(NativeHandle* outHandle) override;


### PR DESCRIPTION
The D3D12 TextureImpl gets created in 3 different places.

In `DeviceImpl::createTexture`, where the values on the `TextureImpl` are set right away: 
```
    texture->m_format = resourceDesc.Format;
    texture->m_isTypeless = isTypeless;
```
But in `createTextureFromNativeHandle` and in `SurfaceImpl::createSwapchainTextures` the `m_format` and `m_isTypeless` have been left uninitialized.

When a subsequent call to `getRTV` is made, the format is determined like so:
```
viewDesc.Format = m_isTypeless ? D3DUtil::getFormatMapping(format).rtvFormat : m_format;
```

and with both `m_isTypeless` and `m_format` uninitialized, you can get garbage values. I've tested this by setting `m_format` to `123456` and the error pretty much stopped being intermittent and started firing all the time.

The specific offensive texture came from the `createSwapchainTextures`. I've tried to make the `m_isTypeless` private and use setter and getter to discover all places that would be setting it after creation, and there was no obvious place that would set it after either `createSwapchainTextures` or `createTextureFromNativeHandle`.

I propose we set these members to reasonable default values. Alternatively, in the debug mode, we could set them to unreasonable values (e.g., the `m_format` be set to 123456) and assert they don't make it into actual calls. 

This is not caught by any test (tested by setting `m_isTypeless` false, `m_format` to 123456, and throwing exception `if (viewDesc.Format > DXGI_FORMAT_A4B4G4R4_UNORM`).

This can be in other places and might require a sweeping check.

I'd also propose we adopt the policy that seems to be part of the slang-rhi API, where each member gets a default value so we never have uninitialized memory.
