### PR TITLE
cleanup workflows

### DIFF
--- a/.github/workflows/ci-gcp.yml
+++ b/.github/workflows/ci-gcp.yml
@@ -1,11 +1,21 @@
-name: CI-GCP
+name: ci-gcp
 
 on:
   workflow_dispatch:
-  pull_request:
-  push:
-    branches:
-      - main
+  # push:
+  #   branches: [main]
+  #   paths-ignore:
+  #     - "docs/**"
+  #     - "LICENSES/**"
+  #     - "LICENSE"
+  #     - "**.md"
+  # pull_request:
+  #   branches: [main]
+  #   paths-ignore:
+  #     - "docs/**"
+  #     - "LICENSES/**"
+  #     - "LICENSE"
+  #     - "**.md"
 
 jobs:
   build:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,11 +1,23 @@
-name: CI
+name: ci
 
 on:
   workflow_dispatch:
-  pull_request:
   push:
-    branches:
-      - main
+    branches: [main]
+    paths-ignore:
+      - "docs/**"
+      - "LICENSES/**"
+      - "LICENSE"
+      - "**.md"
+      - .github/workflows/ci-gcp.yml
+  pull_request:
+    branches: [main]
+    paths-ignore:
+      - "docs/**"
+      - "LICENSES/**"
+      - "LICENSE"
+      - "**.md"
+      - .github/workflows/ci-gcp.yml
 
 jobs:
   build:


### PR DESCRIPTION
- don't trigger main ci when changing `ci-gcp.yml`
- don't trigger `ci-gcp` workflow on `push` and `pull_request` for now