### PR TITLE
GPU tests implementation

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -35,6 +35,8 @@ Testing:
     - The 'shared' tests are currently known to fail on multi-gpu systems.
     - Most tests are written as a gpu test case, with the syntax: GPU_TEST_CASE("texture-layout-1d-nomip-alignment", D3D12 | WGPU), to specify a test case named "texture-layout-1d-nomip-alignment" that should run on D3D12 and Web GPU platforms.
     - The possible test flags are in #tests/testing.h, named 'TestFlags'. For a test to run on all platforms, it should specify 'ALL'.
+    - GPU tests register a new test case for each device type using "<name>.<deviceType>" as the test name.
+    - Running a specific GPU test requires to pass "--test-case=<name>.*" to run all variations of the test case, or "--test-case=<name>.d3d12" for example to run the D3D12 variation.
 
 Code style:
     - Class names should start with a capital letter.

--- a/tests/doctest-reporter.h
+++ b/tests/doctest-reporter.h
@@ -7,8 +7,6 @@
 
 namespace doctest {
 
-#define LOCK() std::lock_guard<std::mutex> lock(mutex);
-
 struct CustomReporter : public IReporter
 {
     // caching pointers/references to objects of these types - safe to do
@@ -16,14 +14,12 @@ struct CustomReporter : public IReporter
     const ContextOptions& opt;
     ConsoleReporter consoleReporter;
     const TestCaseData* tc;
-    const SubcaseSignature* sc;
-    std::mutex mutex;
-    Timer timer;
+
     int cursorPos = 0;
+    int testCaseStartCursorPos = 0;
     Timer runTimer;
 
     const int resultPos = 64;
-    const char* indent = "    ";
 
     // constructor has to accept the ContextOptions by ref as a single argument
     CustomReporter(const ContextOptions& in)
@@ -33,11 +29,22 @@ struct CustomReporter : public IReporter
     {
     }
 
-    void report_query(const QueryData& in) override { consoleReporter.report_query(in); }
+    void report_query(const QueryData& in) override
+    {
+        consoleReporter.report_query(in);
+        if (opt.help)
+        {
+            // clang-format off
+            stream << Color::Cyan << "\n[doctest] " << Color::None;
+            stream << "Additional slang-rhi specific options. Available:\n\n";
+            stream << " -verbose                              print messages from the slang-rhi layer\n";
+            stream << " -check-devices                        print information about detected GPU devices on startup\n";
+            // clang-format on
+        }
+    }
 
     void test_run_start() override
     {
-        LOCK();
         runTimer.start();
         stream << Color::None;
         consoleReporter.test_run_start();
@@ -50,7 +57,6 @@ struct CustomReporter : public IReporter
 
     void test_run_end(const TestRunStats& in) override
     {
-        LOCK();
         stream << Color::None;
 
         fill(79, '-');
@@ -63,73 +69,57 @@ struct CustomReporter : public IReporter
 
     void test_case_start(const TestCaseData& in) override
     {
-        LOCK();
-        ensure_newline();
         consoleReporter.test_case_start(in);
         tc = &in;
-        color(Color::Grey);
-        fill(79, '-');
-        printf("\n");
         color(Color::None);
-        printf("%s\n", tc->m_name);
+        printf("%s ", tc->m_name);
+        testCaseStartCursorPos = cursorPos;
     }
 
     // called when a test case is reentered because of unfinished subcases
-    void test_case_reenter(const TestCaseData& in) override
-    {
-        LOCK();
-        ensure_newline();
-        consoleReporter.test_case_reenter(in);
-    }
+    void test_case_reenter(const TestCaseData& in) override { consoleReporter.test_case_reenter(in); }
 
     void test_case_end(const CurrentTestCaseStats& in) override
     {
-        LOCK();
-        ensure_newline();
-        consoleReporter.test_case_end(in);
         color(Color::None);
-        printf("%s", tc->m_name);
+        if (cursorPos != testCaseStartCursorPos)
+        {
+            ensure_newline();
+            printf("%s ", tc->m_name);
+        }
         fill(resultPos);
-        if (in.failure_flags)
+        if (const char* msg = rhi::testing::getSkipMessage(tc))
+        {
+            color(Color::Yellow);
+            print("SKIPPED");
+            color(Color::LightGrey);
+            printf(" (%s)\n", msg);
+        }
+        else if (in.failure_flags)
         {
             color(Color::Red);
             print("FAILED");
+            color(Color::LightGrey);
+            printf(" (%.2fs)\n", in.seconds);
         }
         else
         {
             color(Color::Green);
             printf("PASSED");
+            color(Color::LightGrey);
+            printf(" (%.2fs)\n", in.seconds);
         }
-        color(Color::LightGrey);
-        printf(" (%.2fs)\n", in.seconds);
     }
 
     void test_case_exception(const TestCaseException& in) override
     {
-        LOCK();
         ensure_newline();
         consoleReporter.test_case_exception(in);
     }
 
-    void subcase_start(const SubcaseSignature& in) override
-    {
-        LOCK();
-        sc = &in;
-        timer.start();
-        stream << Color::LightGrey;
-        printf("%s (%s)", tc->m_name, sc->m_name.c_str());
-    }
+    void subcase_start(const SubcaseSignature& in) override { consoleReporter.subcase_start(in); }
 
-    void subcase_end() override
-    {
-        LOCK();
-        double seconds = timer.getElapsedSeconds();
-        stream << Color::LightGrey;
-        if (cursorPos == 0)
-            printf("%s (%s)", tc->m_name, sc->m_name.c_str());
-        fill(resultPos);
-        printf("  DONE (%.2fs)\n", seconds);
-    }
+    void subcase_end() override { consoleReporter.subcase_end(); }
 
     void log_assert(const AssertData& in) override
     {
@@ -139,14 +129,12 @@ struct CustomReporter : public IReporter
         if (!in.m_failed && !opt.success)
             return;
 
-        LOCK();
         ensure_newline();
         consoleReporter.log_assert(in);
     }
 
     void log_message(const MessageData& in) override
     {
-        LOCK();
         ensure_newline();
         consoleReporter.log_message(in);
     }

--- a/tests/doctest-reporter.h
+++ b/tests/doctest-reporter.h
@@ -203,7 +203,7 @@ private:
     {
         printSeparator();
         printf("Checking for available devices:\n");
-        for (rhi::DeviceType deviceType : ALL_DEVICE_TYPES)
+        for (rhi::DeviceType deviceType : rhi::testing::kPlatformDeviceTypes)
         {
             printSeparator();
             printf("%s: ", rhi::getRHI()->getDeviceTypeName(deviceType));

--- a/tests/main.cpp
+++ b/tests/main.cpp
@@ -52,6 +52,7 @@ int main(int argc, char** argv)
         doctest::Context context(argc, argv);
 
         context.setOption("--reporters", "custom");
+        context.setOption("--order-by", "name");
 
         // Select specific test suite to run
         // context.setOption("-tc", "shader-cache-*");

--- a/tests/testing.cpp
+++ b/tests/testing.cpp
@@ -873,7 +873,7 @@ static void gpuTestTrampoline()
     }
     else
     {
-        SKIP("Device not available");
+        SKIP("device not available");
     }
 }
 
@@ -949,6 +949,19 @@ int registerGpuTest(const char* name, GpuTestFunc func, GpuTestFlags flags, cons
     }
 
     return 0;
+}
+
+static std::map<const doctest::TestCaseData*, const char*> sSkipMessages;
+
+void reportSkip(const doctest::detail::TestCase* tc, const char* reason)
+{
+    sSkipMessages[tc] = reason;
+}
+
+const char* getSkipMessage(const doctest::TestCaseData* tc)
+{
+    auto it = sSkipMessages.find(tc);
+    return it != sSkipMessages.end() ? it->second : nullptr;
 }
 
 } // namespace rhi::testing

--- a/tests/testing.cpp
+++ b/tests/testing.cpp
@@ -922,6 +922,10 @@ int registerGpuTest(const char* name, GpuTestFunc func, GpuTestFlags flags, cons
             continue;
 
         DeviceType deviceType = DeviceType(i);
+
+        if (!isPlatformDeviceType(deviceType))
+            continue;
+
         size_t testNameLen = strlen(name) + 16;
 
         GpuTestInfo* info = static_cast<GpuTestInfo*>(allocator.allocate(sizeof(GpuTestInfo) + testNameLen));
@@ -930,7 +934,7 @@ int registerGpuTest(const char* name, GpuTestFunc func, GpuTestFlags flags, cons
         info->flags = flags;
 
         char* testName = reinterpret_cast<char*>(info + 1);
-        snprintf(testName, testNameLen, "%s[%s]", name, deviceTypeToString(deviceType));
+        snprintf(testName, testNameLen, "%s.%s", name, deviceTypeToString(deviceType));
         testName[testNameLen - 1] = '\0';
 
         doctest::detail::regTest(

--- a/tests/testing.h
+++ b/tests/testing.h
@@ -285,16 +285,39 @@ auto makeArray(Args... args)
     return std::array<T, sizeof...(Args)>{static_cast<T>(args)...};
 }
 
-#define ALL_DEVICE_TYPES                                                                                               \
-    {                                                                                                                  \
-        rhi::DeviceType::D3D11,                                                                                        \
-        rhi::DeviceType::D3D12,                                                                                        \
-        rhi::DeviceType::Vulkan,                                                                                       \
-        rhi::DeviceType::Metal,                                                                                        \
-        rhi::DeviceType::CPU,                                                                                          \
-        rhi::DeviceType::CUDA,                                                                                         \
-        rhi::DeviceType::WGPU,                                                                                         \
+static constexpr DeviceType kPlatformDeviceTypes[] = {
+#if SLANG_WINDOWS_FAMILY
+    rhi::DeviceType::D3D11,
+    rhi::DeviceType::D3D12,
+    rhi::DeviceType::Vulkan,
+    rhi::DeviceType::CPU,
+    rhi::DeviceType::CUDA,
+    rhi::DeviceType::WGPU,
+#elif SLANG_LINUX_FAMILY
+    rhi::DeviceType::Vulkan,
+    rhi::DeviceType::CPU,
+    rhi::DeviceType::CUDA,
+    rhi::DeviceType::WGPU,
+#elif SLANG_APPLE_FAMILY
+    rhi::DeviceType::Vulkan,
+    rhi::DeviceType::Metal,
+    rhi::DeviceType::CPU,
+    rhi::DeviceType::CUDA,
+    rhi::DeviceType::WGPU,
+#endif
+};
+
+inline bool isPlatformDeviceType(DeviceType deviceType)
+{
+    for (DeviceType platformDeviceType : kPlatformDeviceTypes)
+    {
+        if (platformDeviceType == deviceType)
+        {
+            return true;
+        }
     }
+    return false;
+}
 
 using GpuTestFunc = void (*)(GpuTestContext*, ComPtr<IDevice>);
 
@@ -345,7 +368,7 @@ int registerGpuTest(const char* name, GpuTestFunc func, GpuTestFlags flags, cons
 
 // Register a GPU test case.
 // This will register one test case for each device type specified in the flags.
-// Each test will be named <name>[<deviceType>] where `deviceType` is the string representation of the device type.
+// Each test will be named <name>.<deviceType> where <deviceType> is the string representation of the device type.
 // The GPU test function has the following signature: void func(GpuTestContext* ctx, ComPtr<IDevice> device)
 // In addition to the device flags, the following flags can be used:
 // - GpuTestFlag::DontCreateDevice: Do not create a device (device argument is nullptr)

--- a/tests/testing.h
+++ b/tests/testing.h
@@ -350,6 +350,9 @@ static_assert(std::is_pod_v<GpuTestInfo>, "GpuTestInfo must be POD");
 
 int registerGpuTest(const char* name, GpuTestFunc func, GpuTestFlags flags, const char* file, int line);
 
+void reportSkip(const doctest::detail::TestCase* tc, const char* reason);
+const char* getSkipMessage(const doctest::TestCaseData* tc);
+
 } // namespace rhi::testing
 
 #define GPU_TEST_CASE_IMPL(name, func, flags)                                                                          \
@@ -378,9 +381,13 @@ int registerGpuTest(const char* name, GpuTestFunc func, GpuTestFlags flags, cons
 #define CHECK_CALL(x) CHECK(!SLANG_FAILED(x))
 #define REQUIRE_CALL(x) REQUIRE(!SLANG_FAILED(x))
 
+// doctest does not support skipping tests at runtime.
+// We add this functionality using this SKIP macro which should only be called in the main scope of the test function.
+// The `reason` argument MUST be a string literal.
 #define SKIP(reason)                                                                                                   \
     do                                                                                                                 \
     {                                                                                                                  \
+        ::rhi::testing::reportSkip(::doctest::getContextOptions()->currentTest, "" reason);                            \
         return;                                                                                                        \
     }                                                                                                                  \
     while (0)

--- a/tests/testing.h
+++ b/tests/testing.h
@@ -298,10 +298,10 @@ auto makeArray(Args... args)
 
 using GpuTestFunc = void (*)(GpuTestContext*, ComPtr<IDevice>);
 
-void runGpuTestFunc(GpuTestFunc func, int testFlags);
-
 enum GpuTestFlags
 {
+    None = 0,
+
     // Device type flags
     D3D11 = (1 << (int)DeviceType::D3D11),
     D3D12 = (1 << (int)DeviceType::D3D12),
@@ -317,17 +317,40 @@ enum GpuTestFlags
     DontCacheDevice = (1 << 11),  // Do not use cached devices (create a new device for this test case)
 };
 
+struct GpuTestInfo
+{
+    GpuTestFunc func;
+    DeviceType deviceType;
+    GpuTestFlags flags;
+};
+static_assert(std::is_pod_v<GpuTestInfo>, "GpuTestInfo must be POD");
+
+int registerGpuTest(const char* name, GpuTestFunc func, GpuTestFlags flags, const char* file, int line);
+
 } // namespace rhi::testing
 
-#define GPU_TEST_CASE_IMPL(name, func, testFlags)                                                                      \
+#define GPU_TEST_CASE_IMPL(name, func, flags)                                                                          \
     static void func(::rhi::testing::GpuTestContext* ctx, ::ComPtr<::rhi::IDevice> device);                            \
-    TEST_CASE(name)                                                                                                    \
-    {                                                                                                                  \
-        ::rhi::testing::runGpuTestFunc(func, testFlags);                                                               \
-    }                                                                                                                  \
+    DOCTEST_GLOBAL_NO_WARNINGS(                                                                                        \
+        DOCTEST_ANONYMOUS(DOCTEST_ANON_VAR_),                                                                          \
+        ::rhi::testing::registerGpuTest(                                                                               \
+            name,                                                                                                      \
+            func,                                                                                                      \
+            static_cast<::rhi::testing::GpuTestFlags>(flags),                                                          \
+            __FILE__,                                                                                                  \
+            __LINE__                                                                                                   \
+        )                                                                                                              \
+    )                                                                                                                  \
     static void func(::rhi::testing::GpuTestContext* ctx, ::ComPtr<::rhi::IDevice> device)
 
-#define GPU_TEST_CASE(name, testFlags) GPU_TEST_CASE_IMPL(name, DOCTEST_ANONYMOUS(GPU_TEST_ANONYMOUS_), testFlags)
+// Register a GPU test case.
+// This will register one test case for each device type specified in the flags.
+// Each test will be named <name>[<deviceType>] where `deviceType` is the string representation of the device type.
+// The GPU test function has the following signature: void func(GpuTestContext* ctx, ComPtr<IDevice> device)
+// In addition to the device flags, the following flags can be used:
+// - GpuTestFlag::DontCreateDevice: Do not create a device (device argument is nullptr)
+// - GpuTestFlag::DontCacheDevice: Do not use cached devices (create a new device for this test case)
+#define GPU_TEST_CASE(name, flags) GPU_TEST_CASE_IMPL(name, DOCTEST_ANONYMOUS(GPU_TEST_ANONYMOUS_), flags)
 
 #define CHECK_CALL(x) CHECK(!SLANG_FAILED(x))
 #define REQUIRE_CALL(x) REQUIRE(!SLANG_FAILED(x))


### PR DESCRIPTION
This PR changes the way `slang-rhi-tests` runs GPU tests:
Previously, we relied on doctest's `SUBCASE` infrastructure to run one sub test per device type for each GPU test.
There were various issues with that approach:
- custom reporter had to do special handling for sub cases including timing (and currently crashed with nested sub tests)
- skipping tests was unreliable and not reported
- generally hijacking the sub test infrastructure making it less useful in all test cases

This PR changes GPU tests to register one test case per device type named `<name>.<deviceType>`. This resolves the various issues with sub case handling. Also, this enables an easy way of keeping track of skipped tests at runtime and log appropriate output (fixes #492). Selecting test cases has changed a bit due to this change:
- Selecting a single GPU test case requires `-tc=gpu-test-name.*` to run the test for all device types (previously it was `-tc=gpu-test-name`)
- Selecting a single GPU test on one device type (D3D12 for example) requires `-tc=gpu-test-name.d3d12` (previously it was `-tc=gpu-test-name -sc=d3d12`)
- Selecting a single GPU test on two device types (D3D12 and Vulkan for example) requires `-tc=gpu-test-name.d3d12,gpu-test-name.vulkan` (previously it was just `-tc=gpu-test-name -sc=d3d12,vulkan`)
While the first two cases are somewhat OK, the last is a bit annoying. We might add a separate `-device-types` argument to make this easier.