### PR TITLE
Allow Surface to be unconfigured

### DIFF
--- a/examples/surface/example-surface.cpp
+++ b/examples/surface/example-surface.cpp
@@ -44,6 +44,9 @@ public:
 
     virtual void draw() override
     {
+        if (!surface->getConfig())
+            return;
+
         ComPtr<ITexture> texture;
         surface->acquireNextImage(texture.writeRef());
         if (!texture)

--- a/include/slang-rhi.h
+++ b/include/slang-rhi.h
@@ -2488,8 +2488,9 @@ class ISurface : public ISlangUnknown
 
 public:
     virtual SLANG_NO_THROW const SurfaceInfo& SLANG_MCALL getInfo() = 0;
-    virtual SLANG_NO_THROW const SurfaceConfig& SLANG_MCALL getConfig() = 0;
+    virtual SLANG_NO_THROW const SurfaceConfig* SLANG_MCALL getConfig() = 0;
     virtual SLANG_NO_THROW Result SLANG_MCALL configure(const SurfaceConfig& config) = 0;
+    virtual SLANG_NO_THROW Result SLANG_MCALL unconfigure() = 0;
     virtual SLANG_NO_THROW Result SLANG_MCALL acquireNextImage(ITexture** outTexture) = 0;
     virtual SLANG_NO_THROW Result SLANG_MCALL present() = 0;
 

--- a/src/d3d/d3d-surface.h
+++ b/src/d3d/d3d-surface.h
@@ -122,11 +122,27 @@ public:
         destroySwapchain();
         SLANG_RETURN_ON_FAIL(createSwapchain());
         m_configured = true;
+
+        return SLANG_OK;
+    }
+
+    virtual SLANG_NO_THROW Result SLANG_MCALL unconfigure() override
+    {
+        if (!m_configured)
+        {
+            return SLANG_OK;
+        }
+
+        m_configured = false;
+        destroySwapchain();
+
         return SLANG_OK;
     }
 
     virtual SLANG_NO_THROW Result SLANG_MCALL acquireNextImage(ITexture** outTexture) override
     {
+        *outTexture = nullptr;
+
         if (!m_configured)
         {
             return SLANG_FAIL;
@@ -165,7 +181,6 @@ public:
     DXGI_SWAP_EFFECT m_swapEffect;
     ComPtr<IDXGISwapChain2> m_swapChain;
     short_vector<RefPtr<Texture>> m_textures;
-    bool m_configured = false;
 };
 
 } // namespace rhi

--- a/src/d3d11/d3d11-surface.cpp
+++ b/src/d3d11/d3d11-surface.cpp
@@ -44,6 +44,11 @@ Result SurfaceImpl::configure(const SurfaceConfig& config)
     return D3DSurface::configure(config);
 }
 
+Result SurfaceImpl::unconfigure()
+{
+    return D3DSurface::unconfigure();
+}
+
 Result DeviceImpl::createSurface(WindowHandle windowHandle, ISurface** outSurface)
 {
     RefPtr<SurfaceImpl> surface = new SurfaceImpl();

--- a/src/d3d11/d3d11-surface.h
+++ b/src/d3d11/d3d11-surface.h
@@ -18,6 +18,7 @@ public:
     virtual IUnknown* getOwningDevice() override { return m_d3dDevice; }
 
     virtual SLANG_NO_THROW Result SLANG_MCALL configure(const SurfaceConfig& config) override;
+    virtual SLANG_NO_THROW Result SLANG_MCALL unconfigure() override;
 };
 
 } // namespace rhi::d3d11

--- a/src/d3d12/d3d12-surface.cpp
+++ b/src/d3d12/d3d12-surface.cpp
@@ -58,8 +58,18 @@ Result SurfaceImpl::configure(const SurfaceConfig& config)
     return D3DSurface::configure(config);
 }
 
