### PR TITLE
Implement dummy Sampler object for CUDA backend

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -691,6 +691,7 @@ if(SLANG_RHI_ENABLE_CUDA)
         src/cuda/cuda-dual-page-allocator.cpp
         src/cuda/cuda-pipeline.cpp
         src/cuda/cuda-query.cpp
+        src/cuda/cuda-sampler.cpp
         src/cuda/cuda-shader-object-layout.cpp
         src/cuda/cuda-shader-object.cpp
         src/cuda/cuda-shader-program.cpp

--- a/src/cuda/cuda-base.h
+++ b/src/cuda/cuda-base.h
@@ -16,6 +16,7 @@ namespace rhi::cuda {
 class BufferImpl;
 class TextureImpl;
 class TextureViewImpl;
+class SamplerImpl;
 class ShaderObjectLayoutImpl;
 class RootShaderObjectLayoutImpl;
 class ShaderProgramImpl;

--- a/src/cuda/cuda-device.cpp
+++ b/src/cuda/cuda-device.cpp
@@ -3,6 +3,7 @@
 #include "cuda-buffer.h"
 #include "cuda-pipeline.h"
 #include "cuda-query.h"
+#include "cuda-sampler.h"
 #include "cuda-shader-object-layout.h"
 #include "cuda-shader-object.h"
 #include "cuda-shader-program.h"
@@ -525,8 +526,8 @@ Result DeviceImpl::getQueue(QueueType type, ICommandQueue** outQueue)
 
 Result DeviceImpl::createSampler(const SamplerDesc& desc, ISampler** outSampler)
 {
-    SLANG_UNUSED(desc);
-    *outSampler = nullptr;
+    RefPtr<SamplerImpl> samplerImpl = new SamplerImpl(this, desc);
+    returnComPtr(outSampler, samplerImpl);
     return SLANG_OK;
 }
 

--- a/src/cuda/cuda-sampler.cpp
+++ b/src/cuda/cuda-sampler.cpp
@@ -1,0 +1,15 @@
+#include "cuda-sampler.h"
+#include "cuda-device.h"
+
+namespace rhi::cuda {
+
+SamplerImpl::SamplerImpl(Device* device, const SamplerDesc& desc)
+    : Sampler(device, desc)
+{
+}
+
+SamplerImpl::~SamplerImpl()
+{
+}
+
+} // namespace rhi::cuda

--- a/src/cuda/cuda-sampler.cpp
+++ b/src/cuda/cuda-sampler.cpp
@@ -8,8 +8,6 @@ SamplerImpl::SamplerImpl(Device* device, const SamplerDesc& desc)
 {
 }
 
-SamplerImpl::~SamplerImpl()
-{
-}
+SamplerImpl::~SamplerImpl() {}
 
 } // namespace rhi::cuda

--- a/src/cuda/cuda-sampler.h
+++ b/src/cuda/cuda-sampler.h
@@ -1,0 +1,14 @@
+#pragma once
+
+#include "cuda-base.h"
+
+namespace rhi::cuda {
+
+class SamplerImpl : public Sampler
+{
+public:
+    SamplerImpl(Device* device, const SamplerDesc& desc);
+    ~SamplerImpl();
+};
+
+} // namespace rhi::cuda


### PR DESCRIPTION
Device::createSampler now returns a dummy sampler object on CUDA. While CUDA doesn't support sampler objects in practice, this makes the slang-rhi API more consistent.