### PR TITLE
Add CUDA synchronization points

### DIFF
--- a/src/cuda/cuda-device.cpp
+++ b/src/cuda/cuda-device.cpp
@@ -549,6 +549,8 @@ Result DeviceImpl::readTexture(
 {
     SLANG_CUDA_CTX_SCOPE(this);
 
+    cuStreamSynchronize(m_queue->m_stream);
+
     auto textureImpl = checked_cast<TextureImpl*>(texture);
 
     CUarray srcArray = textureImpl->m_cudaArray;
@@ -578,6 +580,8 @@ Result DeviceImpl::readTexture(
 Result DeviceImpl::readBuffer(IBuffer* buffer, size_t offset, size_t size, void* outData)
 {
     SLANG_CUDA_CTX_SCOPE(this);
+
+    cuStreamSynchronize(m_queue->m_stream);
 
     auto bufferImpl = checked_cast<BufferImpl*>(buffer);
     if (offset + size > bufferImpl->m_desc.size)


### PR DESCRIPTION
Add cuStreamSynchronize calls before kernel launches and before reading buffers/textures. This fixes issues with texture writes not being visible in subsequent launches. CUDA driver API does less automatic synchronization compared to CUDA runtime API. This needs more investigation and switching to a finer grained synchronization scheme.