+Result SurfaceImpl::unconfigure()
+{
+    return D3DSurface::unconfigure();
+}
+
 Result SurfaceImpl::acquireNextImage(ITexture** outTexture)
 {
+    if (!m_configured)
+    {
+        *outTexture = nullptr;
+        return SLANG_FAIL;
+    }
     auto result = (int)m_swapChain3->GetCurrentBackBufferIndex();
     WaitForSingleObject(m_frameEvents[result], INFINITE);
     ResetEvent(m_frameEvents[result]);
@@ -69,6 +79,10 @@ Result SurfaceImpl::acquireNextImage(ITexture** outTexture)
 
 Result SurfaceImpl::present()
 {
+    if (!m_configured)
+    {
+        return SLANG_FAIL;
+    }
     m_fence->SetEventOnCompletion(fenceValue, m_frameEvents[m_swapChain3->GetCurrentBackBufferIndex()]);
     SLANG_RETURN_ON_FAIL(D3DSurface::present());
     fenceValue++;

--- a/src/d3d12/d3d12-surface.h
+++ b/src/d3d12/d3d12-surface.h
@@ -23,6 +23,7 @@ public:
     virtual IUnknown* getOwningDevice() override { return m_queue; }
 
     virtual SLANG_NO_THROW Result SLANG_MCALL configure(const SurfaceConfig& config) override;
+    virtual SLANG_NO_THROW Result SLANG_MCALL unconfigure() override;
     virtual SLANG_NO_THROW Result SLANG_MCALL acquireNextImage(ITexture** outTexture) override;
     virtual SLANG_NO_THROW Result SLANG_MCALL present() override;
 };

--- a/src/debug-layer/debug-surface.cpp
+++ b/src/debug-layer/debug-surface.cpp
@@ -10,7 +10,7 @@ const SurfaceInfo& DebugSurface::getInfo()
     return baseObject->getInfo();
 }
 
-const SurfaceConfig& DebugSurface::getConfig()
+const SurfaceConfig* DebugSurface::getConfig()
 {
     SLANG_RHI_API_FUNC;
 
@@ -57,6 +57,23 @@ Result DebugSurface::configure(const SurfaceConfig& config)
     {
         m_configured = true;
         m_state = State::Initial;
+    }
+
+    return result;
+}
+
+Result DebugSurface::unconfigure()
+{
+    if (!m_configured)
+    {
+        RHI_VALIDATION_WARNING("Surface is not configured.");
+    }
+
+    Result result = baseObject->unconfigure();
+
+    if (SLANG_SUCCEEDED(result))
+    {
+        m_configured = false;
     }
 
     return result;

--- a/src/debug-layer/debug-surface.h
+++ b/src/debug-layer/debug-surface.h
@@ -26,8 +26,9 @@ public:
     State m_state = State::Initial;
 
     virtual SLANG_NO_THROW const SurfaceInfo& SLANG_MCALL getInfo() override;
-    virtual SLANG_NO_THROW const SurfaceConfig& SLANG_MCALL getConfig() override;
+    virtual SLANG_NO_THROW const SurfaceConfig* SLANG_MCALL getConfig() override;
     virtual SLANG_NO_THROW Result SLANG_MCALL configure(const SurfaceConfig& config) override;
+    virtual SLANG_NO_THROW Result SLANG_MCALL unconfigure() override;
     virtual SLANG_NO_THROW Result SLANG_MCALL acquireNextImage(ITexture** outTexture) override;
     virtual SLANG_NO_THROW Result SLANG_MCALL present() override;
 };

--- a/src/metal/metal-surface.cpp
+++ b/src/metal/metal-surface.cpp
@@ -45,12 +45,25 @@ Result SurfaceImpl::configure(const SurfaceConfig& config)
     m_metalLayer->setDrawableSize(CGSize{(float)m_config.width, (float)m_config.height});
     m_metalLayer->setFramebufferOnly(m_config.usage == TextureUsage::RenderTarget);
     // m_metalLayer->setDisplaySyncEnabled(config.vsync);
+    m_configured = true;
 
