### PR TITLE
Refactor returning compilation reports

### DIFF
--- a/src/debug-layer/debug-device.cpp
+++ b/src/debug-layer/debug-device.cpp
@@ -576,11 +576,11 @@ Result DebugDevice::createRayTracingPipeline(const RayTracingPipelineDesc& desc,
     return baseObject->createRayTracingPipeline(patchedDesc, outPipeline);
 }
 
-Result DebugDevice::getCompilationReports(CompilationReportType type, ISlangBlob** outReportBlob)
+Result DebugDevice::getCompilationReportList(ISlangBlob** outReportListBlob)
 {
     SLANG_RHI_API_FUNC;
 
-    return baseObject->getCompilationReports(type, outReportBlob);
+    return baseObject->getCompilationReportList(outReportListBlob);
 }
 
 Result DebugDevice::readTexture(

--- a/src/debug-layer/debug-device.h
+++ b/src/debug-layer/debug-device.h
@@ -76,8 +76,7 @@ public:
     createComputePipeline(const ComputePipelineDesc& desc, IComputePipeline** outPipeline) override;
     virtual SLANG_NO_THROW Result SLANG_MCALL
     createRayTracingPipeline(const RayTracingPipelineDesc& desc, IRayTracingPipeline** outPipeline) override;
-    virtual SLANG_NO_THROW Result SLANG_MCALL
-    getCompilationReports(CompilationReportType type, ISlangBlob** outReportBlob) override;
+    virtual SLANG_NO_THROW Result SLANG_MCALL getCompilationReportList(ISlangBlob** outReportListBlob) override;
     virtual SLANG_NO_THROW Result SLANG_MCALL
     readTexture(ITexture* texture, uint32_t layer, uint32_t mip, const SubresourceLayout& layout, void* outData)
         override;

--- a/src/device.cpp
+++ b/src/device.cpp
@@ -677,13 +677,13 @@ Result Device::createRayTracingPipeline(const RayTracingPipelineDesc& desc, IRay
     }
 }
 
