### PR TITLE
Minor clean for gDebugDisableStateTracking option

### DIFF
--- a/src/d3d12/d3d12-command.cpp
+++ b/src/d3d12/d3d12-command.cpp
@@ -1407,7 +1407,7 @@ void CommandRecorder::requireTextureState(TextureImpl* texture, SubresourceRange
 
 void CommandRecorder::commitBarriers()
 {
-    if (detail::gDebugDisableStateTracking)
+    if (testing::gDebugDisableStateTracking)
         return;
 
     short_vector<D3D12_RESOURCE_BARRIER, 16> barriers;

--- a/src/device.cpp
+++ b/src/device.cpp
@@ -8,10 +8,9 @@
 
 namespace rhi {
 
-namespace detail {
-// Debug option for tests to turn off state tracking (so we can effectively test explicit barriers)
+namespace testing {
 bool gDebugDisableStateTracking = false;
-} // namespace detail
+} // namespace testing
 
 // ----------------------------------------------------------------------------
 // ShaderCache

--- a/src/device.h
+++ b/src/device.h
@@ -17,6 +17,11 @@
 
 namespace rhi {
 
+namespace testing {
+// Debug option for tests to turn off state tracking (so we can effectively test explicit barriers)
+extern bool gDebugDisableStateTracking;
+} // namespace testing
+
 struct ComponentKey
 {
     std::string typeName;

--- a/src/state-tracking.h
+++ b/src/state-tracking.h
@@ -7,10 +7,6 @@
 
 namespace rhi {
 
-namespace detail {
-extern bool gDebugDisableStateTracking;
-}
-
 struct BufferState
 {
     ResourceState state = ResourceState::Undefined;

--- a/src/vulkan/vk-command.cpp
+++ b/src/vulkan/vk-command.cpp
@@ -1383,7 +1383,7 @@ void CommandRecorder::requireTextureState(TextureImpl* texture, SubresourceRange
 
 void CommandRecorder::commitBarriers()
 {
-    if (detail::gDebugDisableStateTracking)
+    if (testing::gDebugDisableStateTracking)
         return;
 
     short_vector<VkBufferMemoryBarrier, 16> bufferBarriers;

--- a/tests/test-buffer-barrier.cpp
+++ b/tests/test-buffer-barrier.cpp
@@ -131,9 +131,9 @@ GPU_TEST_CASE("buffer-no-barrier-race-condition", ALL)
         }
 
         // Disable state tracking for the submit
-        detail::gDebugDisableStateTracking = true;
+        testing::gDebugDisableStateTracking = true;
         queue->submit(commandEncoder->finish());
-        detail::gDebugDisableStateTracking = false;
+        testing::gDebugDisableStateTracking = false;
         queue->waitOnHost();
     }
 
@@ -193,9 +193,9 @@ GPU_TEST_CASE("buffer-global-barrier", D3D12 | Vulkan)
         }
 
         // Disable state tracking for the submit
-        detail::gDebugDisableStateTracking = true;
+        testing::gDebugDisableStateTracking = true;
         queue->submit(commandEncoder->finish());
-        detail::gDebugDisableStateTracking = false;
+        testing::gDebugDisableStateTracking = false;
         queue->waitOnHost();
     }
 


### PR DESCRIPTION
Moved declaration to device.h into testing namespace, as this is only used for testing purposes.