+    return SLANG_OK;
+}
+
+Result SurfaceImpl::unconfigure()
+{
+    m_configured = false;
     return SLANG_OK;
 }
 
 Result SurfaceImpl::acquireNextImage(ITexture** outTexture)
 {
+    *outTexture = nullptr;
+    if (!m_configured)
+    {
+        return SLANG_FAIL;
+    }
+
     m_currentDrawable = NS::RetainPtr(m_metalLayer->nextDrawable());
     if (!m_currentDrawable)
     {

--- a/src/metal/metal-surface.h
+++ b/src/metal/metal-surface.h
@@ -16,6 +16,7 @@ public:
     ~SurfaceImpl();
 
     virtual SLANG_NO_THROW Result SLANG_MCALL configure(const SurfaceConfig& config) override;
+    virtual SLANG_NO_THROW Result SLANG_MCALL unconfigure() override;
     virtual SLANG_NO_THROW Result SLANG_MCALL acquireNextImage(ITexture** outTexture) override;
     virtual SLANG_NO_THROW Result SLANG_MCALL present() override;
 };

--- a/src/rhi-shared.h
+++ b/src/rhi-shared.h
@@ -297,7 +297,10 @@ public:
 
 public:
     virtual SLANG_NO_THROW const SurfaceInfo& SLANG_MCALL getInfo() override { return m_info; }
-    virtual SLANG_NO_THROW const SurfaceConfig& SLANG_MCALL getConfig() override { return m_config; }
+    virtual SLANG_NO_THROW const SurfaceConfig* SLANG_MCALL getConfig() override
+    {
+        return m_configured ? &m_config : nullptr;
+    }
 
 public:
     void setInfo(const SurfaceInfo& info);
@@ -307,6 +310,7 @@ public:
     StructHolder m_infoHolder;
     SurfaceConfig m_config;
     StructHolder m_configHolder;
+    bool m_configured = false;
 };
 
 struct DebugCallbackAdapter

--- a/src/vulkan/vk-surface.h
+++ b/src/vulkan/vk-surface.h
@@ -34,7 +34,6 @@ public:
 #if SLANG_APPLE_FAMILY
     void* m_metalLayer;
 #endif
-    bool m_configured = false;
 
 public:
     ~SurfaceImpl();
@@ -44,6 +43,7 @@ public:
     void destroySwapchain();
 
     virtual SLANG_NO_THROW Result SLANG_MCALL configure(const SurfaceConfig& config) override;
+    virtual SLANG_NO_THROW Result SLANG_MCALL unconfigure() override;
     virtual SLANG_NO_THROW Result SLANG_MCALL acquireNextImage(ITexture** outTexture) override;
     virtual SLANG_NO_THROW Result SLANG_MCALL present() override;
 };

--- a/src/wgpu/wgpu-surface.cpp
+++ b/src/wgpu/wgpu-surface.cpp
@@ -183,11 +183,25 @@ Result SurfaceImpl::configure(const SurfaceConfig& config)
     return SLANG_OK;
 }
 
-Result SurfaceImpl::acquireNextImage(ITexture** outTexture)
+Result SurfaceImpl::unconfigure()
 {
     if (!m_configured)
     {
-        *outTexture = nullptr;
+        return SLANG_OK;
+    }
+
+    m_device->m_ctx.api.wgpuSurfaceUnconfigure(m_surface);
+    m_configured = false;
+
+    return SLANG_OK;
+}
+
+Result SurfaceImpl::acquireNextImage(ITexture** outTexture)
+{
+    *outTexture = nullptr;
+
+    if (!m_configured)
+    {
         return SLANG_FAIL;
     }
 
@@ -195,7 +209,6 @@ Result SurfaceImpl::acquireNextImage(ITexture** outTexture)
     m_device->m_ctx.api.wgpuSurfaceGetCurrentTexture(m_surface, &surfaceTexture);
     if (surfaceTexture.status != WGPUSurfaceGetCurrentTextureStatus_Success)
     {
-        *outTexture = nullptr;
         return SLANG_FAIL;
     }
 

--- a/src/wgpu/wgpu-surface.h
+++ b/src/wgpu/wgpu-surface.h
@@ -14,13 +14,13 @@ public:
     WGPUSurface m_surface = nullptr;
     WGPUPresentMode m_vsyncOffMode = WGPUPresentMode(0);
     WGPUPresentMode m_vsyncOnMode = WGPUPresentMode(0);
-    bool m_configured = false;
 
     ~SurfaceImpl();
 
     Result init(DeviceImpl* device, WindowHandle windowHandle);
 
     virtual SLANG_NO_THROW Result SLANG_MCALL configure(const SurfaceConfig& config) override;
+    virtual SLANG_NO_THROW Result SLANG_MCALL unconfigure() override;
     virtual SLANG_NO_THROW Result SLANG_MCALL acquireNextImage(ITexture** outTexture) override;
     virtual SLANG_NO_THROW Result SLANG_MCALL present() override;
 };


### PR DESCRIPTION
When minimizing a window, we want to be able to unconfigure a surface, because there is no window to render to. This change adds `ISurface::unconfigure` to do so. In addition, `ISurface::getConfig` now returns a pointer which is null if the surface is not configured.