### PR TITLE
Improve vulkan capability detection

### DIFF
--- a/include/slang-rhi.h
+++ b/include/slang-rhi.h
@@ -2974,7 +2974,7 @@ public:
     };
 
     virtual SLANG_NO_THROW Result SLANG_MCALL
-    getCooperativeVectorProperties(CooperativeVectorProperties* properties, uint32_t* propertyCount) = 0;
+    getCooperativeVectorProperties(CooperativeVectorProperties* properties, uint32_t* propertiesCount) = 0;
 
     virtual SLANG_NO_THROW Result SLANG_MCALL
     convertCooperativeVectorMatrix(const ConvertCooperativeVectorMatrixDesc* descs, uint32_t descCount) = 0;

--- a/src/d3d12/d3d12-device.cpp
+++ b/src/d3d12/d3d12-device.cpp
@@ -1829,7 +1829,7 @@ Result DeviceImpl::createAccelerationStructure(
 #endif
 }
 
-Result DeviceImpl::getCooperativeVectorProperties(CooperativeVectorProperties* properties, uint32_t* propertyCount)
+Result DeviceImpl::getCooperativeVectorProperties(CooperativeVectorProperties* properties, uint32_t* propertiesCount)
 {
 #if SLANG_RHI_ENABLE_NVAPI
     if (!NVAPIUtil::isAvailable())
@@ -1858,7 +1858,7 @@ Result DeviceImpl::getCooperativeVectorProperties(CooperativeVectorProperties* p
         }
     }
 
-    return Device::getCooperativeVectorProperties(properties, propertyCount);
+    return Device::getCooperativeVectorProperties(properties, propertiesCount);
 #else
     return SLANG_E_NOT_AVAILABLE;
 #endif

--- a/src/d3d12/d3d12-device.h
+++ b/src/d3d12/d3d12-device.h
@@ -176,7 +176,7 @@ public:
     ) override;
 
     virtual SLANG_NO_THROW Result SLANG_MCALL
-    getCooperativeVectorProperties(CooperativeVectorProperties* properties, uint32_t* propertyCount) override;
+    getCooperativeVectorProperties(CooperativeVectorProperties* properties, uint32_t* propertiesCount) override;
 
     virtual SLANG_NO_THROW Result SLANG_MCALL
     convertCooperativeVectorMatrix(const ConvertCooperativeVectorMatrixDesc* descs, uint32_t descCount) override;

--- a/src/debug-layer/debug-device.cpp
+++ b/src/debug-layer/debug-device.cpp
@@ -739,10 +739,10 @@ Result DebugDevice::getTextureRowAlignment(Format format, size_t* outAlignment)
     return baseObject->getTextureRowAlignment(format, outAlignment);
 }
 
-Result DebugDevice::getCooperativeVectorProperties(CooperativeVectorProperties* properties, uint32_t* propertyCount)
+Result DebugDevice::getCooperativeVectorProperties(CooperativeVectorProperties* properties, uint32_t* propertiesCount)
 {
     SLANG_RHI_API_FUNC;
-    return baseObject->getCooperativeVectorProperties(properties, propertyCount);
+    return baseObject->getCooperativeVectorProperties(properties, propertiesCount);
 }
 
 Result DebugDevice::convertCooperativeVectorMatrix(const ConvertCooperativeVectorMatrixDesc* descs, uint32_t descCount)

--- a/src/debug-layer/debug-device.h
+++ b/src/debug-layer/debug-device.h
@@ -96,7 +96,7 @@ public:
     getTextureAllocationInfo(const TextureDesc& desc, size_t* outSize, size_t* outAlignment) override;
     virtual SLANG_NO_THROW Result SLANG_MCALL getTextureRowAlignment(Format format, size_t* outAlignment) override;
     virtual SLANG_NO_THROW Result SLANG_MCALL
-    getCooperativeVectorProperties(CooperativeVectorProperties* properties, uint32_t* propertyCount) override;
+    getCooperativeVectorProperties(CooperativeVectorProperties* properties, uint32_t* propertiesCount) override;
     virtual SLANG_NO_THROW Result SLANG_MCALL
     convertCooperativeVectorMatrix(const ConvertCooperativeVectorMatrixDesc* descs, uint32_t descCount) override;
     virtual SLANG_NO_THROW Result SLANG_MCALL

--- a/src/device.cpp
+++ b/src/device.cpp
@@ -786,25 +786,28 @@ Result Device::createSurface(WindowHandle windowHandle, ISurface** outSurface)
     return SLANG_E_NOT_AVAILABLE;
 }
 
-Result Device::getCooperativeVectorProperties(CooperativeVectorProperties* properties, uint32_t* propertyCount)
+Result Device::getCooperativeVectorProperties(CooperativeVectorProperties* properties, uint32_t* propertiesCount)
 {
+    if (!propertiesCount)
+    {
+        return SLANG_E_INVALID_ARG;
+    }
     if (m_cooperativeVectorProperties.empty())
     {
         return SLANG_E_NOT_AVAILABLE;
     }
-
-    if (*propertyCount == 0)
+    if (properties)
     {
-        *propertyCount = uint32_t(m_cooperativeVectorProperties.size());
-        return SLANG_OK;
+        uint32_t count = min(*propertiesCount, uint32_t(m_cooperativeVectorProperties.size()));
+        ::memcpy(properties, m_cooperativeVectorProperties.data(), count * sizeof(CooperativeVectorProperties));
+        Result result = count == *propertiesCount ? SLANG_OK : SLANG_E_BUFFER_TOO_SMALL;
+        *propertiesCount = count;
+        return result;
     }
     else
     {
-        uint32_t count = min(*propertyCount, uint32_t(m_cooperativeVectorProperties.size()));
-        ::memcpy(properties, m_cooperativeVectorProperties.data(), count * sizeof(CooperativeVectorProperties));
-        Result result = count == *propertyCount ? SLANG_OK : SLANG_E_BUFFER_TOO_SMALL;
-        *propertyCount = count;
-        return result;
+        *propertiesCount = uint32_t(m_cooperativeVectorProperties.size());
+        return SLANG_OK;
     }
 }
 

