### PR TITLE
Use GPU_TEST_CASE for all GPU tests

### DIFF
--- a/tests/test-buffer-shared.cpp
+++ b/tests/test-buffer-shared.cpp
@@ -3,11 +3,14 @@
 using namespace rhi;
 using namespace rhi::testing;
 
-template<DeviceType DstDeviceType>
-void testSharedBuffer(GpuTestContext* ctx, DeviceType deviceType)
+#if SLANG_WIN64
+GPU_TEST_CASE("buffer-shared-cuda", D3D12 | Vulkan | NoDevice)
 {
-    ComPtr<IDevice> srcDevice = createTestingDevice(ctx, deviceType);
-    ComPtr<IDevice> dstDevice = createTestingDevice(ctx, DstDeviceType);
+    if (!isDeviceTypeAvailable(DeviceType::CUDA))
+        SKIP("CUDA not available");
+
+    ComPtr<IDevice> srcDevice = createTestingDevice(ctx, ctx->deviceType);
+    ComPtr<IDevice> dstDevice = createTestingDevice(ctx, DeviceType::CUDA);
 
     // Create a shareable buffer using srcDevice, get its handle, then create a buffer using the handle using
     // dstDevice. Read back the buffer and check that its contents are correct.
@@ -63,20 +66,5 @@ void testSharedBuffer(GpuTestContext* ctx, DeviceType deviceType)
     }
 
     compareComputeResult(dstDevice, dstBuffer, makeArray<float>(1.0f, 2.0f, 3.0f, 4.0f));
-}
-
-#if SLANG_WIN64
-TEST_CASE("buffer-shared-cuda")
-{
-    if (!isDeviceTypeAvailable(DeviceType::CUDA))
-        SKIP("CUDA not available");
-
-    runGpuTests(
-        testSharedBuffer<DeviceType::CUDA>,
-        {
-            DeviceType::D3D12,
-            DeviceType::Vulkan,
-        }
-    );
 }
 #endif

--- a/tests/test-compilation-report.cpp
+++ b/tests/test-compilation-report.cpp
@@ -88,116 +88,111 @@ inline const CompilationReportList* getCompilationReportList(IDevice* device)
     return reportList;
 }
 
