### PR TITLE
Ordered freeing of command buffers

### DIFF
--- a/src/cuda/cuda-command.cpp
+++ b/src/cuda/cuda-command.cpp
@@ -778,7 +778,7 @@ Result CommandQueueImpl::retireCommandBuffers()
             // Not ready means event hasn't been triggered yet, so it's still in-flight.
             // As command buffers are ordered, this should mean that all subsequent command buffers
             // are also still in-flight, so we can stop checking.
-            break;            
+            break;
         }
         else
         {


### PR DESCRIPTION
CUDA pending command buffers are implicitly ordered, so if we find one that can't yet be retired, there is no need to keep iterating through them all.