--- a/src/device.h
+++ b/src/device.h
@@ -237,7 +237,7 @@ public:
 
     // Provides a default implementation that returns SLANG_E_NOT_AVAILABLE.
     virtual SLANG_NO_THROW Result SLANG_MCALL
-    getCooperativeVectorProperties(CooperativeVectorProperties* properties, uint32_t* propertyCount) override;
+    getCooperativeVectorProperties(CooperativeVectorProperties* properties, uint32_t* propertiesCount) override;
 
     // Provides a default implementation that returns SLANG_E_NOT_AVAILABLE.
     virtual SLANG_NO_THROW Result SLANG_MCALL

--- a/src/enum-strings.cpp
+++ b/src/enum-strings.cpp
@@ -391,4 +391,42 @@ const char* enumToString(QueryType value)
     return S_INVALID;
 }
 
+const char* enumToString(CooperativeVectorComponentType value)
+{
+    switch (value)
+    {
+    case CooperativeVectorComponentType::Float16:
+        return S_CooperativeVectorComponentType_Float16;
+    case CooperativeVectorComponentType::Float32:
+        return S_CooperativeVectorComponentType_Float32;
+    case CooperativeVectorComponentType::Float64:
+        return S_CooperativeVectorComponentType_Float64;
+    case CooperativeVectorComponentType::Sint8:
+        return S_CooperativeVectorComponentType_Sint8;
+    case CooperativeVectorComponentType::Sint16:
+        return S_CooperativeVectorComponentType_Sint16;
+    case CooperativeVectorComponentType::Sint32:
+        return S_CooperativeVectorComponentType_Sint32;
+    case CooperativeVectorComponentType::Sint64:
+        return S_CooperativeVectorComponentType_Sint64;
+    case CooperativeVectorComponentType::Uint8:
+        return S_CooperativeVectorComponentType_Uint8;
+    case CooperativeVectorComponentType::Uint16:
+        return S_CooperativeVectorComponentType_Uint16;
+    case CooperativeVectorComponentType::Uint32:
+        return S_CooperativeVectorComponentType_Uint32;
+    case CooperativeVectorComponentType::Uint64:
+        return S_CooperativeVectorComponentType_Uint64;
+    case CooperativeVectorComponentType::Sint8Packed:
+        return S_CooperativeVectorComponentType_Sint8Packed;
+    case CooperativeVectorComponentType::Uint8Packed:
+        return S_CooperativeVectorComponentType_Uint8Packed;
+    case CooperativeVectorComponentType::FloatE4M3:
+        return S_CooperativeVectorComponentType_FloatE4M3;
+    case CooperativeVectorComponentType::FloatE5M2:
+        return S_CooperativeVectorComponentType_FloatE5M2;
+    }
+    return S_INVALID;
+}
+
 } // namespace rhi

--- a/src/enum-strings.h
+++ b/src/enum-strings.h
@@ -24,5 +24,6 @@ const char* enumToString(TextureReductionOp value);
 const char* enumToString(InputSlotClass value);
 const char* enumToString(PrimitiveTopology value);
 const char* enumToString(QueryType value);
+const char* enumToString(CooperativeVectorComponentType value);
 
 } // namespace rhi

--- a/src/strings.h
+++ b/src/strings.h
@@ -153,6 +153,24 @@
 #define S_QueryType_AccelerationStructureSerializedSize "AccelerationStructureSerializedSize"
 #define S_QueryType_AccelerationStructureCurrentSize "AccelerationStructureCurrentSize"
 
+// CooperativeVectorComponentType
+#define S_CooperativeVectorComponentType_Float16 "Float16"
+#define S_CooperativeVectorComponentType_Float32 "Float32"
+#define S_CooperativeVectorComponentType_Float64 "Float64"
+#define S_CooperativeVectorComponentType_Sint8 "Sint8"
+#define S_CooperativeVectorComponentType_Sint16 "Sint16"
+#define S_CooperativeVectorComponentType_Sint32 "Sint32"
+#define S_CooperativeVectorComponentType_Sint64 "Sint64"
+#define S_CooperativeVectorComponentType_Uint8 "Uint8"
+#define S_CooperativeVectorComponentType_Uint16 "Uint16"
+#define S_CooperativeVectorComponentType_Uint32 "Uint32"
+#define S_CooperativeVectorComponentType_Uint64 "Uint64"
+#define S_CooperativeVectorComponentType_Sint8Packed "Sint8Packed"
+#define S_CooperativeVectorComponentType_Uint8Packed "Uint8Packed"
+#define S_CooperativeVectorComponentType_FloatE4M3 "FloatE4M3"
+#define S_CooperativeVectorComponentType_FloatE5M2 "FloatE5M2"
+
+
 // ----------------------------------------------------------------------------
 // Functions
 // ----------------------------------------------------------------------------

