### PR TITLE
Compilation reports

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -744,6 +744,7 @@ if(SLANG_RHI_BUILD_TESTS)
         tests/test-buffer-barrier.cpp
         tests/test-buffer-from-handle.cpp
         tests/test-buffer-shared.cpp
+        tests/test-compilation-report.cpp
         tests/test-cmd-clear-buffer.cpp
         tests/test-cmd-clear-texture.cpp
         tests/test-cmd-copy-buffer.cpp

--- a/include/slang-rhi.h
+++ b/include/slang-rhi.h
@@ -181,6 +181,30 @@ enum class AccessFlag
 
 class IPersistentCache;
 
+enum class CompilationReportType
+{
+    /// Compilation report as a `CompilationReport` struct.
+    Struct,
+    /// Compilation report as a JSON string.
+    JSON,
+};
+
+struct CompilationReport
+{
+    /// Shader program label.
+    char label[128];
+    /// Total time spent creating the shader program (seconds).
+    double createTime;
+    /// Total time spent compiling entry points (seconds).
+    double compileTime;
+    /// Total time spent in the slang compiler backend (seconds).
+    double compileSlangTime;
+    /// Total time spent in the downstream compiler (seconds).
+    double compileDownstreamTime;
+    /// Total time spent creating pipelines (seconds).
+    double createPipelineTime;
+};
+
 /// Defines how linking should be performed for a shader program.
 enum class LinkingStyle
 {
@@ -222,6 +246,8 @@ class IShaderProgram : public ISlangUnknown
 
 public:
     virtual SLANG_NO_THROW const ShaderProgramDesc& SLANG_MCALL getDesc() = 0;
+    virtual SLANG_NO_THROW Result SLANG_MCALL
+    getCompilationReport(CompilationReportType type, ISlangBlob** outReportBlob) = 0;
     virtual SLANG_NO_THROW slang::TypeReflection* SLANG_MCALL findTypeByName(const char* name) = 0;
 };
 
@@ -2630,6 +2656,9 @@ struct DeviceDesc
     bool enableRayTracingValidation = false;
     /// Debug callback. If not null, this will be called for each debug message.
     IDebugCallback* debugCallback = nullptr;
+
+    /// Enable reporting of shader compilation timings.
+    bool enableCompilationReports = false;
 
     /// Size of a page in staging heap.
     Size stagingHeapPageSize = 16 * 1024 * 1024;

