### PR TITLE
Pipeline labels

### DIFF
--- a/include/slang-rhi.h
+++ b/include/slang-rhi.h
@@ -1704,6 +1704,8 @@ struct RenderPipelineDesc
     DepthStencilDesc depthStencil;
     RasterizerDesc rasterizer;
     MultisampleDesc multisample;
+
+    const char* label = nullptr;
 };
 
 struct ComputePipelineDesc
@@ -1713,6 +1715,8 @@ struct ComputePipelineDesc
 
     IShaderProgram* program = nullptr;
     void* d3d12RootSignatureOverride = nullptr;
+
+    const char* label = nullptr;
 };
 
 enum class RayTracingPipelineFlags
@@ -1744,6 +1748,8 @@ struct RayTracingPipelineDesc
     uint32_t maxRayPayloadSize = 0;
     uint32_t maxAttributeSizeInBytes = 8;
     RayTracingPipelineFlags flags = RayTracingPipelineFlags::None;
+
+    const char* label = nullptr;
 };
 
 // Specifies the bytes to overwrite into a record in the shader table.
@@ -1798,16 +1804,25 @@ public:
 class IRenderPipeline : public IPipeline
 {
     SLANG_COM_INTERFACE(0xf2eb0472, 0xfa25, 0x44f9, {0xb1, 0x90, 0xdc, 0x3e, 0x29, 0xaa, 0x56, 0x6a});
+
+public:
+    virtual SLANG_NO_THROW const RenderPipelineDesc& SLANG_MCALL getDesc() = 0;
 };
 
 class IComputePipeline : public IPipeline
 {
     SLANG_COM_INTERFACE(0x16eded28, 0xdc04, 0x434d, {0x85, 0xb7, 0xd6, 0xfa, 0xa0, 0x00, 0x5d, 0xf3});
+
+public:
+    virtual SLANG_NO_THROW const ComputePipelineDesc& SLANG_MCALL getDesc() = 0;
 };
 
 class IRayTracingPipeline : public IPipeline
 {
     SLANG_COM_INTERFACE(0x5047f5d7, 0xc6f6, 0x4482, {0xab, 0x49, 0x08, 0x57, 0x1b, 0xcf, 0xe8, 0xda});
+
+public:
+    virtual SLANG_NO_THROW const RayTracingPipelineDesc& SLANG_MCALL getDesc() = 0;
 };
 
 struct ScissorRect

