### PR TITLE
Enable merge-queue; add CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @shader-slang/dev

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,9 @@ on:
       - "LICENSE"
       - "**.md"
       - .github/workflows/ci-gcp.yml
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   build:


### PR DESCRIPTION
This is needed to match slang commit workflow for slang-rhi.
1. Add a CODEOWNERS to enforce that code owners must approve changes before merging
2. Add merge_queue settings to CI

Closes: #453