-TEST_CASE("compilation-report")
+GPU_TEST_CASE("compilation-report", ALL | NoDevice)
 {
-    runGpuTests(
-        [](GpuTestContext* ctx, DeviceType deviceType)
-        {
-            // On CPU backend, compilation is done late during pipeline creation.
-            // Skip for now, as report is missing compilation times.
-            if (deviceType == DeviceType::CPU)
-            {
-                return;
-            }
+    // On CPU backend, compilation is done late during pipeline creation.
+    // Skip for now, as report is missing compilation times.
+    if (ctx->deviceType == DeviceType::CPU)
+    {
+        return;
+    }
 
-            DeviceExtraOptions options = {};
-            options.enableCompilationReports = true;
-            ComPtr<IDevice> device = createTestingDevice(ctx, deviceType, false, &options);
-            REQUIRE(device);
+    DeviceExtraOptions options = {};
+    options.enableCompilationReports = true;
+    device = createTestingDevice(ctx, ctx->deviceType, false, &options);
+    REQUIRE(device);
 
-            // Create first shader program.
-            ComPtr<IShaderProgram> shaderProgram1 = createShaderProgram(device.get());
+    // Create first shader program.
+    ComPtr<IShaderProgram> shaderProgram1 = createShaderProgram(device.get());
 
-            // We expect no compilation has taken place yet, so the report should be empty.
-            const CompilationReport* report1a = getCompilationReport(shaderProgram1.get());
-            CHECK(report1a->alive == true);
-            CHECK(report1a->createTime == 0.0);
-            CHECK(report1a->compileTime == 0.0);
-            CHECK(report1a->compileSlangTime == 0.0);
-            CHECK(report1a->compileDownstreamTime == 0.0);
-            CHECK(report1a->createPipelineTime == 0.0);
-            CHECK(report1a->entryPointReportCount == 0);
-            CHECK(report1a->pipelineReportCount == 0);
+    // We expect no compilation has taken place yet, so the report should be empty.
+    const CompilationReport* report1a = getCompilationReport(shaderProgram1.get());
+    CHECK(report1a->alive == true);
+    CHECK(report1a->createTime == 0.0);
+    CHECK(report1a->compileTime == 0.0);
+    CHECK(report1a->compileSlangTime == 0.0);
+    CHECK(report1a->compileDownstreamTime == 0.0);
+    CHECK(report1a->createPipelineTime == 0.0);
+    CHECK(report1a->entryPointReportCount == 0);
+    CHECK(report1a->pipelineReportCount == 0);
 
-            // The report should be registered in the device.
-            const CompilationReportList* reports1a = getCompilationReportList(device.get());
-            CHECK(reports1a->reportCount == 1);
-            CHECK(isEqual(&reports1a->reports[0], report1a));
+    // The report should be registered in the device.
+    const CompilationReportList* reports1a = getCompilationReportList(device.get());
+    CHECK(reports1a->reportCount == 1);
+    CHECK(isEqual(&reports1a->reports[0], report1a));
 
-            // Create and dispatch first pipeline.
-            ComPtr<IComputePipeline> pipeline1 = createPipeline(device.get(), shaderProgram1.get());
-            dispatchPipeline(device.get(), pipeline1.get());
+    // Create and dispatch first pipeline.
+    ComPtr<IComputePipeline> pipeline1 = createPipeline(device.get(), shaderProgram1.get());
+    dispatchPipeline(device.get(), pipeline1.get());
 
-            // We expect compilation and pipeline creation has taken place, so the report should contain non-zero times.
-            const CompilationReport* report1b = getCompilationReport(shaderProgram1.get());
-            CHECK(report1b->alive == true);
-            CHECK(report1b->createTime > 0.0);
-            CHECK(report1b->compileTime > 0.0);
-            CHECK(report1b->compileSlangTime > 0.0);
-            // Downstream compilation time may be zero if no downstream compiler is used.
-            CHECK(report1b->compileDownstreamTime >= 0.0);
-            CHECK(report1b->createPipelineTime > 0.0);
-            CHECK(report1b->entryPointReportCount == 1);
-            CHECK(report1b->pipelineReportCount == 1);
+    // We expect compilation and pipeline creation has taken place, so the report should contain non-zero times.
+    const CompilationReport* report1b = getCompilationReport(shaderProgram1.get());
+    CHECK(report1b->alive == true);
+    CHECK(report1b->createTime > 0.0);
+    CHECK(report1b->compileTime > 0.0);
+    CHECK(report1b->compileSlangTime > 0.0);
+    // Downstream compilation time may be zero if no downstream compiler is used.
+    CHECK(report1b->compileDownstreamTime >= 0.0);
+    CHECK(report1b->createPipelineTime > 0.0);
+    CHECK(report1b->entryPointReportCount == 1);
+    CHECK(report1b->pipelineReportCount == 1);
 
-            // The report should still be registered in the device.
-            const CompilationReportList* reports1b = getCompilationReportList(device.get());
-            CHECK(reports1b->reportCount == 1);
-            CHECK(isEqual(&reports1b->reports[0], report1b));
+    // The report should still be registered in the device.
+    const CompilationReportList* reports1b = getCompilationReportList(device.get());
+    CHECK(reports1b->reportCount == 1);
+    CHECK(isEqual(&reports1b->reports[0], report1b));
 
-            // Create second shader program.
-            ComPtr<IShaderProgram> shaderProgram2 = createShaderProgram(device.get());
+    // Create second shader program.
+    ComPtr<IShaderProgram> shaderProgram2 = createShaderProgram(device.get());
 
-            // We expect no compilation has taken place yet, so the report should be empty.
-            const CompilationReport* report2a = getCompilationReport(shaderProgram2.get());
-            CHECK(report2a->alive == true);
-            CHECK(report2a->createTime == 0.0);
-            CHECK(report2a->compileTime == 0.0);
-            CHECK(report2a->compileSlangTime == 0.0);
-            CHECK(report2a->compileDownstreamTime == 0.0);
-            CHECK(report2a->createPipelineTime == 0.0);
-            CHECK(report2a->entryPointReportCount == 0);
-            CHECK(report2a->pipelineReportCount == 0);
+    // We expect no compilation has taken place yet, so the report should be empty.
+    const CompilationReport* report2a = getCompilationReport(shaderProgram2.get());
+    CHECK(report2a->alive == true);
+    CHECK(report2a->createTime == 0.0);
+    CHECK(report2a->compileTime == 0.0);
+    CHECK(report2a->compileSlangTime == 0.0);
+    CHECK(report2a->compileDownstreamTime == 0.0);
+    CHECK(report2a->createPipelineTime == 0.0);
+    CHECK(report2a->entryPointReportCount == 0);
+    CHECK(report2a->pipelineReportCount == 0);
 
-            // The report should be registered in the device.
-            const CompilationReportList* reports2a = getCompilationReportList(device.get());
-            CHECK(reports2a->reportCount == 2);
-            CHECK(isEqual(&reports2a->reports[0], report1b));
-            CHECK(isEqual(&reports2a->reports[1], report2a));
+    // The report should be registered in the device.
+    const CompilationReportList* reports2a = getCompilationReportList(device.get());
+    CHECK(reports2a->reportCount == 2);
+    CHECK(isEqual(&reports2a->reports[0], report1b));
+    CHECK(isEqual(&reports2a->reports[1], report2a));
 
-            // Create and dispatch second pipeline.
-            ComPtr<IComputePipeline> pipeline2 = createPipeline(device.get(), shaderProgram2.get());
-            dispatchPipeline(device.get(), pipeline2.get());
+    // Create and dispatch second pipeline.
+    ComPtr<IComputePipeline> pipeline2 = createPipeline(device.get(), shaderProgram2.get());
+    dispatchPipeline(device.get(), pipeline2.get());
 
-            // We expect compilation and pipeline creation has taken place, so the report should contain non-zero times.
-            const CompilationReport* report2b = getCompilationReport(shaderProgram2.get());
-            CHECK(report2b->alive == true);
-            CHECK(report2b->createTime > 0.0);
-            CHECK(report2b->compileTime > 0.0);
-            CHECK(report2b->compileSlangTime > 0.0);
-            // Downstream compilation time may be zero if no downstream compiler is used.
-            CHECK(report2b->compileDownstreamTime >= 0.0);
-            CHECK(report2b->createPipelineTime > 0.0);
-            CHECK(report2b->entryPointReportCount == 1);
-            CHECK(report2b->pipelineReportCount == 1);
+    // We expect compilation and pipeline creation has taken place, so the report should contain non-zero times.
+    const CompilationReport* report2b = getCompilationReport(shaderProgram2.get());
+    CHECK(report2b->alive == true);
+    CHECK(report2b->createTime > 0.0);
+    CHECK(report2b->compileTime > 0.0);
+    CHECK(report2b->compileSlangTime > 0.0);
+    // Downstream compilation time may be zero if no downstream compiler is used.
+    CHECK(report2b->compileDownstreamTime >= 0.0);
+    CHECK(report2b->createPipelineTime > 0.0);
+    CHECK(report2b->entryPointReportCount == 1);
+    CHECK(report2b->pipelineReportCount == 1);
 
-            // The report should still be registered in the device.
-            const CompilationReportList* reports2b = getCompilationReportList(device.get());
-            CHECK(reports2b->reportCount == 2);
-            CHECK(isEqual(&reports2b->reports[0], report1b));
-            CHECK(isEqual(&reports2b->reports[1], report2b));
+    // The report should still be registered in the device.
+    const CompilationReportList* reports2b = getCompilationReportList(device.get());
+    CHECK(reports2b->reportCount == 2);
+    CHECK(isEqual(&reports2b->reports[0], report1b));
+    CHECK(isEqual(&reports2b->reports[1], report2b));
 
-            // Release the first shader program and pipeline.
-            shaderProgram1 = nullptr;
-            pipeline1 = nullptr;
+    // Release the first shader program and pipeline.
+    shaderProgram1 = nullptr;
+    pipeline1 = nullptr;
 
-            // The report first the first program should still be returned, but marked as no longer alive.
-            const CompilationReportList* reports3 = getCompilationReportList(device.get());
-            CompilationReport report1c = *report1b;
-            report1c.alive = false; // The first program is no longer alive.
-            CHECK(reports3->reportCount == 2);
-            CHECK(isEqual(&reports3->reports[0], &report1c));
-            CHECK(isEqual(&reports3->reports[1], report2b));
-        }
-    );
+    // The report first the first program should still be returned, but marked as no longer alive.
+    const CompilationReportList* reports3 = getCompilationReportList(device.get());
+    CompilationReport report1c = *report1b;
+    report1c.alive = false; // The first program is no longer alive.
+    CHECK(reports3->reportCount == 2);
+    CHECK(isEqual(&reports3->reports[0], &report1c));
+    CHECK(isEqual(&reports3->reports[1], report2b));
 }

