### PR TITLE
Fix no member named 'terminate' when building with Clang on macOS

### DIFF
--- a/src/core/span.h
+++ b/src/core/span.h
@@ -25,6 +25,7 @@ http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2019/n4820.pdf
 #ifndef TCB_SPAN_NO_EXCEPTIONS
 #include <cstdio>
 #include <stdexcept>
+#include <exception>
 #endif
 
 // Various feature test macros


### PR DESCRIPTION
On macOS, latest LLVM Clang (20.1.8) with libc++ I get this error when building.

```
error: no member named 'terminate' in namespace 'std'; did you mean 'template'?
[build]    73 |     std::terminate();
[build]       |     ~~~~~^~~~~~~~~
[build]       |          template
[build] slang-rhi-src/src/core/span.h:73:19: error: expected unqualified-id
[build]    73 |     std::terminate();
[build]       |                   ^
[build] 2 errors generated.
```

including `<exception>` fixes the issue