### PR TITLE
Fix linking errros when buildling slang-rhi examples w/ slang

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,6 @@
 [submodule "external/metal-cpp"]
 	path = external/metal-cpp
 	url = https://github.com/bkaradzic/metal-cpp.git
+[submodule "external/optix-dev"]
+	path = external/optix-dev
+	url = https://github.com/NVIDIA/optix-dev.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -800,7 +800,7 @@ if(SLANG_RHI_BUILD_EXAMPLES)
         add_executable(${name} ${source})
         target_compile_features(${name} PRIVATE cxx_std_17)
         target_include_directories(${name} PRIVATE examples/base)
-        target_link_libraries(${name} PRIVATE slang slang-rhi glfw)
+        target_link_libraries(${name} PRIVATE slang-rhi slang glfw)
     endfunction()
 
     add_example(example-surface examples/surface/example-surface.cpp)

--- a/cmake/FindOptiX.cmake
+++ b/cmake/FindOptiX.cmake
@@ -2,7 +2,16 @@ include(FindPackageHandleStandardArgs)
 
 set(Optix_ROOT_DIR "" CACHE PATH "Path to an installed OptiX SDK")
 
-if(Optix_ROOT_DIR)
+# First try the git submodule location
+find_path(
+    OptiX_INCLUDE_DIRS
+    NAMES optix.h
+    PATHS "${CMAKE_CURRENT_SOURCE_DIR}/external/optix-dev/include"
+    NO_DEFAULT_PATH
+)
+
+# If not found and a custom path is provided, try that
+if(NOT OptiX_INCLUDE_DIRS AND Optix_ROOT_DIR)
     find_path(
         OptiX_INCLUDE_DIRS
         NAMES optix.h
@@ -10,7 +19,10 @@ if(Optix_ROOT_DIR)
         PATHS "${Optix_ROOT_DIR}"
         NO_DEFAULT_PATH
     )
-else()
+endif()
+
+# Finally, try system paths as fallback
+if(NOT OptiX_INCLUDE_DIRS)
     find_path(OptiX_INCLUDE_DIRS NAMES optix.h)
 endif()
 


### PR DESCRIPTION
Add optix-dev submodule

target_link_libraries(example-surface PRIVATE slang-rhi slang glfw) By listing slang-rhi first, the linker identifies the symbols it needs. Then, when it processes slang (libslang.so), it can find and link the required spReflection... functions, resolving the "undefined reference" errors.