### PR TITLE
Skip the null-handle assignment when not available

### DIFF
--- a/src/vulkan/vk-shader-object.cpp
+++ b/src/vulkan/vk-shader-object.cpp
@@ -113,6 +113,7 @@ inline void writeAccelerationStructureDescriptor(
     // pAccelerationStructures must not be VK_NULL_HANDLE
     if (!as && !device->m_api.m_extendedFeatures.robustness2Features.nullDescriptor)
     {
+        SLANG_RHI_ASSERT_FAILURE("nullDescriptor feature is not available on the device");
         return;
     }
 


### PR DESCRIPTION
This PR is to address the following Vulkan Validation Layer Error,
```
error: error: -1248876731 - VUID-VkWriteDescriptorSetAccelerationStructureKHR-pAccelerationStructures-03580:
     vkUpdateDescriptorSets(): pDescriptorWrites[0].pNext<VkWriteDescriptorSetAccelerationStructureKHR>.pAccelerationStructures[0] found in the template
     update has an invalid VkAccelerationStructureKHR 0x0 (while trying to update a descriptorType of VK_DESCRIPTOR_TYPE_ACCELERATION_STRUCTURE_KHR). Make
     sure your pData is pointing to vkAccelerationStructureKHR and not VkWriteDescriptorSetAccelerationStructureKHR.
     The Vulkan spec states: If the nullDescriptor feature is not enabled, each element of pAccelerationStructures must not be VK_NULL_HANDLE
     (https://vulkan.lunarg.com/doc/view/1.4.321.1/windows/antora/spec/latest/chapters/descriptorsets.html#VUID-VkWriteDescriptorSetAccelerationStructureKHR-p
     AccelerationStructures-03580)
```

Although it turned out to be a bug on the VVL implementation, it is good to handle this case more reliably.
This PR will skip the use of null-handle when the hardware doesn't support it.

Related to
- https://github.com/shader-slang/slang/issues/8289