--- a/src/vulkan/vk-api.h
+++ b/src/vulkan/vk-api.h
@@ -255,12 +255,13 @@ namespace rhi::vk {
 
 #define VK_API_DECLARE_PROC(NAME) PFN_##NAME NAME = nullptr;
 
-struct VulkanExtendedFeatureProperties
+struct VulkanExtendedFeatures
 {
     // 16 bit storage features
     VkPhysicalDevice16BitStorageFeatures storage16BitFeatures = {
         VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_16BIT_STORAGE_FEATURES_KHR
     };
+
     // Atomic Float features
     VkPhysicalDeviceShaderAtomicFloatFeaturesEXT atomicFloatFeatures = {
         VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_ATOMIC_FLOAT_FEATURES_EXT
@@ -268,43 +269,58 @@ struct VulkanExtendedFeatureProperties
     VkPhysicalDeviceShaderAtomicFloat2FeaturesEXT atomicFloat2Features = {
         VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_ATOMIC_FLOAT_2_FEATURES_EXT
     };
+
     // Image int64 atomic features
     VkPhysicalDeviceShaderImageAtomicInt64FeaturesEXT imageInt64AtomicFeatures = {
         VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_IMAGE_ATOMIC_INT64_FEATURES_EXT
     };
+
     // Extended dynamic state features
     VkPhysicalDeviceExtendedDynamicStateFeaturesEXT extendedDynamicStateFeatures = {
         VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTENDED_DYNAMIC_STATE_FEATURES_EXT
     };
+
     // Acceleration structure features
     VkPhysicalDeviceAccelerationStructureFeaturesKHR accelerationStructureFeatures = {
         VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_ACCELERATION_STRUCTURE_FEATURES_KHR
     };
+
     // Ray tracing pipeline features
     VkPhysicalDeviceRayTracingPipelineFeaturesKHR rayTracingPipelineFeatures = {
         VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_RAY_TRACING_PIPELINE_FEATURES_KHR
     };
+
     // Ray query (inline ray-tracing) features
     VkPhysicalDeviceRayQueryFeaturesKHR rayQueryFeatures = {VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_RAY_QUERY_FEATURES_KHR};
+
+    // Ray tracing position fetch features
+    VkPhysicalDeviceRayTracingPositionFetchFeaturesKHR rayTracingPositionFetchFeatures = {
+        VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_RAY_TRACING_POSITION_FETCH_FEATURES_KHR
+    };
+
     // Inline uniform block features
     VkPhysicalDeviceInlineUniformBlockFeaturesEXT inlineUniformBlockFeatures = {
         VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_INLINE_UNIFORM_BLOCK_FEATURES_EXT
     };
+
     // Robustness2 features
     VkPhysicalDeviceRobustness2FeaturesEXT robustness2Features = {
         VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_ROBUSTNESS_2_FEATURES_EXT
     };
 
+    // Ray tracing invocation reorder features
     VkPhysicalDeviceRayTracingInvocationReorderFeaturesNV rayTracingInvocationReorderFeatures = {
         VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_RAY_TRACING_INVOCATION_REORDER_FEATURES_NV
     };
 
+    // Variable pointers features
     VkPhysicalDeviceVariablePointerFeaturesKHR variablePointersFeatures = {
         VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VARIABLE_POINTER_FEATURES_KHR
     };
 
-    VkPhysicalDeviceComputeShaderDerivativesFeaturesNV computeShaderDerivativeFeatures = {
-        VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_COMPUTE_SHADER_DERIVATIVES_FEATURES_NV
+    // Compute shader derivatives features
+    VkPhysicalDeviceComputeShaderDerivativesFeaturesKHR computeShaderDerivativesFeatures = {
+        VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_COMPUTE_SHADER_DERIVATIVES_FEATURES_KHR
     };
 
     // Clock features
@@ -343,14 +359,17 @@ struct VulkanExtendedFeatureProperties
         VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DYNAMIC_RENDERING_FEATURES_KHR
     };
 
+    // Custom border color features
     VkPhysicalDeviceCustomBorderColorFeaturesEXT customBorderColorFeatures = {
         VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_CUSTOM_BORDER_COLOR_FEATURES_EXT
     };
 
+    // Dynamic rendering local read features
     VkPhysicalDeviceDynamicRenderingLocalReadFeaturesKHR dynamicRenderingLocalReadFeatures = {
         VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DYNAMIC_RENDERING_LOCAL_READ_FEATURES_KHR
     };
 
+    // 4444 formats features
     VkPhysicalDevice4444FormatsFeaturesEXT formats4444Features = {
         VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_4444_FORMATS_FEATURES_EXT
     };
@@ -409,6 +428,21 @@ struct VulkanExtendedFeatureProperties
     VkPhysicalDeviceShaderSubgroupRotateFeatures shaderSubgroupRotateFeatures = {
         VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_SUBGROUP_ROTATE_FEATURES_KHR
     };
+
+    // Shader replicated composites features
+    VkPhysicalDeviceShaderReplicatedCompositesFeaturesEXT shaderReplicatedCompositesFeatures = {
+        VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_REPLICATED_COMPOSITES_FEATURES_EXT
+    };
+
+    // Fragment shader barycentric features
+    VkPhysicalDeviceFragmentShaderBarycentricFeaturesKHR fragmentShaderBarycentricFeatures = {
+        VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FRAGMENT_SHADER_BARYCENTRIC_FEATURES_KHR
+    };
+
+    // Fragment shader interlock features
+    VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT fragmentShaderInterlockFeatures = {
+        VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FRAGMENT_SHADER_INTERLOCK_FEATURES_EXT
+    };
 };
 
 struct VulkanApi
@@ -454,7 +488,7 @@ struct VulkanApi
     VkPhysicalDeviceRayTracingPipelinePropertiesKHR m_rtProperties;
     VkPhysicalDeviceFeatures m_deviceFeatures;
     VkPhysicalDeviceMemoryProperties m_deviceMemoryProperties;
-    VulkanExtendedFeatureProperties m_extendedFeatures;
+    VulkanExtendedFeatures m_extendedFeatures;
 };
 
 } // namespace rhi::vk

--- a/src/vulkan/vk-device.cpp
+++ b/src/vulkan/vk-device.cpp
@@ -1638,7 +1638,7 @@ Result DeviceImpl::getTextureRowAlignment(Format format, Size* outAlignment)
     return SLANG_OK;
 }
 
-Result DeviceImpl::getCooperativeVectorProperties(CooperativeVectorProperties* properties, uint32_t* propertyCount)
+Result DeviceImpl::getCooperativeVectorProperties(CooperativeVectorProperties* properties, uint32_t* propertiesCount)
 {
     if (!m_api.m_extendedFeatures.cooperativeVectorFeatures.cooperativeVector ||
         !m_api.vkGetPhysicalDeviceCooperativeVectorPropertiesNV)
@@ -1672,7 +1672,7 @@ Result DeviceImpl::getCooperativeVectorProperties(CooperativeVectorProperties* p
         }
     }
 
-    return Device::getCooperativeVectorProperties(properties, propertyCount);
+    return Device::getCooperativeVectorProperties(properties, propertiesCount);
 }
 
 Result DeviceImpl::convertCooperativeVectorMatrix(const ConvertCooperativeVectorMatrixDesc* descs, uint32_t descCount)

