### PR TITLE
Global barriers

### DIFF
--- a/include/slang-rhi.h
+++ b/include/slang-rhi.h
@@ -2424,6 +2424,8 @@ public:
         ResourceState state
     ) = 0;
 
+    virtual SLANG_NO_THROW void SLANG_MCALL globalBarrier() = 0;
+
     inline void setTextureState(ITexture* texture, ResourceState state)
     {
         setTextureState(texture, kEntireTexture, state);

--- a/src/command-buffer.cpp
+++ b/src/command-buffer.cpp
@@ -817,6 +817,13 @@ void CommandEncoder::setTextureState(ITexture* texture, SubresourceRange subreso
     m_commandList->write(std::move(cmd));
 }
 
+void CommandEncoder::globalBarrier()
+{
+    commands::GlobalBarrier cmd;
+    m_commandList->write(std::move(cmd));
+}
+
+
 void CommandEncoder::pushDebugGroup(const char* name, const MarkerColor& color)
 {
     commands::PushDebugGroup cmd;

--- a/src/command-buffer.h
+++ b/src/command-buffer.h
@@ -356,6 +356,8 @@ public:
         ResourceState state
     ) override;
 
+    virtual SLANG_NO_THROW void SLANG_MCALL globalBarrier() override;
+
     virtual SLANG_NO_THROW void SLANG_MCALL pushDebugGroup(const char* name, const MarkerColor& color) override;
     virtual SLANG_NO_THROW void SLANG_MCALL popDebugGroup() override;
     virtual SLANG_NO_THROW void SLANG_MCALL insertDebugMarker(const char* name, const MarkerColor& color) override;

--- a/src/command-list.cpp
+++ b/src/command-list.cpp
@@ -321,6 +321,11 @@ void CommandList::write(commands::SetTextureState&& cmd)
     writeCommand(std::move(cmd));
 }
 
+void CommandList::write(commands::GlobalBarrier&& cmd)
+{
+    writeCommand(std::move(cmd));
+}
+
 void CommandList::write(commands::PushDebugGroup&& cmd)
 {
     if (cmd.name)

--- a/src/command-list.h
+++ b/src/command-list.h
@@ -44,6 +44,7 @@
     x(ConvertCooperativeVectorMatrix) \
     x(SetBufferState) \
     x(SetTextureState) \
+    x(GlobalBarrier) \
     x(PushDebugGroup) \
     x(PopDebugGroup) \
     x(InsertDebugMarker) \
@@ -304,6 +305,9 @@ struct SetTextureState
     ResourceState state;
 };
 
+struct GlobalBarrier
+{};
+
 struct PushDebugGroup
 {
     const char* name;
@@ -422,6 +426,7 @@ public:
     void write(commands::ConvertCooperativeVectorMatrix&& cmd);
     void write(commands::SetBufferState&& cmd);
     void write(commands::SetTextureState&& cmd);
+    void write(commands::GlobalBarrier&& cmd);
     void write(commands::PushDebugGroup&& cmd);
     void write(commands::PopDebugGroup&& cmd);
     void write(commands::InsertDebugMarker&& cmd);

--- a/src/cpu/cpu-command.cpp
+++ b/src/cpu/cpu-command.cpp
@@ -58,6 +58,7 @@ public:
     void cmdConvertCooperativeVectorMatrix(const commands::ConvertCooperativeVectorMatrix& cmd);
     void cmdSetBufferState(const commands::SetBufferState& cmd);
     void cmdSetTextureState(const commands::SetTextureState& cmd);
+    void cmdGlobalBarrier(const commands::GlobalBarrier& cmd);
     void cmdPushDebugGroup(const commands::PushDebugGroup& cmd);
     void cmdPopDebugGroup(const commands::PopDebugGroup& cmd);
     void cmdInsertDebugMarker(const commands::InsertDebugMarker& cmd);
@@ -298,6 +299,11 @@ void CommandExecutor::cmdSetBufferState(const commands::SetBufferState& cmd)
 }
 
 void CommandExecutor::cmdSetTextureState(const commands::SetTextureState& cmd)
+{
+    SLANG_UNUSED(cmd);
+}
+
+void CommandExecutor::cmdGlobalBarrier(const commands::GlobalBarrier& cmd)
 {
     SLANG_UNUSED(cmd);
 }