--- a/tests/test-nvapi.cpp
+++ b/tests/test-nvapi.cpp
@@ -5,141 +5,131 @@ using namespace rhi::testing;
 
 #if SLANG_RHI_ENABLE_NVAPI
 
-TEST_CASE("nvapi-implicit")
+GPU_TEST_CASE("nvapi-implicit", D3D12 | NoDevice)
 {
-    auto testFunc = [](GpuTestContext* ctx, DeviceType deviceType)
+    device = createTestingDevice(ctx, ctx->deviceType, true);
+
+    ComPtr<IShaderProgram> shaderProgram;
+    slang::ProgramLayout* slangReflection = nullptr;
+    REQUIRE_CALL(loadComputeProgram(device, shaderProgram, "test-nvapi-implicit", "computeMain", slangReflection));
+
+    ComputePipelineDesc pipelineDesc = {};
+    pipelineDesc.program = shaderProgram.get();
+    ComPtr<IComputePipeline> pipeline;
+    REQUIRE_CALL(device->createComputePipeline(pipelineDesc, pipeline.writeRef()));
+
+    uint32_t globalVar = 1000;
+
+    ComPtr<IBuffer> globalBuffer;
     {
-        ComPtr<IDevice> device = createTestingDevice(ctx, deviceType, true);
+        uint32_t initialData[] = {2000};
+        BufferDesc desc = {};
+        desc.size = 4;
+        desc.usage = BufferUsage::ShaderResource | BufferUsage::CopyDestination;
+        REQUIRE_CALL(device->createBuffer(desc, initialData, globalBuffer.writeRef()));
+    }
 
-        ComPtr<IShaderProgram> shaderProgram;
-        slang::ProgramLayout* slangReflection = nullptr;
-        REQUIRE_CALL(loadComputeProgram(device, shaderProgram, "test-nvapi-implicit", "computeMain", slangReflection));
+    ComPtr<IBuffer> buffer;
+    {
+        uint32_t initialData[] = {3000};
+        BufferDesc desc = {};
+        desc.size = 4;
+        desc.usage = BufferUsage::ShaderResource | BufferUsage::CopyDestination;
+        REQUIRE_CALL(device->createBuffer(desc, initialData, buffer.writeRef()));
+    }
 
-        ComputePipelineDesc pipelineDesc = {};
-        pipelineDesc.program = shaderProgram.get();
-        ComPtr<IComputePipeline> pipeline;
-        REQUIRE_CALL(device->createComputePipeline(pipelineDesc, pipeline.writeRef()));
+    ComPtr<IBuffer> result;
+    {
+        BufferDesc desc = {};
+        desc.size = 16;
+        desc.usage = BufferUsage::UnorderedAccess | BufferUsage::CopySource;
+        REQUIRE_CALL(device->createBuffer(desc, nullptr, result.writeRef()));
+    }
 
-        uint32_t globalVar = 1000;
+    {
+        auto queue = device->getQueue(QueueType::Graphics);
+        auto commandEncoder = queue->createCommandEncoder();
+        auto passEncoder = commandEncoder->beginComputePass();
+        IShaderObject* rootObject = passEncoder->bindPipeline(pipeline);
+        ShaderCursor globalCursor(rootObject);
+        globalCursor["globalVar"].setData(globalVar);
+        globalCursor["globalBuffer"].setBinding(globalBuffer);
+        ShaderCursor entryPointCursor(rootObject->getEntryPoint(0));
+        entryPointCursor["buffer"].setBinding(buffer);
+        entryPointCursor["result"].setBinding(result);
+        passEncoder->dispatchCompute(1, 1, 1);
+        passEncoder->end();
 
-        ComPtr<IBuffer> globalBuffer;
-        {
-            uint32_t initialData[] = {2000};
-            BufferDesc desc = {};
-            desc.size = 4;
-            desc.usage = BufferUsage::ShaderResource | BufferUsage::CopyDestination;
-            REQUIRE_CALL(device->createBuffer(desc, initialData, globalBuffer.writeRef()));
-        }
+        queue->submit(commandEncoder->finish());
+        queue->waitOnHost();
+    }
 
-        ComPtr<IBuffer> buffer;
-        {
-            uint32_t initialData[] = {3000};
-            BufferDesc desc = {};
-            desc.size = 4;
-            desc.usage = BufferUsage::ShaderResource | BufferUsage::CopyDestination;
-            REQUIRE_CALL(device->createBuffer(desc, initialData, buffer.writeRef()));
-        }
-
-        ComPtr<IBuffer> result;
-        {
-            BufferDesc desc = {};
-            desc.size = 16;
-            desc.usage = BufferUsage::UnorderedAccess | BufferUsage::CopySource;
-            REQUIRE_CALL(device->createBuffer(desc, nullptr, result.writeRef()));
-        }
-
-        {
-            auto queue = device->getQueue(QueueType::Graphics);
-            auto commandEncoder = queue->createCommandEncoder();
-            auto passEncoder = commandEncoder->beginComputePass();
-            IShaderObject* rootObject = passEncoder->bindPipeline(pipeline);
-            ShaderCursor globalCursor(rootObject);
-            globalCursor["globalVar"].setData(globalVar);
-            globalCursor["globalBuffer"].setBinding(globalBuffer);
-            ShaderCursor entryPointCursor(rootObject->getEntryPoint(0));
-            entryPointCursor["buffer"].setBinding(buffer);
-            entryPointCursor["result"].setBinding(result);
-            passEncoder->dispatchCompute(1, 1, 1);
-            passEncoder->end();
-
-            queue->submit(commandEncoder->finish());
-            queue->waitOnHost();
-        }
-
-        compareComputeResult(device, result, std::array{1000, 2000, 3000});
-    };
-
-    runGpuTests(testFunc, {DeviceType::D3D12});
+    compareComputeResult(device, result, std::array{1000, 2000, 3000});
 }
 
