### PR TITLE
Enable compiler warnings in tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -450,7 +450,8 @@ if(APPLE)
 endif()
 
 # Setup compiler warnings
-target_compile_options(slang-rhi PRIVATE
+add_library(slang-rhi-warnings INTERFACE)
+target_compile_options(slang-rhi-warnings INTERFACE
     $<$<CXX_COMPILER_ID:MSVC>:
         /W4 /WX
         /w14062 # enumerator 'identifier' in switch of enum 'enumeration' is not handled
@@ -501,6 +502,7 @@ target_compile_options(slang-rhi PRIVATE
         -Wno-nested-anon-types
     >
 )
+target_link_libraries(slang-rhi PRIVATE slang-rhi-warnings)
 
 target_sources(slang-rhi PRIVATE
     src/command-buffer.cpp
@@ -815,6 +817,7 @@ if(SLANG_RHI_BUILD_TESTS)
     )
     target_compile_features(slang-rhi-tests PRIVATE cxx_std_17)
     target_include_directories(slang-rhi-tests PRIVATE tests src)
+    target_link_libraries(slang-rhi-tests PRIVATE slang-rhi-warnings)
     target_link_libraries(slang-rhi-tests PRIVATE doctest slang-rhi-stb slang slang-rhi $<$<BOOL:${SLANG_RHI_BUILD_TESTS_WITH_GLFW}>:glfw> renderdoc)
     if(SLANG_RHI_ENABLE_OPTIX)
         target_link_libraries(slang-rhi-tests PRIVATE slang-rhi-optix)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -453,7 +453,7 @@ endif()
 add_library(slang-rhi-warnings INTERFACE)
 target_compile_options(slang-rhi-warnings INTERFACE
     $<$<CXX_COMPILER_ID:MSVC>:
-        /W4 /WX
+        /W4
         /w14062 # enumerator 'identifier' in switch of enum 'enumeration' is not handled
         /wd4267 # conversion from 'size_t' to 'type', possible loss of data
         /wd4244 # conversion from 'type1' to 'type2', possible loss of data
@@ -465,14 +465,14 @@ target_compile_options(slang-rhi-warnings INTERFACE
         /wd4389 # signed/unsigned mismatch
     >
     $<$<CXX_COMPILER_ID:GNU>:
-        -Wall -Wextra -Wpedantic -Werror
+        -Wall -Wextra -Wpedantic
         -Wshadow=local
         -Wno-unused-parameter
         -Wno-missing-field-initializers
         -Wno-sign-compare
     >
     $<$<CXX_COMPILER_ID:Clang>:
-        -Wall -Wextra -Wpedantic -Werror
+        -Wall -Wextra -Wpedantic
         -Wshadow
         -Wno-unknown-warning-option
         -Wno-unused-parameter
@@ -491,7 +491,7 @@ target_compile_options(slang-rhi-warnings INTERFACE
         -Wno-language-extension-token
     >
     $<$<CXX_COMPILER_ID:AppleClang>:
-        -Wall -Wextra -Wpedantic -Werror
+        -Wall -Wextra -Wpedantic
         -Wshadow
         -Wno-unknown-warning-option
         -Wno-unused-parameter
@@ -502,7 +502,14 @@ target_compile_options(slang-rhi-warnings INTERFACE
         -Wno-nested-anon-types
     >
 )
-target_link_libraries(slang-rhi PRIVATE slang-rhi-warnings)
+add_library(slang-rhi-warnings-as-errors INTERFACE)
+target_compile_options(slang-rhi-warnings-as-errors INTERFACE
+    $<$<CXX_COMPILER_ID:MSVC>:/WX>
+    $<$<CXX_COMPILER_ID:GNU>:-Werror>
+    $<$<CXX_COMPILER_ID:Clang>:-Werror>
+    $<$<CXX_COMPILER_ID:AppleClang>:-Werror>
+)
+target_link_libraries(slang-rhi PRIVATE slang-rhi-warnings slang-rhi-warnings-as-errors)
 
 target_sources(slang-rhi PRIVATE
     src/command-buffer.cpp
@@ -817,7 +824,7 @@ if(SLANG_RHI_BUILD_TESTS)
     )
     target_compile_features(slang-rhi-tests PRIVATE cxx_std_17)
     target_include_directories(slang-rhi-tests PRIVATE tests src)
-    target_link_libraries(slang-rhi-tests PRIVATE slang-rhi-warnings)
+    target_link_libraries(slang-rhi-tests PRIVATE slang-rhi-warnings slang-rhi-warnings-as-errors)
     target_link_libraries(slang-rhi-tests PRIVATE doctest slang-rhi-stb slang slang-rhi $<$<BOOL:${SLANG_RHI_BUILD_TESTS_WITH_GLFW}>:glfw> renderdoc)
     if(SLANG_RHI_ENABLE_OPTIX)
         target_link_libraries(slang-rhi-tests PRIVATE slang-rhi-optix)

--- a/tests/test-benchmark-command.cpp
+++ b/tests/test-benchmark-command.cpp
@@ -67,9 +67,6 @@ GPU_TEST_CASE("benchmark-command", ALL)
                 auto computePass = commandEncoder->beginComputePass();
                 auto shaderObject = computePass->bindPipeline(shader.pipeline);
 
-                uint32_t a = 1;
-                uint32_t b = 2;
-
                 ShaderCursor cursor(shaderObject);
                 ShaderCursor block = cursor["addKernelData"];
                 block["a"].setBinding(bufA);

--- a/tests/test-bindless-descriptor-handles.cpp
+++ b/tests/test-bindless-descriptor-handles.cpp
@@ -11,7 +11,7 @@ GPU_TEST_CASE("bindless-descriptor-handles", D3D12 | Vulkan)
     }
 
     ComPtr<IShaderProgram> shaderProgram;
-    slang::ProgramLayout* slangReflection;
+    slang::ProgramLayout* slangReflection = nullptr;
     REQUIRE_CALL(
         loadComputeProgram(device, shaderProgram, "test-bindless-descriptor-handles", "computeMain", slangReflection)
     );

--- a/tests/test-buffer-from-handle.cpp
+++ b/tests/test-buffer-from-handle.cpp
@@ -6,7 +6,7 @@ using namespace rhi::testing;
 GPU_TEST_CASE("buffer-from-handle", D3D12 | Vulkan)
 {
     ComPtr<IShaderProgram> shaderProgram;
-    slang::ProgramLayout* slangReflection;
+    slang::ProgramLayout* slangReflection = nullptr;
     REQUIRE_CALL(loadComputeProgram(device, shaderProgram, "test-compute-trivial", "computeMain", slangReflection));
 
     ComputePipelineDesc pipelineDesc = {};

--- a/tests/test-buffer-shared.cpp
+++ b/tests/test-buffer-shared.cpp
@@ -40,7 +40,7 @@ void testSharedBuffer(GpuTestContext* ctx, DeviceType deviceType)
     compareComputeResult(dstDevice, dstBuffer, makeArray<float>(0.0f, 1.0f, 2.0f, 3.0f));
 
     ComPtr<IShaderProgram> shaderProgram;
-    slang::ProgramLayout* slangReflection;
+    slang::ProgramLayout* slangReflection = nullptr;
     REQUIRE_CALL(loadComputeProgram(dstDevice, shaderProgram, "test-compute-trivial", "computeMain", slangReflection));
 
     ComputePipelineDesc pipelineDesc = {};

--- a/tests/test-cmd-copy-buffer-to-texture.cpp
+++ b/tests/test-cmd-copy-buffer-to-texture.cpp
@@ -65,7 +65,7 @@ GPU_TEST_CASE("cmd-copy-buffer-to-texture-full", D3D12 | Vulkan | Metal | WGPU |
             REQUIRE_CALL(getSizeAndMakeBuffer(c, textureData, &totalSize, buffer.writeRef()));
 
             // Map buffer for write, and copy subresources in
-            void* bufferData_;
+            void* bufferData_ = nullptr;
             REQUIRE_CALL(device->mapBuffer(buffer, CpuAccessMode::Write, &bufferData_));
             uint8_t* bufferData = (uint8_t*)bufferData_;
             for (uint32_t layer = 0; layer < textureData.desc.getLayerCount(); layer++)

--- a/tests/test-cmd-copy-texture-to-buffer.cpp
+++ b/tests/test-cmd-copy-texture-to-buffer.cpp
@@ -86,7 +86,7 @@ GPU_TEST_CASE("cmd-copy-texture-to-buffer-full", D3D12 | Vulkan | Metal | WGPU |
             queue->waitOnHost();
 
             // Verify buffer contents match texture data
-            void* bufferData_;
+            void* bufferData_ = nullptr;
             REQUIRE_CALL(device->mapBuffer(buffer, CpuAccessMode::Read, &bufferData_));
             uint8_t* bufferData = (uint8_t*)bufferData_;
 
@@ -202,7 +202,7 @@ GPU_TEST_CASE("cmd-copy-texture-to-buffer-rowalignment", D3D12 | Vulkan | Metal 
             queue->waitOnHost();
 
             // Verify buffer contents match texture data
-            void* bufferData_;
+            void* bufferData_ = nullptr;
             REQUIRE_CALL(device->mapBuffer(buffer, CpuAccessMode::Read, &bufferData_));
             uint8_t* bufferData = (uint8_t*)bufferData_;
 
@@ -258,7 +258,7 @@ GPU_TEST_CASE("cmd-copy-texture-to-buffer-offset", D3D12 | Vulkan | Metal | WGPU
 
             // Get cpu side data.
             TextureData& data = c->getTextureData();
-            uint64_t totalSize;
+            uint64_t totalSize = 0;
             ComPtr<IBuffer> buffer;
             REQUIRE_CALL(getSizeAndMakeBuffer(c, &totalSize, buffer.writeRef()));
 
@@ -309,7 +309,7 @@ GPU_TEST_CASE("cmd-copy-texture-to-buffer-offset", D3D12 | Vulkan | Metal | WGPU
             queue->waitOnHost();
 
             // Verify buffer contents match texture data
-            void* bufferData_;
+            void* bufferData_ = nullptr;
             REQUIRE_CALL(device->mapBuffer(buffer, CpuAccessMode::Read, &bufferData_));
             uint8_t* bufferData = (uint8_t*)bufferData_;
 
@@ -363,7 +363,7 @@ GPU_TEST_CASE("cmd-copy-texture-to-buffer-sizeoffset", D3D12 | Vulkan | Metal | 
 
             // Get cpu side data.
             TextureData& data = c->getTextureData();
-            uint64_t totalSize;
+            uint64_t totalSize = 0;
             ComPtr<IBuffer> buffer;
             REQUIRE_CALL(getSizeAndMakeBuffer(c, &totalSize, buffer.writeRef()));
 
@@ -418,7 +418,7 @@ GPU_TEST_CASE("cmd-copy-texture-to-buffer-sizeoffset", D3D12 | Vulkan | Metal | 
             queue->waitOnHost();
 
             // Verify buffer contents match texture data
-            void* bufferData_;
+            void* bufferData_ = nullptr;
             REQUIRE_CALL(device->mapBuffer(buffer, CpuAccessMode::Read, &bufferData_));
             uint8_t* bufferData = (uint8_t*)bufferData_;
 
@@ -471,7 +471,7 @@ GPU_TEST_CASE("cmd-copy-texture-to-buffer-offset-mip1", D3D12 | Vulkan | Metal |
 
             // Get cpu side data.
             TextureData& data = c->getTextureData();
-            uint64_t totalSize;
+            uint64_t totalSize = 0;
             ComPtr<IBuffer> buffer;
             REQUIRE_CALL(getSizeAndMakeBuffer(c, &totalSize, buffer.writeRef()));
 
@@ -522,7 +522,7 @@ GPU_TEST_CASE("cmd-copy-texture-to-buffer-offset-mip1", D3D12 | Vulkan | Metal |
             queue->waitOnHost();
 
             // Verify buffer contents match texture data
-            void* bufferData_;
+            void* bufferData_ = nullptr;
             REQUIRE_CALL(device->mapBuffer(buffer, CpuAccessMode::Read, &bufferData_));
             uint8_t* bufferData = (uint8_t*)bufferData_;
 
@@ -577,7 +577,7 @@ GPU_TEST_CASE("cmd-copy-texture-to-buffer-sizeoffset-mip1", D3D12 | Vulkan | Met
 
             // Get cpu side data.
             TextureData& data = c->getTextureData();
-            uint64_t totalSize;
+            uint64_t totalSize = 0;
             ComPtr<IBuffer> buffer;
             REQUIRE_CALL(getSizeAndMakeBuffer(c, &totalSize, buffer.writeRef()));
 
@@ -632,7 +632,7 @@ GPU_TEST_CASE("cmd-copy-texture-to-buffer-sizeoffset-mip1", D3D12 | Vulkan | Met
             queue->waitOnHost();
 
             // Verify buffer contents match texture data
-            void* bufferData_;
+            void* bufferData_ = nullptr;
             REQUIRE_CALL(device->mapBuffer(buffer, CpuAccessMode::Read, &bufferData_));
             uint8_t* bufferData = (uint8_t*)bufferData_;
 

--- a/tests/test-cmd-debug.cpp
+++ b/tests/test-cmd-debug.cpp
@@ -11,7 +11,7 @@ static const MarkerColor BLUE = {0.f, 0.f, 1.f};
 GPU_TEST_CASE("cmd-debug", ALL)
 {
     ComPtr<IShaderProgram> shaderProgram;
-    slang::ProgramLayout* slangReflection;
+    slang::ProgramLayout* slangReflection = nullptr;
     REQUIRE_CALL(loadComputeProgram(device, shaderProgram, "test-cmd-debug", "computeMain", slangReflection));
 
     ComputePipelineDesc pipelineDesc = {};

--- a/tests/test-cmd-draw.cpp
+++ b/tests/test-cmd-draw.cpp
@@ -108,7 +108,7 @@ public:
     ComPtr<ITexture> colorBuffer;
     ComPtr<ITextureView> colorBufferView;
 
-    void init(IDevice* device) { this->device = device; }
+    void init(IDevice* device_) { this->device = device_; }
 
     void createRequiredResources()
     {
@@ -138,7 +138,7 @@ public:
         colorBuffer = createColorBuffer(device);
 
         ComPtr<IShaderProgram> shaderProgram;
-        slang::ProgramLayout* slangReflection;
+        slang::ProgramLayout* slangReflection = nullptr;
         REQUIRE_CALL(
             loadGraphicsProgram(device, shaderProgram, "test-cmd-draw", "vertexMain", "fragmentMain", slangReflection)
         );
@@ -318,20 +318,20 @@ struct DrawIndirectTest : BaseDrawTest
         IndirectDrawArguments args;
     };
 
-    ComPtr<IBuffer> createIndirectBuffer(IDevice* device)
+    ComPtr<IBuffer> createIndirectBuffer()
     {
         static const IndirectArgData kIndirectData = {
             42.0f,        // padding
             {6, 2, 0, 0}, // args
         };
 
-        BufferDesc indirectBufferDesc;
-        indirectBufferDesc.size = sizeof(IndirectArgData);
-        indirectBufferDesc.usage = BufferUsage::IndirectArgument;
-        indirectBufferDesc.defaultState = ResourceState::IndirectArgument;
-        ComPtr<IBuffer> indirectBuffer = device->createBuffer(indirectBufferDesc, &kIndirectData);
-        REQUIRE(indirectBuffer != nullptr);
-        return indirectBuffer;
+        BufferDesc bufferDesc;
+        bufferDesc.size = sizeof(IndirectArgData);
+        bufferDesc.usage = BufferUsage::IndirectArgument;
+        bufferDesc.defaultState = ResourceState::IndirectArgument;
+        ComPtr<IBuffer> buffer = device->createBuffer(bufferDesc, &kIndirectData);
+        REQUIRE(buffer != nullptr);
+        return buffer;
     }
 
     void setUpAndDraw()
@@ -373,7 +373,7 @@ struct DrawIndirectTest : BaseDrawTest
 
     void run()
     {
-        indirectBuffer = createIndirectBuffer(device);
+        indirectBuffer = createIndirectBuffer();
 
         setUpAndDraw();
 
@@ -398,20 +398,20 @@ struct DrawIndexedIndirectTest : BaseDrawTest
         IndirectDrawIndexedArguments args;
     };
 
-    ComPtr<IBuffer> createIndirectBuffer(IDevice* device)
+    ComPtr<IBuffer> createIndirectBuffer()
     {
         static const IndexedIndirectArgData kIndexedIndirectData = {
             42.0f,           // padding
             {6, 2, 0, 0, 0}, // args
         };
 
-        BufferDesc indirectBufferDesc;
-        indirectBufferDesc.size = sizeof(IndexedIndirectArgData);
-        indirectBufferDesc.usage = BufferUsage::IndirectArgument;
-        indirectBufferDesc.defaultState = ResourceState::IndirectArgument;
-        ComPtr<IBuffer> indexBuffer = device->createBuffer(indirectBufferDesc, &kIndexedIndirectData);
-        REQUIRE(indexBuffer != nullptr);
-        return indexBuffer;
+        BufferDesc bufferDesc;
+        bufferDesc.size = sizeof(IndexedIndirectArgData);
+        bufferDesc.usage = BufferUsage::IndirectArgument;
+        bufferDesc.defaultState = ResourceState::IndirectArgument;
+        ComPtr<IBuffer> buffer = device->createBuffer(bufferDesc, &kIndexedIndirectData);
+        REQUIRE(buffer != nullptr);
+        return buffer;
     }
 
     void setUpAndDraw()
@@ -456,7 +456,7 @@ struct DrawIndexedIndirectTest : BaseDrawTest
     void run()
     {
         indexBuffer = createIndexBuffer(device);
-        indirectBuffer = createIndirectBuffer(device);
+        indirectBuffer = createIndirectBuffer();
 
         setUpAndDraw();
 

--- a/tests/test-compilation-report.cpp
+++ b/tests/test-compilation-report.cpp
@@ -48,7 +48,7 @@ inline void dispatchPipeline(IDevice* device, IComputePipeline* pipeline)
     auto commandEncoder = queue->createCommandEncoder();
 
     auto passEncoder = commandEncoder->beginComputePass();
-    auto rootObject = passEncoder->bindPipeline(pipeline);
+    passEncoder->bindPipeline(pipeline);
     passEncoder->dispatchCompute(1, 1, 1);
     passEncoder->end();
 

--- a/tests/test-compute-smoke.cpp
+++ b/tests/test-compute-smoke.cpp
@@ -6,7 +6,7 @@ using namespace rhi::testing;
 GPU_TEST_CASE("compute-smoke", ALL)
 {
     ComPtr<IShaderProgram> shaderProgram;
-    slang::ProgramLayout* slangReflection;
+    slang::ProgramLayout* slangReflection = nullptr;
     REQUIRE_CALL(loadComputeProgram(device, shaderProgram, "test-compute-smoke", "computeMain", slangReflection));
 
     ComputePipelineDesc pipelineDesc = {};

--- a/tests/test-compute-trivial.cpp
+++ b/tests/test-compute-trivial.cpp
@@ -6,7 +6,7 @@ using namespace rhi::testing;
 GPU_TEST_CASE("compute-trivial", ALL)
 {
     ComPtr<IShaderProgram> shaderProgram;
-    slang::ProgramLayout* slangReflection;
+    slang::ProgramLayout* slangReflection = nullptr;
     REQUIRE_CALL(loadComputeProgram(device, shaderProgram, "test-compute-trivial", "computeMain", slangReflection));
 
     ComputePipelineDesc pipelineDesc = {};

--- a/tests/test-cooperative-vector.cpp
+++ b/tests/test-cooperative-vector.cpp
@@ -8,7 +8,7 @@ GPU_TEST_CASE("cooperative-vector-properties", D3D12 | Vulkan)
     if (!device->hasFeature(Feature::CooperativeVector))
         SKIP("cooperative vector not supported");
 
-    uint32_t propertiesCount;
+    uint32_t propertiesCount = 0;
     REQUIRE_CALL(device->getCooperativeVectorProperties(nullptr, &propertiesCount));
     std::vector<CooperativeVectorProperties> properties(propertiesCount);
     REQUIRE_CALL(device->getCooperativeVectorProperties(properties.data(), &propertiesCount));

--- a/tests/test-device-from-handle.cpp
+++ b/tests/test-device-from-handle.cpp
@@ -24,7 +24,7 @@ GPU_TEST_CASE("device-from-handle", D3D12 | Vulkan | CUDA)
     CHECK_CALL(getRHI()->createDevice(newDeviceDesc, newDevice.writeRef()));
 
     ComPtr<IShaderProgram> shaderProgram;
-    slang::ProgramLayout* slangReflection;
+    slang::ProgramLayout* slangReflection = nullptr;
     REQUIRE_CALL(loadComputeProgram(newDevice, shaderProgram, "test-compute-trivial", "computeMain", slangReflection));
 
     ComputePipelineDesc pipelineDesc = {};

--- a/tests/test-formats.slang
+++ b/tests/test-formats.slang
@@ -185,38 +185,3 @@ void copyTexFloat1(
     tex.GetDimensions(width, height);
     buffer[sv_dispatchThreadID.x] = tex[uint2(sv_dispatchThreadID.x % width, sv_dispatchThreadID.x / width)];
 }
-
-#if 0
-// Sample from "tex" at texture coordinates (0.5, 0.5) and save the results in "buffer".
-[shader("compute")]
-[numthreads(4,1,1)]
-void sampleTex(
-    uint3 sv_dispatchThreadID : SV_DispatchThreadID,
-    uniform Texture2D<float4> tex,
-    uniform SamplerState sampler,
-    uniform RWStructuredBuffer<float> buffer)
-{
-    float4 result = tex.SampleLevel(sampler, float2(0.5, 0.5), 0);
-    buffer[sv_dispatchThreadID.x * 4] = result.r;
-    buffer[sv_dispatchThreadID.x * 4 + 1] = result.g;
-    buffer[sv_dispatchThreadID.x * 4 + 2] = result.b;
-    buffer[sv_dispatchThreadID.x * 4 + 3] = result.a;
-}
-
-// Sample from "tex" at texture coordinates (0.5, 0.5) and save the resuls in "buffer".
-// This should only be used with textures containing two mip levels.
-[shader("compute")]
-[numthreads(2,1,1)]
-void sampleMips(
-    uint3 sv_dispatchThreadID : SV_DispatchThreadID,
-    uniform Texture2D<float4> tex,
-    uniform SamplerState sampler,
-    uniform RWStructuredBuffer<float> buffer)
-{
-    float4 result = tex.SampleLevel(sampler, float2(0.5, 0.5), float(sv_dispatchThreadID.x));
-    buffer[sv_dispatchThreadID.x * 4] = result.r;
-    buffer[sv_dispatchThreadID.x * 4 + 1] = result.g;
-    buffer[sv_dispatchThreadID.x * 4 + 2] = result.b;
-    buffer[sv_dispatchThreadID.x * 4 + 3] = result.a;
-}
-#endif

--- a/tests/test-link-time-constant.cpp
+++ b/tests/test-link-time-constant.cpp
@@ -55,7 +55,7 @@ static Result loadProgram(
 GPU_TEST_CASE("link-time-constant", ALL)
 {
     ComPtr<IShaderProgram> shaderProgram;
-    slang::ProgramLayout* slangReflection;
+    slang::ProgramLayout* slangReflection = nullptr;
     REQUIRE_CALL(loadProgram(
         device,
         shaderProgram,

--- a/tests/test-link-time-default.cpp
+++ b/tests/test-link-time-default.cpp
@@ -102,7 +102,7 @@ GPU_TEST_CASE("link-time-default", D3D11 | D3D12 | Vulkan | Metal | CPU | WGPU |
     // Create pipeline without linking a specialization override module, so we should
     // see the default value of `extern Foo`.
     ComPtr<IShaderProgram> shaderProgram;
-    slang::ProgramLayout* slangReflection;
+    slang::ProgramLayout* slangReflection = nullptr;
     REQUIRE_CALL(loadProgram(device, shaderProgram, slangReflection, false));
 
     ComputePipelineDesc pipelineDesc = {};

--- a/tests/test-link-time-options.cpp
+++ b/tests/test-link-time-options.cpp
@@ -62,7 +62,7 @@ static Result loadProgram(
 GPU_TEST_CASE("link-time-options", D3D12)
 {
     ComPtr<IShaderProgram> shaderProgram;
-    slang::ProgramLayout* slangReflection;
+    slang::ProgramLayout* slangReflection = nullptr;
     REQUIRE_CALL(loadProgram(device, shaderProgram, "test-link-time-options", "computeMain", slangReflection));
 
     ComputePipelineDesc pipelineDesc = {};

--- a/tests/test-link-time-type.cpp
+++ b/tests/test-link-time-type.cpp
@@ -101,7 +101,7 @@ static Result loadProgram(
 GPU_TEST_CASE("link-time-type", D3D11 | D3D12 | Vulkan | Metal | CPU | WGPU | NoDeviceCache)
 {
     ComPtr<IShaderProgram> shaderProgram;
-    slang::ProgramLayout* slangReflection;
+    slang::ProgramLayout* slangReflection = nullptr;
     REQUIRE_CALL(loadProgram(device, shaderProgram, slangReflection));
 
     ComputePipelineDesc pipelineDesc = {};

--- a/tests/test-mutable-shader-object.cpp
+++ b/tests/test-mutable-shader-object.cpp
@@ -12,7 +12,7 @@ GPU_TEST_CASE("mutable-shader-object", ALL)
     REQUIRE_CALL(device->createTransientResourceHeap(transientHeapDesc, transientHeap.writeRef()));
 
     ComPtr<IShaderProgram> shaderProgram;
-    slang::ProgramLayout* slangReflection;
+    slang::ProgramLayout* slangReflection = nullptr;
     REQUIRE_CALL(loadComputeProgram(device, shaderProgram, "test-mutable-shader-object", "computeMain", slangReflection)
     );
 

--- a/tests/test-nested-parameter-block.cpp
+++ b/tests/test-nested-parameter-block.cpp
@@ -6,7 +6,6 @@ using namespace rhi::testing;
 ComPtr<IBuffer> createBuffer(IDevice* device, uint32_t data, ResourceState defaultState)
 {
     uint32_t initialData[] = {data, data, data, data};
-    const int numberCount = SLANG_COUNT_OF(initialData);
     BufferDesc bufferDesc = {};
     bufferDesc.size = sizeof(initialData);
     bufferDesc.format = Format::Undefined;
@@ -32,7 +31,7 @@ GPU_TEST_CASE("nested-parameter-block", ALL)
         SKIP("no support for parameter blocks");
 
     ComPtr<IShaderProgram> shaderProgram;
-    slang::ProgramLayout* slangReflection;
+    slang::ProgramLayout* slangReflection = nullptr;
     REQUIRE_CALL(
         loadComputeProgram(device, shaderProgram, "test-nested-parameter-block", "computeMain", slangReflection)
     );
@@ -129,7 +128,7 @@ GPU_TEST_CASE("nested-parameter-block-2", ALL)
         SKIP("no support for parameter blocks");
 
     ComPtr<IShaderProgram> shaderProgram;
-    slang::ProgramLayout* slangReflection;
+    slang::ProgramLayout* slangReflection = nullptr;
     REQUIRE_CALL(
         loadComputeProgram(device, shaderProgram, "test-nested-parameter-block", "computeMain", slangReflection)
     );

--- a/tests/test-null-views.cpp
+++ b/tests/test-null-views.cpp
@@ -9,7 +9,7 @@ using namespace rhi::testing;
 GPU_TEST_CASE("null-views", ALL & ~(D3D11 | CPU | WGPU))
 {
     ComPtr<IShaderProgram> shaderProgram;
-    slang::ProgramLayout* slangReflection;
+    slang::ProgramLayout* slangReflection = nullptr;
     REQUIRE_CALL(loadComputeProgram(device, shaderProgram, "test-null-views", "computeMain", slangReflection));
 
     ComputePipelineDesc pipelineDesc = {};

--- a/tests/test-pipeline-cache.cpp
+++ b/tests/test-pipeline-cache.cpp
@@ -318,7 +318,7 @@ struct PipelineCacheTestRender : PipelineCacheTest
         renderPass.colorAttachments = &colorAttachment;
         renderPass.colorAttachmentCount = 1;
         auto passEncoder = commandEncoder->beginRenderPass(renderPass);
-        auto rootObject = passEncoder->bindPipeline(renderPipeline);
+        passEncoder->bindPipeline(renderPipeline);
         RenderState renderState = {};
         renderState.viewports[0] = Viewport::fromSize(2, 2);
         renderState.viewportCount = 1;

--- a/tests/test-precompiled-module-cache.cpp
+++ b/tests/test-precompiled-module-cache.cpp
@@ -125,7 +125,7 @@ void precompiledModuleCacheTestImpl(IDevice* device, UnitTestContext* context)
 
     // Precompile a module.
     ComPtr<IShaderProgram> shaderProgram;
-    slang::ProgramLayout* slangReflection;
+    slang::ProgramLayout* slangReflection = nullptr;
     REQUIRE_CALL(precompileProgram(device, memoryFileSystem.get(), "precompiled-module-imported"));
 
     // Next, load the precompiled slang program.

--- a/tests/test-precompiled-module.cpp
+++ b/tests/test-precompiled-module.cpp
@@ -96,13 +96,12 @@ static Result precompileProgram(
     // Write loaded modules to files.
     for (SlangInt i = 0; i < slangSession->getLoadedModuleCount(); i++)
     {
-        auto module = slangSession->getLoadedModule(i);
-        auto path = module->getFilePath();
-        if (path)
+        auto loadedModule = slangSession->getLoadedModule(i);
+        if (loadedModule->getFilePath())
         {
-            auto path = (dir / module->getName()).replace_extension(".slang-module");
+            auto path = (dir / loadedModule->getName()).replace_extension(".slang-module");
             ComPtr<ISlangBlob> outBlob;
-            module->serialize(outBlob.writeRef());
+            loadedModule->serialize(outBlob.writeRef());
             writeFile(path.string(), outBlob->getBufferPointer(), outBlob->getBufferSize());
         }
     }
@@ -117,7 +116,7 @@ static void testPrecompiledModuleImpl(IDevice* device, bool mixed, bool precompi
     std::string tempDirStr = tempDir.string();
 
     ComPtr<IShaderProgram> shaderProgram;
-    slang::ProgramLayout* slangReflection;
+    slang::ProgramLayout* slangReflection = nullptr;
     REQUIRE_CALL(precompileProgram(
         device,
         mixed ? "test-precompiled-module-imported" : "test-precompiled-module",

--- a/tests/test-ray-tracing-sphere.cpp
+++ b/tests/test-ray-tracing-sphere.cpp
@@ -28,10 +28,10 @@ struct RayTracingSphereTestBase
     ComPtr<IAccelerationStructure> TLAS;
     ComPtr<IShaderTable> shaderTable;
 
-    void init(IDevice* device) { this->device = device; }
+    void init(IDevice* device_) { this->device = device_; }
 
     // Load and compile shader code from source.
-    Result loadShaderProgram(IDevice* device, span<const char*> entryPointNames, IShaderProgram** outProgram)
+    Result loadShaderProgram(span<const char*> entryPointNames, IShaderProgram** outProgram)
     {
         ComPtr<slang::ISession> slangSession;
         slangSession = device->getSlangSession();
@@ -224,7 +224,7 @@ struct RayTracingSphereTestBase
         const char* entryPointNames[] = {raygenName, missName, closestHitName};
 
         ComPtr<IShaderProgram> rayTracingProgram;
-        REQUIRE_CALL(loadShaderProgram(device, entryPointNames, rayTracingProgram.writeRef()));
+        REQUIRE_CALL(loadShaderProgram(entryPointNames, rayTracingProgram.writeRef()));
 
         HitGroupDesc hitGroups[1];
         hitGroups[0].hitGroupName = hitgroupNames[0];

--- a/tests/test-ray-tracing.cpp
+++ b/tests/test-ray-tracing.cpp
@@ -76,10 +76,10 @@ struct BaseRayTracingTest
     uint32_t width = 128;
     uint32_t height = 128;
 
-    void init(IDevice* device) { this->device = device; }
+    void init(IDevice* device_) { this->device = device_; }
 
     // Load and compile shader code from source.
-    Result loadShaderProgram(IDevice* device, IShaderProgram** outProgram)
+    Result loadShaderProgram(IShaderProgram** outProgram)
     {
         ComPtr<slang::ISession> slangSession;
         slangSession = device->getSlangSession();
@@ -294,7 +294,7 @@ struct BaseRayTracingTest
         const char* hitgroupNames[] = {"hitgroupA", "hitgroupB"};
 
         ComPtr<IShaderProgram> rayTracingProgram;
-        REQUIRE_CALL(loadShaderProgram(device, rayTracingProgram.writeRef()));
+        REQUIRE_CALL(loadShaderProgram(rayTracingProgram.writeRef()));
         RayTracingPipelineDesc rtpDesc = {};
         rtpDesc.program = rayTracingProgram;
         rtpDesc.hitGroupCount = 2;

--- a/tests/test-resolve-resource-tests.cpp
+++ b/tests/test-resolve-resource-tests.cpp
@@ -72,7 +72,7 @@ struct BaseResolveResourceTest
         const SubresourceData* initData;
     };
 
-    void init(IDevice* device) { this->device = device; }
+    void init(IDevice* device_) { this->device = device_; }
 
     void createRequiredResources(TextureInfo msaaTextureInfo, TextureInfo dstTextureInfo, Format format)
     {
@@ -120,7 +120,7 @@ struct BaseResolveResourceTest
         vertexBuffer = createVertexBuffer(device);
 
         ComPtr<IShaderProgram> shaderProgram;
-        slang::ProgramLayout* slangReflection;
+        slang::ProgramLayout* slangReflection = nullptr;
         REQUIRE_CALL(loadGraphicsProgram(
             device,
             shaderProgram,

--- a/tests/test-resource-states.cpp
+++ b/tests/test-resource-states.cpp
@@ -8,7 +8,7 @@ using namespace rhi::testing;
 GPU_TEST_CASE("buffer-resource-states", D3D12 | Vulkan)
 {
     ComPtr<IShaderProgram> shaderProgram;
-    slang::ProgramLayout* slangReflection;
+    slang::ProgramLayout* slangReflection = nullptr;
     REQUIRE_CALL(loadComputeProgram(device, shaderProgram, "test-dummy", "computeMain", slangReflection));
 
     ComputePipelineDesc pipelineDesc = {};
@@ -63,7 +63,7 @@ GPU_TEST_CASE("buffer-resource-states", D3D12 | Vulkan)
 GPU_TEST_CASE("texture-resource-states", D3D12 | Vulkan)
 {
     ComPtr<IShaderProgram> shaderProgram;
-    slang::ProgramLayout* slangReflection;
+    slang::ProgramLayout* slangReflection = nullptr;
     REQUIRE_CALL(loadComputeProgram(device, shaderProgram, "test-dummy", "computeMain", slangReflection));
 
     ComputePipelineDesc pipelineDesc = {};
@@ -76,8 +76,7 @@ GPU_TEST_CASE("texture-resource-states", D3D12 | Vulkan)
     for (uint32_t i = 1; i < (uint32_t)Format::_Count; ++i)
     {
         auto format = (Format)i;
-        const FormatInfo& info = getFormatInfo(format);
-        FormatSupport formatSupport;
+        FormatSupport formatSupport = FormatSupport::None;
         REQUIRE_CALL(device->getFormatSupport(format, &formatSupport));
 
         if (!is_set(formatSupport, FormatSupport::Texture))

--- a/tests/test-root-mutable-shader-object.cpp
+++ b/tests/test-root-mutable-shader-object.cpp
@@ -7,7 +7,7 @@ using namespace rhi::testing;
 GPU_TEST_CASE("root-mutable-shader-object", WGPU)
 {
     ComPtr<IShaderProgram> shaderProgram;
-    slang::ProgramLayout* slangReflection;
+    slang::ProgramLayout* slangReflection = nullptr;
     REQUIRE_CALL(loadComputeProgram(device, shaderProgram, "test-mutable-shader-object", "computeMain", slangReflection)
     );
 

--- a/tests/test-root-shader-parameter.cpp
+++ b/tests/test-root-shader-parameter.cpp
@@ -27,7 +27,7 @@ GPU_TEST_CASE("root-shader-parameter", ALL)
         SKIP("no support for parameter blocks");
 
     ComPtr<IShaderProgram> shaderProgram;
-    slang::ProgramLayout* slangReflection;
+    slang::ProgramLayout* slangReflection = nullptr;
     REQUIRE_CALL(loadComputeProgram(device, shaderProgram, "test-root-shader-parameter", "computeMain", slangReflection)
     );
 

--- a/tests/test-sampler-array.cpp
+++ b/tests/test-sampler-array.cpp
@@ -29,7 +29,7 @@ GPU_TEST_CASE("sampler-array", D3D12 | Vulkan | Metal)
         SKIP("no support for parameter blocks");
 
     ComPtr<IShaderProgram> shaderProgram;
-    slang::ProgramLayout* slangReflection;
+    slang::ProgramLayout* slangReflection = nullptr;
     REQUIRE_CALL(loadComputeProgram(device, shaderProgram, "test-sampler-array", "computeMain", slangReflection));
 
     ComputePipelineDesc pipelineDesc = {};

--- a/tests/test-sampler.cpp
+++ b/tests/test-sampler.cpp
@@ -72,13 +72,13 @@ struct SamplerTest
     ComPtr<IBuffer> resultBuffer;
     ComPtr<IComputePipeline> pipeline;
 
-    void init(IDevice* device)
+    void init(IDevice* device_)
     {
-        this->device = device;
+        this->device = device_;
         REQUIRE_CALL(createTestTexture(device, texture.writeRef()));
 
         ComPtr<IShaderProgram> shaderProgram;
-        slang::ProgramLayout* slangReflection;
+        slang::ProgramLayout* slangReflection = nullptr;
         REQUIRE_CALL(loadComputeProgram(device, shaderProgram, "test-sampler", "sampleTexture", slangReflection));
 
         ComputePipelineDesc pipelineDesc = {};

--- a/tests/test-shader-object-large.cpp
+++ b/tests/test-shader-object-large.cpp
@@ -30,7 +30,7 @@ inline ComPtr<ITexture> createTexture(IDevice* device, float value)
 GPU_TEST_CASE("shader-object-large", D3D12 | Vulkan)
 {
     ComPtr<IShaderProgram> shaderProgram;
-    slang::ProgramLayout* slangReflection;
+    slang::ProgramLayout* slangReflection = nullptr;
     REQUIRE_CALL(loadComputeProgram(device, shaderProgram, "test-shader-object-large", "computeMain", slangReflection));
 
     ComputePipelineDesc pipelineDesc = {};

--- a/tests/test-shader-object-resource-tracking.cpp
+++ b/tests/test-shader-object-resource-tracking.cpp
@@ -6,7 +6,7 @@ using namespace rhi::testing;
 GPU_TEST_CASE("shader-object-resource-tracking", ALL & ~CPU)
 {
     ComPtr<IShaderProgram> shaderProgram;
-    slang::ProgramLayout* slangReflection;
+    slang::ProgramLayout* slangReflection = nullptr;
     REQUIRE_CALL(loadComputeProgram(
         device,
         shaderProgram,

--- a/tests/test-surface.cpp
+++ b/tests/test-surface.cpp
@@ -48,13 +48,13 @@ struct SurfaceTest
     virtual void initResources() = 0;
     virtual void renderFrame(ITexture* texture, uint32_t width, uint32_t height, uint32_t frameIndex) = 0;
 
-    void init(IDevice* device)
+    void init(IDevice* device_)
     {
         glfwWindowHint(GLFW_CLIENT_API, GLFW_NO_API);
 
         this->window = glfwCreateWindow(512, 512, "test-surface", nullptr, nullptr);
 
-        this->device = device;
+        this->device = device_;
         this->queue = device->getQueue(QueueType::Graphics);
         REQUIRE(this->queue);
         this->surface = device->createSurface(getWindowHandleFromGLFW(window));
@@ -152,7 +152,7 @@ struct RenderSurfaceTest : SurfaceTest
         REQUIRE(vertexBuffer);
 
         ComPtr<IShaderProgram> shaderProgram;
-        slang::ProgramLayout* slangReflection;
+        slang::ProgramLayout* slangReflection = nullptr;
         REQUIRE_CALL(loadGraphicsProgram(
             device,
             shaderProgram,
@@ -190,7 +190,7 @@ struct RenderSurfaceTest : SurfaceTest
         renderPass.colorAttachmentCount = 1;
 
         auto passEncoder = commandEncoder->beginRenderPass(renderPass);
-        auto rootObject = passEncoder->bindPipeline(pipeline);
+        passEncoder->bindPipeline(pipeline);
 
         RenderState renderState = {};
         renderState.viewports[0] = Viewport::fromSize(width, height);
@@ -236,7 +236,7 @@ struct ComputeSurfaceTest : SurfaceTest
     void initResources() override
     {
         ComPtr<IShaderProgram> shaderProgram;
-        slang::ProgramLayout* slangReflection;
+        slang::ProgramLayout* slangReflection = nullptr;
         REQUIRE_CALL(loadComputeProgram(device, shaderProgram, "test-surface-compute", "computeMain", slangReflection));
 
         ComputePipelineDesc pipelineDesc = {};

--- a/tests/test-texture-shared.cpp
+++ b/tests/test-texture-shared.cpp
@@ -12,7 +12,7 @@ static void setUpAndRunShader(
 )
 {
     ComPtr<IShaderProgram> shaderProgram;
-    slang::ProgramLayout* slangReflection;
+    slang::ProgramLayout* slangReflection = nullptr;
     REQUIRE_CALL(loadComputeProgram(device, shaderProgram, "trivial-copy", entryPoint, slangReflection));
 
     ComputePipelineDesc pipelineDesc = {};

--- a/tests/test-texture-types.cpp
+++ b/tests/test-texture-types.cpp
@@ -27,10 +27,10 @@ struct TextureTest
 
     const void* expectedTextureData;
 
-    void init(IDevice* device, Format format, RefPtr<ValidationTextureFormatBase> validationFormat, TextureType type)
+    void init(IDevice* device_, Format format, RefPtr<ValidationTextureFormatBase> validationFormat_, TextureType type)
     {
-        this->device = device;
-        this->validationFormat = validationFormat;
+        this->device = device_;
+        this->validationFormat = validationFormat_;
 
         this->textureInfo = new TextureInfo();
         this->textureInfo->format = format;
@@ -44,15 +44,15 @@ struct TextureAccessTest : TextureTest
     bool readWrite;
 
     void init(
-        IDevice* device,
+        IDevice* device_,
         Format format,
-        RefPtr<ValidationTextureFormatBase> validationFormat,
+        RefPtr<ValidationTextureFormatBase> validationFormat_,
         TextureType type,
-        bool readWrite
+        bool readWrite_
     )
     {
-        TextureTest::init(device, format, validationFormat, type);
-        this->readWrite = readWrite;
+        TextureTest::init(device_, format, validationFormat_, type);
+        this->readWrite = readWrite_;
     }
 
     std::string getShaderEntryPoint()
@@ -75,6 +75,8 @@ struct TextureAccessTest : TextureTest
         case TextureType::TextureCube:
             name += "Cube";
             break;
+        default:
+            FAIL("Unsupported texture type");
         }
 
         return name;
@@ -114,7 +116,7 @@ struct TextureAccessTest : TextureTest
     void submitShaderWork(const char* entryPoint)
     {
         ComPtr<IShaderProgram> shaderProgram;
-        slang::ProgramLayout* slangReflection;
+        slang::ProgramLayout* slangReflection = nullptr;
         REQUIRE_CALL(loadComputeProgram(device, shaderProgram, "test-texture-types", entryPoint, slangReflection));
 
         ComputePipelineDesc pipelineDesc = {};
@@ -332,7 +334,7 @@ struct RenderTargetTests : TextureTest
         REQUIRE(inputLayout != nullptr);
 
         ComPtr<IShaderProgram> shaderProgram;
-        slang::ProgramLayout* slangReflection;
+        slang::ProgramLayout* slangReflection = nullptr;
         REQUIRE_CALL(loadGraphicsProgram(
             device,
             shaderProgram,

--- a/tests/test-texture-view-3d.cpp
+++ b/tests/test-texture-view-3d.cpp
@@ -25,7 +25,7 @@ struct TestTextureViews
     ComPtr<IDevice> device;
     std::map<std::string, ComPtr<IComputePipeline>> cachedPipelines;
 
-    void init(IDevice* device) { this->device = device; }
+    void init(IDevice* device_) { this->device = device_; }
 
     ComPtr<IBuffer> createResultBuffer(int size)
     {
@@ -108,7 +108,7 @@ struct TestTextureViews
         if (!pipeline)
         {
             ComPtr<IShaderProgram> shaderProgram;
-            slang::ProgramLayout* slangReflection;
+            slang::ProgramLayout* slangReflection = nullptr;
             REQUIRE_CALL(loadComputeProgram(
                 device,
                 shaderProgram,

--- a/tests/test-texture-view.cpp
+++ b/tests/test-texture-view.cpp
@@ -30,6 +30,7 @@ inline std::string getTextureType(TextureType type)
     default:
         FAIL("Unknown texture type");
     }
+    return "";
 };
 
 inline std::string getRWTextureType(TextureType type)
@@ -53,10 +54,10 @@ inline std::string getRWTextureType(TextureType type)
     case TextureType::TextureCube:
     case TextureType::TextureCubeArray:
         FAIL("Unsupported texture type");
-        return "";
     default:
         FAIL("Unknown texture type");
     }
+    return "";
 };
 
 inline std::string getFormatType(Format format)

--- a/tests/test-uint16-structured-buffer.cpp
+++ b/tests/test-uint16-structured-buffer.cpp
@@ -8,7 +8,7 @@ using namespace rhi::testing;
 GPU_TEST_CASE("uint16-structured-buffer", D3D12 | Vulkan | Metal | CPU | CUDA)
 {
     ComPtr<IShaderProgram> shaderProgram;
-    slang::ProgramLayout* slangReflection;
+    slang::ProgramLayout* slangReflection = nullptr;
     REQUIRE_CALL(loadComputeProgram(device, shaderProgram, "test-uint16-buffer", "computeMain", slangReflection));
 
     ComputePipelineDesc pipelineDesc = {};

--- a/tests/testing.cpp
+++ b/tests/testing.cpp
@@ -831,7 +831,7 @@ slang::IGlobalSession* getSlangGlobalSession()
 {
     static slang::IGlobalSession* slangGlobalSession = []()
     {
-        slang::IGlobalSession* session;
+        slang::IGlobalSession* session = nullptr;
         REQUIRE_CALL(slang::createGlobalSession(&session));
         return session;
     }();

--- a/tests/texture-test.cpp
+++ b/tests/texture-test.cpp
@@ -1262,28 +1262,28 @@ void TextureTestOptions::applyTextureSize(int state, TextureTestVariant variant)
         // Make adjustments for power of 2 sizes. We need to increment dimensions
         // that aren't only 1 pixel wide until they're a non-power of 2 multiple
         // of the block size.
-        for (auto& testTexture : variant.descriptors)
+        for (auto& testDescA : variant.descriptors)
         {
-            const FormatInfo& info = getFormatInfo(testTexture.desc.format);
+            const FormatInfo& info = getFormatInfo(testDescA.desc.format);
             if (!info.supportsNonPowerOf2)
                 return;
 
-            for (auto& testTexture : variant.descriptors)
+            for (auto& testDescB : variant.descriptors)
             {
-                if (testTexture.desc.size.width > 1)
+                if (testDescB.desc.size.width > 1)
                 {
-                    while (math::isPowerOf2(testTexture.desc.size.width))
-                        testTexture.desc.size.width += info.blockWidth;
+                    while (math::isPowerOf2(testDescB.desc.size.width))
+                        testDescB.desc.size.width += info.blockWidth;
                 }
-                if (testTexture.desc.size.height > 1)
+                if (testDescB.desc.size.height > 1)
                 {
-                    while (math::isPowerOf2(testTexture.desc.size.height))
-                        testTexture.desc.size.height += info.blockHeight;
+                    while (math::isPowerOf2(testDescB.desc.size.height))
+                        testDescB.desc.size.height += info.blockHeight;
                 }
-                if (testTexture.desc.size.depth > 1)
+                if (testDescB.desc.size.depth > 1)
                 {
-                    while (math::isPowerOf2(testTexture.desc.size.depth))
-                        testTexture.desc.size.depth++;
+                    while (math::isPowerOf2(testDescB.desc.size.depth))
+                        testDescB.desc.size.depth++;
                 }
             }
         }


### PR DESCRIPTION
- add `slang-rhi-warnings` and `slang-rhi-warnings-as-errors` targets to make it easy to share with slang-rhi-tests
- fix a whole bunch of warnings in tests