### PR TITLE
Remove fixupBufferDesc and fixupTextureDesc in debug layer

### DIFF
--- a/src/debug-layer/debug-device.cpp
+++ b/src/debug-layer/debug-device.cpp
@@ -220,7 +220,7 @@ Result DebugDevice::createTexture(const TextureDesc& desc, const SubresourceData
         break;
     }
 
-    TextureDesc patchedDesc = fixupTextureDesc(desc);
+    TextureDesc patchedDesc = desc;
     std::string label;
     if (!patchedDesc.label)
     {
@@ -254,7 +254,7 @@ Result DebugDevice::createBuffer(const BufferDesc& desc, const void* initData, I
 {
     SLANG_RHI_API_FUNC;
 
-    BufferDesc patchedDesc = fixupBufferDesc(desc);
+    BufferDesc patchedDesc = desc;
     std::string label;
     if (!patchedDesc.label)
     {

--- a/src/wgpu/wgpu-buffer.cpp
+++ b/src/wgpu/wgpu-buffer.cpp
@@ -37,8 +37,10 @@ Result BufferImpl::getSharedHandle(NativeHandle* outHandle)
     return SLANG_E_NOT_AVAILABLE;
 }
 
-Result DeviceImpl::createBuffer(const BufferDesc& desc, const void* initData, IBuffer** outBuffer)
+Result DeviceImpl::createBuffer(const BufferDesc& desc_, const void* initData, IBuffer** outBuffer)
 {
+    BufferDesc desc = fixupBufferDesc(desc_);
+
     RefPtr<BufferImpl> buffer = new BufferImpl(this, desc);
     WGPUBufferDescriptor bufferDesc = {};
     bufferDesc.size = desc.size;


### PR DESCRIPTION
Debug layer should not modify the descriptors (other than setting a default label). Added missing fixup in WGPU backend.