-TEST_CASE("nvapi-explicit")
+GPU_TEST_CASE("nvapi-explicit", D3D12 | NoDevice)
 {
-    auto testFunc = [](GpuTestContext* ctx, DeviceType deviceType)
+    DeviceExtraOptions extraOptions;
+    const char* nvapiSearchPath = SLANG_RHI_NVAPI_INCLUDE_DIR;
+    extraOptions.searchPaths.push_back(nvapiSearchPath);
+    device = createTestingDevice(ctx, ctx->deviceType, false, &extraOptions);
+
+    ComPtr<IShaderProgram> shaderProgram;
+    slang::ProgramLayout* slangReflection = nullptr;
+    REQUIRE_CALL(loadComputeProgram(device, shaderProgram, "test-nvapi-explicit", "computeMain", slangReflection));
+
+    ComputePipelineDesc pipelineDesc = {};
+    pipelineDesc.program = shaderProgram.get();
+    ComPtr<IComputePipeline> pipeline;
+    REQUIRE_CALL(device->createComputePipeline(pipelineDesc, pipeline.writeRef()));
+
+    uint32_t globalVar = 1000;
+
+    ComPtr<IBuffer> globalBuffer;
     {
-        DeviceExtraOptions extraOptions;
-        const char* nvapiSearchPath = SLANG_RHI_NVAPI_INCLUDE_DIR;
-        extraOptions.searchPaths.push_back(nvapiSearchPath);
-        ComPtr<IDevice> device = createTestingDevice(ctx, deviceType, false, &extraOptions);
+        uint32_t initialData[] = {2000};
+        BufferDesc desc = {};
+        desc.size = 4;
+        desc.usage = BufferUsage::ShaderResource | BufferUsage::CopyDestination;
+        REQUIRE_CALL(device->createBuffer(desc, initialData, globalBuffer.writeRef()));
+    }
 
-        ComPtr<IShaderProgram> shaderProgram;
-        slang::ProgramLayout* slangReflection = nullptr;
-        REQUIRE_CALL(loadComputeProgram(device, shaderProgram, "test-nvapi-explicit", "computeMain", slangReflection));
+    ComPtr<IBuffer> buffer;
+    {
+        uint32_t initialData[] = {3000};
+        BufferDesc desc = {};
+        desc.size = 4;
+        desc.usage = BufferUsage::ShaderResource | BufferUsage::CopyDestination;
+        REQUIRE_CALL(device->createBuffer(desc, initialData, buffer.writeRef()));
+    }
 
-        ComputePipelineDesc pipelineDesc = {};
-        pipelineDesc.program = shaderProgram.get();
-        ComPtr<IComputePipeline> pipeline;
-        REQUIRE_CALL(device->createComputePipeline(pipelineDesc, pipeline.writeRef()));
+    ComPtr<IBuffer> result;
+    {
+        BufferDesc desc = {};
+        desc.size = 16;
+        desc.usage = BufferUsage::UnorderedAccess | BufferUsage::CopySource;
+        REQUIRE_CALL(device->createBuffer(desc, nullptr, result.writeRef()));
+    }
 
-        uint32_t globalVar = 1000;
+    {
+        auto queue = device->getQueue(QueueType::Graphics);
+        auto commandEncoder = queue->createCommandEncoder();
+        auto passEncoder = commandEncoder->beginComputePass();
+        IShaderObject* rootObject = passEncoder->bindPipeline(pipeline);
+        ShaderCursor globalCursor(rootObject);
+        globalCursor["globalVar"].setData(globalVar);
+        globalCursor["globalBuffer"].setBinding(globalBuffer);
+        ShaderCursor entryPointCursor(rootObject->getEntryPoint(0));
+        entryPointCursor["buffer"].setBinding(buffer);
+        entryPointCursor["result"].setBinding(result);
+        passEncoder->dispatchCompute(1, 1, 1);
+        passEncoder->end();
 
-        ComPtr<IBuffer> globalBuffer;
-        {
-            uint32_t initialData[] = {2000};
-            BufferDesc desc = {};
-            desc.size = 4;
-            desc.usage = BufferUsage::ShaderResource | BufferUsage::CopyDestination;
-            REQUIRE_CALL(device->createBuffer(desc, initialData, globalBuffer.writeRef()));
-        }
+        queue->submit(commandEncoder->finish());
+        queue->waitOnHost();
+    }
 
-        ComPtr<IBuffer> buffer;
-        {
-            uint32_t initialData[] = {3000};
-            BufferDesc desc = {};
-            desc.size = 4;
-            desc.usage = BufferUsage::ShaderResource | BufferUsage::CopyDestination;
-            REQUIRE_CALL(device->createBuffer(desc, initialData, buffer.writeRef()));
-        }
-
-        ComPtr<IBuffer> result;
-        {
-            BufferDesc desc = {};
-            desc.size = 16;
-            desc.usage = BufferUsage::UnorderedAccess | BufferUsage::CopySource;
-            REQUIRE_CALL(device->createBuffer(desc, nullptr, result.writeRef()));
-        }
-
-        {
-            auto queue = device->getQueue(QueueType::Graphics);
-            auto commandEncoder = queue->createCommandEncoder();
-            auto passEncoder = commandEncoder->beginComputePass();
-            IShaderObject* rootObject = passEncoder->bindPipeline(pipeline);
-            ShaderCursor globalCursor(rootObject);
-            globalCursor["globalVar"].setData(globalVar);
-            globalCursor["globalBuffer"].setBinding(globalBuffer);
-            ShaderCursor entryPointCursor(rootObject->getEntryPoint(0));
-            entryPointCursor["buffer"].setBinding(buffer);
-            entryPointCursor["result"].setBinding(result);
-            passEncoder->dispatchCompute(1, 1, 1);
-            passEncoder->end();
-
-            queue->submit(commandEncoder->finish());
-            queue->waitOnHost();
-        }
-
-        compareComputeResult(device, result, std::array{1000, 2000, 3000});
-    };
-
-    runGpuTests(testFunc, {DeviceType::D3D12});
+    compareComputeResult(device, result, std::array{1000, 2000, 3000});
 }
 
 #endif

