### PR TITLE
Add deferTargetCompilation to pipeline descs

### DIFF
--- a/include/slang-rhi.h
+++ b/include/slang-rhi.h
@@ -1787,6 +1787,9 @@ struct RenderPipelineDesc
     RasterizerDesc rasterizer;
     MultisampleDesc multisample;
 
+    // Defer target code compilation of program to dispatch time.
+    bool deferTargetCompilation = false;
+
     const char* label = nullptr;
 };
 
@@ -1797,6 +1800,9 @@ struct ComputePipelineDesc
 
     IShaderProgram* program = nullptr;
     void* d3d12RootSignatureOverride = nullptr;
+
+    // Defer target code compilation of program to dispatch time.
+    bool deferTargetCompilation = false;
 
     const char* label = nullptr;
 };
@@ -1831,6 +1837,9 @@ struct RayTracingPipelineDesc
     uint32_t maxRayPayloadSize = 0;
     uint32_t maxAttributeSizeInBytes = 8;
     RayTracingPipelineFlags flags = RayTracingPipelineFlags::None;
+
+    // Defer target code compilation of program to dispatch time.
+    bool deferTargetCompilation = false;
 
     const char* label = nullptr;
 };

--- a/src/device.cpp
+++ b/src/device.cpp
@@ -634,7 +634,7 @@ Result Device::createInputLayout(const InputLayoutDesc& desc, IInputLayout** out
 Result Device::createRenderPipeline(const RenderPipelineDesc& desc, IRenderPipeline** outPipeline)
 {
     ShaderProgram* program = checked_cast<ShaderProgram*>(desc.program);
-    bool createVirtual = program->isSpecializable();
+    bool createVirtual = desc.deferTargetCompilation | program->isSpecializable();
     if (createVirtual)
     {
         RefPtr<VirtualRenderPipeline> pipeline = new VirtualRenderPipeline(this, desc);
@@ -651,7 +651,7 @@ Result Device::createRenderPipeline(const RenderPipelineDesc& desc, IRenderPipel
 Result Device::createComputePipeline(const ComputePipelineDesc& desc, IComputePipeline** outPipeline)
 {
     ShaderProgram* program = checked_cast<ShaderProgram*>(desc.program);
-    bool createVirtual = program->isSpecializable();
+    bool createVirtual = desc.deferTargetCompilation | program->isSpecializable();
     if (createVirtual)
     {
         RefPtr<VirtualComputePipeline> pipeline = new VirtualComputePipeline(this, desc);
@@ -668,7 +668,7 @@ Result Device::createComputePipeline(const ComputePipelineDesc& desc, IComputePi
 Result Device::createRayTracingPipeline(const RayTracingPipelineDesc& desc, IRayTracingPipeline** outPipeline)
 {
     ShaderProgram* program = checked_cast<ShaderProgram*>(desc.program);
-    bool createVirtual = program->isSpecializable();
+    bool createVirtual = desc.deferTargetCompilation | program->isSpecializable();
     if (createVirtual)
     {
         RefPtr<VirtualRayTracingPipeline> pipeline = new VirtualRayTracingPipeline(this, desc);


### PR DESCRIPTION
This flag allows for deferred target code compilation at dispatch time. In the future, we plan to compile all target code needed for a command buffer in parallel. For now, compilation still happens single-threaded.