### PR TITLE
Add linear swept sphere tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -788,6 +788,7 @@ if(SLANG_RHI_BUILD_TESTS)
         # tests/test-precompiled-module-cache.cpp
         tests/test-precompiled-module.cpp
         tests/test-ray-tracing.cpp
+        tests/test-ray-tracing-lss.cpp
         tests/test-ray-tracing-sphere.cpp
         tests/test-resolve-resource-tests.cpp
         tests/test-resource-states.cpp

--- a/include/slang-rhi.h
+++ b/include/slang-rhi.h
@@ -1793,6 +1793,7 @@ enum class RayTracingPipelineFlags
     SkipTriangles = (1 << 0),
     SkipProcedurals = (1 << 1),
     EnableSpheres = (1 << 2),
+    EnableLinearSweptSpheres = (1 << 3),
 };
 SLANG_RHI_ENUM_CLASS_OPERATORS(RayTracingPipelineFlags);
 

--- a/src/cuda/cuda-acceleration-structure.cpp
+++ b/src/cuda/cuda-acceleration-structure.cpp
@@ -196,7 +196,49 @@ Result AccelerationStructureBuildDescConverter::convert(
     }
     case AccelerationStructureBuildInputType::LinearSweptSpheres:
     {
-        return SLANG_E_NOT_AVAILABLE;
+        for (uint32_t i = 0; i < buildDesc.inputCount; ++i)
+        {
+            const AccelerationStructureBuildInputLinearSweptSpheres& linearSweptSpheres =
+                buildDesc.inputs[i].linearSweptSpheres;
+            if (linearSweptSpheres.vertexBufferCount != 1)
+            {
+                return SLANG_E_INVALID_ARG;
+            }
+            if (linearSweptSpheres.vertexPositionFormat != Format::RGB32Float)
+            {
+                return SLANG_E_INVALID_ARG;
+            }
+            if (linearSweptSpheres.vertexRadiusFormat != Format::R32Float)
+            {
+                return SLANG_E_INVALID_ARG;
+            }
+            if (!linearSweptSpheres.indexBuffer)
+            {
+                return SLANG_E_INVALID_ARG;
+            }
+
+            OptixBuildInput& buildInput = buildInputs[i];
+            buildInput = {};
+            buildInput.type = OPTIX_BUILD_INPUT_TYPE_CURVES;
+            buildInput.curveArray.curveType = OPTIX_PRIMITIVE_TYPE_ROUND_LINEAR;
+            buildInput.curveArray.numPrimitives = linearSweptSpheres.primitiveCount;
+
+            pointerList.push_back(linearSweptSpheres.vertexPositionBuffers[0].getDeviceAddress());
+            buildInput.curveArray.numVertices = linearSweptSpheres.vertexCount;
+            buildInput.curveArray.vertexBuffers = &pointerList.back();
+            buildInput.curveArray.vertexStrideInBytes = linearSweptSpheres.vertexPositionStride;
+
+            pointerList.push_back(linearSweptSpheres.vertexRadiusBuffers[0].getDeviceAddress());
+            buildInput.curveArray.widthBuffers = &pointerList.back();
+            buildInput.curveArray.widthStrideInBytes = linearSweptSpheres.vertexRadiusStride;
+
+            buildInput.curveArray.indexBuffer = linearSweptSpheres.indexBuffer.getDeviceAddress();
+
+            buildInput.curveArray.flag = translateGeometryFlags(linearSweptSpheres.flags);
+
+            // TODO: Add support for end caps
+        }
+        break;
     }
     default:
         return SLANG_E_INVALID_ARG;

--- a/src/cuda/cuda-acceleration-structure.cpp
+++ b/src/cuda/cuda-acceleration-structure.cpp
@@ -216,6 +216,10 @@ Result AccelerationStructureBuildDescConverter::convert(
             {
                 return SLANG_E_INVALID_ARG;
             }
+            if (linearSweptSpheres.endCapsMode == LinearSweptSpheresEndCapsMode::None)
+            {
+                return SLANG_E_INVALID_ARG;
+            }
 
             OptixBuildInput& buildInput = buildInputs[i];
             buildInput = {};
@@ -236,10 +240,9 @@ Result AccelerationStructureBuildDescConverter::convert(
 
             buildInput.curveArray.flag = translateGeometryFlags(linearSweptSpheres.flags);
 
-            // TODO: Add support for end caps
+            }
         }
         break;
-    }
     default:
         return SLANG_E_INVALID_ARG;
     }

--- a/src/cuda/cuda-acceleration-structure.cpp
+++ b/src/cuda/cuda-acceleration-structure.cpp
@@ -239,10 +239,9 @@ Result AccelerationStructureBuildDescConverter::convert(
             buildInput.curveArray.indexBuffer = linearSweptSpheres.indexBuffer.getDeviceAddress();
 
             buildInput.curveArray.flag = translateGeometryFlags(linearSweptSpheres.flags);
-
-            }
         }
-        break;
+    }
+    break;
     default:
         return SLANG_E_INVALID_ARG;
     }

--- a/src/cuda/cuda-device.cpp
+++ b/src/cuda/cuda-device.cpp
@@ -327,6 +327,7 @@ Result DeviceImpl::initialize(const DeviceDesc& desc)
 
             addFeature(Feature::AccelerationStructure);
             addFeature(Feature::AccelerationStructureSpheres);
