### PR TITLE
Fix sphere and LSS tests under D3D12 and Vulkan

### DIFF
--- a/src/d3d12/d3d12-acceleration-structure.cpp
+++ b/src/d3d12/d3d12-acceleration-structure.cpp
@@ -386,7 +386,7 @@ Result AccelerationStructureBuildDescConverterNVAPI::convert(
                 return SLANG_E_INVALID_ARG;
             }
             NVAPI_D3D12_RAYTRACING_GEOMETRY_DESC_EX& geomDesc = geomDescs[i];
-            geomDesc.type = NVAPI_D3D12_RAYTRACING_GEOMETRY_TYPE_SPHERES_EX;
+            geomDesc.type = NVAPI_D3D12_RAYTRACING_GEOMETRY_TYPE_LSS_EX;
             geomDesc.flags = translateGeometryFlags(lss.flags);
             geomDesc.lss.vertexCount = lss.vertexCount;
             geomDesc.lss.vertexPositionBuffer.StartAddress = lss.vertexPositionBuffers[0].getDeviceAddress();

--- a/src/d3d12/d3d12-shader-object-layout.cpp
+++ b/src/d3d12/d3d12-shader-object-layout.cpp
@@ -963,6 +963,21 @@ Result RootShaderObjectLayoutImpl::createRootSignatureFromSlang(
         builder.addAsValue(entryPoint->getVarLayout(), rootDescriptorSetIndex);
     }
 
+#if SLANG_RHI_ENABLE_NVAPI
+    // Add NVAPI shader extension UAV slot if enabled
+    if (device->m_nvapiShaderExtension)
+    {
+        builder.addDescriptorRange(
+            rootDescriptorSetIndex,
+            D3D12_DESCRIPTOR_RANGE_TYPE_UAV,
+            device->m_nvapiShaderExtension.uavSlot,
+            device->m_nvapiShaderExtension.registerSpace,
+            1,
+            false
+        );
+    }
+#endif
+
     // This is hacky, before calling build(), m_rootParameters contains only the root parameters.
     rootLayout->m_rootSignatureRootParameterCount = builder.m_rootParameters.size();
     auto& rootSignatureDesc = builder.build();

--- a/src/d3d12/d3d12-shader-object.cpp
+++ b/src/d3d12/d3d12-shader-object.cpp
@@ -121,6 +121,29 @@ Result BindingDataBuilder::bindAsRoot(
         bindAsConstantBuffer(shaderObject, descriptorSet, rootOffset, rootParamIndex, specializedLayout)
     );
 
