### PR TITLE
Propagate range offset from ParameterBlock

### DIFF
--- a/src/d3d12/d3d12-shader-object-layout.cpp
+++ b/src/d3d12/d3d12-shader-object-layout.cpp
@@ -845,6 +845,7 @@ void RootShaderObjectLayoutImpl::RootSignatureDescBuilder::addAsValue(
             offsetForChildrenThatNeedNewSpace += BindingRegisterOffsetPair(elementVarLayout);
             BindingRegisterOffsetPair offsetForOrindaryChildren = subDescriptorSetOffset;
             offsetForOrindaryChildren += BindingRegisterOffsetPair(containerVarLayout);
+            offsetForOrindaryChildren += inElementOffset;
 
             addAsConstantBuffer(
                 elementTypeLayout,


### PR DESCRIPTION
ParameterBlocks have binding offsets associated with them that need to be propagated to their subobjects.

Fixes https://github.com/shader-slang/slang/issues/7611