### PR TITLE
Add unique IDs to DeviceChild

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -507,6 +507,7 @@ target_sources(slang-rhi PRIVATE
     src/command-list.cpp
     src/cuda-driver-api.cpp
     src/device.cpp
+    src/device-child.cpp
     src/enum-strings.cpp
     src/flag-combiner.cpp
     src/format-conversion.cpp

--- a/src/device-child.cpp
+++ b/src/device-child.cpp
@@ -1,0 +1,21 @@
+#include "device-child.h"
+#include "device.h"
+
+namespace rhi {
+
+DeviceChild::DeviceChild(Device* device)
+    : m_device(device)
+{
+}
+
+void DeviceChild::breakStrongReferenceToDevice()
+{
+    m_device.breakStrongReference();
+}
+
+void DeviceChild::establishStrongReferenceToDevice()
+{
+    m_device.establishStrongReference();
+}
+
+} // namespace rhi

--- a/src/device-child.cpp
+++ b/src/device-child.cpp
@@ -6,6 +6,7 @@ namespace rhi {
 DeviceChild::DeviceChild(Device* device)
     : m_device(device)
 {
+    m_uid = device->m_nextDeviceChildUID.fetch_add(1);
 }
 
 void DeviceChild::breakStrongReferenceToDevice()

--- a/src/device-child.h
+++ b/src/device-child.h
@@ -8,10 +8,7 @@ namespace rhi {
 class DeviceChild : public ComObject
 {
 public:
-    DeviceChild(Device* device)
-        : m_device(device)
-    {
-    }
+    DeviceChild(Device* device);
 
     template<typename T = Device>
     T* getDevice()
@@ -19,9 +16,8 @@ public:
         return static_cast<T*>(m_device.get());
     }
 
-    void breakStrongReferenceToDevice() { m_device.breakStrongReference(); }
-
-    void establishStrongReferenceToDevice() { m_device.establishStrongReference(); }
+    void breakStrongReferenceToDevice();
+    void establishStrongReferenceToDevice();
 
 protected:
     BreakableReference<Device> m_device;

--- a/src/device-child.h
+++ b/src/device-child.h
@@ -16,11 +16,14 @@ public:
         return static_cast<T*>(m_device.get());
     }
 
+    uint64_t getUID() const { return m_uid; }
+
     void breakStrongReferenceToDevice();
     void establishStrongReferenceToDevice();
 
 protected:
     BreakableReference<Device> m_device;
+    uint64_t m_uid;
 };
 
 } // namespace rhi

--- a/src/device.cpp
+++ b/src/device.cpp
@@ -70,9 +70,23 @@ ShaderComponentID ShaderCache::getComponentId(ComponentKey key)
     return resultId;
 }
 
+RefPtr<Pipeline> ShaderCache::getSpecializedPipeline(PipelineKey programKey)
+{
+    auto it = specializedPipelines.find(programKey);
+    if (it != specializedPipelines.end())
+        return it->second;
+    return nullptr;
+}
+
 void ShaderCache::addSpecializedPipeline(PipelineKey key, RefPtr<Pipeline> specializedPipeline)
 {
     specializedPipelines[key] = specializedPipeline;
+}
+
+void ShaderCache::free()
+{
+    componentIds = decltype(componentIds)();
+    specializedPipelines = decltype(specializedPipelines)();
 }
 
 // ----------------------------------------------------------------------------

--- a/src/device.h
+++ b/src/device.h
@@ -11,6 +11,7 @@
 
 #include "rhi-shared-fwd.h"
 
+#include <atomic>
 #include <map>
 #include <unordered_map>
 
@@ -330,6 +331,8 @@ public:
     std::map<slang::TypeLayoutReflection*, RefPtr<ShaderObjectLayout>> m_shaderObjectLayoutCache;
 
     IDebugCallback* m_debugCallback = nullptr;
+
+    std::atomic<uint64_t> m_nextDeviceChildUID = 0;
 };
 
 } // namespace rhi

--- a/src/device.h
+++ b/src/device.h
@@ -77,21 +77,11 @@ public:
     ShaderComponentID getComponentId(std::string_view name);
     ShaderComponentID getComponentId(ComponentKey key);
 
-    RefPtr<Pipeline> getSpecializedPipeline(PipelineKey programKey)
-    {
-        auto it = specializedPipelines.find(programKey);
-        if (it != specializedPipelines.end())
-            return it->second;
-        return nullptr;
-    }
+    RefPtr<Pipeline> getSpecializedPipeline(PipelineKey programKey);
 
     void addSpecializedPipeline(PipelineKey key, RefPtr<Pipeline> specializedPipeline);
 
-    void free()
-    {
-        componentIds = decltype(componentIds)();
-        specializedPipelines = decltype(specializedPipelines)();
-    }
+    void free();
 
 protected:
     struct ComponentKeyHasher

--- a/src/rhi-shared-fwd.h
+++ b/src/rhi-shared-fwd.h
@@ -40,6 +40,6 @@ class VirtualRayTracingPipeline;
 struct SpecializationKey;
 class ShaderProgram;
 
-
 typedef uint32_t ShaderComponentID;
+
 } // namespace rhi

--- a/src/staging-heap.h
+++ b/src/staging-heap.h
@@ -54,7 +54,7 @@ public:
         int getId() const { return m_id; }
 
         // Get device buffer mapped to this page.
-        RefPtr<Buffer> getBuffer() const { return m_buffer; }
+        Buffer* getBuffer() const { return m_buffer.get(); }
 
         // Get total capacity of the page.
         size_t getCapacity() const { return m_totalCapacity; }
@@ -97,7 +97,7 @@ public:
         Size getSize() const { return node->size; }
         Page* getPage() const { return page; }
         int getPageId() const { return page->getId(); }
-        Buffer* getBuffer() const { return page->getBuffer().get(); }
+        Buffer* getBuffer() const { return page->getBuffer(); }
         const MetaData& getMetaData() const { return node->metadata; }
     };
 


### PR DESCRIPTION
Unique IDs are going to be used for generating a report on compile times for shader programs and pipelines.