### PR TITLE
Enable vertexAttributeRobustnessFeatures

### DIFF
--- a/src/vulkan/vk-api.h
+++ b/src/vulkan/vk-api.h
@@ -439,6 +439,11 @@ struct VulkanExtendedFeatures
         VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FRAGMENT_SHADER_BARYCENTRIC_FEATURES_KHR
     };
 
+    // Vertex attribute robustness features
+    VkPhysicalDeviceVertexAttributeRobustnessFeaturesEXT vertexAttributeRobustnessFeatures = {
+        VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VERTEX_ATTRIBUTE_ROBUSTNESS_FEATURES_EXT
+    };
+
     // Fragment shader interlock features
     VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT fragmentShaderInterlockFeatures = {
         VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FRAGMENT_SHADER_INTERLOCK_FEATURES_EXT

--- a/src/vulkan/vk-device.cpp
+++ b/src/vulkan/vk-device.cpp
@@ -471,6 +471,7 @@ Result DeviceImpl::initVulkanInstanceAndDevice(
         EXTEND_DESC_CHAIN(deviceFeatures2, extendedFeatures.shaderSubgroupRotateFeatures);
         EXTEND_DESC_CHAIN(deviceFeatures2, extendedFeatures.shaderReplicatedCompositesFeatures);
         EXTEND_DESC_CHAIN(deviceFeatures2, extendedFeatures.fragmentShaderBarycentricFeatures);
+        EXTEND_DESC_CHAIN(deviceFeatures2, extendedFeatures.vertexAttributeRobustnessFeatures);
         EXTEND_DESC_CHAIN(deviceFeatures2, extendedFeatures.fragmentShaderInterlockFeatures);
         EXTEND_DESC_CHAIN(deviceFeatures2, extendedFeatures.shaderDemoteToHelperInvocationFeatures);
 
@@ -616,6 +617,13 @@ Result DeviceImpl::initVulkanInstanceAndDevice(
             customBorderColors,
             VK_EXT_CUSTOM_BORDER_COLOR_EXTENSION_NAME,
             { availableFeatures.push_back(Feature::CustomBorderColor); }
+        );
+
+        SIMPLE_EXTENSION_FEATURE(
+            extendedFeatures.vertexAttributeRobustnessFeatures,
+            vertexAttributeRobustness,
+            VK_EXT_VERTEX_ATTRIBUTE_ROBUSTNESS_EXTENSION_NAME,
+            {/* Enable vertex attribute robustness to avoid validation errors */}
         );
 
         if (extendedFeatures.vulkan14Features.shaderSubgroupRotate &&


### PR DESCRIPTION
This is needed to fix VUID-VkGraphicsPipelineCreateInfo-Input-07904 when porting gfx-test to use slang-rhi