### PR TITLE
Dump live objects with class names if RTTI data is available

### DIFF
--- a/src/core/smart-pointer.cpp
+++ b/src/core/smart-pointer.cpp
@@ -26,11 +26,20 @@ void RefObjectTracker::reportLiveObjects()
         printf("Found %zu live RHI objects!\n", objects.size());
         for (auto obj : objects)
         {
+            uint64_t referenceCount = obj->getReferenceCount();
+            uint64_t internalReferenceCount = obj->getInternalReferenceCount();
 #ifdef RTTI_ENABLED
-            printf("Live object: %p (%s)\n", static_cast<void*>(obj), typeid(*obj).name());
+            const char* typeName = typeid(*obj).name();
 #else
-            printf("Live object: %p\n", static_cast<void*>(obj));
+            const char* typeName = "unknown";
 #endif
+            printf(
+                "Live object: 0x%" PRIXPTR " referenceCount=%llu internalReferenceCount=%llu type=\"%s\"\n",
+                reinterpret_cast<uintptr_t>(obj),
+                referenceCount,
+                internalReferenceCount,
+                typeName
+            );
         }
     }
 }

--- a/src/core/smart-pointer.cpp
+++ b/src/core/smart-pointer.cpp
@@ -2,6 +2,20 @@
 
 #include <cstdio>
 
+#if SLANG_VC
+#if defined(_CPPRTTI)
+#define RTTI_ENABLED
+#endif
+#elif SLANG_CLANG
+#if __has_feature(cxx_rtti)
+#define RTTI_ENABLED
+#endif
+#elif SLANG_GCC
+#if defined(__GXX_RTTI)
+#define RTTI_ENABLED
+#endif
+#endif
+
 namespace rhi {
 
 #if SLANG_RHI_ENABLE_REF_OBJECT_TRACKING
@@ -12,7 +26,11 @@ void RefObjectTracker::reportLiveObjects()
         printf("Found %zu live RHI objects!\n", objects.size());
         for (auto obj : objects)
         {
+#ifdef RTTI_ENABLED
+            printf("Live object: %p (%s)\n", static_cast<void*>(obj), typeid(*obj).name());
+#else
             printf("Live object: %p\n", static_cast<void*>(obj));
+#endif
         }
     }
 }

--- a/src/core/smart-pointer.h
+++ b/src/core/smart-pointer.h
@@ -153,7 +153,8 @@ public:
         }
     }
 
-    uint64_t debugGetReferenceCount() { return referenceCount; }
+    uint64_t getReferenceCount() const { return referenceCount; }
+    uint64_t getInternalReferenceCount() const { return internalReferenceCount; }
 
     virtual void makeExternal() {}
     virtual void makeInternal() {}

--- a/tests/test-device-lifetime.cpp
+++ b/tests/test-device-lifetime.cpp
@@ -23,7 +23,7 @@ GPU_TEST_CASE("device-lifetime", ALL)
     bufferDesc.size = 1024;
     bufferDesc.usage = BufferUsage::ShaderResource;
     REQUIRE_CALL(testDevice->createBuffer(bufferDesc, nullptr, buffer.writeRef()));
-    uint64_t deviceRefCountBuffer = devicePtr->debugGetReferenceCount();
+    uint64_t deviceRefCountBuffer = devicePtr->getReferenceCount();
 
     // Create a texture
     ComPtr<ITexture> texture;
@@ -31,13 +31,13 @@ GPU_TEST_CASE("device-lifetime", ALL)
     textureDesc.format = Format::RGBA32Float;
     textureDesc.usage = TextureUsage::ShaderResource;
     REQUIRE_CALL(testDevice->createTexture(textureDesc, nullptr, texture.writeRef()));
-    uint64_t deviceRefCountTexture = devicePtr->debugGetReferenceCount();
+    uint64_t deviceRefCountTexture = devicePtr->getReferenceCount();
 
     // Create a sampler
     ComPtr<ISampler> sampler;
     SamplerDesc samplerDesc = {};
     REQUIRE_CALL(testDevice->createSampler(samplerDesc, sampler.writeRef()));
-    uint64_t deviceRefCountSampler = devicePtr->debugGetReferenceCount();
+    uint64_t deviceRefCountSampler = devicePtr->getReferenceCount();
 
     // Create acceleration structure
     ComPtr<IAccelerationStructure> accelerationStructure;
@@ -49,7 +49,7 @@ GPU_TEST_CASE("device-lifetime", ALL)
             testDevice->createAccelerationStructure(accelerationStructureDesc, accelerationStructure.writeRef())
         );
     }
-    uint64_t deviceRefCountAccelerationStructure = devicePtr->debugGetReferenceCount();
+    uint64_t deviceRefCountAccelerationStructure = devicePtr->getReferenceCount();
 
     // Create fence
     ComPtr<IFence> fence;
@@ -58,22 +58,22 @@ GPU_TEST_CASE("device-lifetime", ALL)
         FenceDesc fenceDesc = {};
         REQUIRE_CALL(testDevice->createFence(fenceDesc, fence.writeRef()));
     }
-    uint64_t deviceRefCountFence = devicePtr->debugGetReferenceCount();
+    uint64_t deviceRefCountFence = devicePtr->getReferenceCount();
 
     testDevice.setNull();
 
-    CHECK(devicePtr->debugGetReferenceCount() == deviceRefCountFence - 1);
+    CHECK(devicePtr->getReferenceCount() == deviceRefCountFence - 1);
     fence.setNull();
 
-    CHECK(devicePtr->debugGetReferenceCount() == deviceRefCountAccelerationStructure - 1);
+    CHECK(devicePtr->getReferenceCount() == deviceRefCountAccelerationStructure - 1);
     accelerationStructure.setNull();
 
-    CHECK(devicePtr->debugGetReferenceCount() == deviceRefCountSampler - 1);
+    CHECK(devicePtr->getReferenceCount() == deviceRefCountSampler - 1);
     sampler.setNull();
 
-    CHECK(devicePtr->debugGetReferenceCount() == deviceRefCountTexture - 1);
+    CHECK(devicePtr->getReferenceCount() == deviceRefCountTexture - 1);
     texture.setNull();
 
-    CHECK(devicePtr->debugGetReferenceCount() == deviceRefCountBuffer - 1);
+    CHECK(devicePtr->getReferenceCount() == deviceRefCountBuffer - 1);
     buffer.setNull();
 }


### PR DESCRIPTION
- Improve the information dumped in `reportLifeObjects`
- Minor internal API cleanup