### PR TITLE
Add IPassEncoder::writeTimestamp

### DIFF
--- a/include/slang-rhi.h
+++ b/include/slang-rhi.h
@@ -2206,6 +2206,8 @@ public:
     virtual SLANG_NO_THROW void SLANG_MCALL popDebugGroup() = 0;
     virtual SLANG_NO_THROW void SLANG_MCALL insertDebugMarker(const char* name, const MarkerColor& color) = 0;
 
+    virtual SLANG_NO_THROW void SLANG_MCALL writeTimestamp(IQueryPool* queryPool, uint32_t queryIndex) = 0;
+
     virtual SLANG_NO_THROW void SLANG_MCALL end() = 0;
 };
 

--- a/src/command-buffer.cpp
+++ b/src/command-buffer.cpp
@@ -168,6 +168,17 @@ void RenderPassEncoder::insertDebugMarker(const char* name, const MarkerColor& c
     }
 }
 
+void RenderPassEncoder::writeTimestamp(IQueryPool* queryPool, uint32_t queryIndex)
+{
+    if (m_commandList)
+    {
+        commands::WriteTimestamp cmd;
+        cmd.queryPool = checked_cast<QueryPool*>(queryPool);
+        cmd.queryIndex = queryIndex;
+        m_commandList->write(std::move(cmd));
+    }
+}
+
 void RenderPassEncoder::end()
 {
     if (m_commandList)
@@ -285,6 +296,17 @@ void ComputePassEncoder::insertDebugMarker(const char* name, const MarkerColor& 
     }
 }
 
+void ComputePassEncoder::writeTimestamp(IQueryPool* queryPool, uint32_t queryIndex)
+{
+    if (m_commandList)
+    {
+        commands::WriteTimestamp cmd;
+        cmd.queryPool = checked_cast<QueryPool*>(queryPool);
+        cmd.queryIndex = queryIndex;
+        m_commandList->write(std::move(cmd));
+    }
+}
+
 void ComputePassEncoder::end()
 {
     if (m_commandList)
@@ -396,6 +418,17 @@ void RayTracingPassEncoder::insertDebugMarker(const char* name, const MarkerColo
         commands::InsertDebugMarker cmd;
         cmd.name = name;
         cmd.color = color;
+        m_commandList->write(std::move(cmd));
+    }
+}
+
+void RayTracingPassEncoder::writeTimestamp(IQueryPool* queryPool, uint32_t queryIndex)
+{
+    if (m_commandList)
+    {
+        commands::WriteTimestamp cmd;
+        cmd.queryPool = checked_cast<QueryPool*>(queryPool);
+        cmd.queryIndex = queryIndex;
         m_commandList->write(std::move(cmd));
     }
 }

--- a/src/command-buffer.h
+++ b/src/command-buffer.h
@@ -92,6 +92,8 @@ public:
     virtual SLANG_NO_THROW void SLANG_MCALL popDebugGroup() override;
     virtual SLANG_NO_THROW void SLANG_MCALL insertDebugMarker(const char* name, const MarkerColor& color) override;
 
+    virtual SLANG_NO_THROW void SLANG_MCALL writeTimestamp(IQueryPool* queryPool, uint32_t queryIndex) override;
+
     virtual SLANG_NO_THROW void SLANG_MCALL end() override;
 };
 
@@ -127,6 +129,8 @@ public:
     virtual SLANG_NO_THROW void SLANG_MCALL pushDebugGroup(const char* name, const MarkerColor& color) override;
     virtual SLANG_NO_THROW void SLANG_MCALL popDebugGroup() override;
     virtual SLANG_NO_THROW void SLANG_MCALL insertDebugMarker(const char* name, const MarkerColor& color) override;
+
+    virtual SLANG_NO_THROW void SLANG_MCALL writeTimestamp(IQueryPool* queryPool, uint32_t queryIndex) override;
 
     virtual SLANG_NO_THROW void SLANG_MCALL end() override;
 };
@@ -172,6 +176,8 @@ public:
     virtual SLANG_NO_THROW void SLANG_MCALL pushDebugGroup(const char* name, const MarkerColor& color) override;
     virtual SLANG_NO_THROW void SLANG_MCALL popDebugGroup() override;
     virtual SLANG_NO_THROW void SLANG_MCALL insertDebugMarker(const char* name, const MarkerColor& color) override;