+            addFeature(Feature::AccelerationStructureLinearSweptSpheres);
             addFeature(Feature::RayTracing);
             addCapability(Capability::_raygen);
             addCapability(Capability::_intersection);

--- a/src/cuda/cuda-pipeline.cpp
+++ b/src/cuda/cuda-pipeline.cpp
@@ -283,7 +283,8 @@ Result DeviceImpl::createRayTracingPipeline2(const RayTracingPipelineDesc& desc,
         {
             if (std::strcmp(hitGroupDesc.intersectionEntryPoint, "__builtin_intersection__sphere") == 0)
                 optixProgramGroupDesc.hitgroup.moduleIS = builtinISModuleSphere;
-            else if (std::strcmp(hitGroupDesc.intersectionEntryPoint, "__builtin_intersection__linear_swept_spheres") == 0)
+            else if (std::strcmp(hitGroupDesc.intersectionEntryPoint, "__builtin_intersection__linear_swept_spheres") ==
+                     0)
                 optixProgramGroupDesc.hitgroup.moduleIS = builtinISModuleLinearSweptSpheres;
             else
             {

--- a/src/debug-layer/debug-helper-functions.cpp
+++ b/src/debug-layer/debug-helper-functions.cpp
@@ -289,7 +289,50 @@ void validateAccelerationStructureBuildDesc(DebugContext* ctx, const Acceleratio
         {
             const AccelerationStructureBuildInputLinearSweptSpheres& linearSweptSpheres =
                 buildDesc.inputs[i].linearSweptSpheres;
-            SLANG_UNUSED(linearSweptSpheres);
+
+            switch (linearSweptSpheres.vertexPositionFormat)
+            {
+            case Format::RGB32Float:
+                break;
+            default:
+                RHI_VALIDATION_ERROR("Unsupported vertexPositionFormat. Valid values are RGB32Float.");
+            }
+
+            switch (linearSweptSpheres.vertexRadiusFormat)
+            {
+            case Format::R32Float:
+                break;
+            default:
+                RHI_VALIDATION_ERROR("Unsupported vertexRadiusFormat. Valid values are R32Float.");
+            }
+
+            if (!linearSweptSpheres.indexBuffer)
+            {
+                RHI_VALIDATION_ERROR("indexBuffer cannot be null.");
+            }
+
+            if (linearSweptSpheres.indexFormat != IndexFormat::Uint32)
+            {
+                RHI_VALIDATION_ERROR("indexFormat must be Uint32.");
+            }
+
+            if (linearSweptSpheres.indexCount != linearSweptSpheres.primitiveCount)
+            {
+                RHI_VALIDATION_ERROR("indexCount must be equal to primitiveCount.");
+            }
+
+            if (linearSweptSpheres.vertexBufferCount < 1)
+            {
+                RHI_VALIDATION_ERROR("vertexBufferCount cannot be <= 1.");
+            }
+            for (uint32_t j = 0; j < linearSweptSpheres.vertexBufferCount; ++j)
+            {
+                if (!linearSweptSpheres.vertexPositionBuffers[j].buffer)
+                {
+                    RHI_VALIDATION_ERROR("vertexBuffers cannot be null.");
+                }
+            }
+
             break;
         }
         default:

--- a/src/debug-layer/debug-helper-functions.cpp
+++ b/src/debug-layer/debug-helper-functions.cpp
@@ -333,6 +333,14 @@ void validateAccelerationStructureBuildDesc(DebugContext* ctx, const Acceleratio
                 }
             }
 
+            if (ctx->deviceType == DeviceType::CUDA)
+            {
+                if (linearSweptSpheres.endCapsMode == LinearSweptSpheresEndCapsMode::None)
+                {
+                    RHI_VALIDATION_ERROR("OptiX requires endCapsMode to be Chained.");
+                }
+            }
+
             break;
         }
         default:

--- a/tests/test-ray-tracing-lss.cpp
+++ b/tests/test-ray-tracing-lss.cpp
@@ -120,6 +120,7 @@ struct RayTracingLssTestBase
             buildInput.linearSweptSpheres.indexFormat = IndexFormat::Uint32;
             buildInput.linearSweptSpheres.indexCount = primitiveCount;
             buildInput.linearSweptSpheres.flags = AccelerationStructureGeometryFlags::Opaque;
+            buildInput.linearSweptSpheres.endCapsMode = LinearSweptSpheresEndCapsMode::Chained;
 
             AccelerationStructureBuildDesc buildDesc = {};
             buildDesc.inputs = &buildInput;

--- a/tests/test-ray-tracing-lss.cpp
+++ b/tests/test-ray-tracing-lss.cpp
@@ -1,0 +1,500 @@
+#include "testing.h"
+#include "texture-utils.h"
+
+#include <slang-rhi/acceleration-structure-utils.h>
+
+using namespace rhi;
+using namespace rhi::testing;
+
+struct float3
+{
+    float x, y, z;
+};
+
+struct RayTracingLssTestBase
+{
+    IDevice* device;
+
+    ComPtr<ICommandQueue> queue;
+
+    ComPtr<IRayTracingPipeline> raytracingPipeline;
+    ComPtr<IBuffer> positionBuffer;
+    ComPtr<IBuffer> radiusBuffer;
+    ComPtr<IBuffer> indexBuffer;
+    ComPtr<IBuffer> transformBuffer;
+    ComPtr<IBuffer> instanceBuffer;
+    ComPtr<IBuffer> BLASBuffer;
+    ComPtr<IAccelerationStructure> BLAS;
+    ComPtr<IBuffer> TLASBuffer;
+    ComPtr<IAccelerationStructure> TLAS;
+    ComPtr<IShaderTable> shaderTable;
+
+    void init(IDevice* device_) { this->device = device_; }
+
+    // Load and compile shader code from source.
+    Result loadShaderProgram(span<const char*> entryPointNames, IShaderProgram** outProgram)
+    {
+        ComPtr<slang::ISession> slangSession;
+        slangSession = device->getSlangSession();
+
+        ComPtr<slang::IBlob> diagnosticsBlob;
+        slang::IModule* module = slangSession->loadModule("test-ray-tracing-lss", diagnosticsBlob.writeRef());
+        diagnoseIfNeeded(diagnosticsBlob);
+        if (!module)
+            return SLANG_FAIL;
+
+        std::vector<slang::IComponentType*> componentTypes;
+        componentTypes.push_back(module);
+
+        ComPtr<slang::IEntryPoint> entryPoint;
+        for (const char* entryPointName : entryPointNames)
+        {
+            SLANG_RETURN_ON_FAIL(module->findEntryPointByName(entryPointName, entryPoint.writeRef()));
+            componentTypes.push_back(entryPoint);
+        }
+
+        ComPtr<slang::IComponentType> linkedProgram;
+        Result result = slangSession->createCompositeComponentType(
+            componentTypes.data(),
+            componentTypes.size(),
+            linkedProgram.writeRef(),
+            diagnosticsBlob.writeRef()
+        );
+        SLANG_RETURN_ON_FAIL(result);
+
+        ShaderProgramDesc programDesc = {};
+        programDesc.slangGlobalScope = linkedProgram;
+        SLANG_RETURN_ON_FAIL(device->createShaderProgram(programDesc, outProgram));
+
+        return SLANG_OK;
+    }
+
+    void createRequiredResources(
+        unsigned primitiveCount,
+        unsigned segmentCount,
+        const float3* positions,
+        const float* radii,
+        const unsigned* indices,
+        const char* raygenName,
+        const char* closestHitName,
+        const char* missName
+    )
+    {
+        queue = device->getQueue(QueueType::Graphics);
+
+        BufferDesc positionBufferDesc;
+        positionBufferDesc.size = segmentCount * sizeof(float3);
+        positionBufferDesc.usage = BufferUsage::AccelerationStructureBuildInput;
+        positionBufferDesc.defaultState = ResourceState::AccelerationStructureBuildInput;
+        positionBuffer = device->createBuffer(positionBufferDesc, positions);
+        REQUIRE(positionBuffer != nullptr);
+
+        BufferDesc radiusBufferDesc;
+        radiusBufferDesc.size = segmentCount * sizeof(float);
+        radiusBufferDesc.usage = BufferUsage::AccelerationStructureBuildInput;
+        radiusBufferDesc.defaultState = ResourceState::AccelerationStructureBuildInput;
+        radiusBuffer = device->createBuffer(radiusBufferDesc, radii);
+        REQUIRE(radiusBuffer != nullptr);
+
+        BufferDesc indexBufferDesc;
+        indexBufferDesc.size = primitiveCount * sizeof(unsigned);
+        indexBufferDesc.usage = BufferUsage::AccelerationStructureBuildInput;
+        indexBufferDesc.defaultState = ResourceState::AccelerationStructureBuildInput;
+        indexBuffer = device->createBuffer(indexBufferDesc, indices);
+        REQUIRE(indexBuffer != nullptr);
+
+        // Build bottom level acceleration structure.
+        {
+            AccelerationStructureBuildInput buildInput = {};
+            buildInput.type = AccelerationStructureBuildInputType::LinearSweptSpheres;
+            buildInput.linearSweptSpheres.primitiveCount = primitiveCount;
+            buildInput.linearSweptSpheres.vertexBufferCount = 1;
+            buildInput.linearSweptSpheres.vertexCount = segmentCount;
+            buildInput.linearSweptSpheres.vertexPositionBuffers[0] = positionBuffer;
+            buildInput.linearSweptSpheres.vertexPositionFormat = Format::RGB32Float;
+            buildInput.linearSweptSpheres.vertexPositionStride = sizeof(float3);
+            buildInput.linearSweptSpheres.vertexRadiusBuffers[0] = radiusBuffer;
+            buildInput.linearSweptSpheres.vertexRadiusFormat = Format::R32Float;
+            buildInput.linearSweptSpheres.vertexRadiusStride = sizeof(float);
+            buildInput.linearSweptSpheres.indexBuffer = indexBuffer;
+            buildInput.linearSweptSpheres.indexFormat = IndexFormat::Uint32;
+            buildInput.linearSweptSpheres.indexCount = primitiveCount;
+            buildInput.linearSweptSpheres.flags = AccelerationStructureGeometryFlags::Opaque;
+
+            AccelerationStructureBuildDesc buildDesc = {};
+            buildDesc.inputs = &buildInput;
+            buildDesc.inputCount = 1;
+            buildDesc.flags = AccelerationStructureBuildFlags::AllowCompaction;
+
+            // Query buffer size for acceleration structure build.
+            AccelerationStructureSizes sizes;
+            REQUIRE_CALL(device->getAccelerationStructureSizes(buildDesc, &sizes));
+
+            // Allocate buffers for acceleration structure.
+            BufferDesc scratchBufferDesc;
+            scratchBufferDesc.usage = BufferUsage::UnorderedAccess;
+            scratchBufferDesc.defaultState = ResourceState::UnorderedAccess;
+            scratchBufferDesc.size = sizes.scratchSize;
+            ComPtr<IBuffer> scratchBuffer = device->createBuffer(scratchBufferDesc);
+
+            // Build acceleration structure.
+            ComPtr<IQueryPool> compactedSizeQuery;
+            QueryPoolDesc queryPoolDesc;
+            queryPoolDesc.count = 1;
+            queryPoolDesc.type = QueryType::AccelerationStructureCompactedSize;
+            REQUIRE_CALL(device->createQueryPool(queryPoolDesc, compactedSizeQuery.writeRef()));
+
+            ComPtr<IAccelerationStructure> draftAS;
+            AccelerationStructureDesc draftCreateDesc;
+            draftCreateDesc.size = sizes.accelerationStructureSize;
+            REQUIRE_CALL(device->createAccelerationStructure(draftCreateDesc, draftAS.writeRef()));
+
+            compactedSizeQuery->reset();
+
+            auto commandEncoder = queue->createCommandEncoder();
+            AccelerationStructureQueryDesc compactedSizeQueryDesc = {};
+            compactedSizeQueryDesc.queryPool = compactedSizeQuery;
+            compactedSizeQueryDesc.queryType = QueryType::AccelerationStructureCompactedSize;
+            commandEncoder
+                ->buildAccelerationStructure(buildDesc, draftAS, nullptr, scratchBuffer, 1, &compactedSizeQueryDesc);
+            queue->submit(commandEncoder->finish());
+            queue->waitOnHost();
+
+            uint64_t compactedSize = 0;
+            compactedSizeQuery->getResult(0, 1, &compactedSize);
+            AccelerationStructureDesc createDesc;
+            createDesc.size = compactedSize;
+            device->createAccelerationStructure(createDesc, BLAS.writeRef());
+
+            commandEncoder = queue->createCommandEncoder();
+            commandEncoder->copyAccelerationStructure(BLAS, draftAS, AccelerationStructureCopyMode::Compact);
+            queue->submit(commandEncoder->finish());
+            queue->waitOnHost();
+        }
+
+        // Build top level acceleration structure.
+        {
+            AccelerationStructureInstanceDescType nativeInstanceDescType =
+                getAccelerationStructureInstanceDescType(device);
+            Size nativeInstanceDescSize = getAccelerationStructureInstanceDescSize(nativeInstanceDescType);
+
+            std::vector<AccelerationStructureInstanceDescGeneric> genericInstanceDescs;
+            genericInstanceDescs.resize(1);
+            float transformMatrix[] = {1.0f, 0.0f, 0.0f, 0.0f, 0.0f, 1.0f, 0.0f, 0.0f, 0.0f, 0.0f, 1.0f, 0.0f};
+            memcpy(&genericInstanceDescs[0].transform[0][0], transformMatrix, sizeof(float) * 12);
+            genericInstanceDescs[0].instanceID = 0;
+            genericInstanceDescs[0].instanceMask = 0xFF;
+            genericInstanceDescs[0].instanceContributionToHitGroupIndex = 0;
+            genericInstanceDescs[0].accelerationStructure = BLAS->getHandle();
+
+            std::vector<uint8_t> nativeInstanceDescs(genericInstanceDescs.size() * nativeInstanceDescSize);
+            convertAccelerationStructureInstanceDescs(
+                genericInstanceDescs.size(),
+                nativeInstanceDescType,
+                nativeInstanceDescs.data(),
+                nativeInstanceDescSize,
+                genericInstanceDescs.data(),
+                sizeof(AccelerationStructureInstanceDescGeneric)
+            );
+
+            BufferDesc instanceBufferDesc;
+            instanceBufferDesc.size = nativeInstanceDescs.size();
+            instanceBufferDesc.usage = BufferUsage::ShaderResource;
+            instanceBufferDesc.defaultState = ResourceState::ShaderResource;
+            instanceBuffer = device->createBuffer(instanceBufferDesc, nativeInstanceDescs.data());
+            REQUIRE(instanceBuffer != nullptr);
+
+            AccelerationStructureBuildInput buildInput = {};
+            buildInput.type = AccelerationStructureBuildInputType::Instances;
+            buildInput.instances.instanceBuffer = instanceBuffer;
+            buildInput.instances.instanceCount = 1;
+            buildInput.instances.instanceStride = nativeInstanceDescSize;
+            AccelerationStructureBuildDesc buildDesc = {};
+            buildDesc.inputs = &buildInput;
+            buildDesc.inputCount = 1;
+
+            // Query buffer size for acceleration structure build.
+            AccelerationStructureSizes sizes;
+            REQUIRE_CALL(device->getAccelerationStructureSizes(buildDesc, &sizes));
+
+            BufferDesc scratchBufferDesc;
+            scratchBufferDesc.usage = BufferUsage::UnorderedAccess;
+            scratchBufferDesc.defaultState = ResourceState::UnorderedAccess;
+            scratchBufferDesc.size = sizes.scratchSize;
+            ComPtr<IBuffer> scratchBuffer = device->createBuffer(scratchBufferDesc);
+
+            AccelerationStructureDesc createDesc;
+            createDesc.size = sizes.accelerationStructureSize;
+            REQUIRE_CALL(device->createAccelerationStructure(createDesc, TLAS.writeRef()));
+
+            auto commandEncoder = queue->createCommandEncoder();
+            commandEncoder->buildAccelerationStructure(buildDesc, TLAS, nullptr, scratchBuffer, 0, nullptr);
+            queue->submit(commandEncoder->finish());
+            queue->waitOnHost();
+        }
+
+        const char* hitgroupNames[] = {"hitgroup"};
+
+        const char* entryPointNames[] = {raygenName, missName, closestHitName};
+
+        ComPtr<IShaderProgram> rayTracingProgram;
+        REQUIRE_CALL(loadShaderProgram(entryPointNames, rayTracingProgram.writeRef()));
+
+        HitGroupDesc hitGroups[1];
+        hitGroups[0].hitGroupName = hitgroupNames[0];
+        hitGroups[0].closestHitEntryPoint = closestHitName;
+        hitGroups[0].intersectionEntryPoint = "__builtin_intersection__linear_swept_spheres";
+
+        RayTracingPipelineDesc rtpDesc = {};
+        rtpDesc.program = rayTracingProgram;
+        rtpDesc.hitGroupCount = 1;
+        rtpDesc.hitGroups = hitGroups;
+        rtpDesc.maxRayPayloadSize = 64;
+        rtpDesc.maxAttributeSizeInBytes = 8;
+        rtpDesc.maxRecursion = 2;
+        rtpDesc.flags = RayTracingPipelineFlags::EnableLinearSweptSpheres;
+        REQUIRE_CALL(device->createRayTracingPipeline(rtpDesc, raytracingPipeline.writeRef()));
+        REQUIRE(raytracingPipeline != nullptr);
+
+        ShaderTableDesc shaderTableDesc = {};
+        shaderTableDesc.program = rayTracingProgram;
+        shaderTableDesc.hitGroupCount = 1;
+        shaderTableDesc.hitGroupNames = hitgroupNames;
+        shaderTableDesc.rayGenShaderCount = 1;
+        shaderTableDesc.rayGenShaderEntryPointNames = &raygenName;
+        shaderTableDesc.missShaderCount = 1;
+        shaderTableDesc.missShaderEntryPointNames = &missName;
+        REQUIRE_CALL(device->createShaderTable(shaderTableDesc, shaderTable.writeRef()));
+    }
+};
+
+struct ExpectedPixel
+{
+    uint32_t pos[2];
+    float color[4];
+};
+
+#define EXPECTED_PIXEL(x, y, r, g, b, a)                                                                               \
+    {                                                                                                                  \
+        {x, y},                                                                                                        \
+        {                                                                                                              \
+            r, g, b, a                                                                                                 \
+        }                                                                                                              \
+    }
+
+// Test that the ray tracing pipeline can perform sphere intersection.
+struct RayTracingLssTest : public RayTracingLssTestBase
+{
+    static constexpr int kSegmentCount = 3;
+    static constexpr int kPrimitiveCount = 2;
+
+    static constexpr float3 kPositions[kSegmentCount] = {
+        {-0.5f, -0.5f, 3.0f},
+        {0.0, 0.5f, 3.0f},
+        {0.5f, -0.5f, 3.0f},
+    };
+
+    static constexpr float kRadii[kSegmentCount] = {0.2f, 0.2f, 0.2f};
+
+    static constexpr unsigned kIndices[kPrimitiveCount] = {0, 1};
+
+    ComPtr<ITexture> resultTexture;
+
+    uint32_t width = 128;
+    uint32_t height = 128;
+
+    void createResultTexture()
+    {
+        TextureDesc resultTextureDesc = {};
+        resultTextureDesc.type = TextureType::Texture2D;
+        resultTextureDesc.mipCount = 1;
+        resultTextureDesc.size.width = width;
+        resultTextureDesc.size.height = height;
+        resultTextureDesc.size.depth = 1;
+        resultTextureDesc.usage = TextureUsage::UnorderedAccess | TextureUsage::CopySource;
+        resultTextureDesc.defaultState = ResourceState::UnorderedAccess;
+        resultTextureDesc.format = Format::RGBA32Float;
+        resultTexture = device->createTexture(resultTextureDesc);
+    }
+
+    void checkTestResults(span<ExpectedPixel> expectedPixels)
+    {
+        ComPtr<ISlangBlob> resultBlob;
+        SubresourceLayout layout;
+        REQUIRE_CALL(device->readTexture(resultTexture, 0, 0, resultBlob.writeRef(), &layout));
+#if 1 // for debugging only
+        writeImage("test-ray-tracing-lss-intersection.hdr", resultBlob, width, height, layout.rowPitch, layout.colPitch);
+#endif
+
+        // for (const auto& ep : expectedPixels)
+        // {
+        //     uint32_t x = ep.pos[0];
+        //     uint32_t y = ep.pos[1];
+        //     const float* color = reinterpret_cast<const float*>(
+        //         static_cast<const uint8_t*>(resultBlob->getBufferPointer()) + y * layout.rowPitch + x * layout.colPitch
+        //     );
+        //     CAPTURE(x);
+        //     CAPTURE(y);
+        //     CHECK_EQ(color[0], ep.color[0]);
+        //     CHECK_EQ(color[1], ep.color[1]);
+        //     CHECK_EQ(color[2], ep.color[2]);
+        //     CHECK_EQ(color[3], ep.color[3]);
+        // }
+    }
+
+    void renderFrame()
+    {
+        auto commandEncoder = queue->createCommandEncoder();
+
+        auto passEncoder = commandEncoder->beginRayTracingPass();
+        auto rootObject = passEncoder->bindPipeline(raytracingPipeline, shaderTable);
+        auto cursor = ShaderCursor(rootObject);
+        uint32_t dims[2] = {width, height};
+        cursor["dims"].setData(dims, sizeof(dims));
+        cursor["resultTexture"].setBinding(resultTexture);
+        cursor["sceneBVH"].setBinding(TLAS);
+        passEncoder->dispatchRays(0, width, height, 1);
+        passEncoder->end();
+
+        queue->submit(commandEncoder->finish());
+        queue->waitOnHost();
+    }
+
+    void run()
+    {
+        createRequiredResources(
+            kPrimitiveCount,
+            kSegmentCount,
+            kPositions,
+            kRadii,
+            kIndices,
+            "rayGenShader",
+            "closestHitShader",
+            "missShader"
+        );
+
+        createResultTexture();
+        renderFrame();
+
+        ExpectedPixel expectedPixels[] = {
+            EXPECTED_PIXEL(32, 32, 1.f, 0.f, 0.f, 1.f), // Sphere 1
+            EXPECTED_PIXEL(96, 32, 0.f, 1.f, 0.f, 1.f), // Sphere 2
+            EXPECTED_PIXEL(64, 96, 0.f, 0.f, 1.f, 1.f), // Sphere 3
+
+            // Corners should all be misses
+            EXPECTED_PIXEL(0, 0, 1.f, 1.0f, 1.0f, 1.0f),     // Miss
+            EXPECTED_PIXEL(127, 0, 1.f, 1.0f, 1.0f, 1.0f),   // Miss
+            EXPECTED_PIXEL(127, 127, 1.f, 1.0f, 1.0f, 1.0f), // Miss
+            EXPECTED_PIXEL(0, 127, 1.f, 1.0f, 1.0f, 1.0f),   // Miss
+        };
+        checkTestResults(expectedPixels);
+    }
+};
+
+// GPU_TEST_CASE("ray-tracing-lss-intersection", ALL)
+GPU_TEST_CASE("ray-tracing-lss-intersection", CUDA)
+{
+    if (!device->hasFeature(Feature::RayTracing))
+        SKIP("ray tracing not supported");
+    if (!device->hasFeature(Feature::AccelerationStructureLinearSweptSpheres))
+        SKIP("acceleration structure linear swept spheres not supported");
+
+    RayTracingLssTest test;
+    test.init(device);
+    test.run();
+}
+
+#if 0
+
+struct TestResult
+{
+    int isSphereHit;
+    int pad[3];
+    float spherePositionAndRadius[4];
+};
+
+struct RayTracingSphereIntrinsicsTest : public RayTracingSphereTestBase
+{
+    static constexpr int kSphereCount = 1;
+
+    static constexpr float3 kPositions[kSphereCount] = {
+        {0.0f, 0.0f, -3.0f},
+    };
+
+    static constexpr float kRadii[kSphereCount] = {2.0f};
+
+    ComPtr<IBuffer> resultBuffer;
+
+    void createResultBuffer()
+    {
+        BufferDesc resultBufferDesc = {};
+        resultBufferDesc.size = sizeof(TestResult);
+        resultBufferDesc.elementSize = sizeof(TestResult);
+        resultBufferDesc.memoryType = MemoryType::DeviceLocal;
+        resultBufferDesc.usage = BufferUsage::UnorderedAccess | BufferUsage::CopySource;
+        resultBuffer = device->createBuffer(resultBufferDesc);
+        REQUIRE(resultBuffer != nullptr);
+    }
+
+    void checkTestResults()
+    {
+        ComPtr<ISlangBlob> resultBlob;
+        REQUIRE_CALL(device->readBuffer(resultBuffer, 0, sizeof(TestResult), resultBlob.writeRef()));
+
+        const TestResult* result = reinterpret_cast<const TestResult*>(resultBlob->getBufferPointer());
+        CHECK_EQ(result->isSphereHit, 1);
+        CHECK_EQ(result->spherePositionAndRadius[0], 0.0f);
+        CHECK_EQ(result->spherePositionAndRadius[1], 0.0f);
+        CHECK_EQ(result->spherePositionAndRadius[2], -3.0f);
+        CHECK_EQ(result->spherePositionAndRadius[3], 2.0f);
+    }
+
+    void renderFrame()
+    {
+        auto commandEncoder = queue->createCommandEncoder();
+
+        auto passEncoder = commandEncoder->beginRayTracingPass();
+        auto rootObject = passEncoder->bindPipeline(raytracingPipeline, shaderTable);
+        auto cursor = ShaderCursor(rootObject);
+        cursor["resultBuffer"].setBinding(resultBuffer);
+        cursor["sceneBVH"].setBinding(TLAS);
+        passEncoder->dispatchRays(0, 1, 1, 1);
+        passEncoder->end();
+
+        queue->submit(commandEncoder->finish());
+        queue->waitOnHost();
+    }
+
+    void run(const char* raygenName, const char* closestHitName)
+    {
+        createRequiredResources(kSphereCount, kPositions, kRadii, raygenName, closestHitName, "missNOP");
+        createResultBuffer();
+        renderFrame();
+        checkTestResults();
+    }
+};
+
+GPU_TEST_CASE("ray-tracing-sphere-intrinsics", ALL)
+{
+    if (!device->hasFeature(Feature::RayTracing))
+        SKIP("ray tracing not supported");
+    if (!device->hasFeature(Feature::AccelerationStructureSpheres))
+        SKIP("acceleration structure spheres not supported");
+
+    RayTracingSphereIntrinsicsTest test;
+    test.init(device);
+    test.run("rayGenSphereIntrinsics", "closestHitSphereIntrinsics");
+}
+
+GPU_TEST_CASE("ray-tracing-sphere-intrinsics-hit-object", ALL)
+{
+    if (!device->hasFeature(Feature::RayTracing))
+        SKIP("ray tracing not supported");
+    if (!device->hasFeature(Feature::AccelerationStructureSpheres))
+        SKIP("acceleration structure spheres not supported");
+
+    RayTracingSphereIntrinsicsTest test;
+    test.init(device);
+    test.run("rayGenSphereIntrinsicsHitObject", "closestHitNOP");
+}
+#endif

--- a/tests/test-ray-tracing-lss.cpp
+++ b/tests/test-ray-tracing-lss.cpp
@@ -428,7 +428,6 @@ struct RayTracingLssIntrinsicsTest : public RayTracingLssTestBase
     static constexpr unsigned kIndices[kPrimitiveCount] = {0};
 
 
-
     ComPtr<IBuffer> resultBuffer;
 
     void createResultBuffer()
@@ -486,7 +485,16 @@ struct RayTracingLssIntrinsicsTest : public RayTracingLssTestBase
 
     void run(const char* raygenName, const char* closestHitName)
     {
-        createRequiredResources(kPrimitiveCount, kVertexCount, kPositions, kRadii, kIndices, raygenName, closestHitName, "missNOP");
+        createRequiredResources(
+            kPrimitiveCount,
+            kVertexCount,
+            kPositions,
+            kRadii,
+            kIndices,
+            raygenName,
+            closestHitName,
+            "missNOP"
+        );
         createResultBuffer();
         renderFrame();
         checkTestResults();

--- a/tests/test-ray-tracing-lss.slang
+++ b/tests/test-ray-tracing-lss.slang
@@ -1,0 +1,127 @@
+// test-ray-tracing-lss.slang
+
+// NOP shaders
+
+[shader("miss")]
+void missNOP(inout RayPayload payload)
+{
+    // Nop
+}
+
+[shader("closesthit")]
+void closestHitNOP(inout RayPayload payload)
+{
+    // Nop
+}
+
+// Simple sphere intersection
+
+[raypayload]
+struct RayPayload
+{
+    float4 color : read(caller) : write(caller, closesthit, miss);
+};
+
+uniform uint2 dims;
+uniform RWTexture2D resultTexture;
+uniform RaytracingAccelerationStructure sceneBVH;
+
+[shader("raygeneration")]
+void rayGenShader()
+{
+    uint2 pixel = DispatchRaysIndex().xy;
+    if (any(pixel >= dims))
+        return;
+
+    float2 uv = float2(pixel) / float2(dims - 1);
+
+    // Trace the ray.
+    RayDesc ray;
+    ray.Origin = float3(uv * 2.0 - 1.0, 0.0);
+    ray.Direction = float3(0, 0, 1);
+    ray.TMin = 0.001;
+    ray.TMax = 10000.0;
+    RayPayload payload = { float4(0, 0, 0, 0) };
+    TraceRay(sceneBVH, RAY_FLAG_NONE, ~0, 0, 0, 0, ray, payload);
+
+    resultTexture[pixel] = payload.color;
+}
+
+[shader("miss")]
+void missShader(inout RayPayload payload)
+{
+    payload.color = float4(1, 1, 1, 1);
+}
+
+[shader("closesthit")]
+void closestHitShader(inout RayPayload payload)
+{
+    uint primitiveIndex = PrimitiveIndex();
+    float4 color = float4(0, 0, 0, 1);
+    color[primitiveIndex] = 1;
+    payload.color = color;
+}
+
+// Sphere intrinsics called from closest hit
+
+struct Result
+{
+    int isSphereHit;
+    float4 spherePositionAndRadius;
+};
+
+[raypayload]
+struct RayPayloadIntrinsics
+{
+    Result res : read(caller) : write(caller, closesthit);
+};
+
+uniform RWStructuredBuffer<Result> resultBuffer;
+
+// Assume a single pixel launch. Trace a ray directly toward the target sphere and write out the
+// results of calling the various sphere intrinsics.
+
+[shader("raygeneration")]
+void rayGenSphereIntrinsics()
+{
+    float3 spherePos = {0.0f, 0.0f, 1.0f};
+
+    // Trace the ray.
+    RayDesc ray;
+    ray.Origin = {0.0f, 0.0f, 0.0f};
+    ray.Direction = {0.0f, 0.0f, -1.0f};
+    ray.TMin = 0.001;
+    ray.TMax = 10000.0;
+    RayPayloadIntrinsics payload = { {} };
+    TraceRay(sceneBVH, RAY_FLAG_NONE, ~0, 0, 0, 0, ray, payload);
+
+    resultBuffer[0] = payload.res;
+}
+
+[shader("closesthit")]
+void closestHitSphereIntrinsics(inout RayPayloadIntrinsics payload)
+{
+    payload.res.isSphereHit = IsSphereHit();
+    payload.res.spherePositionAndRadius = GetSpherePositionAndRadius();
+}
+
+
+// Hit object sphere intrinsics called from raygen
+
+[shader("raygeneration")]
+void rayGenSphereIntrinsicsHitObject()
+{
+    float3 spherePos = {0.0f, 0.0f, 1.0f};
+
+    // Trace the ray.
+    RayDesc ray;
+    ray.Origin = {0.0f, 0.0f, 0.0f};
+    ray.Direction = {0.0f, 0.0f, -1.0f};
+    ray.TMin = 0.001;
+    ray.TMax = 10000.0;
+    RayPayload payload = { {} };
+    HitObject hit = HitObject.TraceRay(sceneBVH, RAY_FLAG_NONE, ~0, 0, 0, 0, ray, payload);
+
+    resultBuffer[0].isSphereHit = hit.IsSphereHit();
+    resultBuffer[0].spherePositionAndRadius = hit.GetSpherePositionAndRadius();
+}

--- a/tests/test-ray-tracing-lss.slang
+++ b/tests/test-ray-tracing-lss.slang
@@ -66,8 +66,8 @@ void closestHitShader(inout RayPayload payload)
 
 struct Result
 {
-    int isSphereHit;
-    float4 spherePositionAndRadius;
+    int isLssHit;
+    float2x4 lssPositionsAndRadii;
 };
 
 [raypayload]
@@ -82,10 +82,8 @@ uniform RWStructuredBuffer<Result> resultBuffer;
 // results of calling the various sphere intrinsics.
 
 [shader("raygeneration")]
-void rayGenSphereIntrinsics()
+void rayGenLssIntrinsics()
 {
-    float3 spherePos = {0.0f, 0.0f, 1.0f};
-
     // Trace the ray.
     RayDesc ray;
     ray.Origin = {0.0f, 0.0f, 0.0f};
@@ -99,20 +97,18 @@ void rayGenSphereIntrinsics()
 }
 
 [shader("closesthit")]
-void closestHitSphereIntrinsics(inout RayPayloadIntrinsics payload)
+void closestHitLssIntrinsics(inout RayPayloadIntrinsics payload)
 {
-    payload.res.isSphereHit = IsSphereHit();
-    payload.res.spherePositionAndRadius = GetSpherePositionAndRadius();
+    payload.res.isLssHit = IsLssHit();
+    payload.res.lssPositionsAndRadii = GetLssPositionsAndRadii();
 }
 
 
 // Hit object sphere intrinsics called from raygen
 
 [shader("raygeneration")]
-void rayGenSphereIntrinsicsHitObject()
+void rayGenLssIntrinsicsHitObject()
 {
-    float3 spherePos = {0.0f, 0.0f, 1.0f};
-
     // Trace the ray.
     RayDesc ray;
     ray.Origin = {0.0f, 0.0f, 0.0f};
@@ -122,6 +118,6 @@ void rayGenSphereIntrinsicsHitObject()
     RayPayload payload = { {} };
     HitObject hit = HitObject.TraceRay(sceneBVH, RAY_FLAG_NONE, ~0, 0, 0, 0, ray, payload);
 
-    resultBuffer[0].isSphereHit = hit.IsSphereHit();
-    resultBuffer[0].spherePositionAndRadius = hit.GetSpherePositionAndRadius();
+    resultBuffer[0].isLssHit = hit.IsLssHit();
+    resultBuffer[0].lssPositionsAndRadii = hit.GetLssPositionsAndRadii();
 }


### PR DESCRIPTION
Add tests that check that we can intersect with linear swept spheres and that the associated plain and hit object intrinsics work as expected.

Also add the plumbing necessary to use LSS with OptiX:
- Add the LSS feature to OptiX devices
- Add `EnableLinearSweptSpheres` flag to `RayTracingPipelineFlags`
- Update OptiX accel structure validation and conversion to handle LSS
- Add `__builtin_intersection__linear_swept_spheres` intersection program to OptiX pipelines and make it available when  `EnableLinearSweptSpheres` is set