-Result Device::getCompilationReports(CompilationReportType type, ISlangBlob** outReportBlob)
+Result Device::getCompilationReportList(ISlangBlob** outReportListBlob)
 {
     if (!m_shaderCompilationReporter)
     {
         return SLANG_E_NOT_AVAILABLE;
     }
-    return m_shaderCompilationReporter->getCompilationReports(type, outReportBlob);
+    return m_shaderCompilationReporter->getCompilationReportList(outReportListBlob);
 }
 
 Result Device::createShaderObject(

--- a/src/device.h
+++ b/src/device.h
@@ -164,8 +164,7 @@ public:
     virtual SLANG_NO_THROW Result SLANG_MCALL
     createRayTracingPipeline(const RayTracingPipelineDesc& desc, IRayTracingPipeline** outPipeline) override;
 
-    virtual SLANG_NO_THROW Result SLANG_MCALL
-    getCompilationReports(CompilationReportType type, ISlangBlob** outReportBlob) override;
+    virtual SLANG_NO_THROW Result SLANG_MCALL getCompilationReportList(ISlangBlob** outReportListBlob) override;
 
     virtual SLANG_NO_THROW Result SLANG_MCALL createShaderObject(
         slang::ISession* session,

--- a/tests/test-compilation-report.cpp
+++ b/tests/test-compilation-report.cpp
@@ -3,6 +3,25 @@
 using namespace rhi;
 using namespace rhi::testing;
 
+// List of retained blobs to prevent them from being released too early.
+static std::vector<ComPtr<ISlangBlob>> s_blobs;
+
+inline bool isEqual(const CompilationReport* a, const CompilationReport* b)
+{
+    return std::memcmp(a, b, offsetof(CompilationReport, entryPointReports)) == 0 &&
+           a->entryPointReportCount == b->entryPointReportCount && a->pipelineReportCount == b->pipelineReportCount &&
+           std::memcmp(
+               a->entryPointReports,
+               b->entryPointReports,
+               a->entryPointReportCount * sizeof(CompilationReport::EntryPointReport)
+           ) == 0 &&
+           std::memcmp(
+               a->pipelineReports,
+               b->pipelineReports,
+               a->pipelineReportCount * sizeof(CompilationReport::PipelineReport)
+           ) == 0;
+}
+
 inline ComPtr<IShaderProgram> createShaderProgram(IDevice* device)
 {
     ComPtr<IShaderProgram> shaderProgram;
@@ -37,22 +56,36 @@ inline void dispatchPipeline(IDevice* device, IComputePipeline* pipeline)
     REQUIRE_CALL(queue->waitOnHost());
 }
 
-inline CompilationReport getCompilationReport(IShaderProgram* shaderProgram)
+inline const CompilationReport* getCompilationReport(IShaderProgram* shaderProgram)
 {
     ComPtr<ISlangBlob> reportBlob;
-    REQUIRE_CALL(shaderProgram->getCompilationReport(CompilationReportType::Struct, reportBlob.writeRef()));
-    CHECK(reportBlob->getBufferSize() == sizeof(CompilationReport));
-    return *(const CompilationReport*)reportBlob->getBufferPointer();
+    REQUIRE_CALL(shaderProgram->getCompilationReport(reportBlob.writeRef()));
+    s_blobs.push_back(reportBlob);
+    CHECK(reportBlob->getBufferSize() >= sizeof(CompilationReport));
+    const CompilationReport* report = (const CompilationReport*)reportBlob->getBufferPointer();
+    size_t expectedSize = sizeof(CompilationReport);
+    expectedSize += report->entryPointReportCount * sizeof(CompilationReport::EntryPointReport);
+    expectedSize += report->pipelineReportCount * sizeof(CompilationReport::PipelineReport);
+    CHECK(reportBlob->getBufferSize() == expectedSize);
+    return report;
 }
 
-inline std::vector<CompilationReport> getCompilationReports(IDevice* device)
+inline const CompilationReportList* getCompilationReportList(IDevice* device)
 {
-    ComPtr<ISlangBlob> reportBlob;
-    REQUIRE_CALL(device->getCompilationReports(CompilationReportType::Struct, reportBlob.writeRef()));
-    CHECK(reportBlob->getBufferSize() % sizeof(CompilationReport) == 0);
-    size_t count = reportBlob->getBufferSize() / sizeof(CompilationReport);
-    const CompilationReport* reports = (const CompilationReport*)reportBlob->getBufferPointer();
-    return std::vector<CompilationReport>(reports, reports + count);
+    ComPtr<ISlangBlob> reportListBlob;
+    REQUIRE_CALL(device->getCompilationReportList(reportListBlob.writeRef()));
+    s_blobs.push_back(reportListBlob);
+    CHECK(reportListBlob->getBufferSize() >= sizeof(CompilationReportList));
+    const CompilationReportList* reportList = (const CompilationReportList*)reportListBlob->getBufferPointer();
+    size_t expectedSize = sizeof(CompilationReportList);
+    for (uint32_t i = 0; i < reportList->reportCount; ++i)
+    {
+        expectedSize += sizeof(CompilationReport);
+        expectedSize += reportList->reports[i].entryPointReportCount * sizeof(CompilationReport::EntryPointReport);
+        expectedSize += reportList->reports[i].pipelineReportCount * sizeof(CompilationReport::PipelineReport);
+    }
+    CHECK(reportListBlob->getBufferSize() == expectedSize);
+    return reportList;
 }
 
 TEST_CASE("compilation-report")
@@ -76,87 +109,95 @@ TEST_CASE("compilation-report")
             ComPtr<IShaderProgram> shaderProgram1 = createShaderProgram(device.get());
 
             // We expect no compilation has taken place yet, so the report should be empty.
-            CompilationReport report1a = getCompilationReport(shaderProgram1.get());
-            CHECK(report1a.alive == true);
-            CHECK(report1a.createTime == 0.0);
-            CHECK(report1a.compileTime == 0.0);
-            CHECK(report1a.compileSlangTime == 0.0);
-            CHECK(report1a.compileDownstreamTime == 0.0);
-            CHECK(report1a.createPipelineTime == 0.0);
+            const CompilationReport* report1a = getCompilationReport(shaderProgram1.get());
+            CHECK(report1a->alive == true);
+            CHECK(report1a->createTime == 0.0);
+            CHECK(report1a->compileTime == 0.0);
+            CHECK(report1a->compileSlangTime == 0.0);
+            CHECK(report1a->compileDownstreamTime == 0.0);
+            CHECK(report1a->createPipelineTime == 0.0);
+            CHECK(report1a->entryPointReportCount == 0);
+            CHECK(report1a->pipelineReportCount == 0);
 
             // The report should be registered in the device.
-            std::vector<CompilationReport> reports1a = getCompilationReports(device.get());
-            CHECK(reports1a.size() == 1);
-            CHECK(std::memcmp(&reports1a[0], &report1a, sizeof(CompilationReport)) == 0);
+            const CompilationReportList* reports1a = getCompilationReportList(device.get());
+            CHECK(reports1a->reportCount == 1);
+            CHECK(isEqual(&reports1a->reports[0], report1a));
 
             // Create and dispatch first pipeline.
             ComPtr<IComputePipeline> pipeline1 = createPipeline(device.get(), shaderProgram1.get());
             dispatchPipeline(device.get(), pipeline1.get());
 
             // We expect compilation and pipeline creation has taken place, so the report should contain non-zero times.
-            CompilationReport report1b = getCompilationReport(shaderProgram1.get());
-            CHECK(report1b.alive == true);
-            CHECK(report1b.createTime > 0.0);
-            CHECK(report1b.compileTime > 0.0);
-            CHECK(report1b.compileSlangTime > 0.0);
+            const CompilationReport* report1b = getCompilationReport(shaderProgram1.get());
+            CHECK(report1b->alive == true);
+            CHECK(report1b->createTime > 0.0);
+            CHECK(report1b->compileTime > 0.0);
+            CHECK(report1b->compileSlangTime > 0.0);
             // Downstream compilation time may be zero if no downstream compiler is used.
-            CHECK(report1b.compileDownstreamTime >= 0.0);
-            CHECK(report1b.createPipelineTime > 0.0);
+            CHECK(report1b->compileDownstreamTime >= 0.0);
+            CHECK(report1b->createPipelineTime > 0.0);
+            CHECK(report1b->entryPointReportCount == 1);
+            CHECK(report1b->pipelineReportCount == 1);
 
             // The report should still be registered in the device.
-            std::vector<CompilationReport> reports1b = getCompilationReports(device.get());
-            CHECK(reports1b.size() == 1);
-            CHECK(std::memcmp(&reports1b[0], &report1b, sizeof(CompilationReport)) == 0);
+            const CompilationReportList* reports1b = getCompilationReportList(device.get());
+            CHECK(reports1b->reportCount == 1);
+            CHECK(isEqual(&reports1b->reports[0], report1b));
 
             // Create second shader program.
             ComPtr<IShaderProgram> shaderProgram2 = createShaderProgram(device.get());
 
             // We expect no compilation has taken place yet, so the report should be empty.
-            CompilationReport report2a = getCompilationReport(shaderProgram2.get());
-            CHECK(report2a.alive == true);
-            CHECK(report2a.createTime == 0.0);
-            CHECK(report2a.compileTime == 0.0);
-            CHECK(report2a.compileSlangTime == 0.0);
-            CHECK(report2a.compileDownstreamTime == 0.0);
-            CHECK(report2a.createPipelineTime == 0.0);
+            const CompilationReport* report2a = getCompilationReport(shaderProgram2.get());
+            CHECK(report2a->alive == true);
+            CHECK(report2a->createTime == 0.0);
+            CHECK(report2a->compileTime == 0.0);
+            CHECK(report2a->compileSlangTime == 0.0);
+            CHECK(report2a->compileDownstreamTime == 0.0);
+            CHECK(report2a->createPipelineTime == 0.0);
+            CHECK(report2a->entryPointReportCount == 0);
+            CHECK(report2a->pipelineReportCount == 0);
 
             // The report should be registered in the device.
-            std::vector<CompilationReport> reports2a = getCompilationReports(device.get());
-            CHECK(reports2a.size() == 2);
-            CHECK(std::memcmp(&reports2a[0], &report1b, sizeof(CompilationReport)) == 0);
-            CHECK(std::memcmp(&reports2a[1], &report2a, sizeof(CompilationReport)) == 0);
+            const CompilationReportList* reports2a = getCompilationReportList(device.get());
+            CHECK(reports2a->reportCount == 2);
+            CHECK(isEqual(&reports2a->reports[0], report1b));
+            CHECK(isEqual(&reports2a->reports[1], report2a));
 
             // Create and dispatch second pipeline.
             ComPtr<IComputePipeline> pipeline2 = createPipeline(device.get(), shaderProgram2.get());
             dispatchPipeline(device.get(), pipeline2.get());
 
             // We expect compilation and pipeline creation has taken place, so the report should contain non-zero times.
-            CompilationReport report2b = getCompilationReport(shaderProgram2.get());
-            CHECK(report2b.alive == true);
-            CHECK(report2b.createTime > 0.0);
-            CHECK(report2b.compileTime > 0.0);
-            CHECK(report2b.compileSlangTime > 0.0);
+            const CompilationReport* report2b = getCompilationReport(shaderProgram2.get());
+            CHECK(report2b->alive == true);
+            CHECK(report2b->createTime > 0.0);
+            CHECK(report2b->compileTime > 0.0);
+            CHECK(report2b->compileSlangTime > 0.0);
             // Downstream compilation time may be zero if no downstream compiler is used.
-            CHECK(report2b.compileDownstreamTime >= 0.0);
-            CHECK(report2b.createPipelineTime > 0.0);
+            CHECK(report2b->compileDownstreamTime >= 0.0);
+            CHECK(report2b->createPipelineTime > 0.0);
+            CHECK(report2b->entryPointReportCount == 1);
+            CHECK(report2b->pipelineReportCount == 1);
 
             // The report should still be registered in the device.
-            std::vector<CompilationReport> reports2b = getCompilationReports(device.get());
-            CHECK(reports2b.size() == 2);
-            CHECK(std::memcmp(&reports2b[0], &report1b, sizeof(CompilationReport)) == 0);
-            CHECK(std::memcmp(&reports2b[1], &report2b, sizeof(CompilationReport)) == 0);
+            const CompilationReportList* reports2b = getCompilationReportList(device.get());
+            CHECK(reports2b->reportCount == 2);
+            CHECK(isEqual(&reports2b->reports[0], report1b));
+            CHECK(isEqual(&reports2b->reports[1], report2b));
 
             // Release the first shader program and pipeline.
             shaderProgram1 = nullptr;
             pipeline1 = nullptr;
 
             // The report first the first program should still be returned, but marked as no longer alive.
-            std::vector<CompilationReport> reports3 = getCompilationReports(device.get());
-            CompilationReport report1c = report1b;
+            const CompilationReportList* reports3 = getCompilationReportList(device.get());
+            CompilationReport report1c = *report1b;
             report1c.alive = false; // The first program is no longer alive.
-            CHECK(reports3.size() == 2);
-            CHECK(std::memcmp(&reports3[0], &report1c, sizeof(CompilationReport)) == 0);
-            CHECK(std::memcmp(&reports3[1], &report2b, sizeof(CompilationReport)) == 0);
+            CHECK(reports3->reportCount == 2);
+            CHECK(isEqual(&reports3->reports[0], &report1c));
+            CHECK(isEqual(&reports3->reports[1], report2b));
         }
     );
 }


### PR DESCRIPTION
- removed Struct/JSON option, just returns a struct now
- returned report contains entry point and pipeline records
- returned report list contains multiple reports