+
+    virtual SLANG_NO_THROW void SLANG_MCALL writeTimestamp(IQueryPool* queryPool, uint32_t queryIndex) override;
 
     virtual SLANG_NO_THROW void SLANG_MCALL end() override;
 };

--- a/src/debug-layer/debug-command-encoder.cpp
+++ b/src/debug-layer/debug-command-encoder.cpp
@@ -112,6 +112,14 @@ void DebugRenderPassEncoder::insertDebugMarker(const char* name, const MarkerCol
     baseObject->insertDebugMarker(name, color);
 }
 
+void DebugRenderPassEncoder::writeTimestamp(IQueryPool* queryPool, uint32_t queryIndex)
+{
+    SLANG_RHI_API_FUNC;
+    m_commandEncoder->requireOpen();
+    m_commandEncoder->requireRenderPass();
+    baseObject->writeTimestamp(queryPool, queryIndex);
+}
+
 void DebugRenderPassEncoder::end()
 {
     SLANG_RHI_API_FUNC;
@@ -184,6 +192,14 @@ void DebugComputePassEncoder::insertDebugMarker(const char* name, const MarkerCo
     m_commandEncoder->requireOpen();
     m_commandEncoder->requireComputePass();
     baseObject->insertDebugMarker(name, color);
+}
+
+void DebugComputePassEncoder::writeTimestamp(IQueryPool* queryPool, uint32_t queryIndex)
+{
+    SLANG_RHI_API_FUNC;
+    m_commandEncoder->requireOpen();
+    m_commandEncoder->requireComputePass();
+    baseObject->writeTimestamp(queryPool, queryIndex);
 }
 
 void DebugComputePassEncoder::end()
@@ -259,6 +275,14 @@ void DebugRayTracingPassEncoder::insertDebugMarker(const char* name, const Marke
     m_commandEncoder->requireOpen();
     m_commandEncoder->requireRayTracingPass();
     baseObject->insertDebugMarker(name, color);
+}
+
+void DebugRayTracingPassEncoder::writeTimestamp(IQueryPool* queryPool, uint32_t queryIndex)
+{
+    SLANG_RHI_API_FUNC;
+    m_commandEncoder->requireOpen();
+    m_commandEncoder->requireRayTracingPass();
+    baseObject->writeTimestamp(queryPool, queryIndex);
 }
 
 void DebugRayTracingPassEncoder::end()

--- a/src/debug-layer/debug-command-encoder.h
+++ b/src/debug-layer/debug-command-encoder.h
@@ -41,6 +41,8 @@ public:
     virtual SLANG_NO_THROW void SLANG_MCALL popDebugGroup() override;
     virtual SLANG_NO_THROW void SLANG_MCALL insertDebugMarker(const char* name, const MarkerColor& color) override;
 
+    virtual SLANG_NO_THROW void SLANG_MCALL writeTimestamp(IQueryPool* queryPool, uint32_t queryIndex) override;
+
     virtual SLANG_NO_THROW void SLANG_MCALL end() override;
 };
 
@@ -70,6 +72,8 @@ public:
     virtual SLANG_NO_THROW void SLANG_MCALL pushDebugGroup(const char* name, const MarkerColor& color) override;
     virtual SLANG_NO_THROW void SLANG_MCALL popDebugGroup() override;
     virtual SLANG_NO_THROW void SLANG_MCALL insertDebugMarker(const char* name, const MarkerColor& color) override;
+
+    virtual SLANG_NO_THROW void SLANG_MCALL writeTimestamp(IQueryPool* queryPool, uint32_t queryIndex) override;
 
     virtual SLANG_NO_THROW void SLANG_MCALL end() override;
 };
@@ -108,6 +112,8 @@ public:
     virtual SLANG_NO_THROW void SLANG_MCALL pushDebugGroup(const char* name, const MarkerColor& color) override;
     virtual SLANG_NO_THROW void SLANG_MCALL popDebugGroup() override;
     virtual SLANG_NO_THROW void SLANG_MCALL insertDebugMarker(const char* name, const MarkerColor& color) override;
+
+    virtual SLANG_NO_THROW void SLANG_MCALL writeTimestamp(IQueryPool* queryPool, uint32_t queryIndex) override;
 
     virtual SLANG_NO_THROW void SLANG_MCALL end() override;
 };


### PR DESCRIPTION
Add new interface for writing timestamps on pass encoders.
This will just work for the existing backends that support timestamp writing (D3D11, D3D12, Vulkan, CUDA and CPU). Metal and WebGPU don't implement timestamp writing at all currently.