### PR TITLE
Improve surface usage handling

### DIFF
--- a/include/slang-rhi.h
+++ b/include/slang-rhi.h
@@ -2456,21 +2456,32 @@ public:
 
 struct SurfaceInfo
 {
+    /// The preferred format for the surface.
     Format preferredFormat;
+    /// The supported texture usage for the surface.
+    /// The actual support may be more limited depending on the format.
     TextureUsage supportedUsage;
+    /// The list of supported formats for the surface.
     const Format* formats;
+    /// The number of supported formats for the surface.
     uint32_t formatCount;
 };
 
 struct SurfaceConfig
 {
+    /// Surface format. If left undefined, the preferred format is used.
     Format format = Format::Undefined;
-    TextureUsage usage = TextureUsage::RenderTarget;
+    /// Usage of the surface. If left undefined, the supported usage is used.
+    TextureUsage usage = TextureUsage::None;
     // size_t viewFormatCount;
     // const Format* viewFormats;
+    /// Width of the surface in pixels.
     uint32_t width = 0;
+    /// Height of the surface in pixels.
     uint32_t height = 0;
+    /// Desired number of images in the swap chain.
     uint32_t desiredImageCount = 3;
+    /// Enable/disable vertical synchronization.
     bool vsync = true;
 };
 

--- a/src/cuda/cuda-surface.cpp
+++ b/src/cuda/cuda-surface.cpp
@@ -192,8 +192,7 @@ Result SurfaceImpl::init(DeviceImpl* device, WindowHandle windowHandle)
     }
 
     m_info.preferredFormat = preferredFormat;
-    m_info.supportedUsage = TextureUsage::Present | TextureUsage::RenderTarget | TextureUsage::UnorderedAccess |
-                            TextureUsage::CopyDestination;
+    m_info.supportedUsage = TextureUsage::Present | TextureUsage::UnorderedAccess | TextureUsage::CopyDestination;
     m_info.formats = m_supportedFormats.data();
     m_info.formatCount = (uint32_t)m_supportedFormats.size();
 
@@ -765,6 +764,10 @@ Result SurfaceImpl::configure(const SurfaceConfig& config)
     if (m_config.format == Format::Undefined)
     {
         m_config.format = m_info.preferredFormat;
+    }
+    if (m_config.usage == TextureUsage::None)
+    {
+        m_config.usage = m_info.supportedUsage;
     }
 
     m_configured = false;

--- a/src/d3d/d3d-surface.h
+++ b/src/d3d/d3d-surface.h
@@ -109,7 +109,14 @@ public:
     virtual SLANG_NO_THROW Result SLANG_MCALL configure(const SurfaceConfig& config) override
     {
         setConfig(config);
-        m_config.format = m_config.format == Format::Undefined ? m_info.preferredFormat : m_config.format;
+        if (m_config.format == Format::Undefined)
+        {
+            m_config.format = m_info.preferredFormat;
+        }
+        if (m_config.usage == TextureUsage::None)
+        {
+            m_config.usage = m_info.supportedUsage;
+        }
 
         m_configured = false;
         destroySwapchain();

--- a/src/metal/metal-surface.cpp
+++ b/src/metal/metal-surface.cpp
@@ -35,6 +35,11 @@ Result SurfaceImpl::configure(const SurfaceConfig& config)
     {
         m_config.format = m_info.preferredFormat;
     }
+    if (m_config.usage == TextureUsage::None)
+    {
+        // TODO: Once we have propert support for format support, we can add additional usages depending on the format.
+        m_config.usage = TextureUsage::Present | TextureUsage::RenderTarget | TextureUsage::CopyDestination;
+    }
 
     m_metalLayer->setPixelFormat(MetalUtil::translatePixelFormat(m_config.format));
     m_metalLayer->setDrawableSize(CGSize{(float)m_config.width, (float)m_config.height});

--- a/src/wgpu/wgpu-surface.cpp
+++ b/src/wgpu/wgpu-surface.cpp
@@ -154,6 +154,10 @@ Result SurfaceImpl::configure(const SurfaceConfig& config)
     {
         m_config.format = m_info.preferredFormat;
     }
+    if (m_config.usage == TextureUsage::None)
+    {
+        m_config.usage = m_info.supportedUsage;
+    }
 
     // sRGB formats cannot be used as storage textures.
     TextureUsage usage = m_config.usage;

--- a/tests/test-surface.cpp
+++ b/tests/test-surface.cpp
@@ -75,9 +75,7 @@ struct SurfaceTest
         queue->waitOnHost();
 
         SurfaceConfig config = {};
-        config.format = surface->getInfo().preferredFormat;
         config.format = getSurfaceFormat();
-        config.usage = surface->getInfo().supportedUsage;
         config.width = width;
         config.height = height;
         config.vsync = false;


### PR DESCRIPTION
When creating a surface, the texture usage flags are now auto-detected and set accordingly. 