--- a/src/cpu/cpu-pipeline.cpp
+++ b/src/cpu/cpu-pipeline.cpp
@@ -4,8 +4,8 @@
 
 namespace rhi::cpu {
 
-ComputePipelineImpl::ComputePipelineImpl(Device* device)
-    : ComputePipeline(device)
+ComputePipelineImpl::ComputePipelineImpl(Device* device, const ComputePipelineDesc& desc)
+    : ComputePipeline(device, desc)
 {
 }
 
@@ -45,7 +45,7 @@ Result DeviceImpl::createComputePipeline2(const ComputePipelineDesc& desc, IComp
         return SLANG_FAIL;
     }
 
-    RefPtr<ComputePipelineImpl> pipeline = new ComputePipelineImpl(this);
+    RefPtr<ComputePipelineImpl> pipeline = new ComputePipelineImpl(this, desc);
     pipeline->m_program = checked_cast<ShaderProgram*>(desc.program);
     pipeline->m_sharedLibrary = sharedLibrary;
     pipeline->m_func = func;

--- a/src/cpu/cpu-pipeline.h
+++ b/src/cpu/cpu-pipeline.h
@@ -10,7 +10,7 @@ public:
     ComPtr<ISlangSharedLibrary> m_sharedLibrary;
     slang_prelude::ComputeFunc m_func;
 
-    ComputePipelineImpl(Device* device);
+    ComputePipelineImpl(Device* device, const ComputePipelineDesc& desc);
 
     // IComputePipeline implementation
     virtual SLANG_NO_THROW Result SLANG_MCALL getNativeHandle(NativeHandle* outHandle) override;

--- a/src/cuda/cuda-pipeline.cpp
+++ b/src/cuda/cuda-pipeline.cpp
@@ -5,8 +5,8 @@
 
 namespace rhi::cuda {
 
-ComputePipelineImpl::ComputePipelineImpl(Device* device)
-    : ComputePipeline(device)
+ComputePipelineImpl::ComputePipelineImpl(Device* device, const ComputePipelineDesc& desc)
+    : ComputePipeline(device, desc)
 {
 }
 
@@ -31,7 +31,7 @@ Result DeviceImpl::createComputePipeline2(const ComputePipelineDesc& desc, IComp
     SLANG_RHI_ASSERT(!program->m_modules.empty());
     const auto& module = program->m_modules[0];
 
-    RefPtr<ComputePipelineImpl> pipeline = new ComputePipelineImpl(this);
+    RefPtr<ComputePipelineImpl> pipeline = new ComputePipelineImpl(this, desc);
     pipeline->m_program = program;
     pipeline->m_rootObjectLayout = program->m_rootObjectLayout;
 
@@ -77,8 +77,8 @@ Result DeviceImpl::createComputePipeline2(const ComputePipelineDesc& desc, IComp
 
 #if SLANG_RHI_ENABLE_OPTIX
 
-RayTracingPipelineImpl::RayTracingPipelineImpl(Device* device)
-    : RayTracingPipeline(device)
+RayTracingPipelineImpl::RayTracingPipelineImpl(Device* device, const RayTracingPipelineDesc& desc)
+    : RayTracingPipeline(device, desc)
 {
 }
 
@@ -288,7 +288,7 @@ Result DeviceImpl::createRayTracingPipeline2(const RayTracingPipelineDesc& desc,
         this
     );
 
-    RefPtr<RayTracingPipelineImpl> pipeline = new RayTracingPipelineImpl(this);
+    RefPtr<RayTracingPipelineImpl> pipeline = new RayTracingPipelineImpl(this, desc);
     pipeline->m_program = program;
     pipeline->m_rootObjectLayout = program->m_rootObjectLayout;
     pipeline->m_modules = std::move(optixModules);

--- a/src/cuda/cuda-pipeline.h
+++ b/src/cuda/cuda-pipeline.h
@@ -16,7 +16,7 @@ public:
     size_t m_paramBufferSize = 0;
     size_t m_sharedMemorySize = 0;
 
-    ComputePipelineImpl(Device* device);
+    ComputePipelineImpl(Device* device, const ComputePipelineDesc& desc);
     ~ComputePipelineImpl();
 
     // IComputePipeline implementation
@@ -34,7 +34,7 @@ public:
     std::map<std::string, uint32_t> m_shaderGroupNameToIndex;
     OptixPipeline m_pipeline = nullptr;
 
-    RayTracingPipelineImpl(Device* device);
+    RayTracingPipelineImpl(Device* device, const RayTracingPipelineDesc& desc);
     ~RayTracingPipelineImpl();
 
     // IRayTracingPipeline implementation

--- a/src/d3d11/d3d11-pipeline.cpp
+++ b/src/d3d11/d3d11-pipeline.cpp
@@ -8,8 +8,8 @@
 
 namespace rhi::d3d11 {
 
-RenderPipelineImpl::RenderPipelineImpl(Device* device)
-    : RenderPipeline(device)
+RenderPipelineImpl::RenderPipelineImpl(Device* device, const RenderPipelineDesc& desc)
+    : RenderPipeline(device, desc)
 {
 }
 
@@ -159,7 +159,7 @@ Result DeviceImpl::createRenderPipeline2(const RenderPipelineDesc& desc, IRender
         SLANG_RETURN_ON_FAIL(m_device->CreateBlendState(&dstDesc, blendState.writeRef()));
     }
 
-    RefPtr<RenderPipelineImpl> pipeline = new RenderPipelineImpl(this);
+    RefPtr<RenderPipelineImpl> pipeline = new RenderPipelineImpl(this, desc);
     pipeline->m_program = program;
     pipeline->m_inputLayout = checked_cast<InputLayoutImpl*>(desc.inputLayout);
     pipeline->m_vertexShader = vertexShader;
@@ -178,8 +178,8 @@ Result DeviceImpl::createRenderPipeline2(const RenderPipelineDesc& desc, IRender
     return SLANG_OK;
 }
 
-ComputePipelineImpl::ComputePipelineImpl(Device* device)
-    : ComputePipeline(device)
+ComputePipelineImpl::ComputePipelineImpl(Device* device, const ComputePipelineDesc& desc)
+    : ComputePipeline(device, desc)
 {
 }
 
@@ -215,7 +215,7 @@ Result DeviceImpl::createComputePipeline2(const ComputePipelineDesc& desc, IComp
         ));
     }
 
-    RefPtr<ComputePipelineImpl> pipeline = new ComputePipelineImpl(this);
+    RefPtr<ComputePipelineImpl> pipeline = new ComputePipelineImpl(this, desc);
     pipeline->m_program = program;
     pipeline->m_computeShader = computeShader;
     returnComPtr(outPipeline, pipeline);

--- a/src/d3d11/d3d11-pipeline.h
+++ b/src/d3d11/d3d11-pipeline.h
@@ -21,7 +21,7 @@ public:
     float m_blendColor[4];
     UINT m_sampleMask;
 
-    RenderPipelineImpl(Device* device);
+    RenderPipelineImpl(Device* device, const RenderPipelineDesc& desc);
 
     // IRenderPipeline implementation
     virtual SLANG_NO_THROW Result SLANG_MCALL getNativeHandle(NativeHandle* outHandle) override;
@@ -32,7 +32,7 @@ class ComputePipelineImpl : public ComputePipeline
 public:
     ComPtr<ID3D11ComputeShader> m_computeShader;
 
-    ComputePipelineImpl(Device* device);
+    ComputePipelineImpl(Device* device, const ComputePipelineDesc& desc);
 
     // IComputePipeline implementation
     virtual SLANG_NO_THROW Result SLANG_MCALL getNativeHandle(NativeHandle* outHandle) override;

--- a/src/d3d12/d3d12-pipeline.cpp
+++ b/src/d3d12/d3d12-pipeline.cpp
@@ -191,8 +191,8 @@ Result createPipelineWithCache(
 }
 
 
-RenderPipelineImpl::RenderPipelineImpl(Device* device)
-    : RenderPipeline(device)
+RenderPipelineImpl::RenderPipelineImpl(Device* device, const RenderPipelineDesc& desc)
+    : RenderPipeline(device, desc)
 {
 }
 
@@ -414,7 +414,7 @@ Result DeviceImpl::createRenderPipeline2(const RenderPipelineDesc& desc, IRender
         SLANG_RETURN_ON_FAIL(result);
     }
 
-    RefPtr<RenderPipelineImpl> pipeline = new RenderPipelineImpl(this);
+    RefPtr<RenderPipelineImpl> pipeline = new RenderPipelineImpl(this, desc);
     pipeline->m_program = program;
     pipeline->m_inputLayout = inputLayout;
     pipeline->m_rootObjectLayout = program->m_rootObjectLayout;
@@ -424,8 +424,8 @@ Result DeviceImpl::createRenderPipeline2(const RenderPipelineDesc& desc, IRender
     return SLANG_OK;
 }
 
-ComputePipelineImpl::ComputePipelineImpl(Device* device)
-    : ComputePipeline(device)
+ComputePipelineImpl::ComputePipelineImpl(Device* device, const ComputePipelineDesc& desc)
+    : ComputePipeline(device, desc)
 {
 }
 
@@ -486,7 +486,7 @@ Result DeviceImpl::createComputePipeline2(const ComputePipelineDesc& desc, IComp
     );
     SLANG_RETURN_ON_FAIL(result);
 
-    RefPtr<ComputePipelineImpl> pipeline = new ComputePipelineImpl(this);
+    RefPtr<ComputePipelineImpl> pipeline = new ComputePipelineImpl(this, desc);
     pipeline->m_program = program;
     pipeline->m_rootObjectLayout = program->m_rootObjectLayout;
     pipeline->m_pipelineState = pipelineState;
@@ -494,8 +494,8 @@ Result DeviceImpl::createComputePipeline2(const ComputePipelineDesc& desc, IComp
     return SLANG_OK;
 }
 
-RayTracingPipelineImpl::RayTracingPipelineImpl(Device* device)
-    : RayTracingPipeline(device)
+RayTracingPipelineImpl::RayTracingPipelineImpl(Device* device, const RayTracingPipelineDesc& desc)
+    : RayTracingPipeline(device, desc)
 {
 }
 
@@ -674,7 +674,7 @@ Result DeviceImpl::createRayTracingPipeline2(const RayTracingPipelineDesc& desc,
     }
 #endif // SLANG_RHI_ENABLE_NVAPI
 
-    RefPtr<RayTracingPipelineImpl> pipeline = new RayTracingPipelineImpl(this);
+    RefPtr<RayTracingPipelineImpl> pipeline = new RayTracingPipelineImpl(this, desc);
     pipeline->m_program = program;
     pipeline->m_rootObjectLayout = program->m_rootObjectLayout;
     pipeline->m_stateObject = stateObject;

--- a/src/d3d12/d3d12-pipeline.cpp
+++ b/src/d3d12/d3d12-pipeline.cpp
@@ -414,6 +414,11 @@ Result DeviceImpl::createRenderPipeline2(const RenderPipelineDesc& desc, IRender
         SLANG_RETURN_ON_FAIL(result);
     }
 
+    if (desc.label)
+    {
+        pipelineState->SetName(string::to_wstring(desc.label).c_str());
+    }
+
     RefPtr<RenderPipelineImpl> pipeline = new RenderPipelineImpl(this, desc);
     pipeline->m_program = program;
     pipeline->m_inputLayout = inputLayout;
@@ -485,6 +490,11 @@ Result DeviceImpl::createComputePipeline2(const ComputePipelineDesc& desc, IComp
         pipelineState.writeRef()
     );
     SLANG_RETURN_ON_FAIL(result);
+
+    if (desc.label)
+    {
+        pipelineState->SetName(string::to_wstring(desc.label).c_str());
+    }
 
     RefPtr<ComputePipelineImpl> pipeline = new ComputePipelineImpl(this, desc);
     pipeline->m_program = program;
@@ -673,6 +683,11 @@ Result DeviceImpl::createRayTracingPipeline2(const RayTracingPipelineDesc& desc,
         SLANG_RHI_NVAPI_RETURN_ON_FAIL(NvAPI_D3D12_SetNvShaderExtnSlotSpace(m_device, 0xffffffff, 0));
     }
 #endif // SLANG_RHI_ENABLE_NVAPI
+
+    if (desc.label)
+    {
+        stateObject->SetName(string::to_wstring(desc.label).c_str());
+    }
 
     RefPtr<RayTracingPipelineImpl> pipeline = new RayTracingPipelineImpl(this, desc);
     pipeline->m_program = program;

--- a/src/d3d12/d3d12-pipeline.h
+++ b/src/d3d12/d3d12-pipeline.h
@@ -12,7 +12,7 @@ public:
     ComPtr<ID3D12PipelineState> m_pipelineState;
     D3D_PRIMITIVE_TOPOLOGY m_primitiveTopology;
 
-    RenderPipelineImpl(Device* device);
+    RenderPipelineImpl(Device* device, const RenderPipelineDesc& desc);
 
     // IRenderPipeline implementation
     virtual SLANG_NO_THROW Result SLANG_MCALL getNativeHandle(NativeHandle* outHandle) override;
@@ -24,7 +24,7 @@ public:
     RefPtr<RootShaderObjectLayoutImpl> m_rootObjectLayout;
     ComPtr<ID3D12PipelineState> m_pipelineState;
 
-    ComputePipelineImpl(Device* device);
+    ComputePipelineImpl(Device* device, const ComputePipelineDesc& desc);
 
     // IComputePipeline implementation
     virtual SLANG_NO_THROW Result SLANG_MCALL getNativeHandle(NativeHandle* outHandle) override;
@@ -36,7 +36,7 @@ public:
     RefPtr<RootShaderObjectLayoutImpl> m_rootObjectLayout;
     ComPtr<ID3D12StateObject> m_stateObject;
 
-    RayTracingPipelineImpl(Device* device);
+    RayTracingPipelineImpl(Device* device, const RayTracingPipelineDesc& desc);
 
     // IRayTracingPipeline implementation
     virtual SLANG_NO_THROW Result SLANG_MCALL getNativeHandle(NativeHandle* outHandle) override;

--- a/src/debug-layer/debug-device.cpp
+++ b/src/debug-layer/debug-device.cpp
@@ -535,21 +535,45 @@ Result DebugDevice::createRenderPipeline(const RenderPipelineDesc& desc, IRender
 {
     SLANG_RHI_API_FUNC;
 
-    return baseObject->createRenderPipeline(desc, outPipeline);
+    RenderPipelineDesc patchedDesc = desc;
+    std::string label;
+    if (!patchedDesc.label)
+    {
+        label = createRenderPipelineLabel(patchedDesc);
+        patchedDesc.label = label.c_str();
+    }
+
+    return baseObject->createRenderPipeline(patchedDesc, outPipeline);
 }
 
 Result DebugDevice::createComputePipeline(const ComputePipelineDesc& desc, IComputePipeline** outPipeline)
 {
     SLANG_RHI_API_FUNC;
 
-    return baseObject->createComputePipeline(desc, outPipeline);
+    ComputePipelineDesc patchedDesc = desc;
+    std::string label;
+    if (!patchedDesc.label)
+    {
+        label = createComputePipelineLabel(patchedDesc);
+        patchedDesc.label = label.c_str();
+    }
+
+    return baseObject->createComputePipeline(patchedDesc, outPipeline);
 }
 
 Result DebugDevice::createRayTracingPipeline(const RayTracingPipelineDesc& desc, IRayTracingPipeline** outPipeline)
 {
     SLANG_RHI_API_FUNC;
 
-    return baseObject->createRayTracingPipeline(desc, outPipeline);
+    RayTracingPipelineDesc patchedDesc = desc;
+    std::string label;
+    if (!patchedDesc.label)
+    {
+        label = createRayTracingPipelineLabel(patchedDesc);
+        patchedDesc.label = label.c_str();
+    }
+
+    return baseObject->createRayTracingPipeline(patchedDesc, outPipeline);
 }
 
 Result DebugDevice::readTexture(

--- a/src/debug-layer/debug-helper-functions.cpp
+++ b/src/debug-layer/debug-helper-functions.cpp
@@ -133,17 +133,17 @@ std::string createQueryPoolLabel(const QueryPoolDesc& desc)
 
 std::string createRenderPipelineLabel(const RenderPipelineDesc& desc)
 {
-    return string::format("Unnamed render pipeline");
+    return std::string("Unnamed render pipeline");
 }
 
 std::string createComputePipelineLabel(const ComputePipelineDesc& desc)
 {
-    return string::format("Unnamed compute pipeline");
+    return std::string("Unnamed compute pipeline");
 }
 
 std::string createRayTracingPipelineLabel(const RayTracingPipelineDesc& desc)
 {
-    return string::format("Unnamed ray tracing pipeline");
+    return std::string("Unnamed ray tracing pipeline");
 }
 
 void validateAccelerationStructureBuildDesc(DebugContext* ctx, const AccelerationStructureBuildDesc& buildDesc)

--- a/src/debug-layer/debug-helper-functions.cpp
+++ b/src/debug-layer/debug-helper-functions.cpp
@@ -131,6 +131,20 @@ std::string createQueryPoolLabel(const QueryPoolDesc& desc)
     return string::format("Unnamed query pool (type=%s, count=%u)", enumToString(desc.type), desc.count);
 }
 
+std::string createRenderPipelineLabel(const RenderPipelineDesc& desc)
+{
+    return string::format("Unnamed render pipeline");
+}
+
+std::string createComputePipelineLabel(const ComputePipelineDesc& desc)
+{
+    return string::format("Unnamed compute pipeline");
+}
+
+std::string createRayTracingPipelineLabel(const RayTracingPipelineDesc& desc)
+{
+    return string::format("Unnamed ray tracing pipeline");
+}
 
 void validateAccelerationStructureBuildDesc(DebugContext* ctx, const AccelerationStructureBuildDesc& buildDesc)
 {

--- a/src/debug-layer/debug-helper-functions.h
+++ b/src/debug-layer/debug-helper-functions.h
@@ -161,6 +161,9 @@ std::string createSamplerLabel(const SamplerDesc& desc);
 std::string createAccelerationStructureLabel(const AccelerationStructureDesc& desc);
 std::string createFenceLabel(const FenceDesc& desc);
 std::string createQueryPoolLabel(const QueryPoolDesc& desc);
+std::string createRenderPipelineLabel(const RenderPipelineDesc& desc);
+std::string createComputePipelineLabel(const ComputePipelineDesc& desc);
+std::string createRayTracingPipelineLabel(const RayTracingPipelineDesc& desc);
 
 void validateAccelerationStructureBuildDesc(DebugContext* ctx, const AccelerationStructureBuildDesc& buildDesc);
 

--- a/src/metal/metal-pipeline.cpp
+++ b/src/metal/metal-pipeline.cpp
@@ -194,11 +194,18 @@ Result DeviceImpl::createComputePipeline2(const ComputePipelineDesc& desc, IComp
     if (!function)
         return SLANG_FAIL;
 
-    // TODO: We should use a ComputePipelineDescriptor to allow setting the label
+    NS::SharedPtr<MTL::ComputePipelineDescriptor> pd = NS::TransferPtr(MTL::ComputePipelineDescriptor::alloc()->init());
+
+    pd->setComputeFunction(function.get());
+
+    if (desc.label)
+    {
+        pd->setLabel(MetalUtil::createString(desc.label).get());
+    }
 
     NS::Error* error;
     NS::SharedPtr<MTL::ComputePipelineState> pipelineState =
-        NS::TransferPtr(m_device->newComputePipelineState(function.get(), &error));
+        NS::TransferPtr(m_device->newComputePipelineState(pd.get(), MTL::PipelineOptionNone, nullptr, &error));
     if (!pipelineState)
     {
         if (error)

--- a/src/metal/metal-pipeline.cpp
+++ b/src/metal/metal-pipeline.cpp
@@ -98,6 +98,11 @@ Result DeviceImpl::createRenderPipeline2(const RenderPipelineDesc& desc, IRender
 
     pd->setRasterSampleCount(desc.multisample.sampleCount);
 
+    if (desc.label)
+    {
+        pd->setLabel(MetalUtil::createString(desc.label).get());
+    }
+
     NS::Error* error;
     NS::SharedPtr<MTL::RenderPipelineState> pipelineState =
         NS::TransferPtr(m_device->newRenderPipelineState(pd.get(), &error));
@@ -188,6 +193,8 @@ Result DeviceImpl::createComputePipeline2(const ComputePipelineDesc& desc, IComp
     NS::SharedPtr<MTL::Function> function = NS::TransferPtr(module.library->newFunction(functionName.get()));
     if (!function)
         return SLANG_FAIL;
+
+    // TODO: We should use a ComputePipelineDescriptor to allow setting the label
 
     NS::Error* error;
     NS::SharedPtr<MTL::ComputePipelineState> pipelineState =

--- a/src/metal/metal-pipeline.cpp
+++ b/src/metal/metal-pipeline.cpp
@@ -7,8 +7,8 @@
 
 namespace rhi::metal {
 
-RenderPipelineImpl::RenderPipelineImpl(Device* device)
-    : RenderPipeline(device)
+RenderPipelineImpl::RenderPipelineImpl(Device* device, const RenderPipelineDesc& desc)
+    : RenderPipeline(device, desc)
 {
 }
 
@@ -152,7 +152,7 @@ Result DeviceImpl::createRenderPipeline2(const RenderPipelineDesc& desc, IRender
         return SLANG_FAIL;
     }
 
-    RefPtr<RenderPipelineImpl> pipeline = new RenderPipelineImpl(this);
+    RefPtr<RenderPipelineImpl> pipeline = new RenderPipelineImpl(this, desc);
     pipeline->m_program = program;
     pipeline->m_rootObjectLayout = program->m_rootObjectLayout;
     pipeline->m_pipelineState = pipelineState;
@@ -164,8 +164,8 @@ Result DeviceImpl::createRenderPipeline2(const RenderPipelineDesc& desc, IRender
     return SLANG_OK;
 }
 
-ComputePipelineImpl::ComputePipelineImpl(Device* device)
-    : ComputePipeline(device)
+ComputePipelineImpl::ComputePipelineImpl(Device* device, const ComputePipelineDesc& desc)
+    : ComputePipeline(device, desc)
 {
 }
 
@@ -209,13 +209,18 @@ Result DeviceImpl::createComputePipeline2(const ComputePipelineDesc& desc, IComp
     SlangUInt threadGroupSize[3];
     program->linkedProgram->getLayout()->getEntryPointByIndex(0)->getComputeThreadGroupSize(3, threadGroupSize);
 
-    RefPtr<ComputePipelineImpl> pipeline = new ComputePipelineImpl(this);
+    RefPtr<ComputePipelineImpl> pipeline = new ComputePipelineImpl(this, desc);
     pipeline->m_program = program;
     pipeline->m_rootObjectLayout = program->m_rootObjectLayout;
     pipeline->m_pipelineState = pipelineState;
     pipeline->m_threadGroupSize = MTL::Size(threadGroupSize[0], threadGroupSize[1], threadGroupSize[2]);
     returnComPtr(outPipeline, pipeline);
     return SLANG_OK;
+}
+
+RayTracingPipelineImpl::RayTracingPipelineImpl(Device* device, const RayTracingPipelineDesc& desc)
+    : RayTracingPipeline(device, desc)
+{
 }
 
 Result RayTracingPipelineImpl::getNativeHandle(NativeHandle* outHandle)

--- a/src/metal/metal-pipeline.h
+++ b/src/metal/metal-pipeline.h
@@ -17,7 +17,7 @@ public:
     RasterizerDesc m_rasterizerDesc;
     NS::UInteger m_vertexBufferOffset;
 
-    RenderPipelineImpl(Device* device);
+    RenderPipelineImpl(Device* device, const RenderPipelineDesc& desc);
 
     // IRenderPipeline implementation
     virtual SLANG_NO_THROW Result SLANG_MCALL getNativeHandle(NativeHandle* outHandle) override;
@@ -30,7 +30,7 @@ public:
     NS::SharedPtr<MTL::ComputePipelineState> m_pipelineState;
     MTL::Size m_threadGroupSize;
 
-    ComputePipelineImpl(Device* device);
+    ComputePipelineImpl(Device* device, const ComputePipelineDesc& desc);
 
     // IComputePipeline implementation
     virtual SLANG_NO_THROW Result SLANG_MCALL getNativeHandle(NativeHandle* outHandle) override;
@@ -39,6 +39,8 @@ public:
 class RayTracingPipelineImpl : public RayTracingPipeline
 {
 public:
+    RayTracingPipelineImpl(Device* device, const RayTracingPipelineDesc& desc);
+
     // IRayTracingPipeline implementation
     virtual SLANG_NO_THROW Result SLANG_MCALL getNativeHandle(NativeHandle* outHandle) override;
 };

--- a/src/pipeline.cpp
+++ b/src/pipeline.cpp
@@ -16,15 +16,21 @@ IPipeline* RenderPipeline::getInterface(const Guid& guid)
     return nullptr;
 }
 
+RenderPipeline::RenderPipeline(Device* device, const RenderPipelineDesc& desc)
+    : Pipeline(device)
+    , m_desc(desc)
+{
+    m_descHolder.holdList(m_desc.targets, m_desc.targetCount);
+    m_descHolder.holdString(m_desc.label);
+}
+
 // ----------------------------------------------------------------------------
 // VirtualRenderPipeline
 // ----------------------------------------------------------------------------
 
 VirtualRenderPipeline::VirtualRenderPipeline(Device* device, const RenderPipelineDesc& desc)
-    : RenderPipeline(device)
-    , m_desc(desc)
+    : RenderPipeline(device, desc)
 {
-    m_descHolder.holdList(m_desc.targets, m_desc.targetCount);
     m_program = checked_cast<ShaderProgram*>(desc.program);
     m_inputLayout = checked_cast<InputLayout*>(desc.inputLayout);
 }
@@ -47,13 +53,20 @@ IPipeline* ComputePipeline::getInterface(const Guid& guid)
     return nullptr;
 }
 
+ComputePipeline::ComputePipeline(Device* device, const ComputePipelineDesc& desc)
+    : Pipeline(device)
+    , m_desc(desc)
+{
+    m_descHolder.holdString(m_desc.label);
+}
+
+
 // ----------------------------------------------------------------------------
 // VirtualComputePipeline
 // ----------------------------------------------------------------------------
 
 VirtualComputePipeline::VirtualComputePipeline(Device* device, const ComputePipelineDesc& desc)
-    : ComputePipeline(device)
-    , m_desc(desc)
+    : ComputePipeline(device, desc)
 {
     m_program = checked_cast<ShaderProgram*>(desc.program);
 }
@@ -76,15 +89,12 @@ IPipeline* RayTracingPipeline::getInterface(const Guid& guid)
     return nullptr;
 }
 
-// ----------------------------------------------------------------------------
-// VirtualRayTracingPipeline
-// ----------------------------------------------------------------------------
-
-VirtualRayTracingPipeline::VirtualRayTracingPipeline(Device* device, const RayTracingPipelineDesc& desc)
-    : RayTracingPipeline(device)
+RayTracingPipeline::RayTracingPipeline(Device* device, const RayTracingPipelineDesc& desc)
+    : Pipeline(device)
+    , m_desc(desc)
 {
-    m_desc = desc;
     m_descHolder.holdList(m_desc.hitGroups, m_desc.hitGroupCount);
+    m_descHolder.holdString(m_desc.label);
     for (uint32_t i = 0; i < m_desc.hitGroupCount; i++)
     {
         HitGroupDesc& hitGroup = const_cast<HitGroupDesc&>(m_desc.hitGroups[i]);
@@ -93,6 +103,15 @@ VirtualRayTracingPipeline::VirtualRayTracingPipeline(Device* device, const RayTr
         m_descHolder.holdString(hitGroup.anyHitEntryPoint);
         m_descHolder.holdString(hitGroup.intersectionEntryPoint);
     }
+}
+
+// ----------------------------------------------------------------------------
+// VirtualRayTracingPipeline
+// ----------------------------------------------------------------------------
+
+VirtualRayTracingPipeline::VirtualRayTracingPipeline(Device* device, const RayTracingPipelineDesc& desc)
+    : RayTracingPipeline(device, desc)
+{
     m_program = checked_cast<ShaderProgram*>(desc.program);
 }
 

--- a/src/pipeline.cpp
+++ b/src/pipeline.cpp
@@ -22,6 +22,8 @@ RenderPipeline::RenderPipeline(Device* device, const RenderPipelineDesc& desc)
 {
     m_descHolder.holdList(m_desc.targets, m_desc.targetCount);
     m_descHolder.holdString(m_desc.label);
+    m_program = checked_cast<ShaderProgram*>(desc.program);
+    m_inputLayout = checked_cast<InputLayout*>(desc.inputLayout);
 }
 
 // ----------------------------------------------------------------------------
@@ -31,8 +33,6 @@ RenderPipeline::RenderPipeline(Device* device, const RenderPipelineDesc& desc)
 VirtualRenderPipeline::VirtualRenderPipeline(Device* device, const RenderPipelineDesc& desc)
     : RenderPipeline(device, desc)
 {
-    m_program = checked_cast<ShaderProgram*>(desc.program);
-    m_inputLayout = checked_cast<InputLayout*>(desc.inputLayout);
 }
 
 Result VirtualRenderPipeline::getNativeHandle(NativeHandle* outHandle)
@@ -58,6 +58,7 @@ ComputePipeline::ComputePipeline(Device* device, const ComputePipelineDesc& desc
     , m_desc(desc)
 {
     m_descHolder.holdString(m_desc.label);
+    m_program = checked_cast<ShaderProgram*>(desc.program);
 }
 
 
@@ -68,7 +69,6 @@ ComputePipeline::ComputePipeline(Device* device, const ComputePipelineDesc& desc
 VirtualComputePipeline::VirtualComputePipeline(Device* device, const ComputePipelineDesc& desc)
     : ComputePipeline(device, desc)
 {
-    m_program = checked_cast<ShaderProgram*>(desc.program);
 }
 
 Result VirtualComputePipeline::getNativeHandle(NativeHandle* outHandle)
@@ -103,6 +103,7 @@ RayTracingPipeline::RayTracingPipeline(Device* device, const RayTracingPipelineD
         m_descHolder.holdString(hitGroup.anyHitEntryPoint);
         m_descHolder.holdString(hitGroup.intersectionEntryPoint);
     }
+    m_program = checked_cast<ShaderProgram*>(desc.program);
 }
 
 // ----------------------------------------------------------------------------
@@ -112,7 +113,6 @@ RayTracingPipeline::RayTracingPipeline(Device* device, const RayTracingPipelineD
 VirtualRayTracingPipeline::VirtualRayTracingPipeline(Device* device, const RayTracingPipelineDesc& desc)
     : RayTracingPipeline(device, desc)
 {
-    m_program = checked_cast<ShaderProgram*>(desc.program);
 }
 
 Result VirtualRayTracingPipeline::getNativeHandle(NativeHandle* outHandle)

--- a/src/pipeline.h
+++ b/src/pipeline.h
@@ -39,24 +39,22 @@ public:
     IPipeline* getInterface(const Guid& guid);
 
 public:
-    RenderPipeline(Device* device)
-        : Pipeline(device)
-    {
-    }
+    RenderPipelineDesc m_desc;
+    StructHolder m_descHolder;
+    RefPtr<InputLayout> m_inputLayout;
+
+    RenderPipeline(Device* device, const RenderPipelineDesc& desc);
 
     virtual PipelineType getType() const override { return PipelineType::Render; }
 
     // IPipeline interface
+    virtual SLANG_NO_THROW const RenderPipelineDesc& SLANG_MCALL getDesc() override { return m_desc; }
     virtual SLANG_NO_THROW IShaderProgram* SLANG_MCALL getProgram() override { return m_program.get(); }
 };
 
 class VirtualRenderPipeline : public RenderPipeline
 {
 public:
-    RenderPipelineDesc m_desc;
-    StructHolder m_descHolder;
-    RefPtr<InputLayout> m_inputLayout;
-
     VirtualRenderPipeline(Device* device, const RenderPipelineDesc& desc);
 
     virtual bool isVirtual() const override { return true; }
@@ -72,22 +70,21 @@ public:
     IPipeline* getInterface(const Guid& guid);
 
 public:
-    ComputePipeline(Device* device)
-        : Pipeline(device)
-    {
-    }
+    ComputePipelineDesc m_desc;
+    StructHolder m_descHolder;
+
+    ComputePipeline(Device* device, const ComputePipelineDesc& desc);
 
     virtual PipelineType getType() const override { return PipelineType::Compute; }
 
     // IPipeline interface
+    virtual SLANG_NO_THROW const ComputePipelineDesc& SLANG_MCALL getDesc() override { return m_desc; }
     virtual SLANG_NO_THROW IShaderProgram* SLANG_MCALL getProgram() override { return m_program.get(); }
 };
 
 class VirtualComputePipeline : public ComputePipeline
 {
 public:
-    ComputePipelineDesc m_desc;
-
     VirtualComputePipeline(Device* device, const ComputePipelineDesc& desc);
 
     virtual bool isVirtual() const override { return true; }
@@ -103,23 +100,21 @@ public:
     IPipeline* getInterface(const Guid& guid);
 
 public:
-    RayTracingPipeline(Device* device)
-        : Pipeline(device)
-    {
-    }
+    RayTracingPipelineDesc m_desc;
+    StructHolder m_descHolder;
+
+    RayTracingPipeline(Device* device, const RayTracingPipelineDesc& desc);
 
     virtual PipelineType getType() const override { return PipelineType::RayTracing; }
 
     // IPipeline interface
+    virtual SLANG_NO_THROW const RayTracingPipelineDesc& SLANG_MCALL getDesc() override { return m_desc; }
     virtual SLANG_NO_THROW IShaderProgram* SLANG_MCALL getProgram() override { return m_program.get(); }
 };
 
 class VirtualRayTracingPipeline : public RayTracingPipeline
 {
 public:
-    RayTracingPipelineDesc m_desc;
-    StructHolder m_descHolder;
-
     VirtualRayTracingPipeline(Device* device, const RayTracingPipelineDesc& desc);
 
     virtual bool isVirtual() const override { return true; }

--- a/src/vulkan/vk-pipeline.cpp
+++ b/src/vulkan/vk-pipeline.cpp
@@ -549,6 +549,8 @@ Result DeviceImpl::createRenderPipeline2(const RenderPipelineDesc& desc, IRender
         &vkPipeline
     ));
 
+    _labelObject((uint64_t)vkPipeline, VK_OBJECT_TYPE_PIPELINE, desc.label);
+
     RefPtr<RenderPipelineImpl> pipeline = new RenderPipelineImpl(this, desc);
     pipeline->m_program = program;
     pipeline->m_rootObjectLayout = program->m_rootShaderObjectLayout;
@@ -598,6 +600,8 @@ Result DeviceImpl::createComputePipeline2(const ComputePipelineDesc& desc, IComp
         },
         &vkPipeline
     ));
+
+    _labelObject((uint64_t)vkPipeline, VK_OBJECT_TYPE_PIPELINE, desc.label);
 
     RefPtr<ComputePipelineImpl> pipeline = new ComputePipelineImpl(this, desc);
     pipeline->m_program = program;
@@ -747,6 +751,8 @@ Result DeviceImpl::createRayTracingPipeline2(const RayTracingPipelineDesc& desc,
         },
         &vkPipeline
     ));
+
+    _labelObject((uint64_t)vkPipeline, VK_OBJECT_TYPE_PIPELINE, desc.label);
 
     RefPtr<RayTracingPipelineImpl> pipeline = new RayTracingPipelineImpl(this, desc);
     pipeline->m_program = program;

--- a/src/vulkan/vk-pipeline.cpp
+++ b/src/vulkan/vk-pipeline.cpp
@@ -325,8 +325,8 @@ Result createPipelineWithCache(
     return SLANG_OK;
 }
 
-RenderPipelineImpl::RenderPipelineImpl(Device* device)
-    : RenderPipeline(device)
+RenderPipelineImpl::RenderPipelineImpl(Device* device, const RenderPipelineDesc& desc)
+    : RenderPipeline(device, desc)
 {
 }
 
@@ -549,7 +549,7 @@ Result DeviceImpl::createRenderPipeline2(const RenderPipelineDesc& desc, IRender
         &vkPipeline
     ));
 
-    RefPtr<RenderPipelineImpl> pipeline = new RenderPipelineImpl(this);
+    RefPtr<RenderPipelineImpl> pipeline = new RenderPipelineImpl(this, desc);
     pipeline->m_program = program;
     pipeline->m_rootObjectLayout = program->m_rootShaderObjectLayout;
     pipeline->m_pipeline = vkPipeline;
@@ -557,8 +557,8 @@ Result DeviceImpl::createRenderPipeline2(const RenderPipelineDesc& desc, IRender
     return SLANG_OK;
 }
 
-ComputePipelineImpl::ComputePipelineImpl(Device* device)
-    : ComputePipeline(device)
+ComputePipelineImpl::ComputePipelineImpl(Device* device, const ComputePipelineDesc& desc)
+    : ComputePipeline(device, desc)
 {
 }
 
@@ -599,7 +599,7 @@ Result DeviceImpl::createComputePipeline2(const ComputePipelineDesc& desc, IComp
         &vkPipeline
     ));
 
-    RefPtr<ComputePipelineImpl> pipeline = new ComputePipelineImpl(this);
+    RefPtr<ComputePipelineImpl> pipeline = new ComputePipelineImpl(this, desc);
     pipeline->m_program = program;
     pipeline->m_rootObjectLayout = program->m_rootShaderObjectLayout;
     pipeline->m_pipeline = vkPipeline;
@@ -607,8 +607,8 @@ Result DeviceImpl::createComputePipeline2(const ComputePipelineDesc& desc, IComp
     return SLANG_OK;
 }
 
-RayTracingPipelineImpl::RayTracingPipelineImpl(Device* device)
-    : RayTracingPipeline(device)
+RayTracingPipelineImpl::RayTracingPipelineImpl(Device* device, const RayTracingPipelineDesc& desc)
+    : RayTracingPipeline(device, desc)
 {
 }
 
@@ -748,7 +748,7 @@ Result DeviceImpl::createRayTracingPipeline2(const RayTracingPipelineDesc& desc,
         &vkPipeline
     ));
 
-    RefPtr<RayTracingPipelineImpl> pipeline = new RayTracingPipelineImpl(this);
+    RefPtr<RayTracingPipelineImpl> pipeline = new RayTracingPipelineImpl(this, desc);
     pipeline->m_program = program;
     pipeline->m_rootObjectLayout = program->m_rootShaderObjectLayout;
     pipeline->m_pipeline = vkPipeline;

--- a/src/vulkan/vk-pipeline.h
+++ b/src/vulkan/vk-pipeline.h
@@ -13,7 +13,7 @@ public:
     RefPtr<RootShaderObjectLayoutImpl> m_rootObjectLayout;
     VkPipeline m_pipeline = VK_NULL_HANDLE;
 
-    RenderPipelineImpl(Device* device);
+    RenderPipelineImpl(Device* device, const RenderPipelineDesc& desc);
     ~RenderPipelineImpl();
 
     // IRenderPipeline implementation
@@ -26,7 +26,7 @@ public:
     RefPtr<RootShaderObjectLayoutImpl> m_rootObjectLayout;
     VkPipeline m_pipeline = VK_NULL_HANDLE;
 
-    ComputePipelineImpl(Device* device);
+    ComputePipelineImpl(Device* device, const ComputePipelineDesc& desc);
     ~ComputePipelineImpl();
 
     // IComputePipeline implementation
@@ -41,7 +41,7 @@ public:
     std::map<std::string, uint32_t> m_shaderGroupNameToIndex;
     uint32_t m_shaderGroupCount;
 
-    RayTracingPipelineImpl(Device* device);
+    RayTracingPipelineImpl(Device* device, const RayTracingPipelineDesc& desc);
     ~RayTracingPipelineImpl();
 
     // IRayTracingPipeline implementation

--- a/src/wgpu/wgpu-pipeline.cpp
+++ b/src/wgpu/wgpu-pipeline.cpp
@@ -117,6 +117,8 @@ Result DeviceImpl::createRenderPipeline2(const RenderPipelineDesc& desc, IRender
     fragment.targets = targets.data();
     pipelineDesc.fragment = &fragment;
 
+    pipelineDesc.label = desc.label;
+
     RefPtr<RenderPipelineImpl> pipeline = new RenderPipelineImpl(this, desc);
     pipeline->m_program = program;
     pipeline->m_rootObjectLayout = program->m_rootObjectLayout;
@@ -165,6 +167,8 @@ Result DeviceImpl::createComputePipeline2(const ComputePipelineDesc& desc, IComp
     pipelineDesc.layout = program->m_rootObjectLayout->m_pipelineLayout;
     pipelineDesc.compute.module = computeModule->module;
     pipelineDesc.compute.entryPoint = computeModule->entryPointName.c_str();
+
+    pipelineDesc.label = desc.label;
 
     RefPtr<ComputePipelineImpl> pipeline = new ComputePipelineImpl(this, desc);
     pipeline->m_program = program;

--- a/src/wgpu/wgpu-pipeline.cpp
+++ b/src/wgpu/wgpu-pipeline.cpp
@@ -7,8 +7,8 @@
 
 namespace rhi::wgpu {
 
-RenderPipelineImpl::RenderPipelineImpl(Device* device)
-    : RenderPipeline(device)
+RenderPipelineImpl::RenderPipelineImpl(Device* device, const RenderPipelineDesc& desc)
+    : RenderPipeline(device, desc)
 {
 }
 
@@ -117,7 +117,7 @@ Result DeviceImpl::createRenderPipeline2(const RenderPipelineDesc& desc, IRender
     fragment.targets = targets.data();
     pipelineDesc.fragment = &fragment;
 
-    RefPtr<RenderPipelineImpl> pipeline = new RenderPipelineImpl(this);
+    RefPtr<RenderPipelineImpl> pipeline = new RenderPipelineImpl(this, desc);
     pipeline->m_program = program;
     pipeline->m_rootObjectLayout = program->m_rootObjectLayout;
     pipeline->m_renderPipeline = m_ctx.api.wgpuDeviceCreateRenderPipeline(m_ctx.device, &pipelineDesc);
@@ -129,8 +129,8 @@ Result DeviceImpl::createRenderPipeline2(const RenderPipelineDesc& desc, IRender
     return SLANG_OK;
 }
 
-ComputePipelineImpl::ComputePipelineImpl(Device* device)
-    : ComputePipeline(device)
+ComputePipelineImpl::ComputePipelineImpl(Device* device, const ComputePipelineDesc& desc)
+    : ComputePipeline(device, desc)
 {
 }
 
@@ -166,7 +166,7 @@ Result DeviceImpl::createComputePipeline2(const ComputePipelineDesc& desc, IComp
     pipelineDesc.compute.module = computeModule->module;
     pipelineDesc.compute.entryPoint = computeModule->entryPointName.c_str();
 
-    RefPtr<ComputePipelineImpl> pipeline = new ComputePipelineImpl(this);
+    RefPtr<ComputePipelineImpl> pipeline = new ComputePipelineImpl(this, desc);
     pipeline->m_program = program;
     pipeline->m_rootObjectLayout = program->m_rootObjectLayout;
     pipeline->m_computePipeline = m_ctx.api.wgpuDeviceCreateComputePipeline(m_ctx.device, &pipelineDesc);

--- a/src/wgpu/wgpu-pipeline.h
+++ b/src/wgpu/wgpu-pipeline.h
@@ -10,7 +10,7 @@ public:
     RefPtr<RootShaderObjectLayoutImpl> m_rootObjectLayout;
     WGPURenderPipeline m_renderPipeline = nullptr;
 
-    RenderPipelineImpl(Device* device);
+    RenderPipelineImpl(Device* device, const RenderPipelineDesc& desc);
     ~RenderPipelineImpl();
 
     // IRenderPipeline implementation
@@ -23,7 +23,7 @@ public:
     RefPtr<RootShaderObjectLayoutImpl> m_rootObjectLayout;
     WGPUComputePipeline m_computePipeline = nullptr;
 
-    ComputePipelineImpl(Device* device);
+    ComputePipelineImpl(Device* device, const ComputePipelineDesc& desc);
     ~ComputePipelineImpl();
 
     // IComputePipeline implementation


### PR DESCRIPTION
- Add a `label` to all pipeline descriptors
- Add a `getDesc` method to all pipeline interfaces
- Create default labels when validation layer is enabled
- Move ownership of program etc. to base classes