--- a/tests/test-pipeline-cache.cpp
+++ b/tests/test-pipeline-cache.cpp
@@ -112,7 +112,6 @@ public:
 struct PipelineCacheTest
 {
     GpuTestContext* ctx;
-    DeviceType deviceType;
     std::filesystem::path tempDirectory;
     VirtualCache pipelineCache;
     ComPtr<IDevice> device;
@@ -121,15 +120,14 @@ struct PipelineCacheTest
     {
         DeviceExtraOptions extraOptions;
         extraOptions.persistentPipelineCache = &pipelineCache;
-        device = createTestingDevice(ctx, deviceType, false, &extraOptions);
+        device = createTestingDevice(ctx, ctx->deviceType, false, &extraOptions);
     }
 
     VirtualCache::Stats getStats() { return pipelineCache.stats; }
 
-    void run(GpuTestContext* ctx_, DeviceType deviceType_, std::string tempDirectory_)
+    void run(GpuTestContext* ctx_, std::string tempDirectory_)
     {
         ctx = ctx_;
-        deviceType = deviceType_;
         tempDirectory = tempDirectory_;
 
         pipelineCache.clear();
@@ -385,35 +383,35 @@ struct PipelineCacheTestRender : PipelineCacheTest
 };
 
 template<typename T>
-void runTest(GpuTestContext* ctx, DeviceType deviceType)
+void runTest(GpuTestContext* ctx)
 {
     std::string tempDirectory = getCaseTempDirectory();
     T test;
-    test.run(ctx, deviceType, tempDirectory);
+    test.run(ctx, tempDirectory);
 }
 
-TEST_CASE("pipeline-cache-compute")
+GPU_TEST_CASE("pipeline-cache-compute", D3D12 | Vulkan | NoDevice)
 {
-    runGpuTests(runTest<PipelineCacheTestCompute<false>>, {DeviceType::D3D12, DeviceType::Vulkan});
+    runTest<PipelineCacheTestCompute<false>>(ctx);
 }
 
 #if 0
 // TODO: D3D12 does fail in debug layers and not return an error correctly.
-TEST_CASE("pipeline-cache-compute-corrupt")
+GPU_TEST_CASE("pipeline-cache-compute-corrupt", Vulkan | NoDevice)
 {
-    runGpuTests(runTest<PipelineCacheTestCompute<true>>, {DeviceType::Vulkan});
+    runTest<PipelineCacheTestCompute<true>>(ctx);
 }
 #endif
 
-TEST_CASE("pipeline-cache-render")
+GPU_TEST_CASE("pipeline-cache-render", D3D12 | Vulkan | NoDevice)
 {
-    runGpuTests(runTest<PipelineCacheTestRender<false>>, {DeviceType::D3D12, DeviceType::Vulkan});
+    runTest<PipelineCacheTestRender<false>>(ctx);
 }
 
 #if 0
 // TODO: D3D12 does fail in debug layers and not return an error correctly.
-TEST_CASE("pipeline-cache-render-corrupt")
+GPU_TEST_CASE("pipeline-cache-render-corrupt", Vulkan | NoDevice)
 {
-    runGpuTests(runTest<PipelineCacheTestRender<true>>, {DeviceType::Vulkan});
+    runTest<PipelineCacheTestRender<true>>(ctx);
 }
 #endif

--- a/tests/test-shader-cache.cpp
+++ b/tests/test-shader-cache.cpp
@@ -117,7 +117,6 @@ static VirtualShaderCache shaderCache;
 struct ShaderCacheTest
 {
     GpuTestContext* ctx;
-    DeviceType deviceType;
     std::filesystem::path tempDirectory;
 
     ComPtr<IDevice> device;
@@ -179,7 +178,7 @@ struct ShaderCacheTest
     void createDevice()
     {
         DeviceDesc deviceDesc = {};
-        deviceDesc.deviceType = deviceType;
+        deviceDesc.deviceType = ctx->deviceType;
         deviceDesc.slang.slangGlobalSession = ctx->slangGlobalSession;
         auto searchPaths = getSlangSearchPaths();
         std::string tempDirectoryStr = tempDirectory.string();
@@ -296,10 +295,9 @@ struct ShaderCacheTest
 
     VirtualShaderCache::Stats getStats() { return shaderCache.stats; }
 
-    void run(GpuTestContext* ctx_, DeviceType deviceType_, std::string tempDirectory_)
+    void run(GpuTestContext* ctx_, std::string tempDirectory_)
     {
         ctx = ctx_;
-        deviceType = deviceType_;
         tempDirectory = tempDirectory_;
 
         shaderCache.clear();
@@ -896,101 +894,53 @@ struct ShaderCacheTestGraphicsSplit : ShaderCacheTestGraphics
 };
 
 template<typename T>
-void runTest(GpuTestContext* ctx, DeviceType deviceType)
+void runTest(GpuTestContext* ctx)
 {
     std::string tempDirectory = getCaseTempDirectory();
     T test;
-    test.run(ctx, deviceType, tempDirectory);
+    test.run(ctx, tempDirectory);
 }
 
 // TODO
 // These tests are super expensive because they re-create devices.
 // This is needed because slang doesn't support reloading modules at this time.
 
-TEST_CASE("shader-cache-source-file")
+GPU_TEST_CASE("shader-cache-source-file", D3D12 | Vulkan | NoDevice)
 {
-    runGpuTests(
-        runTest<ShaderCacheTestSourceFile>,
-        {
-            DeviceType::D3D12,
-            DeviceType::Vulkan,
-        }
-    );
+    runTest<ShaderCacheTestSourceFile>(ctx);
 }
 
-TEST_CASE("shader-cache-source-string")
+GPU_TEST_CASE("shader-cache-source-string", D3D12 | Vulkan | NoDevice)
 {
-    runGpuTests(
-        runTest<ShaderCacheTestSourceString>,
-        {
-            DeviceType::D3D12,
-            DeviceType::Vulkan,
-        }
-    );
+    runTest<ShaderCacheTestSourceString>(ctx);
 }
 
-TEST_CASE("shader-cache-entry-point")
+GPU_TEST_CASE("shader-cache-entry-point", D3D12 | Vulkan | NoDevice)
 {
-    runGpuTests(
-        runTest<ShaderCacheTestEntryPoint>,
-        {
-            DeviceType::D3D12,
-            DeviceType::Vulkan,
-        }
-    );
+    runTest<ShaderCacheTestEntryPoint>(ctx);
 }
 
-TEST_CASE("shader-cache-import-include")
+GPU_TEST_CASE("shader-cache-import-include", D3D12 | Vulkan | NoDevice)
 {
-    runGpuTests(
-        runTest<ShaderCacheTestImportInclude>,
-        {
-            DeviceType::D3D12,
-            DeviceType::Vulkan,
-        }
-    );
+    runTest<ShaderCacheTestImportInclude>(ctx);
 }
 
-TEST_CASE("shader-cache-specialization")
+GPU_TEST_CASE("shader-cache-specialization", D3D12 | Vulkan | NoDevice)
 {
-    runGpuTests(
-        runTest<ShaderCacheTestSpecialization>,
-        {
-            DeviceType::D3D12,
-            DeviceType::Vulkan,
-        }
-    );
+    runTest<ShaderCacheTestSpecialization>(ctx);
 }
 
-TEST_CASE("shader-cache-eviction")
+GPU_TEST_CASE("shader-cache-eviction", D3D12 | Vulkan | NoDevice)
 {
-    runGpuTests(
-        runTest<ShaderCacheTestEviction>,
-        {
-            DeviceType::D3D12,
-            DeviceType::Vulkan,
-        }
-    );
+    runTest<ShaderCacheTestEviction>(ctx);
 }
 
-TEST_CASE("shader-cache-graphics")
+GPU_TEST_CASE("shader-cache-graphics", D3D12 | Vulkan | NoDevice)
 {
-    runGpuTests(
-        runTest<ShaderCacheTestEviction>,
-        {
-            DeviceType::D3D12,
-            DeviceType::Vulkan,
-        }
-    );
+    runTest<ShaderCacheTestGraphics>(ctx);
 }
 
-TEST_CASE("shader-cache-graphics-split")
+GPU_TEST_CASE("shader-cache-graphics-split", D3D12 | Vulkan | NoDevice)
 {
-    runGpuTests(
-        runTest<ShaderCacheTestGraphicsSplit>,
-        {
-            DeviceType::D3D12,
-            DeviceType::Vulkan,
-        }
-    );
+    runTest<ShaderCacheTestGraphicsSplit>(ctx);
 }

--- a/tests/test-staging-heap.cpp
+++ b/tests/test-staging-heap.cpp
@@ -17,7 +17,7 @@ static const Size kPageSize = 16 * 1024 * 1024;
 GPU_TEST_CASE("staging-heap-alloc-free", ALL)
 {
     StagingHeap heap;
-    heap.initialize((Device*)device, kPageSize, MemoryType::Upload);
+    heap.initialize((Device*)device.get(), kPageSize, MemoryType::Upload);
 
     Size allocSize = heap.alignUp(16);
 
@@ -61,7 +61,7 @@ GPU_TEST_CASE("staging-heap-alloc-free", ALL)
 GPU_TEST_CASE("staging-heap-large-page", ALL)
 {
     StagingHeap heap;
-    heap.initialize((Device*)device, kPageSize, MemoryType::Upload);
+    heap.initialize((Device*)device.get(), kPageSize, MemoryType::Upload);
 
     StagingHeap::Allocation allocation;
     heap.alloc(16, {2}, &allocation);
@@ -97,7 +97,7 @@ GPU_TEST_CASE("staging-heap-large-page", ALL)
 GPU_TEST_CASE("staging-heap-realloc", ALL)
 {
     StagingHeap heap;
-    heap.initialize((Device*)device, kPageSize, MemoryType::Upload);
+    heap.initialize((Device*)device.get(), kPageSize, MemoryType::Upload);
 
     Size allocSize = heap.getPageSize() / 16;
 
@@ -130,7 +130,7 @@ GPU_TEST_CASE("staging-heap-realloc", ALL)
 GPU_TEST_CASE("staging-heap-handles", ALL)
 {
     StagingHeap heap;
-    heap.initialize((Device*)device, kPageSize, MemoryType::Upload);
+    heap.initialize((Device*)device.get(), kPageSize, MemoryType::Upload);
 
     // Make an allocation using ref counted handle within a scope.
     {
@@ -165,17 +165,17 @@ void thrashHeap(Device* device, StagingHeap* heap, int idx)
 
 GPU_TEST_CASE("staging-heap-mutithreading", ALL)
 {
-    Device* deviceimpl = (Device*)device;
+    Device* deviceImpl = (Device*)device.get();
 
     StagingHeap heap;
-    heap.initialize(deviceimpl, kPageSize, MemoryType::Upload);
+    heap.initialize(deviceImpl, kPageSize, MemoryType::Upload);
 
-    std::thread t1(thrashHeap, deviceimpl, &heap, 1);
-    std::thread t2(thrashHeap, deviceimpl, &heap, 2);
-    std::thread t3(thrashHeap, deviceimpl, &heap, 3);
-    std::thread t4(thrashHeap, deviceimpl, &heap, 4);
-    std::thread t5(thrashHeap, deviceimpl, &heap, 5);
-    std::thread t6(thrashHeap, deviceimpl, &heap, 6);
+    std::thread t1(thrashHeap, deviceImpl, &heap, 1);
+    std::thread t2(thrashHeap, deviceImpl, &heap, 2);
+    std::thread t3(thrashHeap, deviceImpl, &heap, 3);
+    std::thread t4(thrashHeap, deviceImpl, &heap, 4);
+    std::thread t5(thrashHeap, deviceImpl, &heap, 5);
+    std::thread t6(thrashHeap, deviceImpl, &heap, 6);
 
     t1.join();
     t2.join();
@@ -200,19 +200,19 @@ void doTenAllocations(Device* device, StagingHeap* heap, int idx)
 
 GPU_TEST_CASE("staging-heap-threadlock-pages", ALL)
 {
-    Device* deviceimpl = (Device*)device;
+    Device* deviceImpl = (Device*)device.get();
 
     // When pages AREN'T being kept mapped, heap should allocate a new
     // page for each thread. As a result, after 3 threads have done 10
     // allocations we should have 3 pages.
 
     StagingHeap heap;
-    heap.initialize(deviceimpl, kPageSize, MemoryType::Upload);
+    heap.initialize(deviceImpl, kPageSize, MemoryType::Upload);
     heap.testOnlySetKeepPagesMapped(false);
 
-    std::thread t1(doTenAllocations, deviceimpl, &heap, 1);
-    std::thread t2(doTenAllocations, deviceimpl, &heap, 2);
-    std::thread t3(doTenAllocations, deviceimpl, &heap, 3);
+    std::thread t1(doTenAllocations, deviceImpl, &heap, 1);
+    std::thread t2(doTenAllocations, deviceImpl, &heap, 2);
+    std::thread t3(doTenAllocations, deviceImpl, &heap, 3);
 
     t1.join();
     t2.join();
@@ -225,19 +225,19 @@ GPU_TEST_CASE("staging-heap-threadlock-pages", ALL)
 
 GPU_TEST_CASE("staging-heap-shared-pages", ALL)
 {
-    Device* deviceimpl = (Device*)device;
+    Device* deviceImpl = (Device*)device.get();
 
     // When pages ARE being kept mapped, heap should share pages
     // between threads, so 10 small allocations from 3 threads should
     // all fit in the same page.
 
     StagingHeap heap;
-    heap.initialize(deviceimpl, kPageSize, MemoryType::Upload);
+    heap.initialize(deviceImpl, kPageSize, MemoryType::Upload);
     heap.testOnlySetKeepPagesMapped(true);
 
-    std::thread t1(doTenAllocations, deviceimpl, &heap, 1);
-    std::thread t2(doTenAllocations, deviceimpl, &heap, 2);
-    std::thread t3(doTenAllocations, deviceimpl, &heap, 3);
+    std::thread t1(doTenAllocations, deviceImpl, &heap, 1);
+    std::thread t2(doTenAllocations, deviceImpl, &heap, 2);
+    std::thread t3(doTenAllocations, deviceImpl, &heap, 3);
 
     t1.join();
     t2.join();
@@ -250,20 +250,20 @@ GPU_TEST_CASE("staging-heap-shared-pages", ALL)
 
 GPU_TEST_CASE("staging-heap-unlockpage-1", ALL)
 {
-    Device* deviceimpl = (Device*)device;
+    Device* deviceImpl = (Device*)device.get();
 
     // Verify that in none sharing mode, when this thread and another
     // one attempt to allocate, we end up with 2 pages (effectively
     // same as staging-heap-threadlock-pages but with local thread).
 
     StagingHeap heap;
-    heap.initialize(deviceimpl, kPageSize, MemoryType::Upload);
+    heap.initialize(deviceImpl, kPageSize, MemoryType::Upload);
     heap.testOnlySetKeepPagesMapped(false);
 
     StagingHeap::Allocation alloc;
     heap.alloc(16, {1}, &alloc);
 
-    std::thread t1(doTenAllocations, deviceimpl, &heap, 1);
+    std::thread t1(doTenAllocations, deviceImpl, &heap, 1);
 
     t1.join();
 
@@ -274,21 +274,21 @@ GPU_TEST_CASE("staging-heap-unlockpage-1", ALL)
 
 GPU_TEST_CASE("staging-heap-unlockpage-2", ALL)
 {
-    Device* deviceimpl = (Device*)device;
+    Device* deviceImpl = (Device*)device.get();
 
     // Verify that if staging-heap-unlockpage-1 is repeated, but
     // the current thread frees its allocation, the 2nd thread
     // will reuse the page.
 
     StagingHeap heap;
-    heap.initialize(deviceimpl, kPageSize, MemoryType::Upload);
+    heap.initialize(deviceImpl, kPageSize, MemoryType::Upload);
     heap.testOnlySetKeepPagesMapped(false);
 
     StagingHeap::Allocation alloc;
     heap.alloc(16, {1}, &alloc);
     heap.free(alloc);
 
-    std::thread t1(doTenAllocations, deviceimpl, &heap, 1);
+    std::thread t1(doTenAllocations, deviceImpl, &heap, 1);
 
     t1.join();
 

--- a/tests/test-texture-layout.cpp
+++ b/tests/test-texture-layout.cpp
@@ -54,7 +54,7 @@ void testTextureLayout2(
     CHECK_EQ(layout.slicePitch, expectedLayout.slicePitch);
 }
 
-int ALL_TEX = TestFlags::ALL & ~TestFlags::CPU;
+int ALL_TEX = GpuTestFlags::ALL & ~GpuTestFlags::CPU;
 
 GPU_TEST_CASE("texture-layout-1d-nomip", ALL_TEX)
 {

--- a/tests/test-texture-shared.cpp
+++ b/tests/test-texture-shared.cpp
@@ -79,11 +79,13 @@ ComPtr<IBuffer> createBuffer(IDevice* device, int size, void* initialData)
     return outBuffer;
 }
 
-template<DeviceType DstDeviceType>
-void testSharedTexture(GpuTestContext* ctx, DeviceType deviceType)
+GPU_TEST_CASE("texture-shared-cuda", D3D12 | Vulkan | NoDevice)
 {
-    ComPtr<IDevice> srcDevice = createTestingDevice(ctx, deviceType);
-    ComPtr<IDevice> dstDevice = createTestingDevice(ctx, DstDeviceType);
+    if (!isDeviceTypeAvailable(DeviceType::CUDA))
+        SKIP("CUDA not available");
+
+    ComPtr<IDevice> srcDevice = createTestingDevice(ctx, ctx->deviceType);
+    ComPtr<IDevice> dstDevice = createTestingDevice(ctx, DeviceType::CUDA);
 
     SamplerDesc samplerDesc;
     auto sampler = dstDevice->createSampler(samplerDesc);
@@ -136,19 +138,5 @@ void testSharedTexture(GpuTestContext* ctx, DeviceType deviceType)
                 float>(1.0f, 0.0f, 0.0f, 1.0f, 0.0f, 1.0f, 0.0f, 1.0f, 0.0f, 0.0f, 1.0f, 1.0f, 0.5f, 0.5f, 0.5f, 1.0f)
         );
     }
-}
-
-TEST_CASE("texture-shared-cuda")
-{
-    if (!isDeviceTypeAvailable(DeviceType::CUDA))
-        SKIP("CUDA not available");
-
-    runGpuTests(
-        testSharedTexture<DeviceType::CUDA>,
-        {
-            DeviceType::Vulkan,
-            DeviceType::D3D12,
-        }
-    );
 }
 #endif


### PR DESCRIPTION
- change existing GPU tests using `TEST_CASE` to use `GPU_TEST_CASE`
- Add `GpuTestFlags::NoDevice` to allow tests to control device creation (with extra properties etc.)
- Pass `ctx` to GPU test functions
- Pass current device type in `GpuTestCtx`
- Remove `runGpuTests`