+#if SLANG_RHI_ENABLE_NVAPI
+    // Bind a null UAV descriptor for the NVAPI shader extension slot if enabled
+    // This must be done at the root level since the NVAPI range is added to the root signature
+    if (m_device->m_nvapiShaderExtension && descriptorSet.resources.count > 0)
+    {
+        ID3D12Device* d3dDevice = m_device->m_device;
+
+        // The NVAPI UAV descriptor should be at the very last position in the descriptor table
+        // since we added the NVAPI UAV range last during root signature creation
+        uint32_t nvapiDescriptorIndex = descriptorSet.resources.count - 1;
+
+        D3D12_CPU_DESCRIPTOR_HANDLE nullUavDescriptor =
+            m_device->getNullDescriptor(slang::BindingType::MutableRawBuffer, SLANG_STRUCTURED_BUFFER);
+
+        d3dDevice->CopyDescriptorsSimple(
+            1,
+            descriptorSet.resources.getCpuHandle(nvapiDescriptorIndex),
+            nullUavDescriptor,
+            D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV
+        );
+    }
+#endif
+
     size_t entryPointCount = specializedLayout->m_entryPoints.size();
     for (size_t i = 0; i < entryPointCount; ++i)
     {
@@ -162,7 +185,15 @@ Result BindingDataBuilder::allocateDescriptorSets(
     //
     auto& rootParamIndex = ioOffset.rootParam;
 
-    if (uint32_t descriptorCount = specializedLayout->getTotalResourceDescriptorCount())
+    uint32_t descriptorCount = specializedLayout->getTotalResourceDescriptorCount();
+#if SLANG_RHI_ENABLE_NVAPI
+    // Add one extra descriptor for NVAPI UAV slot if enabled
+    if (m_device->m_nvapiShaderExtension)
+    {
+        descriptorCount += 1;
+    }
+#endif
+    if (descriptorCount > 0)
     {
         auto allocation = m_cbvSrvUavArena->allocate(descriptorCount);
         if (!allocation.isValid())
@@ -174,9 +205,9 @@ Result BindingDataBuilder::allocateDescriptorSets(
             createRootDescriptorTable(rootParamIndex, allocation.firstGpuHandle);
         outDescriptorSet.resources = allocation;
     }
-    if (auto descriptorCount = specializedLayout->getTotalSamplerDescriptorCount())
+    if (auto samplerDescriptorCount = specializedLayout->getTotalSamplerDescriptorCount())
     {
-        auto allocation = m_samplerArena->allocate(descriptorCount);
+        auto allocation = m_samplerArena->allocate(samplerDescriptorCount);
         if (!allocation.isValid())
         {
             return SLANG_E_OUT_OF_MEMORY;

--- a/src/vulkan/vk-acceleration-structure.cpp
+++ b/src/vulkan/vk-acceleration-structure.cpp
@@ -237,7 +237,7 @@ Result AccelerationStructureBuildDescConverter::convert(
             }
 
             VkAccelerationStructureGeometryLinearSweptSpheresDataNV& lssData = linearSweptSpheresDatas[i];
-            lssData.sType = VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_GEOMETRY_SPHERES_DATA_NV;
+            lssData.sType = VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_GEOMETRY_LINEAR_SWEPT_SPHERES_DATA_NV;
 
             lssData.vertexFormat = getVkFormat(lss.vertexPositionFormat);
             lssData.vertexData.deviceAddress = lss.vertexPositionBuffers[0].getDeviceAddress();

--- a/src/vulkan/vk-pipeline.cpp
+++ b/src/vulkan/vk-pipeline.cpp
@@ -707,9 +707,13 @@ Result DeviceImpl::createRayTracingPipeline2(const RayTracingPipelineDesc& desc,
     ShaderProgramImpl* program = checked_cast<ShaderProgramImpl*>(desc.program);
     SLANG_RHI_ASSERT(!program->m_modules.empty());
 
+    VkPipelineCreateFlags2CreateInfoKHR createFlags2Info = {VK_STRUCTURE_TYPE_PIPELINE_CREATE_FLAGS_2_CREATE_INFO_KHR};
+    createFlags2Info.pNext = nullptr;
+    createFlags2Info.flags = translateRayTracingPipelineFlags2(desc.flags);
+
     VkRayTracingPipelineCreateInfoKHR createInfo = {VK_STRUCTURE_TYPE_RAY_TRACING_PIPELINE_CREATE_INFO_KHR};
-    createInfo.pNext = nullptr;
-    createInfo.flags = translateRayTracingPipelineFlags(desc.flags);
+    createInfo.pNext = &createFlags2Info;
+    createInfo.flags = 0; // Unused; the extended flags are in the pNext chain.
 
     createInfo.stageCount = (uint32_t)program->m_stageCreateInfos.size();
     createInfo.pStages = program->m_stageCreateInfos.data();

--- a/src/vulkan/vk-utils.cpp
+++ b/src/vulkan/vk-utils.cpp
@@ -213,6 +213,18 @@ VkPipelineCreateFlags translateRayTracingPipelineFlags(RayTracingPipelineFlags f
     return vkFlags;
 }
 
+VkPipelineCreateFlags2 translateRayTracingPipelineFlags2(RayTracingPipelineFlags flags)
+{
+    // The lower bits of the extended flags are the same as the non-extended version, so we can share logic with that.
+    VkPipelineCreateFlags2 vkFlags = translateRayTracingPipelineFlags(flags);
+
+    // Now, handle any flags specific to the extended version.
+    if (is_set(flags, RayTracingPipelineFlags::EnableSpheres) || is_set(flags, RayTracingPipelineFlags::EnableLinearSweptSpheres))
+        vkFlags |= VK_PIPELINE_CREATE_2_RAY_TRACING_ALLOW_SPHERES_AND_LINEAR_SWEPT_SPHERES_BIT_NV;
+
+    return vkFlags;
+}
+
 VkImageLayout translateImageLayout(ResourceState state)
 {
     switch (state)

--- a/src/vulkan/vk-utils.cpp
+++ b/src/vulkan/vk-utils.cpp
@@ -219,7 +219,8 @@ VkPipelineCreateFlags2 translateRayTracingPipelineFlags2(RayTracingPipelineFlags
     VkPipelineCreateFlags2 vkFlags = translateRayTracingPipelineFlags(flags);
 
     // Now, handle any flags specific to the extended version.
-    if (is_set(flags, RayTracingPipelineFlags::EnableSpheres) || is_set(flags, RayTracingPipelineFlags::EnableLinearSweptSpheres))
+    if (is_set(flags, RayTracingPipelineFlags::EnableSpheres) ||
+        is_set(flags, RayTracingPipelineFlags::EnableLinearSweptSpheres))
         vkFlags |= VK_PIPELINE_CREATE_2_RAY_TRACING_ALLOW_SPHERES_AND_LINEAR_SWEPT_SPHERES_BIT_NV;
 
     return vkFlags;

--- a/src/vulkan/vk-utils.h
+++ b/src/vulkan/vk-utils.h
@@ -43,6 +43,7 @@ VkFormat getVkFormat(Format format);
 VkAttachmentLoadOp translateLoadOp(LoadOp loadOp);
 VkAttachmentStoreOp translateStoreOp(StoreOp storeOp);
 VkPipelineCreateFlags translateRayTracingPipelineFlags(RayTracingPipelineFlags flags);
+VkPipelineCreateFlags2 translateRayTracingPipelineFlags2(RayTracingPipelineFlags flags);
 
 VkImageLayout translateImageLayout(ResourceState state);
 

--- a/tests/test-ray-tracing-lss.cpp
+++ b/tests/test-ray-tracing-lss.cpp
@@ -245,7 +245,10 @@ struct RayTracingLssTestBase
         HitGroupDesc hitGroups[1];
         hitGroups[0].hitGroupName = hitgroupNames[0];
         hitGroups[0].closestHitEntryPoint = closestHitName;
-        hitGroups[0].intersectionEntryPoint = "__builtin_intersection__linear_swept_spheres";
+
+        // We must specify an explicit intersection shader for all non-triangle geometry in OptiX.
+        if (device->getDeviceType() == DeviceType::CUDA)
+            hitGroups[0].intersectionEntryPoint = "__builtin_intersection__linear_swept_spheres";
 
         RayTracingPipelineDesc rtpDesc = {};
         rtpDesc.program = rayTracingProgram;

--- a/tests/test-ray-tracing-lss.cpp
+++ b/tests/test-ray-tracing-lss.cpp
@@ -410,6 +410,12 @@ GPU_TEST_CASE("ray-tracing-lss-intersection", ALL)
 struct TestResult
 {
     int isLssHit;
+    float lssPositionsAndRadii[8];
+};
+
+struct TestResultCudaAligned
+{
+    int isLssHit;
     int pad[3];
     float lssPositionsAndRadii[8];
 };
@@ -433,21 +439,25 @@ struct RayTracingLssIntrinsicsTest : public RayTracingLssTestBase
 
     void createResultBuffer()
     {
+        const size_t resultSize =
+            device->getDeviceType() == DeviceType::CUDA ? sizeof(TestResultCudaAligned) : sizeof(TestResult);
+
         BufferDesc resultBufferDesc = {};
-        resultBufferDesc.size = sizeof(TestResult);
-        resultBufferDesc.elementSize = sizeof(TestResult);
+        resultBufferDesc.size = resultSize;
+        resultBufferDesc.elementSize = resultSize;
         resultBufferDesc.memoryType = MemoryType::DeviceLocal;
         resultBufferDesc.usage = BufferUsage::UnorderedAccess | BufferUsage::CopySource;
         resultBuffer = device->createBuffer(resultBufferDesc);
         REQUIRE(resultBuffer != nullptr);
     }
 
+    template<typename T>
     void checkTestResults()
     {
         ComPtr<ISlangBlob> resultBlob;
-        REQUIRE_CALL(device->readBuffer(resultBuffer, 0, sizeof(TestResult), resultBlob.writeRef()));
+        REQUIRE_CALL(device->readBuffer(resultBuffer, 0, sizeof(T), resultBlob.writeRef()));
 
-        const TestResult* result = reinterpret_cast<const TestResult*>(resultBlob->getBufferPointer());
+        const T* result = reinterpret_cast<const T*>(resultBlob->getBufferPointer());
 
         CHECK_EQ(result->isLssHit, 1);
 
@@ -466,6 +476,14 @@ struct RayTracingLssIntrinsicsTest : public RayTracingLssTestBase
 
         // Right endcap radius
         CHECK_EQ(result->lssPositionsAndRadii[7], 0.5f);
+    }
+
+    void checkTestResults()
+    {
+        if (device->getDeviceType() == DeviceType::CUDA)
+            checkTestResults<TestResultCudaAligned>();
+        else
+            checkTestResults<TestResult>();
     }
 
     void renderFrame()

--- a/tests/test-ray-tracing-lss.cpp
+++ b/tests/test-ray-tracing-lss.cpp
@@ -535,7 +535,8 @@ GPU_TEST_CASE("ray-tracing-lss-intrinsics", ALL)
     test.run("rayGenLssIntrinsics", "closestHitLssIntrinsics");
 }
 
-GPU_TEST_CASE("ray-tracing-lss-intrinsics-hit-object", ALL)
+// Disabled under D3D12 due to https://github.com/shader-slang/slang/issues/8128
+GPU_TEST_CASE("ray-tracing-lss-intrinsics-hit-object", CUDA | Vulkan)
 {
     if (!device->hasFeature(Feature::RayTracing))
         SKIP("ray tracing not supported");

--- a/tests/test-ray-tracing-lss.slang
+++ b/tests/test-ray-tracing-lss.slang
@@ -54,7 +54,7 @@ void missShader(inout RayPayload payload)
 }
 
 [shader("closesthit")]
-void closestHitShader(inout RayPayload payload)
+void closestHitShader(inout RayPayload payload, in BuiltInTriangleIntersectionAttributes attr)
 {
     uint primitiveIndex = PrimitiveIndex();
     float4 color = float4(0, 0, 0, 1);
@@ -97,7 +97,7 @@ void rayGenLssIntrinsics()
 }
 
 [shader("closesthit")]
-void closestHitLssIntrinsics(inout RayPayloadIntrinsics payload)
+void closestHitLssIntrinsics(inout RayPayloadIntrinsics payload, in BuiltInTriangleIntersectionAttributes attr)
 {
     payload.res.isLssHit = IsLssHit();
     payload.res.lssPositionsAndRadii = GetLssPositionsAndRadii();

--- a/tests/test-ray-tracing-sphere.cpp
+++ b/tests/test-ray-tracing-sphere.cpp
@@ -229,7 +229,10 @@ struct RayTracingSphereTestBase
         HitGroupDesc hitGroups[1];
         hitGroups[0].hitGroupName = hitgroupNames[0];
         hitGroups[0].closestHitEntryPoint = closestHitName;
-        hitGroups[0].intersectionEntryPoint = "__builtin_intersection__sphere";
+
+        // We must specify an explicit intersection shader for all non-triangle geometry in OptiX.
+        if (device->getDeviceType() == DeviceType::CUDA)
+            hitGroups[0].intersectionEntryPoint = "__builtin_intersection__sphere";
 
         RayTracingPipelineDesc rtpDesc = {};
         rtpDesc.program = rayTracingProgram;

--- a/tests/test-ray-tracing-sphere.cpp
+++ b/tests/test-ray-tracing-sphere.cpp
@@ -477,7 +477,8 @@ GPU_TEST_CASE("ray-tracing-sphere-intrinsics", ALL)
     test.run("rayGenSphereIntrinsics", "closestHitSphereIntrinsics");
 }
 
-GPU_TEST_CASE("ray-tracing-sphere-intrinsics-hit-object", ALL)
+// Disabled under D3D12 due to https://github.com/shader-slang/slang/issues/8128
+GPU_TEST_CASE("ray-tracing-sphere-intrinsics-hit-object", CUDA | Vulkan)
 {
     if (!device->hasFeature(Feature::RayTracing))
         SKIP("ray tracing not supported");

--- a/tests/test-ray-tracing-sphere.cpp
+++ b/tests/test-ray-tracing-sphere.cpp
@@ -379,6 +379,12 @@ GPU_TEST_CASE("ray-tracing-sphere-intersection", ALL)
 struct TestResult
 {
     int isSphereHit;
+    float spherePositionAndRadius[4];
+};
+
+struct TestResultCudaAligned
+{
+    int isSphereHit;
     int pad[3];
     float spherePositionAndRadius[4];
 };
@@ -397,26 +403,38 @@ struct RayTracingSphereIntrinsicsTest : public RayTracingSphereTestBase
 
     void createResultBuffer()
     {
+        const size_t resultSize =
+            device->getDeviceType() == DeviceType::CUDA ? sizeof(TestResultCudaAligned) : sizeof(TestResult);
+
         BufferDesc resultBufferDesc = {};
-        resultBufferDesc.size = sizeof(TestResult);
-        resultBufferDesc.elementSize = sizeof(TestResult);
+        resultBufferDesc.size = resultSize;
+        resultBufferDesc.elementSize = resultSize;
         resultBufferDesc.memoryType = MemoryType::DeviceLocal;
         resultBufferDesc.usage = BufferUsage::UnorderedAccess | BufferUsage::CopySource;
         resultBuffer = device->createBuffer(resultBufferDesc);
         REQUIRE(resultBuffer != nullptr);
     }
 
+    template<typename T>
     void checkTestResults()
     {
         ComPtr<ISlangBlob> resultBlob;
-        REQUIRE_CALL(device->readBuffer(resultBuffer, 0, sizeof(TestResult), resultBlob.writeRef()));
+        REQUIRE_CALL(device->readBuffer(resultBuffer, 0, sizeof(T), resultBlob.writeRef()));
 
-        const TestResult* result = reinterpret_cast<const TestResult*>(resultBlob->getBufferPointer());
+        const T* result = reinterpret_cast<const T*>(resultBlob->getBufferPointer());
         CHECK_EQ(result->isSphereHit, 1);
         CHECK_EQ(result->spherePositionAndRadius[0], 0.0f);
         CHECK_EQ(result->spherePositionAndRadius[1], 0.0f);
         CHECK_EQ(result->spherePositionAndRadius[2], -3.0f);
         CHECK_EQ(result->spherePositionAndRadius[3], 2.0f);
+    }
+
+    void checkTestResults()
+    {
+        if (device->getDeviceType() == DeviceType::CUDA)
+            checkTestResults<TestResultCudaAligned>();
+        else
+            checkTestResults<TestResult>();
     }
 
     void renderFrame()

--- a/tests/test-ray-tracing-sphere.slang
+++ b/tests/test-ray-tracing-sphere.slang
@@ -54,7 +54,7 @@ void missShader(inout RayPayload payload)
 }
 
 [shader("closesthit")]
-void closestHitShader(inout RayPayload payload)
+void closestHitShader(inout RayPayload payload, in BuiltInTriangleIntersectionAttributes attr)
 {
     uint primitiveIndex = PrimitiveIndex();
     float4 color = float4(0, 0, 0, 1);
@@ -99,7 +99,7 @@ void rayGenSphereIntrinsics()
 }
 
 [shader("closesthit")]
-void closestHitSphereIntrinsics(inout RayPayloadIntrinsics payload)
+void closestHitSphereIntrinsics(inout RayPayloadIntrinsics payload, in BuiltInTriangleIntersectionAttributes attr)
 {
     payload.res.isSphereHit = IsSphereHit();
     payload.res.spherePositionAndRadius = GetSpherePositionAndRadius();


### PR DESCRIPTION
I noticed some tests were failing when I ran the test suite on a card that supports LSS and spheres in D3D12 and Vulkan. This PR fixes tests wherever possible and disables the hit object tests under D3D12, because they're blocked by a bug in Slang.