--- a/src/cuda/cuda-command.cpp
+++ b/src/cuda/cuda-command.cpp
@@ -74,6 +74,7 @@ public:
     void cmdConvertCooperativeVectorMatrix(const commands::ConvertCooperativeVectorMatrix& cmd);
     void cmdSetBufferState(const commands::SetBufferState& cmd);
     void cmdSetTextureState(const commands::SetTextureState& cmd);
+    void cmdGlobalBarrier(const commands::GlobalBarrier& cmd);
     void cmdPushDebugGroup(const commands::PushDebugGroup& cmd);
     void cmdPopDebugGroup(const commands::PopDebugGroup& cmd);
     void cmdInsertDebugMarker(const commands::InsertDebugMarker& cmd);
@@ -677,6 +678,11 @@ void CommandExecutor::cmdSetBufferState(const commands::SetBufferState& cmd)
 }
 
 void CommandExecutor::cmdSetTextureState(const commands::SetTextureState& cmd)
+{
+    SLANG_UNUSED(cmd);
+}
+
+void CommandExecutor::cmdGlobalBarrier(const commands::GlobalBarrier& cmd)
 {
     SLANG_UNUSED(cmd);
 }

--- a/src/d3d11/d3d11-command.cpp
+++ b/src/d3d11/d3d11-command.cpp
@@ -85,6 +85,7 @@ public:
     void cmdConvertCooperativeVectorMatrix(const commands::ConvertCooperativeVectorMatrix& cmd);
     void cmdSetBufferState(const commands::SetBufferState& cmd);
     void cmdSetTextureState(const commands::SetTextureState& cmd);
+    void cmdGlobalBarrier(const commands::GlobalBarrier& cmd);
     void cmdPushDebugGroup(const commands::PushDebugGroup& cmd);
     void cmdPopDebugGroup(const commands::PopDebugGroup& cmd);
     void cmdInsertDebugMarker(const commands::InsertDebugMarker& cmd);
@@ -851,6 +852,11 @@ void CommandExecutor::cmdSetBufferState(const commands::SetBufferState& cmd)
 }
 
 void CommandExecutor::cmdSetTextureState(const commands::SetTextureState& cmd)
+{
+    SLANG_UNUSED(cmd);
+}
+
+void CommandExecutor::cmdGlobalBarrier(const commands::GlobalBarrier& cmd)
 {
     SLANG_UNUSED(cmd);
 }

