### PR TITLE
Fix D3D11 TimestampQuery feature detection

### DIFF
--- a/src/d3d11/d3d11-device.cpp
+++ b/src/d3d11/d3d11-device.cpp
@@ -301,7 +301,10 @@ Result DeviceImpl::initialize(const DeviceDesc& desc)
     addFeature(Feature::Surface);
     addFeature(Feature::Rasterization);
     addFeature(Feature::CustomBorderColor);
-    addFeature(Feature::TimestampQuery);
+    if (m_info.timestampFrequency > 0)
+    {
+        addFeature(Feature::TimestampQuery);
+    }
 
     addCapability(Capability::hlsl);
 


### PR DESCRIPTION
Only report `Feature::TimestampQuery` for D3D11 if reported frequency is non-zero.