--- a/src/core/string.h
+++ b/src/core/string.h
@@ -5,6 +5,27 @@
 
 namespace rhi::string {
 
+inline void copy_safe(char* dst, size_t dstSize, const char* src)
+{
+    if (!dst || !src || dstSize == 0)
+    {
+        return;
+    }
+
+    // Copy characters from src to dst until either (dstSize - 1) is exhausted or we hit a null terminator in src.
+    while (dstSize > 1 && *src)
+    {
+        *dst++ = *src++;
+        --dstSize;
+    }
+    // Fill the rest of dst with null characters to ensure null-termination.
+    while (dstSize > 0)
+    {
+        *dst++ = 0;
+        --dstSize;
+    }
+}
+
 inline std::wstring to_wstring(std::string_view str)
 {
     std::wstring wstr;

--- a/src/core/timer.cpp
+++ b/src/core/timer.cpp
@@ -4,7 +4,7 @@
 
 namespace rhi {
 
-Timer::TimePoint Timer::now()
+TimePoint Timer::now()
 {
     using namespace std::chrono;
     return duration_cast<nanoseconds>(high_resolution_clock::now().time_since_epoch()).count();

--- a/src/core/timer.h
+++ b/src/core/timer.h
@@ -4,13 +4,13 @@
 
 namespace rhi {
 
+// Time point in nanoseconds.
+using TimePoint = uint64_t;
+
 /// High resolution CPU timer.
 class Timer
 {
 public:
-    // Time point in nanoseconds.
-    using TimePoint = uint64_t;
-
     Timer() { reset(); }
 
     /// Reset the timer.

--- a/src/cpu/cpu-pipeline.cpp
+++ b/src/cpu/cpu-pipeline.cpp
@@ -17,6 +17,8 @@ Result ComputePipelineImpl::getNativeHandle(NativeHandle* outHandle)
 
 Result DeviceImpl::createComputePipeline2(const ComputePipelineDesc& desc, IComputePipeline** outPipeline)
 {
+    TimePoint startTime = Timer::now();
+
     uint32_t targetIndex = 0;
     uint32_t entryPointIndex = 0;
 
@@ -43,6 +45,19 @@ Result DeviceImpl::createComputePipeline2(const ComputePipelineDesc& desc, IComp
     if (!func)
     {
         return SLANG_FAIL;
+    }
+
+    // Report the pipeline creation time.
+    if (m_shaderCompilationReporter)
+    {
+        m_shaderCompilationReporter->reportCreatePipeline(
+            program,
+            ShaderCompilationReporter::PipelineType::Compute,
+            startTime,
+            Timer::now(),
+            false,
+            0
+        );
     }
 
     RefPtr<ComputePipelineImpl> pipeline = new ComputePipelineImpl(this, desc);

--- a/src/cuda/cuda-pipeline.cpp
+++ b/src/cuda/cuda-pipeline.cpp
@@ -27,6 +27,8 @@ Result DeviceImpl::createComputePipeline2(const ComputePipelineDesc& desc, IComp
 {
     SLANG_CUDA_CTX_SCOPE(this);
 
+    TimePoint startTime = Timer::now();
+
     ShaderProgramImpl* program = checked_cast<ShaderProgramImpl*>(desc.program);
     SLANG_RHI_ASSERT(!program->m_modules.empty());
     const auto& module = program->m_modules[0];
@@ -71,6 +73,19 @@ Result DeviceImpl::createComputePipeline2(const ComputePipelineDesc& desc, IComp
     );
     pipeline->m_sharedMemorySize = sharedSizeBytes;
 
+    // Report the pipeline creation time.
+    if (m_shaderCompilationReporter)
+    {
+        m_shaderCompilationReporter->reportCreatePipeline(
+            program,
+            ShaderCompilationReporter::PipelineType::Compute,
+            startTime,
+            Timer::now(),
+            false,
+            0
+        );
+    }
+
     returnComPtr(outPipeline, pipeline);
     return SLANG_OK;
 }
@@ -107,6 +122,8 @@ Result DeviceImpl::createRayTracingPipeline2(const RayTracingPipelineDesc& desc,
     {
         return SLANG_E_NOT_AVAILABLE;
     }
+
+    TimePoint startTime = Timer::now();
 
     ShaderProgramImpl* program = checked_cast<ShaderProgramImpl*>(desc.program);
     SLANG_RHI_ASSERT(!program->m_modules.empty());
@@ -287,6 +304,19 @@ Result DeviceImpl::createRayTracingPipeline2(const RayTracingPipelineDesc& desc,
         ),
         this
     );
+
+    // Report the pipeline creation time.
+    if (m_shaderCompilationReporter)
+    {
+        m_shaderCompilationReporter->reportCreatePipeline(
+            program,
+            ShaderCompilationReporter::PipelineType::RayTracing,
+            startTime,
+            Timer::now(),
+            false,
+            0
+        );
+    }
 
     RefPtr<RayTracingPipelineImpl> pipeline = new RayTracingPipelineImpl(this, desc);
     pipeline->m_program = program;

--- a/src/d3d11/d3d11-pipeline.cpp
+++ b/src/d3d11/d3d11-pipeline.cpp
@@ -21,6 +21,8 @@ Result RenderPipelineImpl::getNativeHandle(NativeHandle* outHandle)
 
 Result DeviceImpl::createRenderPipeline2(const RenderPipelineDesc& desc, IRenderPipeline** outPipeline)
 {
+    TimePoint startTime = Timer::now();
+
     ShaderProgramImpl* program = checked_cast<ShaderProgramImpl*>(desc.program);
     SLANG_RHI_ASSERT(!program->m_modules.empty());
 
@@ -159,6 +161,19 @@ Result DeviceImpl::createRenderPipeline2(const RenderPipelineDesc& desc, IRender
         SLANG_RETURN_ON_FAIL(m_device->CreateBlendState(&dstDesc, blendState.writeRef()));
     }
 
+    // Report the pipeline creation time.
+    if (m_shaderCompilationReporter)
+    {
+        m_shaderCompilationReporter->reportCreatePipeline(
+            program,
+            ShaderCompilationReporter::PipelineType::Render,
+            startTime,
+            Timer::now(),
+            false,
+            0
+        );
+    }
+
     RefPtr<RenderPipelineImpl> pipeline = new RenderPipelineImpl(this, desc);
     pipeline->m_program = program;
     pipeline->m_inputLayout = checked_cast<InputLayoutImpl*>(desc.inputLayout);
@@ -191,6 +206,8 @@ Result ComputePipelineImpl::getNativeHandle(NativeHandle* outHandle)
 
 Result DeviceImpl::createComputePipeline2(const ComputePipelineDesc& desc, IComputePipeline** outPipeline)
 {
+    TimePoint startTime = Timer::now();
+
     ShaderProgramImpl* program = checked_cast<ShaderProgramImpl*>(desc.program);
     SLANG_RHI_ASSERT(!program->m_modules.empty());
 
@@ -213,6 +230,19 @@ Result DeviceImpl::createComputePipeline2(const ComputePipelineDesc& desc, IComp
             nullptr,
             computeShader.writeRef()
         ));
+    }
+
+    // Report the pipeline creation time.
+    if (m_shaderCompilationReporter)
+    {
+        m_shaderCompilationReporter->reportCreatePipeline(
+            program,
+            ShaderCompilationReporter::PipelineType::Compute,
+            startTime,
+            Timer::now(),
+            false,
+            0
+        );
     }
 
     RefPtr<ComputePipelineImpl> pipeline = new ComputePipelineImpl(this, desc);

--- a/src/device-child.cpp
+++ b/src/device-child.cpp
@@ -6,7 +6,6 @@ namespace rhi {
 DeviceChild::DeviceChild(Device* device)
     : m_device(device)
 {
-    m_uid = device->m_nextDeviceChildUID.fetch_add(1);
 }
 
 void DeviceChild::breakStrongReferenceToDevice()

--- a/src/device-child.h
+++ b/src/device-child.h
@@ -16,14 +16,11 @@ public:
         return static_cast<T*>(m_device.get());
     }
 
-    uint64_t getUID() const { return m_uid; }
-
     void breakStrongReferenceToDevice();
     void establishStrongReferenceToDevice();
 
 protected:
     BreakableReference<Device> m_device;
-    uint64_t m_uid;
 };
 
 } // namespace rhi

--- a/src/device.cpp
+++ b/src/device.cpp
@@ -344,7 +344,7 @@ Result Device::getEntryPointCodeFromShaderCache(
         {
             if (m_shaderCompilationReporter)
             {
-                m_shaderCompilationReporter->reportGetEntryPointCode(
+                m_shaderCompilationReporter->reportCompileEntryPoint(
                     program,
                     entryPointName,
                     startTime,
@@ -379,7 +379,7 @@ Result Device::getEntryPointCodeFromShaderCache(
     // Report compilation time.
     if (m_shaderCompilationReporter)
     {
-        m_shaderCompilationReporter->reportGetEntryPointCode(
+        m_shaderCompilationReporter->reportCompileEntryPoint(
             program,
             entryPointName,
             startTime,

--- a/src/device.cpp
+++ b/src/device.cpp
@@ -1,6 +1,7 @@
 #include "device.h"
 
 #include "rhi-shared.h"
+#include "shader.h"
 
 #include <algorithm>
 #include <cstdarg>
@@ -101,6 +102,16 @@ void Device::printMessage(DebugMessageType type, DebugMessageSource source, cons
     vsnprintf(buffer, sizeof(buffer), message, args);
     va_end(args);
     handleMessage(type, source, buffer);
+}
+
+void Device::printInfo(const char* message, ...)
+{
+    va_list args;
+    va_start(args, message);
+    char buffer[4096];
+    vsnprintf(buffer, sizeof(buffer), message, args);
+    va_end(args);
+    handleMessage(DebugMessageType::Info, DebugMessageSource::Layer, buffer);
 }
 
 void Device::printWarning(const char* message, ...)
@@ -309,36 +320,78 @@ Result Device::createRayTracingPipeline2(const RayTracingPipelineDesc& desc, IRa
 }
 
 Result Device::getEntryPointCodeFromShaderCache(
-    slang::IComponentType* program,
+    ShaderProgram* program,
+    slang::IComponentType* componentType,
+    const char* entryPointName,
     uint32_t entryPointIndex,
     uint32_t targetIndex,
     slang::IBlob** outCode,
     slang::IBlob** outDiagnostics
 )
 {
-    // Immediately call getEntryPointCode if shader cache is not available.
-    if (!m_persistentShaderCache)
+    TimePoint startTime = Timer::now();
+    ComPtr<ISlangBlob> codeBlob;
+    ComPtr<ISlangBlob> hashBlob;
+
+    if (m_persistentShaderCache)
     {
-        return program->getEntryPointCode(entryPointIndex, targetIndex, outCode, outDiagnostics);
+        // Hash all relevant state for generating the entry point shader code to use as a key
+        // for the shader cache.
+        componentType->getEntryPointHash(entryPointIndex, targetIndex, hashBlob.writeRef());
+
+        // Query the shader cache.
+        if (m_persistentShaderCache->queryCache(hashBlob, codeBlob.writeRef()) == SLANG_OK)
+        {
+            if (m_shaderCompilationReporter)
+            {
+                m_shaderCompilationReporter->reportGetEntryPointCode(
+                    program,
+                    entryPointName,
+                    startTime,
+                    Timer::now(),
+                    0.0,
+                    0.0,
+                    true,
+                    codeBlob->getBufferSize()
+                );
+            }
+
+            returnComPtr(outCode, codeBlob);
+            return SLANG_OK;
+        }
     }
 
-    // Hash all relevant state for generating the entry point shader code to use as a key
-    // for the shader cache.
-    ComPtr<ISlangBlob> hashBlob;
-    program->getEntryPointHash(entryPointIndex, targetIndex, hashBlob.writeRef());
+    // Cached entry not found, generate the code and measure compilation time.
+    double startTotalTime, endTotalTime;
+    double startDownstreamTime, endDownstreamTime;
+    componentType->getSession()->getGlobalSession()->getCompilerElapsedTime(&startTotalTime, &startDownstreamTime);
+    SLANG_RETURN_ON_FAIL(
+        componentType->getEntryPointCode(entryPointIndex, targetIndex, codeBlob.writeRef(), outDiagnostics)
+    );
+    componentType->getSession()->getGlobalSession()->getCompilerElapsedTime(&endTotalTime, &endDownstreamTime);
 
-    // Query the shader cache.
-    ComPtr<ISlangBlob> codeBlob;
-    if (m_persistentShaderCache->queryCache(hashBlob, codeBlob.writeRef()) != SLANG_OK)
+    // Write the generated code to the shader cache if available.
+    if (m_persistentShaderCache)
     {
-        // No cached entry found. Generate the code and add it to the cache.
-        SLANG_RETURN_ON_FAIL(
-            program->getEntryPointCode(entryPointIndex, targetIndex, codeBlob.writeRef(), outDiagnostics)
-        );
         m_persistentShaderCache->writeCache(hashBlob, codeBlob);
     }
 
-    *outCode = codeBlob.detach();
+    // Report compilation time.
+    if (m_shaderCompilationReporter)
+    {
+        m_shaderCompilationReporter->reportGetEntryPointCode(
+            program,
+            entryPointName,
+            startTime,
+            Timer::now(),
+            endTotalTime - startTotalTime,
+            endDownstreamTime - startDownstreamTime,
+            false,
+            codeBlob->getBufferSize()
+        );
+    }
+
+    returnComPtr(outCode, codeBlob);
     return SLANG_OK;
 }
 
@@ -365,6 +418,8 @@ Result Device::initialize(const DeviceDesc& desc)
     m_formatSupport.fill(FormatSupport::None);
 
     m_debugCallback = desc.debugCallback ? desc.debugCallback : NullDebugCallback::getInstance();
+
+    m_shaderCompilationReporter = new ShaderCompilationReporter(this);
 
     m_persistentShaderCache = desc.persistentShaderCache;
     m_persistentPipelineCache = desc.persistentPipelineCache;

--- a/src/device.cpp
+++ b/src/device.cpp
@@ -419,7 +419,10 @@ Result Device::initialize(const DeviceDesc& desc)
 
     m_debugCallback = desc.debugCallback ? desc.debugCallback : NullDebugCallback::getInstance();
 
-    m_shaderCompilationReporter = new ShaderCompilationReporter(this);
+    if (desc.enableCompilationReports)
+    {
+        m_shaderCompilationReporter = new ShaderCompilationReporter(this);
+    }
 
     m_persistentShaderCache = desc.persistentShaderCache;
     m_persistentPipelineCache = desc.persistentPipelineCache;

--- a/src/device.h
+++ b/src/device.h
@@ -326,6 +326,7 @@ public:
     SlangContext m_slangContext;
     ShaderCache m_shaderCache;
 
+    std::atomic<uint64_t> m_nextShaderProgramID = 0;
     RefPtr<ShaderCompilationReporter> m_shaderCompilationReporter;
 
     StagingHeap m_uploadHeap;
@@ -337,8 +338,6 @@ public:
     std::map<slang::TypeLayoutReflection*, RefPtr<ShaderObjectLayout>> m_shaderObjectLayoutCache;
 
     IDebugCallback* m_debugCallback = nullptr;
-
-    std::atomic<uint64_t> m_nextDeviceChildUID = 0;
 };
 
 } // namespace rhi

--- a/src/device.h
+++ b/src/device.h
@@ -235,7 +235,9 @@ public:
     convertCooperativeVectorMatrix(const ConvertCooperativeVectorMatrixDesc* descs, uint32_t descCount) override;
 
     Result getEntryPointCodeFromShaderCache(
-        slang::IComponentType* program,
+        ShaderProgram* program,
+        slang::IComponentType* componentType,
+        const char* entryPointName,
         uint32_t entryPointIndex,
         uint32_t targetIndex,
         slang::IBlob** outCode,
@@ -263,6 +265,7 @@ public:
     }
 
     void printMessage(DebugMessageType type, DebugMessageSource source, const char* message, ...);
+    void printInfo(const char* message, ...);
     void printWarning(const char* message, ...);
     void printError(const char* message, ...);
 
@@ -322,6 +325,9 @@ public:
 
     SlangContext m_slangContext;
     ShaderCache m_shaderCache;
+
+    RefPtr<ShaderCompilationReporter> m_shaderCompilationReporter;
+
     StagingHeap m_uploadHeap;
     StagingHeap m_readbackHeap;
 

--- a/src/metal/metal-pipeline.cpp
+++ b/src/metal/metal-pipeline.cpp
@@ -23,6 +23,8 @@ Result DeviceImpl::createRenderPipeline2(const RenderPipelineDesc& desc, IRender
 {
     AUTORELEASEPOOL
 
+    TimePoint startTime = Timer::now();
+
     ShaderProgramImpl* program = checked_cast<ShaderProgramImpl*>(desc.program);
     InputLayoutImpl* inputLayout = checked_cast<InputLayoutImpl*>(desc.inputLayout);
     if (!program)
@@ -157,6 +159,19 @@ Result DeviceImpl::createRenderPipeline2(const RenderPipelineDesc& desc, IRender
         return SLANG_FAIL;
     }
 
+    // Report the pipeline creation time.
+    if (m_shaderCompilationReporter)
+    {
+        m_shaderCompilationReporter->reportCreatePipeline(
+            program,
+            ShaderCompilationReporter::PipelineType::Render,
+            startTime,
+            Timer::now(),
+            false,
+            0
+        );
+    }
+
     RefPtr<RenderPipelineImpl> pipeline = new RenderPipelineImpl(this, desc);
     pipeline->m_program = program;
     pipeline->m_rootObjectLayout = program->m_rootObjectLayout;
@@ -184,6 +199,8 @@ Result ComputePipelineImpl::getNativeHandle(NativeHandle* outHandle)
 Result DeviceImpl::createComputePipeline2(const ComputePipelineDesc& desc, IComputePipeline** outPipeline)
 {
     AUTORELEASEPOOL
+
+    TimePoint startTime = Timer::now();
 
     ShaderProgramImpl* program = checked_cast<ShaderProgramImpl*>(desc.program);
     SLANG_RHI_ASSERT(!program->m_modules.empty());
@@ -222,6 +239,19 @@ Result DeviceImpl::createComputePipeline2(const ComputePipelineDesc& desc, IComp
     // Query thread group size for use during dispatch.
     SlangUInt threadGroupSize[3];
     program->linkedProgram->getLayout()->getEntryPointByIndex(0)->getComputeThreadGroupSize(3, threadGroupSize);
+
+    // Report the pipeline creation time.
+    if (m_shaderCompilationReporter)
+    {
+        m_shaderCompilationReporter->reportCreatePipeline(
+            program,
+            ShaderCompilationReporter::PipelineType::Compute,
+            startTime,
+            Timer::now(),
+            false,
+            0
+        );
+    }
 
     RefPtr<ComputePipelineImpl> pipeline = new ComputePipelineImpl(this, desc);
     pipeline->m_program = program;

--- a/src/rhi-shared-fwd.h
+++ b/src/rhi-shared-fwd.h
@@ -39,6 +39,7 @@ class VirtualRayTracingPipeline;
 
 struct SpecializationKey;
 class ShaderProgram;
+class ShaderCompilationReporter;
 
 typedef uint32_t ShaderComponentID;
 

--- a/src/shader.cpp
+++ b/src/shader.cpp
@@ -24,6 +24,8 @@ ShaderProgram::ShaderProgram(Device* device, const ShaderProgramDesc& desc)
     m_descHolder.holdString(m_desc.label);
     m_descHolder.holdList(m_desc.slangEntryPoints, m_desc.slangEntryPointCount);
 
+    m_id = device->m_nextShaderProgramID.fetch_add(1);
+
     if (m_device->m_shaderCompilationReporter)
     {
         m_device->m_shaderCompilationReporter->registerProgram(this);

--- a/src/shader.cpp
+++ b/src/shader.cpp
@@ -199,7 +199,7 @@ void ShaderCompilationReporter::registerProgram(ShaderProgram* program)
     m_device->printInfo("Register shader program %p\n", program);
 }
 
-void ShaderCompilationReporter::reportGetEntryPointCode(
+void ShaderCompilationReporter::reportCompileEntryPoint(
     ShaderProgram* program,
     const char* entryPointName,
     TimePoint startTime,

--- a/src/shader.cpp
+++ b/src/shader.cpp
@@ -32,6 +32,14 @@ ShaderProgram::ShaderProgram(Device* device, const ShaderProgramDesc& desc)
     }
 }
 
+ShaderProgram::~ShaderProgram()
+{
+    if (m_device->m_shaderCompilationReporter)
+    {
+        m_device->m_shaderCompilationReporter->unregisterProgram(this);
+    }
+}
+
 IShaderProgram* ShaderProgram::getInterface(const Guid& guid)
 {
     if (guid == ISlangUnknown::getTypeGuid() || guid == IShaderProgram::getTypeGuid())
@@ -185,6 +193,25 @@ bool ShaderProgram::isMeshShaderProgram() const
     return false;
 }
 
+const ShaderProgramDesc& ShaderProgram::getDesc()
+{
+    return m_desc;
+}
+
+Result ShaderProgram::getCompilationReport(CompilationReportType type, ISlangBlob** outReportBlob)
+{
+    if (m_device->m_shaderCompilationReporter)
+    {
+        return m_device->m_shaderCompilationReporter->getCompilationReport(this, type, outReportBlob);
+    }
+    return SLANG_E_NOT_AVAILABLE;
+}
+
+slang::TypeReflection* ShaderProgram::findTypeByName(const char* name)
+{
+    return linkedProgram->getLayout()->findTypeByName(name);
+}
+
 // ----------------------------------------------------------------------------
 // ShaderCompilationReporter
 // ----------------------------------------------------------------------------
@@ -192,11 +219,47 @@ bool ShaderProgram::isMeshShaderProgram() const
 ShaderCompilationReporter::ShaderCompilationReporter(Device* device)
     : m_device(device)
 {
+    m_printReports = true;
+    m_recordReports = true;
 }
 
 void ShaderCompilationReporter::registerProgram(ShaderProgram* program)
 {
-    m_device->printInfo("Register shader program %p\n", program);
+    SLANG_RHI_ASSERT(program);
+
+    const char* label = program->m_desc.label ? program->m_desc.label : "unnamed";
+
+    if (m_printReports)
+    {
+        m_device->printInfo("Shader program %llu: Registered (label: \"%s\")", program->m_id, label);
+    }
+
+    if (m_recordReports)
+    {
+        std::lock_guard<std::mutex> lock(m_mutex);
+        m_programReports.resize(max(size_t(program->m_id) + 1, m_programReports.size()));
+        ProgramReport& programReport = m_programReports[program->m_id];
+        programReport.active = true;
+        programReport.label = label;
+    }
+}
+
+void ShaderCompilationReporter::unregisterProgram(ShaderProgram* program)
+{
+    SLANG_RHI_ASSERT(program);
+
+    if (m_printReports)
+    {
+        m_device->printInfo("Shader program %llu: Unregistered", program->m_id);
+    }
+
+    if (m_recordReports)
+    {
+        std::lock_guard<std::mutex> lock(m_mutex);
+        SLANG_RHI_ASSERT(program->m_id < m_programReports.size());
+        ProgramReport& programReport = m_programReports[program->m_id];
+        programReport.active = false;
+    }
 }
 
 void ShaderCompilationReporter::reportCompileEntryPoint(
@@ -210,21 +273,45 @@ void ShaderCompilationReporter::reportCompileEntryPoint(
     size_t cacheSize
 )
 {
-    m_device->printInfo(
-        "Get entry point code for shader program %p - %s took %f ms (slang: %f ms, downstream: %f ms, cached: %s, "
-        "cacheSize: %zd)\n",
-        program,
-        entryPointName,
-        (endTime - startTime) / 1e6,
-        totalTime * 1e3,
-        downstreamTime * 1e3,
-        isCached ? "yes" : "no",
-        cacheSize
-    );
+    SLANG_RHI_ASSERT(program);
+
+    if (m_printReports)
+    {
+        m_device->printInfo(
+            "Shader program %llu: Creating entry point \"%s\" took %.1f ms "
+            "(compilation: %.1f ms, slang: %.1f ms, downstream: %.1f ms, cached: %s, cacheSize: %zd)",
+            program->m_id,
+            entryPointName,
+            Timer::deltaMS(startTime, endTime),
+            totalTime * 1e3,
+            (totalTime - downstreamTime) * 1e3,
+            downstreamTime * 1e3,
+            isCached ? "yes" : "no",
+            cacheSize
+        );
+    }
+
+    if (m_recordReports)
+    {
+        std::lock_guard<std::mutex> lock(m_mutex);
+        SLANG_RHI_ASSERT(program->m_id < m_programReports.size());
+        ProgramReport& programReport = m_programReports[program->m_id];
+        programReport.entryPointReports.push_back({
+            entryPointName,
+            startTime,
+            endTime,
+            Timer::delta(startTime, endTime),
+            totalTime,
+            totalTime - downstreamTime,
+            downstreamTime,
+            isCached,
+            cacheSize,
+        });
+    }
 }
 
 void ShaderCompilationReporter::reportCreatePipeline(
-    ShaderProgram* shaderProgram,
+    ShaderProgram* program,
     PipelineType pipelineType,
     TimePoint startTime,
     TimePoint endTime,
@@ -232,6 +319,8 @@ void ShaderCompilationReporter::reportCreatePipeline(
     size_t cacheSize
 )
 {
+    SLANG_RHI_ASSERT(program);
+
     auto getPipelineTypeName = [](PipelineType type) -> const char*
     {
         switch (type)
@@ -246,14 +335,92 @@ void ShaderCompilationReporter::reportCreatePipeline(
             return "-";
         }
     };
-    m_device->printInfo(
-        "Create %s pipeline for shader program %p took %f ms (cached: %s, cacheSize: %zd)\n",
-        getPipelineTypeName(pipelineType),
-        shaderProgram,
-        (endTime - startTime) / 1e6,
-        isCached ? "yes" : "no",
-        cacheSize
-    );
+
+    if (m_printReports)
+    {
+        m_device->printInfo(
+            "Shader program %llu: Creating %s pipeline took %.1f ms (cached: %s, cacheSize: %zd)",
+            program->m_id,
+            getPipelineTypeName(pipelineType),
+            Timer::deltaMS(startTime, endTime),
+            isCached ? "yes" : "no",
+            cacheSize
+        );
+    }
+
+    if (m_recordReports)
+    {
+        std::lock_guard<std::mutex> lock(m_mutex);
+        SLANG_RHI_ASSERT(program->m_id < m_programReports.size());
+        ProgramReport& programReport = m_programReports[program->m_id];
+        programReport.pipelineReports.push_back({
+            pipelineType,
+            startTime,
+            endTime,
+            Timer::delta(startTime, endTime),
+            isCached,
+            cacheSize,
+        });
+    }
+}
+
+Result ShaderCompilationReporter::getCompilationReport(
+    ShaderProgram* program,
+    CompilationReportType type,
+    ISlangBlob** outReportBlob
+)
+{
+    if (!program || !outReportBlob)
+    {
+        return SLANG_E_INVALID_ARG;
+    }
+
+    std::lock_guard<std::mutex> lock(m_mutex);
+
+    if (program->m_id >= m_programReports.size())
+    {
+        return SLANG_E_NOT_FOUND;
+    }
+    const ProgramReport& programReport = m_programReports[program->m_id];
+
+    // Compute stats for the report
+    double createTime = 0.0;
+    double compileTime = 0.0;
+    double compileSlangTime = 0.0;
+    double compileDownstreamTime = 0.0;
+    for (const auto& entryPointReport : programReport.entryPointReports)
+    {
+        createTime += entryPointReport.createTime;
+        compileTime += entryPointReport.compileTime;
+        compileSlangTime += entryPointReport.compileSlangTime;
+        compileDownstreamTime += entryPointReport.compileDownstreamTime;
+    }
+    double createPipelineTime = 0.0;
+    for (const auto& pipelineReport : programReport.pipelineReports)
+    {
+        createPipelineTime += pipelineReport.createTime;
+    }
+
+    switch (type)
+    {
+    case CompilationReportType::Struct:
+    {
+        Slang::ComPtr<ISlangBlob> reportBlob = OwnedBlob::create(sizeof(CompilationReport));
+        CompilationReport* report = (CompilationReport*)reportBlob->getBufferPointer();
+        string::copy_safe(report->label, sizeof(report->label), programReport.label.c_str());
+        report->createTime = createTime;
+        report->compileTime = compileTime;
+        report->compileSlangTime = compileSlangTime;
+        report->compileDownstreamTime = compileDownstreamTime;
+        report->createPipelineTime = createPipelineTime;
+        returnComPtr(outReportBlob, reportBlob);
+        return SLANG_OK;
+    }
+    case CompilationReportType::JSON:
+        return SLANG_E_NOT_IMPLEMENTED; // TODO: Implement JSON report generation
+    default:
+        return SLANG_E_INVALID_ARG;
+    }
 }
 
 } // namespace rhi

--- a/src/shader.h
+++ b/src/shader.h
@@ -114,7 +114,7 @@ public:
 
     void registerProgram(ShaderProgram* program);
 
-    void reportGetEntryPointCode(
+    void reportCompileEntryPoint(
         ShaderProgram* program,
         const char* entryPointName,
         TimePoint startTime,

--- a/src/shader.h
+++ b/src/shader.h
@@ -147,7 +147,6 @@ private:
         double compileTime;
         double compileSlangTime;
         double compileDownstreamTime;
-        ;
         bool isCached;
         size_t cacheSize;
     };

--- a/src/shader.h
+++ b/src/shader.h
@@ -33,6 +33,8 @@ struct SpecializationKey
     };
 };
 
+using ShaderProgramID = uint64_t;
+
 class ShaderProgram : public IShaderProgram, public DeviceChild
 {
 public:
@@ -41,6 +43,8 @@ public:
 
     ShaderProgramDesc m_desc;
     StructHolder m_descHolder;
+
+    ShaderProgramID m_id;
 
     ComPtr<slang::IComponentType> slangGlobalScope;
     std::vector<ComPtr<slang::IComponentType>> slangEntryPoints;

--- a/src/vulkan/vk-pipeline.cpp
+++ b/src/vulkan/vk-pipeline.cpp
@@ -226,10 +226,15 @@ Result createPipelineWithCache(
     DeviceImpl* device,
     VkPipelineCreateInfo* createInfo,
     VkResult (*createPipelineFunc)(DeviceImpl* device, VkPipelineCreateInfo* createInfo, VkPipeline* outPipeline),
-    VkPipeline* outPipeline
+    VkPipeline* outPipeline,
+    bool& outCached,
+    size_t& outCacheSize
 )
 {
     auto& api = device->m_api;
+
+    outCached = false;
+    outCacheSize = 0;
 
     // Early out if cache is not enabled or the feature is not supported.
     if (!device->m_persistentPipelineCache || !api.m_extendedFeatures.pipelineBinaryFeatures.pipelineBinaries)
@@ -269,6 +274,8 @@ Result createPipelineWithCache(
             if (createPipelineFunc(device, createInfo, &pipeline) == VK_SUCCESS)
             {
                 writeCache = false;
+                outCached = true;
+                outCacheSize = pipelineCacheData->getBufferSize();
             }
             else
             {
@@ -306,6 +313,7 @@ Result createPipelineWithCache(
         if (SLANG_SUCCEEDED(serializePipelineBinaries(device, pipeline, pipelineCacheData.writeRef())))
         {
             device->m_persistentPipelineCache->writeCache(pipelineCacheKey, pipelineCacheData);
+            outCacheSize = pipelineCacheData->getBufferSize();
         }
         else
         {
@@ -349,6 +357,8 @@ Result RenderPipelineImpl::getNativeHandle(NativeHandle* outHandle)
 
 Result DeviceImpl::createRenderPipeline2(const RenderPipelineDesc& desc, IRenderPipeline** outPipeline)
 {
+    TimePoint startTime = Timer::now();
+
     ShaderProgramImpl* program = checked_cast<ShaderProgramImpl*>(desc.program);
     SLANG_RHI_ASSERT(!program->m_modules.empty());
     InputLayoutImpl* inputLayout = checked_cast<InputLayoutImpl*>(desc.inputLayout);
@@ -538,6 +548,8 @@ Result DeviceImpl::createRenderPipeline2(const RenderPipelineDesc& desc, IRender
     createInfo.pDynamicState = &dynamicStateInfo;
 
     VkPipeline vkPipeline = VK_NULL_HANDLE;
+    bool cached = false;
+    size_t cacheSize = 0;
     SLANG_RETURN_ON_FAIL(createPipelineWithCache<VkGraphicsPipelineCreateInfo>(
         this,
         &createInfo,
@@ -546,10 +558,25 @@ Result DeviceImpl::createRenderPipeline2(const RenderPipelineDesc& desc, IRender
             return device->m_api
                 .vkCreateGraphicsPipelines(device->m_device, VK_NULL_HANDLE, 1, createInfo2, nullptr, pipeline);
         },
-        &vkPipeline
+        &vkPipeline,
+        cached,
+        cacheSize
     ));
 
     _labelObject((uint64_t)vkPipeline, VK_OBJECT_TYPE_PIPELINE, desc.label);
+
+    // Report the pipeline creation time.
+    if (m_shaderCompilationReporter)
+    {
+        m_shaderCompilationReporter->reportCreatePipeline(
+            program,
+            ShaderCompilationReporter::PipelineType::Render,
+            startTime,
+            Timer::now(),
+            cached,
+            cacheSize
+        );
+    }
 
     RefPtr<RenderPipelineImpl> pipeline = new RenderPipelineImpl(this, desc);
     pipeline->m_program = program;
@@ -583,6 +610,8 @@ Result ComputePipelineImpl::getNativeHandle(NativeHandle* outHandle)
 
 Result DeviceImpl::createComputePipeline2(const ComputePipelineDesc& desc, IComputePipeline** outPipeline)
 {
+    TimePoint startTime = Timer::now();
+
     ShaderProgramImpl* program = checked_cast<ShaderProgramImpl*>(desc.program);
     SLANG_RHI_ASSERT(!program->m_modules.empty());
 
@@ -591,6 +620,8 @@ Result DeviceImpl::createComputePipeline2(const ComputePipelineDesc& desc, IComp
     createInfo.layout = program->m_rootShaderObjectLayout->m_pipelineLayout;
 
     VkPipeline vkPipeline = VK_NULL_HANDLE;
+    bool cached = false;
+    size_t cacheSize = 0;
     SLANG_RETURN_ON_FAIL(createPipelineWithCache<VkComputePipelineCreateInfo>(
         this,
         &createInfo,
@@ -598,10 +629,25 @@ Result DeviceImpl::createComputePipeline2(const ComputePipelineDesc& desc, IComp
             return device->m_api
                 .vkCreateComputePipelines(device->m_device, VK_NULL_HANDLE, 1, createInfo2, nullptr, pipeline);
         },
-        &vkPipeline
+        &vkPipeline,
+        cached,
+        cacheSize
     ));
 
     _labelObject((uint64_t)vkPipeline, VK_OBJECT_TYPE_PIPELINE, desc.label);
+
+    // Report the pipeline creation time.
+    if (m_shaderCompilationReporter)
+    {
+        m_shaderCompilationReporter->reportCreatePipeline(
+            program,
+            ShaderCompilationReporter::PipelineType::Compute,
+            startTime,
+            Timer::now(),
+            cached,
+            cacheSize
+        );
+    }
 
     RefPtr<ComputePipelineImpl> pipeline = new ComputePipelineImpl(this, desc);
     pipeline->m_program = program;
@@ -651,6 +697,8 @@ inline uint32_t findEntryPointIndexByName(
 
 Result DeviceImpl::createRayTracingPipeline2(const RayTracingPipelineDesc& desc, IRayTracingPipeline** outPipeline)
 {
+    TimePoint startTime = Timer::now();
+
     ShaderProgramImpl* program = checked_cast<ShaderProgramImpl*>(desc.program);
     SLANG_RHI_ASSERT(!program->m_modules.empty());
 
@@ -734,6 +782,8 @@ Result DeviceImpl::createRayTracingPipeline2(const RayTracingPipelineDesc& desc,
     createInfo.basePipelineIndex = 0;
 
     VkPipeline vkPipeline = VK_NULL_HANDLE;
+    bool cached = false;
+    size_t cacheSize = 0;
     SLANG_RETURN_ON_FAIL(createPipelineWithCache<VkRayTracingPipelineCreateInfoKHR>(
         this,
         &createInfo,
@@ -749,10 +799,25 @@ Result DeviceImpl::createRayTracingPipeline2(const RayTracingPipelineDesc& desc,
                 pipeline
             );
         },
-        &vkPipeline
+        &vkPipeline,
+        cached,
+        cacheSize
     ));
 
     _labelObject((uint64_t)vkPipeline, VK_OBJECT_TYPE_PIPELINE, desc.label);
+
+    // Report the pipeline creation time.
+    if (m_shaderCompilationReporter)
+    {
+        m_shaderCompilationReporter->reportCreatePipeline(
+            program,
+            ShaderCompilationReporter::PipelineType::RayTracing,
+            startTime,
+            Timer::now(),
+            cached,
+            cacheSize
+        );
+    }
 
     RefPtr<RayTracingPipelineImpl> pipeline = new RayTracingPipelineImpl(this, desc);
     pipeline->m_program = program;

--- a/src/wgpu/wgpu-pipeline.cpp
+++ b/src/wgpu/wgpu-pipeline.cpp
@@ -123,7 +123,7 @@ Result DeviceImpl::createRenderPipeline2(const RenderPipelineDesc& desc, IRender
 
     WGPURenderPipeline renderPipeline = {};
     renderPipeline = m_ctx.api.wgpuDeviceCreateRenderPipeline(m_ctx.device, &pipelineDesc);
-    if (renderPipeline)
+    if (!renderPipeline)
     {
         return SLANG_FAIL;
     }

--- a/src/wgpu/wgpu-pipeline.cpp
+++ b/src/wgpu/wgpu-pipeline.cpp
@@ -31,6 +31,8 @@ Result RenderPipelineImpl::getNativeHandle(NativeHandle* outHandle)
 
 Result DeviceImpl::createRenderPipeline2(const RenderPipelineDesc& desc, IRenderPipeline** outPipeline)
 {
+    TimePoint startTime = Timer::now();
+
     ShaderProgramImpl* program = checked_cast<ShaderProgramImpl*>(desc.program);
     SLANG_RHI_ASSERT(!program->m_modules.empty());
     InputLayoutImpl* inputLayout = checked_cast<InputLayoutImpl*>(desc.inputLayout);
@@ -119,14 +121,30 @@ Result DeviceImpl::createRenderPipeline2(const RenderPipelineDesc& desc, IRender
 
     pipelineDesc.label = desc.label;
 
-    RefPtr<RenderPipelineImpl> pipeline = new RenderPipelineImpl(this, desc);
-    pipeline->m_program = program;
-    pipeline->m_rootObjectLayout = program->m_rootObjectLayout;
-    pipeline->m_renderPipeline = m_ctx.api.wgpuDeviceCreateRenderPipeline(m_ctx.device, &pipelineDesc);
-    if (!pipeline->m_renderPipeline)
+    WGPURenderPipeline renderPipeline = {};
+    renderPipeline = m_ctx.api.wgpuDeviceCreateRenderPipeline(m_ctx.device, &pipelineDesc);
+    if (renderPipeline)
     {
         return SLANG_FAIL;
     }
+
+    // Report the pipeline creation time.
+    if (m_shaderCompilationReporter)
+    {
+        m_shaderCompilationReporter->reportCreatePipeline(
+            program,
+            ShaderCompilationReporter::PipelineType::Render,
+            startTime,
+            Timer::now(),
+            false,
+            0
+        );
+    }
+
+    RefPtr<RenderPipelineImpl> pipeline = new RenderPipelineImpl(this, desc);
+    pipeline->m_program = program;
+    pipeline->m_rootObjectLayout = program->m_rootObjectLayout;
+    pipeline->m_renderPipeline = renderPipeline;
     returnComPtr(outPipeline, pipeline);
     return SLANG_OK;
 }
@@ -155,6 +173,8 @@ Result ComputePipelineImpl::getNativeHandle(NativeHandle* outHandle)
 
 Result DeviceImpl::createComputePipeline2(const ComputePipelineDesc& desc, IComputePipeline** outPipeline)
 {
+    TimePoint startTime = Timer::now();
+
     ShaderProgramImpl* program = checked_cast<ShaderProgramImpl*>(desc.program);
     SLANG_RHI_ASSERT(!program->m_modules.empty());
     ShaderProgramImpl::Module* computeModule = program->findModule(SlangStage::SLANG_STAGE_COMPUTE);
@@ -170,10 +190,30 @@ Result DeviceImpl::createComputePipeline2(const ComputePipelineDesc& desc, IComp
 
     pipelineDesc.label = desc.label;
 
+    WGPUComputePipeline computePipeline = {};
+    computePipeline = m_ctx.api.wgpuDeviceCreateComputePipeline(m_ctx.device, &pipelineDesc);
+    if (!computePipeline)
+    {
+        return SLANG_FAIL;
+    }
+
+    // Report the pipeline creation time.
+    if (m_shaderCompilationReporter)
+    {
+        m_shaderCompilationReporter->reportCreatePipeline(
+            program,
+            ShaderCompilationReporter::PipelineType::Compute,
+            startTime,
+            Timer::now(),
+            false,
+            0
+        );
+    }
+
     RefPtr<ComputePipelineImpl> pipeline = new ComputePipelineImpl(this, desc);
     pipeline->m_program = program;
     pipeline->m_rootObjectLayout = program->m_rootObjectLayout;
-    pipeline->m_computePipeline = m_ctx.api.wgpuDeviceCreateComputePipeline(m_ctx.device, &pipelineDesc);
+    pipeline->m_computePipeline = computePipeline;
     if (!pipeline->m_computePipeline)
     {
         return SLANG_FAIL;

--- a/tests/doctest-reporter.h
+++ b/tests/doctest-reporter.h
@@ -11,16 +11,6 @@ namespace doctest {
 
 struct CustomReporter : public IReporter
 {
-    struct Options
-    {
-        bool checkDevices = false;
-    };
-    static Options& options()
-    {
-        static Options opts;
-        return opts;
-    }
-
     // caching pointers/references to objects of these types - safe to do
     std::ostream& stream;
     const ContextOptions& opt;
@@ -50,7 +40,7 @@ struct CustomReporter : public IReporter
         stream << Color::None;
         consoleReporter.test_run_start();
 
-        if (options().checkDevices)
+        if (rhi::testing::options().checkDevices)
         {
             checkDevices();
         }

--- a/tests/main.cpp
+++ b/tests/main.cpp
@@ -34,9 +34,13 @@ int main(int argc, char** argv)
 #endif
 
     // Pass extra command line arguments to the custom reporter.
-    auto& options = doctest::CustomReporter::options();
     for (int i = 1; i < argc; ++i)
     {
+        auto& options = rhi::testing::options();
+        if (strcmp(argv[i], "-verbose") == 0)
+        {
+            options.verbose = true;
+        }
         if (strcmp(argv[i], "-check-devices") == 0)
         {
             options.checkDevices = true;

--- a/tests/test-compilation-report.cpp
+++ b/tests/test-compilation-report.cpp
@@ -1,0 +1,73 @@
+#include "testing.h"
+
+using namespace rhi;
+using namespace rhi::testing;
+
+TEST_CASE("compilation-report")
+{
+    runGpuTests(
+        [](GpuTestContext* ctx, DeviceType deviceType)
+        {
+            // On CPU backend, compilation is done late during pipeline creation.
+            // Skip for now, as report is missing compilation times.
+            if (deviceType == DeviceType::CPU)
+            {
+                return;
+            }
+
+            DeviceExtraOptions options = {};
+            options.enableCompilationReports = true;
+            ComPtr<IDevice> device = createTestingDevice(ctx, deviceType, false, &options);
+            REQUIRE(device);
+
+            ComPtr<IShaderProgram> shaderProgram;
+            loadComputeProgramFromSource(device, shaderProgram, R"(
+    [shader("compute")]
+    [numthreads(1, 1, 1)]
+    void computeMain() {}
+    )");
+
+            ComPtr<ISlangBlob> reportBlob;
+            REQUIRE_CALL(shaderProgram->getCompilationReport(CompilationReportType::Struct, reportBlob.writeRef()));
+            CHECK(reportBlob->getBufferSize() == sizeof(CompilationReport));
+            const CompilationReport* report = (const CompilationReport*)reportBlob->getBufferPointer();
+
+            // We expect no compilation has taken place yet, so the report should be empty.
+            CHECK(report->createTime == 0.0);
+            CHECK(report->compileTime == 0.0);
+            CHECK(report->compileSlangTime == 0.0);
+            CHECK(report->compileDownstreamTime == 0.0);
+            CHECK(report->createPipelineTime == 0.0);
+
+            ComputePipelineDesc pipelineDesc = {};
+            pipelineDesc.program = shaderProgram.get();
+            ComPtr<IComputePipeline> pipeline;
+            REQUIRE_CALL(device->createComputePipeline(pipelineDesc, pipeline.writeRef()));
+
+            {
+                auto queue = device->getQueue(QueueType::Graphics);
+                auto commandEncoder = queue->createCommandEncoder();
+
+                auto passEncoder = commandEncoder->beginComputePass();
+                auto rootObject = passEncoder->bindPipeline(pipeline);
+                passEncoder->dispatchCompute(1, 1, 1);
+                passEncoder->end();
+
+                queue->submit(commandEncoder->finish());
+                queue->waitOnHost();
+            }
+
+            REQUIRE_CALL(shaderProgram->getCompilationReport(CompilationReportType::Struct, reportBlob.writeRef()));
+            CHECK(reportBlob->getBufferSize() == sizeof(CompilationReport));
+            report = (const CompilationReport*)reportBlob->getBufferPointer();
+
+            // We expect compilation and pipeline creation has taken place, so the report should contain non-zero times.
+            CHECK(report->createTime > 0.0);
+            CHECK(report->compileTime > 0.0);
+            CHECK(report->compileSlangTime > 0.0);
+            // Downstream compilation time may be zero if no downstream compiler is used.
+            CHECK(report->compileDownstreamTime >= 0.0);
+            CHECK(report->createPipelineTime > 0.0);
+        }
+    );
+}

--- a/tests/test-timer.cpp
+++ b/tests/test-timer.cpp
@@ -27,9 +27,9 @@ TEST_CASE("timer")
     SUBCASE("now")
     {
         double deltaNS = 10000000.0;
-        Timer::TimePoint t0 = Timer::now();
+        TimePoint t0 = Timer::now();
         highPrecisionSleep(deltaNS / 1000000000.0);
-        Timer::TimePoint t1 = Timer::now();
+        TimePoint t1 = Timer::now();
         CHECK(t1 > t0 + deltaNS * 0.9);
     }
 

--- a/tests/testing.cpp
+++ b/tests/testing.cpp
@@ -157,42 +157,73 @@ public:
         if (!doctest::is_running_in_test)
             return;
 
-        auto output = [](const char* msg)
+        doctest::String msg;
+        switch (type)
+        {
+        case DebugMessageType::Info:
+            msg += "[Info] ";
+            break;
+        case DebugMessageType::Warning:
+            msg += "[Warning] ";
+            break;
+        case DebugMessageType::Error:
+            msg += "[Error] ";
+            break;
+        default:
+            break;
+        }
+        switch (source)
+        {
+        case DebugMessageSource::Layer:
+            msg += "[Layer] ";
+            break;
+        case DebugMessageSource::Driver:
+            msg += "[Driver] ";
+            break;
+        case DebugMessageSource::Slang:
+            msg += "[Slang] ";
+            break;
+        default:
+            break;
+        }
+        msg += message;
+
+        auto output = [](const doctest::String& str)
         {
             if (options().verbose)
             {
-                MESSAGE(doctest::String(msg));
+                MESSAGE(str);
             }
             else
             {
-                INFO(doctest::String(msg));
+                INFO(str);
             }
         };
 
         if (type == DebugMessageType::Info)
         {
-            output(message);
+            output(msg);
         }
         else if (type == DebugMessageType::Warning)
         {
             if (shouldIgnoreError(type, source, message))
             {
-                output(message);
+                output(msg);
             }
             else
             {
-                FAIL(doctest::String(message));
+                FAIL(msg);
             }
         }
         else if (type == DebugMessageType::Error)
         {
             if (shouldIgnoreError(type, source, message))
             {
-                output(message);
+                output(msg);
             }
             else
             {
-                FAIL(doctest::String(message));
+                FAIL(msg);
             }
         }
     }

--- a/tests/testing.cpp
+++ b/tests/testing.cpp
@@ -497,6 +497,7 @@ ComPtr<IDevice> createTestingDevice(
             deviceDesc.persistentShaderCache = extraOptions->persistentShaderCache;
         if (extraOptions->persistentPipelineCache)
             deviceDesc.persistentPipelineCache = extraOptions->persistentPipelineCache;
+        deviceDesc.enableCompilationReports = extraOptions->enableCompilationReports;
     }
 
     std::vector<slang::PreprocessorMacroDesc> preprocessorMacros;

--- a/tests/testing.cpp
+++ b/tests/testing.cpp
@@ -156,15 +156,28 @@ public:
     {
         if (!doctest::is_running_in_test)
             return;
+
+        auto output = [](const char* msg)
+        {
+            if (options().verbose)
+            {
+                MESSAGE(doctest::String(msg));
+            }
+            else
+            {
+                INFO(doctest::String(msg));
+            }
+        };
+
         if (type == DebugMessageType::Info)
         {
-            INFO(doctest::String(message));
+            output(message);
         }
         else if (type == DebugMessageType::Warning)
         {
             if (shouldIgnoreError(type, source, message))
             {
-                INFO(doctest::String(message));
+                output(message);
             }
             else
             {
@@ -175,7 +188,7 @@ public:
         {
             if (shouldIgnoreError(type, source, message))
             {
-                INFO(doctest::String(message));
+                output(message);
             }
             else
             {

--- a/tests/testing.h
+++ b/tests/testing.h
@@ -192,6 +192,7 @@ struct DeviceExtraOptions
     std::vector<const char*> searchPaths;
     IPersistentCache* persistentShaderCache = nullptr;
     IPersistentCache* persistentPipelineCache = nullptr;
+    bool enableCompilationReports = false;
 };
 
 ComPtr<IDevice> createTestingDevice(

--- a/tests/testing.h
+++ b/tests/testing.h
@@ -15,6 +15,18 @@
 
 namespace rhi::testing {
 
+struct Options
+{
+    bool verbose = false;
+    bool checkDevices = false;
+};
+
+inline Options& options()
+{
+    static Options opts;
+    return opts;
+}
+
 /// Get name of running test suite (note: defined in main.cpp).
 std::string getCurrentTestSuiteName();
 


### PR DESCRIPTION
Adds detailed reporting of shader compilation times (including pipeline creation).
Reporting is enabled by the new `Device::enableCompilationReports` flag.
Reports are managed by the new `ShaderCompilationReporter` class, storing one report per shader program. The report keeps track of all entry point compilation requests as well as pipeline creation.
Reports can currently be queried through the new `IShaderProgram::getCompilationReport` interface.

There will be future additions to this system in separate PRs:
- Allow querying compilation reports for all alive programs at once
- Allow querying compilation reports for all programs created during the entire device lifetime
- Allow querying compilation reports in JSON format that includes additional on all entry point compilations and pipeline creations