--- a/src/d3d12/d3d12-command.cpp
+++ b/src/d3d12/d3d12-command.cpp
@@ -1407,7 +1407,7 @@ void CommandRecorder::requireTextureState(TextureImpl* texture, SubresourceRange
 
 void CommandRecorder::commitBarriers()
 {
-    if (gDebugDisableStateTracking)
+    if (detail::gDebugDisableStateTracking)
         return;
 
     short_vector<D3D12_RESOURCE_BARRIER, 16> barriers;

--- a/src/debug-layer/debug-command-encoder.cpp
+++ b/src/debug-layer/debug-command-encoder.cpp
@@ -756,6 +756,14 @@ void DebugCommandEncoder::setTextureState(ITexture* texture, SubresourceRange su
     baseObject->setTextureState(texture, subresourceRange, state);
 }
 
+void DebugCommandEncoder::globalBarrier()
+{
+    SLANG_RHI_API_FUNC;
+    requireOpen();
+    requireNoPass();
+    baseObject->globalBarrier();
+}
+
 void DebugCommandEncoder::pushDebugGroup(const char* name, const MarkerColor& color)
 {
     SLANG_RHI_API_FUNC;

--- a/src/debug-layer/debug-command-encoder.h
+++ b/src/debug-layer/debug-command-encoder.h
@@ -270,6 +270,8 @@ public:
         setTextureState(texture, kEntireTexture, state);
     }
 
+    virtual SLANG_NO_THROW void SLANG_MCALL globalBarrier() override;
+
     virtual SLANG_NO_THROW void SLANG_MCALL pushDebugGroup(const char* name, const MarkerColor& color) override;
     virtual SLANG_NO_THROW void SLANG_MCALL popDebugGroup() override;
     virtual SLANG_NO_THROW void SLANG_MCALL insertDebugMarker(const char* name, const MarkerColor& color) override;

--- a/src/device.cpp
+++ b/src/device.cpp
@@ -8,6 +8,9 @@
 
 namespace rhi {
 
+// Debug option for tests to turn off state tracking (so we can effectively test explicit barriers)
+bool gDebugDisableStateTracking = false;
+
 // ----------------------------------------------------------------------------
 // ShaderCache
 // ----------------------------------------------------------------------------

--- a/src/device.cpp
+++ b/src/device.cpp
@@ -8,8 +8,10 @@
 
 namespace rhi {
 
+namespace detail {
 // Debug option for tests to turn off state tracking (so we can effectively test explicit barriers)
 bool gDebugDisableStateTracking = false;
+} // namespace detail
 
 // ----------------------------------------------------------------------------
 // ShaderCache

--- a/src/metal/metal-command.cpp
+++ b/src/metal/metal-command.cpp
@@ -95,6 +95,7 @@ public:
     void cmdConvertCooperativeVectorMatrix(const commands::ConvertCooperativeVectorMatrix& cmd);
     void cmdSetBufferState(const commands::SetBufferState& cmd);
     void cmdSetTextureState(const commands::SetTextureState& cmd);
+    void cmdGlobalBarrier(const commands::GlobalBarrier& cmd);
     void cmdPushDebugGroup(const commands::PushDebugGroup& cmd);
     void cmdPopDebugGroup(const commands::PopDebugGroup& cmd);
     void cmdInsertDebugMarker(const commands::InsertDebugMarker& cmd);
@@ -841,6 +842,11 @@ void CommandRecorder::cmdSetBufferState(const commands::SetBufferState& cmd)
 }
 
 void CommandRecorder::cmdSetTextureState(const commands::SetTextureState& cmd)
+{
+    SLANG_UNUSED(cmd);
+}
+
+void CommandRecorder::cmdGlobalBarrier(const commands::GlobalBarrier& cmd)
 {
     SLANG_UNUSED(cmd);
 }

--- a/src/state-tracking.h
+++ b/src/state-tracking.h
@@ -7,6 +7,8 @@
 
 namespace rhi {
 
+extern bool gDebugDisableStateTracking;
+
 struct BufferState
 {
     ResourceState state = ResourceState::Undefined;

--- a/src/state-tracking.h
+++ b/src/state-tracking.h
@@ -7,7 +7,9 @@
 
 namespace rhi {
 
+namespace detail {
 extern bool gDebugDisableStateTracking;
+}
 
 struct BufferState
 {

--- a/src/vulkan/vk-command.cpp
+++ b/src/vulkan/vk-command.cpp
@@ -1383,7 +1383,7 @@ void CommandRecorder::requireTextureState(TextureImpl* texture, SubresourceRange
 
 void CommandRecorder::commitBarriers()
 {
-    if (gDebugDisableStateTracking)
+    if (detail::gDebugDisableStateTracking)
         return;
 
     short_vector<VkBufferMemoryBarrier, 16> bufferBarriers;

--- a/src/vulkan/vk-command.cpp
+++ b/src/vulkan/vk-command.cpp
@@ -1247,10 +1247,14 @@ void CommandRecorder::cmdSetTextureState(const commands::SetTextureState& cmd)
 
 void CommandRecorder::cmdGlobalBarrier(const commands::GlobalBarrier& cmd)
 {
+    // On vulkan the global barrier is a memory barrier that:
+    // - captures all stages both before and after the barrier
+    // - ensures that all reads after the barrier see all writes before the barrier
+
     VkMemoryBarrier memoryBarrier = {};
     memoryBarrier.sType = VK_STRUCTURE_TYPE_MEMORY_BARRIER;
-    memoryBarrier.srcAccessMask = VK_ACCESS_SHADER_WRITE_BIT;
-    memoryBarrier.dstAccessMask = VK_ACCESS_SHADER_READ_BIT;
+    memoryBarrier.srcAccessMask = VK_ACCESS_MEMORY_WRITE_BIT;
+    memoryBarrier.dstAccessMask = VK_ACCESS_MEMORY_READ_BIT;
 
     m_api.vkCmdPipelineBarrier(
         m_cmdBuffer,

--- a/src/wgpu/wgpu-command.cpp
+++ b/src/wgpu/wgpu-command.cpp
@@ -86,6 +86,7 @@ public:
     void cmdConvertCooperativeVectorMatrix(const commands::ConvertCooperativeVectorMatrix& cmd);
     void cmdSetBufferState(const commands::SetBufferState& cmd);
     void cmdSetTextureState(const commands::SetTextureState& cmd);
+    void cmdGlobalBarrier(const commands::GlobalBarrier& cmd);
     void cmdPushDebugGroup(const commands::PushDebugGroup& cmd);
     void cmdPopDebugGroup(const commands::PopDebugGroup& cmd);
     void cmdInsertDebugMarker(const commands::InsertDebugMarker& cmd);
@@ -777,6 +778,11 @@ void CommandRecorder::cmdSetBufferState(const commands::SetBufferState& cmd)
 }
 
 void CommandRecorder::cmdSetTextureState(const commands::SetTextureState& cmd)
+{
+    SLANG_UNUSED(cmd);
+}
+
+void CommandRecorder::cmdGlobalBarrier(const commands::GlobalBarrier& cmd)
 {
     SLANG_UNUSED(cmd);
 }

--- a/tests/test-bind-pointers.cpp
+++ b/tests/test-bind-pointers.cpp
@@ -6,7 +6,7 @@ using namespace rhi;
 using namespace rhi::testing;
 
 // TODO Add Metal when slang bug https://github.com/shader-slang/slang/issues/7623 fixed
-GPU_TEST_CASE("bind-pointers", Vulkan | CUDA)
+GPU_TEST_CASE("bind-pointers-single-copy", Vulkan | CUDA)
 {
     ComPtr<IShaderProgram> shaderProgram;
     slang::ProgramLayout* slangReflection = nullptr;
@@ -66,4 +66,91 @@ GPU_TEST_CASE("bind-pointers", Vulkan | CUDA)
     }
 
     compareComputeResult(device, dst, span<uint8_t>(data));
+}
+
+GPU_TEST_CASE("bind-pointers-intermediate-copy-nosync", Vulkan | CUDA)
+{
+    ComPtr<IShaderProgram> shaderProgram;
+    slang::ProgramLayout* slangReflection = nullptr;
+    REQUIRE_CALL(loadComputeProgram(device, shaderProgram, "test-pointer-copy", "computeMain", slangReflection));
+
+    ComputePipelineDesc pipelineDesc = {};
+    pipelineDesc.program = shaderProgram.get();
+    ComPtr<IComputePipeline> pipeline;
+    REQUIRE_CALL(device->createComputePipeline(pipelineDesc, pipeline.writeRef()));
+
+    const int numberCount = 4096;
+
+    // Generate random data for 'numberCount' uint32s
+    std::vector<uint8_t> data;
+    std::mt19937 rng(124112);
+    std::uniform_int_distribution<int> dist(0, 255);
+    data.resize(numberCount * 4);
+    for (auto& byte : data)
+        byte = (uint8_t)dist(rng);
+
+    // Setup buffer descriptor
+    BufferDesc bufferDesc = {};
+    bufferDesc.size = numberCount * sizeof(uint32_t);
+    bufferDesc.format = Format::Undefined;
+    bufferDesc.elementSize = sizeof(uint32_t);
+    bufferDesc.usage = BufferUsage::ShaderResource | BufferUsage::UnorderedAccess | BufferUsage::CopyDestination |
+                       BufferUsage::CopySource;
+    bufferDesc.defaultState = ResourceState::UnorderedAccess;
+    bufferDesc.memoryType = MemoryType::DeviceLocal;
+
+    // Create source buffer
+    ComPtr<IBuffer> src;
+    REQUIRE_CALL(device->createBuffer(bufferDesc, (void*)data.data(), src.writeRef()));
+
+    // Create empty dest buffer
+    ComPtr<IBuffer> tmp;
+    REQUIRE_CALL(device->createBuffer(bufferDesc, nullptr, tmp.writeRef()));
+
+    // Create empty dest buffer
+    ComPtr<IBuffer> dst;
+    REQUIRE_CALL(device->createBuffer(bufferDesc, nullptr, dst.writeRef()));
+
+
+    // We have done all the set up work, now it is time to start recording a command buffer for
+    // GPU execution.
+    {
+        auto queue = device->getQueue(QueueType::Graphics);
+        auto commandEncoder = queue->createCommandEncoder();
+
+        {
+            auto passEncoder = commandEncoder->beginComputePass();
+            auto rootObject = passEncoder->bindPipeline(pipeline);
+            ShaderCursor shaderCursor(rootObject);
+            shaderCursor["src"].setData(src->getDeviceAddress());
+            shaderCursor["dst"].setData(tmp->getDeviceAddress());
+            passEncoder->dispatchCompute(numberCount / 32, 1, 1);
+            passEncoder->end();
+        }
+
+        {
+            auto passEncoder = commandEncoder->beginComputePass();
+            auto rootObject = passEncoder->bindPipeline(pipeline);
+            ShaderCursor shaderCursor(rootObject);
+            shaderCursor["src"].setData(tmp->getDeviceAddress());
+            shaderCursor["dst"].setData(dst->getDeviceAddress());
+            passEncoder->dispatchCompute(numberCount / 32, 1, 1);
+            passEncoder->end();
+        }
+
+        queue->submit(commandEncoder->finish());
+        queue->waitOnHost();
+    }
+
+    if (device->getDeviceType() == DeviceType::CUDA)
+    {
+        // CUDA streams never overlap dispatches, so we'd expect syncing to have worked with no manual intervention
+        compareComputeResult(device, dst, span<uint8_t>(data));
+    }
+    else
+    {
+        // GFX APIs like Vulkan and D3D12 require explicit synchronization between dispatches, which
+        // isn't done automatically for pointers, so we'd expect race conditions
+        compareComputeResult(device, dst, span<uint8_t>(data), true);
+    }
 }

--- a/tests/test-buffer-barrier.cpp
+++ b/tests/test-buffer-barrier.cpp
@@ -131,9 +131,9 @@ GPU_TEST_CASE("buffer-no-barrier-race-condition", ALL)
         }
 
         // Disable state tracking for the submit
-        gDebugDisableStateTracking = true;
+        detail::gDebugDisableStateTracking = true;
         queue->submit(commandEncoder->finish());
-        gDebugDisableStateTracking = false;
+        detail::gDebugDisableStateTracking = false;
         queue->waitOnHost();
     }
 
@@ -193,9 +193,9 @@ GPU_TEST_CASE("buffer-global-barrier", D3D12 | Vulkan)
         }
 
         // Disable state tracking for the submit
-        gDebugDisableStateTracking = true;
+        detail::gDebugDisableStateTracking = true;
         queue->submit(commandEncoder->finish());
-        gDebugDisableStateTracking = false;
+        detail::gDebugDisableStateTracking = false;
         queue->waitOnHost();
     }
 

--- a/tests/test-buffer-barrier.cpp
+++ b/tests/test-buffer-barrier.cpp
@@ -1,4 +1,5 @@
 #include "testing.h"
+#include "../src/state-tracking.h"
 
 using namespace rhi;
 using namespace rhi::testing;
@@ -79,6 +80,122 @@ GPU_TEST_CASE("buffer-barrier", ALL)
         }
 
         queue->submit(commandEncoder->finish());
+        queue->waitOnHost();
+    }
+
+    compareComputeResult(device, outputBuffer, makeArray<float>(11.0f, 12.0f, 13.0f, 14.0f));
+}
+
+GPU_TEST_CASE("buffer-no-barrier-race-condition", ALL)
+{
+    Shader programA;
+    Shader programB;
+    REQUIRE_CALL(loadComputeProgram(device, programA.program, "test-buffer-barrier", "computeA", programA.reflection));
+    REQUIRE_CALL(loadComputeProgram(device, programB.program, "test-buffer-barrier", "computeB", programB.reflection));
+    programA.pipelineDesc.program = programA.program.get();
+    programB.pipelineDesc.program = programB.program.get();
+    REQUIRE_CALL(device->createComputePipeline(programA.pipelineDesc, programA.pipeline.writeRef()));
+    REQUIRE_CALL(device->createComputePipeline(programB.pipelineDesc, programB.pipeline.writeRef()));
+
+    float initialData[] = {1.0f, 2.0f, 3.0f, 4.0f};
+    ComPtr<IBuffer> inputBuffer = createFloatBuffer(device, false, 4, initialData);
+    ComPtr<IBuffer> intermediateBuffer = createFloatBuffer(device, true, 4);
+    ComPtr<IBuffer> outputBuffer = createFloatBuffer(device, true, 4);
+
+    // We have done all the set up work, now it is time to start recording a command buffer for
+    // GPU execution.
+    {
+        auto queue = device->getQueue(QueueType::Graphics);
+        auto commandEncoder = queue->createCommandEncoder();
+
+        // Write inputBuffer to intermediateBuffer
+        {
+            auto passEncoder = commandEncoder->beginComputePass();
+            auto rootObject = passEncoder->bindPipeline(programA.pipeline);
+            ShaderCursor cursor(rootObject->getEntryPoint(0));
+            cursor["inBuffer"].setBinding(inputBuffer);
+            cursor["outBuffer"].setBinding(intermediateBuffer);
+            passEncoder->dispatchCompute(1, 1, 1);
+            passEncoder->end();
+        }
+
+        // Write intermediateBuffer to outputBuffer
+        {
+            auto passEncoder = commandEncoder->beginComputePass();
+            auto rootObject = passEncoder->bindPipeline(programB.pipeline);
+            ShaderCursor cursor(rootObject->getEntryPoint(0));
+            cursor["inBuffer"].setBinding(intermediateBuffer);
+            cursor["outBuffer"].setBinding(outputBuffer);
+            passEncoder->dispatchCompute(1, 1, 1);
+            passEncoder->end();
+        }
+
+        // Disable state tracking for the submit
+        gDebugDisableStateTracking = true;
+        queue->submit(commandEncoder->finish());
+        gDebugDisableStateTracking = false;
+        queue->waitOnHost();
+    }
+
+    // We expect the 2 platforms that do explicit state tracking normally to fail,
+    // as we disabled it for the submit.
+    bool expectFailure = device->getDeviceType() == DeviceType::D3D12 || device->getDeviceType() == DeviceType::Vulkan;
+    compareComputeResult(device, outputBuffer, makeArray<float>(11.0f, 12.0f, 13.0f, 14.0f), expectFailure);
+}
+
+GPU_TEST_CASE("buffer-global-barrier", D3D12 | Vulkan)
+{
+    Shader programA;
+    Shader programB;
+    REQUIRE_CALL(loadComputeProgram(device, programA.program, "test-buffer-barrier", "computeA", programA.reflection));
+    REQUIRE_CALL(loadComputeProgram(device, programB.program, "test-buffer-barrier", "computeB", programB.reflection));
+    programA.pipelineDesc.program = programA.program.get();
+    programB.pipelineDesc.program = programB.program.get();
+    REQUIRE_CALL(device->createComputePipeline(programA.pipelineDesc, programA.pipeline.writeRef()));
+    REQUIRE_CALL(device->createComputePipeline(programB.pipelineDesc, programB.pipeline.writeRef()));
+
+    float initialData[] = {1.0f, 2.0f, 3.0f, 4.0f};
+    ComPtr<IBuffer> inputBuffer = createFloatBuffer(device, false, 4, initialData);
+    ComPtr<IBuffer> intermediateBuffer = createFloatBuffer(device, true, 4);
+    ComPtr<IBuffer> outputBuffer = createFloatBuffer(device, true, 4);
+
+    // We have done all the set up work, now it is time to start recording a command buffer for
+    // GPU execution.
+    {
+        auto queue = device->getQueue(QueueType::Graphics);
+        auto commandEncoder = queue->createCommandEncoder();
+
+        // Write inputBuffer to intermediateBuffer
+        {
+            auto passEncoder = commandEncoder->beginComputePass();
+            auto rootObject = passEncoder->bindPipeline(programA.pipeline);
+            ShaderCursor cursor(rootObject->getEntryPoint(0));
+            cursor["inBuffer"].setBinding(inputBuffer);
+            cursor["outBuffer"].setBinding(intermediateBuffer);
+            passEncoder->dispatchCompute(1, 1, 1);
+            passEncoder->end();
+        }
+
+        // Explicitly add a global barrier to the encoder, ensuring all
+        // previous memory operations are visibile before starting the next
+        // pass.
+        commandEncoder->globalBarrier();
+
+        // Write intermediateBuffer to outputBuffer
+        {
+            auto passEncoder = commandEncoder->beginComputePass();
+            auto rootObject = passEncoder->bindPipeline(programB.pipeline);
+            ShaderCursor cursor(rootObject->getEntryPoint(0));
+            cursor["inBuffer"].setBinding(intermediateBuffer);
+            cursor["outBuffer"].setBinding(outputBuffer);
+            passEncoder->dispatchCompute(1, 1, 1);
+            passEncoder->end();
+        }
+
+        // Disable state tracking for the submit
+        gDebugDisableStateTracking = true;
+        queue->submit(commandEncoder->finish());
+        gDebugDisableStateTracking = false;
         queue->waitOnHost();
     }
 


### PR DESCRIPTION
- Add global barrier concept to slang-rhi
- Implemented global barrier in vulkan+d3d12 (other platforms don't need it as state tracking is implicit)
- Debug option to break state tracking + tests to verify the global barrier fixes it