### PR TITLE
disable shader object validation

### DIFF
--- a/src/debug-layer/debug-shader-object.cpp
+++ b/src/debug-layer/debug-shader-object.cpp
@@ -11,22 +11,23 @@ ShaderObjectContainerType DebugShaderObject::getContainerType()
 
 void DebugShaderObject::checkCompleteness()
 {
-    auto layout = baseObject->getElementTypeLayout();
-    for (SlangInt i = 0; i < layout->getBindingRangeCount(); i++)
-    {
-        if (layout->getBindingRangeBindingCount(i) != 0)
-        {
-            if (!m_initializedBindingRanges.count(i))
-            {
-                auto var = layout->getBindingRangeLeafVariable(i);
-                RHI_VALIDATION_ERROR_FORMAT(
-                    "shader parameter '%s' is not initialized in the shader object of type '%s'.",
-                    var->getName(),
-                    m_slangType->getName()
-                );
-            }
-        }
-    }
+    // TODO(shaderobject): Implement better validation for bindings but make that optional as it's expensive.
+    // auto layout = baseObject->getElementTypeLayout();
+    // for (SlangInt i = 0; i < layout->getBindingRangeCount(); i++)
+    // {
+    //     if (layout->getBindingRangeBindingCount(i) != 0)
+    //     {
+    //         if (!m_initializedBindingRanges.count(i))
+    //         {
+    //             auto var = layout->getBindingRangeLeafVariable(i);
+    //             RHI_VALIDATION_ERROR_FORMAT(
+    //                 "shader parameter '%s' is not initialized in the shader object of type '%s'.",
+    //                 var->getName(),
+    //                 m_slangType->getName()
+    //             );
+    //         }
+    //     }
+    // }
 }
 
 void DebugShaderObject::checkNotFinalized()
@@ -109,8 +110,9 @@ Result DebugShaderObject::setObject(const ShaderOffset& offset, IShaderObject* o
     checkNotFinalized();
     auto objectImpl = getDebugObj(object);
     m_objects[ShaderOffsetKey{offset}] = objectImpl;
-    m_initializedBindingRanges.emplace(offset.bindingRangeIndex);
-    objectImpl->checkCompleteness();
+    // TODO(shaderobject): Implement better validation for bindings but make that optional as it's expensive.
+    // m_initializedBindingRanges.emplace(offset.bindingRangeIndex);
+    // objectImpl->checkCompleteness();
     return baseObject->setObject(offset, getInnerObj(object));
 }
 
@@ -118,8 +120,9 @@ Result DebugShaderObject::setBinding(const ShaderOffset& offset, const Binding& 
 {
     SLANG_RHI_API_FUNC;
     checkNotFinalized();
-    m_bindings[ShaderOffsetKey{offset}] = binding;
-    m_initializedBindingRanges.emplace(offset.bindingRangeIndex);
+    // TODO(shaderobject): Implement better validation for bindings but make that optional as it's expensive.
+    // m_bindings[ShaderOffsetKey{offset}] = binding;
+    // m_initializedBindingRanges.emplace(offset.bindingRangeIndex);
     return baseObject->setBinding(offset, binding);
 }
 
@@ -191,7 +194,8 @@ void DebugRootShaderObject::reset()
 {
     m_entryPoints.clear();
     m_objects.clear();
-    m_bindings.clear();
+    // TODO(shaderobject): Implement better validation for bindings but make that optional as it's expensive.
+    // m_bindings.clear();
     baseObject.setNull();
 }
 

--- a/src/debug-layer/debug-shader-object.h
+++ b/src/debug-layer/debug-shader-object.h
@@ -83,8 +83,9 @@ public:
         size_t operator()(const ShaderOffsetKey& key) const { return key.getHashCode(); }
     };
     std::unordered_map<ShaderOffsetKey, RefPtr<DebugShaderObject>, ShaderOffsetKeyHasher> m_objects;
-    std::unordered_map<ShaderOffsetKey, Binding, ShaderOffsetKeyHasher> m_bindings;
-    std::set<SlangInt> m_initializedBindingRanges;
+    // TODO(shaderobject): Implement better validation for bindings but make that optional as it's expensive.
+    // std::unordered_map<ShaderOffsetKey, Binding, ShaderOffsetKeyHasher> m_bindings;
+    // std::set<SlangInt> m_initializedBindingRanges;
 };
 
 class DebugRootShaderObject : public DebugShaderObject


### PR DESCRIPTION
This PR disables shader object validation. It is not correct (we support null views now) and generally quite expensive to do. We should bring it back but also add a "validation level" option that allows enabling more rigorous and expensive validation if the user wants to.