--- a/src/vulkan/vk-device.cpp
+++ b/src/vulkan/vk-device.cpp
@@ -421,152 +421,71 @@ Result DeviceImpl::initVulkanInstanceAndDevice(
 
     auto& extendedFeatures = m_api.m_extendedFeatures;
 
+#define EXTEND_DESC_CHAIN(head_, desc_)                                                                                \
+    {                                                                                                                  \
+        desc_.pNext = head_.pNext;                                                                                     \
+        head_.pNext = &desc_;                                                                                          \
+    }
+
     // API version check, can't use vkGetPhysicalDeviceProperties2 yet since this device might not
     // support it
     if (VK_MAKE_VERSION(majorVersion, minorVersion, 0) >= VK_API_VERSION_1_1 && m_api.vkGetPhysicalDeviceProperties2 &&
         m_api.vkGetPhysicalDeviceFeatures2)
     {
         // Get device features
-        VkPhysicalDeviceFeatures2 deviceFeatures2 = {};
-        deviceFeatures2.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2;
+        VkPhysicalDeviceFeatures2 deviceFeatures2 = {VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2};
 
-        // Inline uniform block
-        extendedFeatures.inlineUniformBlockFeatures.pNext = deviceFeatures2.pNext;
-        deviceFeatures2.pNext = &extendedFeatures.inlineUniformBlockFeatures;
-
-        // Ray query features
-        extendedFeatures.rayQueryFeatures.pNext = deviceFeatures2.pNext;
-        deviceFeatures2.pNext = &extendedFeatures.rayQueryFeatures;
-
-        // Ray tracing pipeline features
-        extendedFeatures.rayTracingPipelineFeatures.pNext = deviceFeatures2.pNext;
-        deviceFeatures2.pNext = &extendedFeatures.rayTracingPipelineFeatures;
-
-        // SER features.
-        extendedFeatures.rayTracingInvocationReorderFeatures.pNext = deviceFeatures2.pNext;
-        deviceFeatures2.pNext = &extendedFeatures.rayTracingInvocationReorderFeatures;
-
-        // Acceleration structure features
-        extendedFeatures.accelerationStructureFeatures.pNext = deviceFeatures2.pNext;
-        deviceFeatures2.pNext = &extendedFeatures.accelerationStructureFeatures;
-
-        // Variable pointer features.
-        extendedFeatures.variablePointersFeatures.pNext = deviceFeatures2.pNext;
-        deviceFeatures2.pNext = &extendedFeatures.variablePointersFeatures;
-
-        // Compute shader derivative features.
-        extendedFeatures.computeShaderDerivativeFeatures.pNext = deviceFeatures2.pNext;
-        deviceFeatures2.pNext = &extendedFeatures.computeShaderDerivativeFeatures;
-
-        // Extended dynamic states
-        extendedFeatures.extendedDynamicStateFeatures.pNext = deviceFeatures2.pNext;
-        deviceFeatures2.pNext = &extendedFeatures.extendedDynamicStateFeatures;
-
-        // 16-bit storage
-        extendedFeatures.storage16BitFeatures.pNext = deviceFeatures2.pNext;
-        deviceFeatures2.pNext = &extendedFeatures.storage16BitFeatures;
-
-        // robustness2 features
-        extendedFeatures.robustness2Features.pNext = deviceFeatures2.pNext;
-        deviceFeatures2.pNext = &extendedFeatures.robustness2Features;
-
-        // clock features
-        extendedFeatures.clockFeatures.pNext = deviceFeatures2.pNext;
-        deviceFeatures2.pNext = &extendedFeatures.clockFeatures;
-
-        // Atomic Float
-        // To detect atomic float we need
-        // https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkPhysicalDeviceShaderAtomicFloatFeaturesEXT.html
-
-        extendedFeatures.atomicFloatFeatures.pNext = deviceFeatures2.pNext;
-        deviceFeatures2.pNext = &extendedFeatures.atomicFloatFeatures;
-
-        // https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VkPhysicalDeviceShaderAtomicFloat2FeaturesEXT.html
-        extendedFeatures.atomicFloat2Features.pNext = deviceFeatures2.pNext;
-        deviceFeatures2.pNext = &extendedFeatures.atomicFloat2Features;
-
-        // Image Int64 Atomic
-        // https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VkPhysicalDeviceShaderImageAtomicInt64FeaturesEXT.html
-        extendedFeatures.imageInt64AtomicFeatures.pNext = deviceFeatures2.pNext;
-        deviceFeatures2.pNext = &extendedFeatures.imageInt64AtomicFeatures;
-
-        // mesh shader features
-        extendedFeatures.meshShaderFeatures.pNext = deviceFeatures2.pNext;
-        deviceFeatures2.pNext = &extendedFeatures.meshShaderFeatures;
-
-        // multiview features
-        extendedFeatures.multiviewFeatures.pNext = deviceFeatures2.pNext;
-        deviceFeatures2.pNext = &extendedFeatures.multiviewFeatures;
-
-        // fragment shading rate features
-        extendedFeatures.fragmentShadingRateFeatures.pNext = deviceFeatures2.pNext;
-        deviceFeatures2.pNext = &extendedFeatures.fragmentShadingRateFeatures;
-
-        // raytracing validation features
-        extendedFeatures.rayTracingValidationFeatures.pNext = deviceFeatures2.pNext;
-        deviceFeatures2.pNext = &extendedFeatures.rayTracingValidationFeatures;
-
-        // shader draw parameters features
-        extendedFeatures.shaderDrawParametersFeatures.pNext = deviceFeatures2.pNext;
-        deviceFeatures2.pNext = &extendedFeatures.shaderDrawParametersFeatures;
-
-        // dynamic rendering features
-        extendedFeatures.dynamicRenderingFeatures.pNext = deviceFeatures2.pNext;
-        deviceFeatures2.pNext = &extendedFeatures.dynamicRenderingFeatures;
-
-        // custom border color features
-        extendedFeatures.customBorderColorFeatures.pNext = deviceFeatures2.pNext;
-        deviceFeatures2.pNext = &extendedFeatures.customBorderColorFeatures;
-
-        extendedFeatures.dynamicRenderingLocalReadFeatures.pNext = deviceFeatures2.pNext;
-        deviceFeatures2.pNext = &extendedFeatures.dynamicRenderingLocalReadFeatures;
-
-        extendedFeatures.formats4444Features.pNext = deviceFeatures2.pNext;
-        deviceFeatures2.pNext = &extendedFeatures.formats4444Features;
-
-        extendedFeatures.shaderMaximalReconvergenceFeatures.pNext = deviceFeatures2.pNext;
-        deviceFeatures2.pNext = &extendedFeatures.shaderMaximalReconvergenceFeatures;
-
-        extendedFeatures.shaderQuadControlFeatures.pNext = deviceFeatures2.pNext;
-        deviceFeatures2.pNext = &extendedFeatures.shaderQuadControlFeatures;
-
-        extendedFeatures.shaderIntegerDotProductFeatures.pNext = deviceFeatures2.pNext;
-        deviceFeatures2.pNext = &extendedFeatures.shaderIntegerDotProductFeatures;
-
-        extendedFeatures.cooperativeVectorFeatures.pNext = deviceFeatures2.pNext;
-        deviceFeatures2.pNext = &extendedFeatures.cooperativeVectorFeatures;
-
-        extendedFeatures.rayTracingLinearSweptSpheresFeatures.pNext = deviceFeatures2.pNext;
-        deviceFeatures2.pNext = &extendedFeatures.rayTracingLinearSweptSpheresFeatures;
-
-        extendedFeatures.cooperativeMatrix1Features.pNext = deviceFeatures2.pNext;
-        deviceFeatures2.pNext = &extendedFeatures.cooperativeMatrix1Features;
-
-        extendedFeatures.descriptorIndexingFeatures.pNext = deviceFeatures2.pNext;
-        deviceFeatures2.pNext = &extendedFeatures.descriptorIndexingFeatures;
-
-        extendedFeatures.mutableDescriptorTypeFeatures.pNext = deviceFeatures2.pNext;
-        deviceFeatures2.pNext = &extendedFeatures.mutableDescriptorTypeFeatures;
-
-        extendedFeatures.pipelineBinaryFeatures.pNext = deviceFeatures2.pNext;
-        deviceFeatures2.pNext = &extendedFeatures.pipelineBinaryFeatures;
+        EXTEND_DESC_CHAIN(deviceFeatures2, extendedFeatures.inlineUniformBlockFeatures);
+        EXTEND_DESC_CHAIN(deviceFeatures2, extendedFeatures.rayTracingPipelineFeatures);
+        EXTEND_DESC_CHAIN(deviceFeatures2, extendedFeatures.rayQueryFeatures);
+        EXTEND_DESC_CHAIN(deviceFeatures2, extendedFeatures.rayTracingPositionFetchFeatures);
+        EXTEND_DESC_CHAIN(deviceFeatures2, extendedFeatures.rayTracingInvocationReorderFeatures);
+        EXTEND_DESC_CHAIN(deviceFeatures2, extendedFeatures.accelerationStructureFeatures);
+        EXTEND_DESC_CHAIN(deviceFeatures2, extendedFeatures.variablePointersFeatures);
+        EXTEND_DESC_CHAIN(deviceFeatures2, extendedFeatures.computeShaderDerivativesFeatures);
+        EXTEND_DESC_CHAIN(deviceFeatures2, extendedFeatures.extendedDynamicStateFeatures);
+        EXTEND_DESC_CHAIN(deviceFeatures2, extendedFeatures.storage16BitFeatures);
+        EXTEND_DESC_CHAIN(deviceFeatures2, extendedFeatures.robustness2Features);
+        EXTEND_DESC_CHAIN(deviceFeatures2, extendedFeatures.clockFeatures);
+        EXTEND_DESC_CHAIN(deviceFeatures2, extendedFeatures.atomicFloatFeatures);
+        EXTEND_DESC_CHAIN(deviceFeatures2, extendedFeatures.atomicFloat2Features);
+        EXTEND_DESC_CHAIN(deviceFeatures2, extendedFeatures.imageInt64AtomicFeatures);
+        EXTEND_DESC_CHAIN(deviceFeatures2, extendedFeatures.meshShaderFeatures);
+        EXTEND_DESC_CHAIN(deviceFeatures2, extendedFeatures.multiviewFeatures);
+        EXTEND_DESC_CHAIN(deviceFeatures2, extendedFeatures.fragmentShadingRateFeatures);
+        EXTEND_DESC_CHAIN(deviceFeatures2, extendedFeatures.rayTracingValidationFeatures);
+        EXTEND_DESC_CHAIN(deviceFeatures2, extendedFeatures.shaderDrawParametersFeatures);
+        EXTEND_DESC_CHAIN(deviceFeatures2, extendedFeatures.dynamicRenderingFeatures);
+        EXTEND_DESC_CHAIN(deviceFeatures2, extendedFeatures.customBorderColorFeatures);
+        EXTEND_DESC_CHAIN(deviceFeatures2, extendedFeatures.dynamicRenderingLocalReadFeatures);
+        EXTEND_DESC_CHAIN(deviceFeatures2, extendedFeatures.formats4444Features);
+        EXTEND_DESC_CHAIN(deviceFeatures2, extendedFeatures.shaderMaximalReconvergenceFeatures);
+        EXTEND_DESC_CHAIN(deviceFeatures2, extendedFeatures.shaderQuadControlFeatures);
+        EXTEND_DESC_CHAIN(deviceFeatures2, extendedFeatures.shaderIntegerDotProductFeatures);
+        EXTEND_DESC_CHAIN(deviceFeatures2, extendedFeatures.cooperativeVectorFeatures);
+        EXTEND_DESC_CHAIN(deviceFeatures2, extendedFeatures.rayTracingLinearSweptSpheresFeatures);
+        EXTEND_DESC_CHAIN(deviceFeatures2, extendedFeatures.cooperativeMatrix1Features);
+        EXTEND_DESC_CHAIN(deviceFeatures2, extendedFeatures.descriptorIndexingFeatures);
+        EXTEND_DESC_CHAIN(deviceFeatures2, extendedFeatures.mutableDescriptorTypeFeatures);
+        EXTEND_DESC_CHAIN(deviceFeatures2, extendedFeatures.pipelineBinaryFeatures);
+        EXTEND_DESC_CHAIN(deviceFeatures2, extendedFeatures.shaderSubgroupRotateFeatures);
+        EXTEND_DESC_CHAIN(deviceFeatures2, extendedFeatures.shaderReplicatedCompositesFeatures);
+        EXTEND_DESC_CHAIN(deviceFeatures2, extendedFeatures.fragmentShaderBarycentricFeatures);
+        EXTEND_DESC_CHAIN(deviceFeatures2, extendedFeatures.fragmentShaderInterlockFeatures);
 
         if (VK_MAKE_VERSION(majorVersion, minorVersion, 0) >= VK_API_VERSION_1_2)
         {
-            extendedFeatures.vulkan12Features.pNext = deviceFeatures2.pNext;
-            deviceFeatures2.pNext = &extendedFeatures.vulkan12Features;
+            EXTEND_DESC_CHAIN(deviceFeatures2, extendedFeatures.vulkan12Features);
         }
 
         if (VK_MAKE_VERSION(majorVersion, minorVersion, 0) >= VK_API_VERSION_1_3)
         {
-            extendedFeatures.vulkan13Features.pNext = deviceFeatures2.pNext;
-            deviceFeatures2.pNext = &extendedFeatures.vulkan13Features;
+            EXTEND_DESC_CHAIN(deviceFeatures2, extendedFeatures.vulkan13Features);
         }
 
         if (VK_MAKE_VERSION(majorVersion, minorVersion, 0) >= VK_API_VERSION_1_4)
         {
-            extendedFeatures.vulkan14Features.pNext = deviceFeatures2.pNext;
-            deviceFeatures2.pNext = &extendedFeatures.vulkan14Features;
+            EXTEND_DESC_CHAIN(deviceFeatures2, extendedFeatures.vulkan14Features);
         }
 
         m_api.vkGetPhysicalDeviceFeatures2(m_api.m_physicalDevice, &deviceFeatures2);
@@ -660,14 +579,21 @@ Result DeviceImpl::initVulkanInstanceAndDevice(
             extendedFeatures.atomicFloatFeatures,
             shaderBufferFloat32Atomics,
             VK_EXT_SHADER_ATOMIC_FLOAT_EXTENSION_NAME,
-            { availableFeatures.push_back(Feature::AtomicFloat); }
+            {
+                availableFeatures.push_back(Feature::AtomicFloat);
+                availableCapabilities.push_back(Capability::SPV_EXT_shader_atomic_float_add);
+            }
         );
 
         SIMPLE_EXTENSION_FEATURE(
             extendedFeatures.atomicFloat2Features,
             shaderBufferFloat16Atomics,
             VK_EXT_SHADER_ATOMIC_FLOAT_2_EXTENSION_NAME,
-            { availableFeatures.push_back(Feature::AtomicFloat); }
+            {
+                availableFeatures.push_back(Feature::AtomicFloat);
+                availableCapabilities.push_back(Capability::SPV_EXT_shader_atomic_float16_add);
+                availableCapabilities.push_back(Capability::SPV_EXT_shader_atomic_float_min_max);
+            }
         );
 
         SIMPLE_EXTENSION_FEATURE(
@@ -718,11 +644,31 @@ Result DeviceImpl::initVulkanInstanceAndDevice(
                 extendedFeatures.rayTracingPipelineFeatures,
                 rayTracingPipeline,
                 VK_KHR_RAY_TRACING_PIPELINE_EXTENSION_NAME,
-                { availableFeatures.push_back(Feature::RayTracing); }
+                {
+                    availableFeatures.push_back(Feature::RayTracing);
+                    availableCapabilities.push_back(Capability::SPV_KHR_ray_tracing);
+                    availableCapabilities.push_back(Capability::spvRayTracingKHR);
+                }
+            );
+
+            SIMPLE_EXTENSION_FEATURE(
+                extendedFeatures.rayTracingPositionFetchFeatures,
+                rayTracingPositionFetch,
+                VK_KHR_RAY_TRACING_POSITION_FETCH_EXTENSION_NAME,
+                {
+                    availableCapabilities.push_back(Capability::SPV_KHR_ray_tracing_position_fetch);
+                    availableCapabilities.push_back(Capability::spvRayTracingPositionFetchKHR);
+                    if (extendedFeatures.rayQueryFeatures.rayQuery)
+                    {
+                        availableCapabilities.push_back(Capability::spvRayQueryPositionFetchKHR);
+                    }
+                }
             );
 
             SIMPLE_EXTENSION_FEATURE(extendedFeatures.rayQueryFeatures, rayQuery, VK_KHR_RAY_QUERY_EXTENSION_NAME, {
                 availableFeatures.push_back(Feature::RayQuery);
+                availableCapabilities.push_back(Capability::SPV_KHR_ray_query);
+                availableCapabilities.push_back(Capability::spvRayQueryKHR);
             });
 
             if (extendedFeatures.rayTracingLinearSweptSpheresFeatures.spheres ||
@@ -761,11 +707,17 @@ Result DeviceImpl::initVulkanInstanceAndDevice(
             extendedFeatures.clockFeatures,
             shaderDeviceClock,
             VK_KHR_SHADER_CLOCK_EXTENSION_NAME,
-            { availableFeatures.push_back(Feature::RealtimeClock); }
+            {
+                availableFeatures.push_back(Feature::RealtimeClock);
+                availableCapabilities.push_back(Capability::SPV_KHR_shader_clock);
+                availableCapabilities.push_back(Capability::spvShaderClockKHR);
+            }
         );
 
         SIMPLE_EXTENSION_FEATURE(extendedFeatures.meshShaderFeatures, meshShader, VK_EXT_MESH_SHADER_EXTENSION_NAME, {
             availableFeatures.push_back(Feature::MeshShader);
+            availableCapabilities.push_back(Capability::SPV_EXT_mesh_shader);
+            availableCapabilities.push_back(Capability::spvMeshShadingEXT);
         });
 
         SIMPLE_EXTENSION_FEATURE(extendedFeatures.multiviewFeatures, multiview, VK_KHR_MULTIVIEW_EXTENSION_NAME, {
@@ -783,7 +735,11 @@ Result DeviceImpl::initVulkanInstanceAndDevice(
             extendedFeatures.rayTracingInvocationReorderFeatures,
             rayTracingInvocationReorder,
             VK_NV_RAY_TRACING_INVOCATION_REORDER_EXTENSION_NAME,
-            { availableFeatures.push_back(Feature::ShaderExecutionReordering); }
+            {
+                availableFeatures.push_back(Feature::ShaderExecutionReordering);
+                availableCapabilities.push_back(Capability::SPV_NV_shader_invocation_reorder);
+                availableCapabilities.push_back(Capability::spvShaderInvocationReorderNV);
+            }
         );
 
         SIMPLE_EXTENSION_FEATURE(
@@ -794,10 +750,10 @@ Result DeviceImpl::initVulkanInstanceAndDevice(
         );
 
         SIMPLE_EXTENSION_FEATURE(
-            extendedFeatures.computeShaderDerivativeFeatures,
-            computeDerivativeGroupLinear,
-            VK_NV_COMPUTE_SHADER_DERIVATIVES_EXTENSION_NAME,
-            {/* "computeDerivativeGroupLinear" */}
+            extendedFeatures.computeShaderDerivativesFeatures,
+            computeDerivativeGroupQuads,
+            VK_KHR_COMPUTE_SHADER_DERIVATIVES_EXTENSION_NAME,
+            { availableCapabilities.push_back(Capability::SPV_KHR_compute_shader_derivatives); }
         );
 
         // Only enable raytracing validation if both requested and supported
@@ -815,14 +771,20 @@ Result DeviceImpl::initVulkanInstanceAndDevice(
             extendedFeatures.shaderMaximalReconvergenceFeatures,
             shaderMaximalReconvergence,
             VK_KHR_SHADER_MAXIMAL_RECONVERGENCE_EXTENSION_NAME,
-            {/* "shader-maximal-reconvergence" */}
+            {
+                availableCapabilities.push_back(Capability::SPV_KHR_maximal_reconvergence);
+                availableCapabilities.push_back(Capability::spvMaximalReconvergenceKHR);
+            }
         );
 
         SIMPLE_EXTENSION_FEATURE(
             extendedFeatures.shaderQuadControlFeatures,
             shaderQuadControl,
             VK_KHR_SHADER_QUAD_CONTROL_EXTENSION_NAME,
-            {/* "shader-quad-control" */}
+            {
+                availableCapabilities.push_back(Capability::SPV_KHR_quad_control);
+                availableCapabilities.push_back(Capability::spvQuadControlKHR);
+            }
         );
 
         SIMPLE_EXTENSION_FEATURE(
@@ -836,14 +798,26 @@ Result DeviceImpl::initVulkanInstanceAndDevice(
             extendedFeatures.cooperativeVectorFeatures,
             cooperativeVector,
             VK_NV_COOPERATIVE_VECTOR_EXTENSION_NAME,
-            { availableFeatures.push_back(Feature::CooperativeVector); }
+            {
+                availableFeatures.push_back(Feature::CooperativeVector);
+                availableCapabilities.push_back(Capability::SPV_NV_cooperative_vector);
+                availableCapabilities.push_back(Capability::spvCooperativeVectorNV);
+                if (extendedFeatures.cooperativeVectorFeatures.cooperativeVectorTraining)
+                {
+                    availableCapabilities.push_back(Capability::spvCooperativeVectorTrainingNV);
+                }
+            }
         );
 
         SIMPLE_EXTENSION_FEATURE(
             extendedFeatures.cooperativeMatrix1Features,
             cooperativeMatrix,
             VK_KHR_COOPERATIVE_MATRIX_EXTENSION_NAME,
-            { availableFeatures.push_back(Feature::CooperativeMatrix); }
+            {
+                availableFeatures.push_back(Feature::CooperativeMatrix);
+                availableCapabilities.push_back(Capability::SPV_KHR_cooperative_matrix);
+                availableCapabilities.push_back(Capability::spvCooperativeMatrixKHR);
+            }
         );
 
         SIMPLE_EXTENSION_FEATURE(
@@ -860,6 +834,27 @@ Result DeviceImpl::initVulkanInstanceAndDevice(
             {
                 deviceExtensions.push_back(VK_KHR_MAINTENANCE_5_EXTENSION_NAME);
                 availableFeatures.push_back(Feature::PipelineCache);
+            }
+        );
+
+        SIMPLE_EXTENSION_FEATURE(
+            extendedFeatures.shaderReplicatedCompositesFeatures,
+            shaderReplicatedComposites,
+            VK_EXT_SHADER_REPLICATED_COMPOSITES_EXTENSION_NAME,
+            {
+                availableCapabilities.push_back(Capability::SPV_EXT_replicated_composites);
+                availableCapabilities.push_back(Capability::spvReplicatedCompositesEXT);
+            }
+        );
+
+        SIMPLE_EXTENSION_FEATURE(
+            extendedFeatures.fragmentShaderBarycentricFeatures,
+            fragmentShaderBarycentric,
+            VK_KHR_FRAGMENT_SHADER_BARYCENTRIC_EXTENSION_NAME,
+            {
+                availableFeatures.push_back(Feature::Barycentrics);
+                availableCapabilities.push_back(Capability::SPV_KHR_fragment_shader_barycentric);
+                availableCapabilities.push_back(Capability::spvFragmentBarycentricKHR);
             }
         );
 
@@ -935,6 +930,18 @@ Result DeviceImpl::initVulkanInstanceAndDevice(
         {
             deviceExtensions.push_back(VK_EXT_CONSERVATIVE_RASTERIZATION_EXTENSION_NAME);
             availableFeatures.push_back(Feature::ConservativeRasterization);
+            availableCapabilities.push_back(Capability::SPV_EXT_fragment_fully_covered);
+            availableCapabilities.push_back(Capability::spvFragmentFullyCoveredEXT);
+        }
+        if (extensionNames.count(VK_EXT_FRAGMENT_SHADER_INTERLOCK_EXTENSION_NAME))
+        {
+            deviceExtensions.push_back(VK_EXT_FRAGMENT_SHADER_INTERLOCK_EXTENSION_NAME);
+            // availableFeatures.push_back(Feature::RasterizerOrderedViews); TODO should this be enabled?
+            availableCapabilities.push_back(Capability::SPV_EXT_fragment_shader_interlock);
+            if (extendedFeatures.fragmentShaderInterlockFeatures.fragmentShaderPixelInterlock)
+            {
+                availableCapabilities.push_back(Capability::spvFragmentShaderPixelInterlockEXT);
+            }
         }
         if (extensionNames.count(VK_EXT_SHADER_VIEWPORT_INDEX_LAYER_EXTENSION_NAME))
         {
@@ -952,15 +959,15 @@ Result DeviceImpl::initVulkanInstanceAndDevice(
         {
             deviceExtensions.push_back(VK_KHR_PUSH_DESCRIPTOR_EXTENSION_NAME);
         }
-        if (extensionNames.count(VK_NV_FRAGMENT_SHADER_BARYCENTRIC_EXTENSION_NAME))
-        {
-            deviceExtensions.push_back(VK_NV_FRAGMENT_SHADER_BARYCENTRIC_EXTENSION_NAME);
-            availableFeatures.push_back(Feature::Barycentrics);
-        }
         if (extensionNames.count(VK_NV_SHADER_SUBGROUP_PARTITIONED_EXTENSION_NAME))
         {
             deviceExtensions.push_back(VK_NV_SHADER_SUBGROUP_PARTITIONED_EXTENSION_NAME);
         }
+    }
+
+    if (extendedFeatures.vulkan12Features.descriptorIndexing)
+    {
+        availableCapabilities.push_back(Capability::SPV_EXT_descriptor_indexing);
     }
 
     if (extendedFeatures.vulkan12Features.descriptorIndexing &&

--- a/src/vulkan/vk-device.h
+++ b/src/vulkan/vk-device.h
@@ -86,7 +86,7 @@ public:
     virtual SLANG_NO_THROW Result SLANG_MCALL getTextureRowAlignment(Format format, Size* outAlignment) override;
 
     virtual SLANG_NO_THROW Result SLANG_MCALL
-    getCooperativeVectorProperties(CooperativeVectorProperties* properties, uint32_t* propertyCount) override;
+    getCooperativeVectorProperties(CooperativeVectorProperties* properties, uint32_t* propertiesCount) override;
 
     virtual SLANG_NO_THROW Result SLANG_MCALL
     convertCooperativeVectorMatrix(const ConvertCooperativeVectorMatrixDesc* descs, uint32_t descCount) override;

--- a/tests/doctest-reporter.h
+++ b/tests/doctest-reporter.h
@@ -252,7 +252,7 @@ private:
             device->getFeatures(&featureCount, nullptr);
             std::vector<rhi::Feature> features(featureCount);
             device->getFeatures(&featureCount, features.data());
-            printf("Features:     ");
+            printf("Features:\n");
             for (uint32_t i = 0; i < featureCount; i++)
                 printf("%s ", rhi::getRHI()->getFeatureName(features[i]));
             printf("\n");
@@ -262,10 +262,30 @@ private:
             device->getCapabilities(&capabilityCount, nullptr);
             std::vector<rhi::Capability> capabilities(capabilityCount);
             device->getCapabilities(&capabilityCount, capabilities.data());
-            printf("Capabilities: ");
+            printf("Capabilities:\n");
             for (uint32_t i = 0; i < capabilityCount; i++)
                 printf("%s ", rhi::getRHI()->getCapabilityName(capabilities[i]));
             printf("\n");
+        }
+        if (device->hasFeature(rhi::Feature::CooperativeVector))
+        {
+            uint32_t propertiesCount;
+            device->getCooperativeVectorProperties(nullptr, &propertiesCount);
+            std::vector<rhi::CooperativeVectorProperties> properties(propertiesCount);
+            device->getCooperativeVectorProperties(properties.data(), &propertiesCount);
+            printf("Cooperative Vector Properties:\n");
+            printf("inputType inputInterpretation matrixInterpretation biasInterpretation resultType\n");
+            for (const auto& prop : properties)
+            {
+                printf(
+                    "%-9s %-19s %-20s %-18s %-10s\n",
+                    rhi::enumToString(prop.inputType),
+                    rhi::enumToString(prop.inputInterpretation),
+                    rhi::enumToString(prop.matrixInterpretation),
+                    rhi::enumToString(prop.biasInterpretation),
+                    rhi::enumToString(prop.resultType)
+                );
+            }
         }
     }
 };

--- a/tests/test-cooperative-vector.cpp
+++ b/tests/test-cooperative-vector.cpp
@@ -8,12 +8,12 @@ GPU_TEST_CASE("cooperative-vector-properties", D3D12 | Vulkan)
     if (!device->hasFeature(Feature::CooperativeVector))
         SKIP("cooperative vector not supported");
 
-    uint32_t propertyCount = 0;
-    REQUIRE_CALL(device->getCooperativeVectorProperties(nullptr, &propertyCount));
-    std::vector<CooperativeVectorProperties> properties(propertyCount);
-    REQUIRE_CALL(device->getCooperativeVectorProperties(properties.data(), &propertyCount));
+    uint32_t propertiesCount;
+    REQUIRE_CALL(device->getCooperativeVectorProperties(nullptr, &propertiesCount));
+    std::vector<CooperativeVectorProperties> properties(propertiesCount);
+    REQUIRE_CALL(device->getCooperativeVectorProperties(properties.data(), &propertiesCount));
 
-    CHECK(propertyCount > 0);
+    CHECK(propertiesCount > 0);
 }
 
 GPU_TEST_CASE("cooperative-vector-query-size", D3D12 | Vulkan)


### PR DESCRIPTION
- improve detecting features and capabilities on Vulkan (see https://github.com/shader-slang/slang-rhi/issues/416 for details)
- fix `Device::getCooperativeVectorProperties` API
- print coopvec properties when using `-check-devices` on `slang-rhi-tests`