### PR TITLE
Added better handling for incompatible anisotropy/min/mag combinations.

### DIFF
--- a/src/d3d12/d3d12-device.cpp
+++ b/src/d3d12/d3d12-device.cpp
@@ -1356,7 +1356,14 @@ Result DeviceImpl::createSampler(const SamplerDesc& desc, ISampler** outSampler)
     D3D12_FILTER dxFilter;
     if (desc.maxAnisotropy > 1)
     {
-        dxFilter = D3D12_ENCODE_ANISOTROPIC_FILTER(dxReduction);
+        if (desc.mipFilter == TextureFilteringMode::Linear)
+        {
+            dxFilter = D3D12_ENCODE_ANISOTROPIC_FILTER(dxReduction);
+        }
+        else
+        {
+            dxFilter = D3D12_ENCODE_MIN_MAG_ANISOTROPIC_MIP_POINT_FILTER(dxReduction);
+        }
     }
     else
     {

--- a/src/debug-layer/debug-device.cpp
+++ b/src/debug-layer/debug-device.cpp
@@ -357,6 +357,11 @@ Result DebugDevice::createSampler(const SamplerDesc& desc, ISampler** outSampler
         RHI_VALIDATION_ERROR("Invalid comparison func");
         return SLANG_E_INVALID_ARG;
     }
+    if (desc.maxAnisotropy > 1 &&
+        (desc.minFilter == TextureFilteringMode::Point || desc.minFilter == TextureFilteringMode::Point))
+    {
+        RHI_VALIDATION_WARNING("maxAnisotropy > 1 can only be set when neither min and mag filter is Point");
+    }
 
     if (desc.addressU == TextureAddressingMode::ClampToBorder ||
         desc.addressV == TextureAddressingMode::ClampToBorder || desc.addressW == TextureAddressingMode::ClampToBorder)


### PR DESCRIPTION
- D3D12 now respects Point mip filter even when Anisotropy > 1
- Validation warns about combination of Point Min/Mag and Anisotropy > 1, as the combination does not really make sense.