### PR TITLE
Remove explicit support for swift shader

### DIFF
--- a/src/cuda/cuda-surface.cpp
+++ b/src/cuda/cuda-surface.cpp
@@ -212,7 +212,7 @@ Result SurfaceImpl::createVulkanInstance()
 {
     SLANG_CUDA_CTX_SCOPE(m_deviceImpl);
 
-    SLANG_RETURN_ON_FAIL(m_module.init(false));
+    SLANG_RETURN_ON_FAIL(m_module.init());
     SLANG_RETURN_ON_FAIL(m_api.initGlobalProcs(m_module));
 
     VkApplicationInfo applicationInfo = {VK_STRUCTURE_TYPE_APPLICATION_INFO};

--- a/src/vulkan/vk-api.cpp
+++ b/src/vulkan/vk-api.cpp
@@ -15,30 +15,22 @@ namespace rhi::vk {
 
 // !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! VulkanModule !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
-Result VulkanModule::init(bool useSoftwareImpl)
+Result VulkanModule::init()
 {
     if (isInitialized())
     {
         destroy();
     }
 
-    const char* dynamicLibraryName = "Unknown";
-    m_isSoftware = useSoftwareImpl;
-
 #if SLANG_WINDOWS_FAMILY
-    dynamicLibraryName = useSoftwareImpl ? "vk_swiftshader.dll" : "vulkan-1.dll";
-    HMODULE module = ::LoadLibraryA(dynamicLibraryName);
+    HMODULE module = ::LoadLibraryA("vulkan-1.dll");
     m_module = (void*)module;
+#elif SLANG_LINUX_FAMILY
+    m_module = dlopen("libvulkan.so.1", RTLD_NOW);
 #elif SLANG_APPLE_FAMILY
-    dynamicLibraryName = useSoftwareImpl ? "libvk_swiftshader.dylib" : "libvulkan.1.dylib";
-    m_module = dlopen(dynamicLibraryName, RTLD_NOW | RTLD_GLOBAL);
+    m_module = dlopen("libvulkan.1.dylib", RTLD_NOW | RTLD_GLOBAL);
 #else
-    dynamicLibraryName = useSoftwareImpl ? "libvk_swiftshader.so" : "libvulkan.so.1";
-    if (useSoftwareImpl)
-    {
-        dlopen("libpthread.so.0", RTLD_NOW | RTLD_GLOBAL);
-    }
-    m_module = dlopen(dynamicLibraryName, RTLD_NOW);
+#error "Unsupported platform"
 #endif
 
     if (!m_module)

--- a/src/vulkan/vk-api.h
+++ b/src/vulkan/vk-api.h
@@ -32,11 +32,8 @@ struct VulkanModule
     /// Get a function by name
     PFN_vkVoidFunction getFunction(const char* name) const;
 
-    /// true if using a software Vulkan implementation.
-    bool isSoftware() const { return m_isSoftware; }
-
     /// Initialize
-    Result init(bool useSoftwareImpl);
+    Result init();
     /// Destroy
     void destroy();
 
@@ -45,7 +42,6 @@ struct VulkanModule
 
 protected:
     void* m_module = nullptr;
-    bool m_isSoftware = false;
 };
 
 // clang-format off

--- a/tests/test-native-handle.cpp
+++ b/tests/test-native-handle.cpp
@@ -9,9 +9,6 @@ using namespace rhi::testing;
 
 GPU_TEST_CASE("native-handle-buffer", D3D12 | Vulkan | Metal | CUDA)
 {
-    if (isSwiftShaderDevice(device))
-        SKIP("not supported with swiftshader");
-
     const int numberCount = 1;
     BufferDesc bufferDesc = {};
     bufferDesc.size = numberCount * sizeof(float);
@@ -67,9 +64,6 @@ GPU_TEST_CASE("native-handle-buffer", D3D12 | Vulkan | Metal | CUDA)
 
 GPU_TEST_CASE("native-handle-texture", D3D12 | Vulkan | Metal | CUDA)
 {
-    if (isSwiftShaderDevice(device))
-        SKIP("not supported with swiftshader");
-
     TextureDesc desc = {};
     desc.type = TextureType::Texture2D;
     desc.mipCount = 1;
@@ -125,9 +119,6 @@ GPU_TEST_CASE("native-handle-texture", D3D12 | Vulkan | Metal | CUDA)
 
 GPU_TEST_CASE("native-handle-command-queue", D3D12 | Vulkan | Metal | CUDA)
 {
-    if (isSwiftShaderDevice(device))
-        SKIP("not supported with swiftshader");
-
     auto queue = device->getQueue(QueueType::Graphics);
     NativeHandle handle;
     REQUIRE_CALL(queue->getNativeHandle(&handle));
@@ -171,9 +162,6 @@ GPU_TEST_CASE("native-handle-command-queue", D3D12 | Vulkan | Metal | CUDA)
 
 GPU_TEST_CASE("native-handle-command-buffer", D3D12 | Vulkan | Metal)
 {
-    if (isSwiftShaderDevice(device))
-        SKIP("not supported with swiftshader");
-
     auto queue = device->getQueue(QueueType::Graphics);
     auto commandEncoder = queue->createCommandEncoder();
     auto commandBuffer = commandEncoder->finish();

--- a/tests/testing.cpp
+++ b/tests/testing.cpp
@@ -824,18 +824,6 @@ bool isDeviceTypeAvailable(DeviceType deviceType)
     return sDeviceTypeAvailable[deviceType];
 }
 
-bool isSwiftShaderDevice(IDevice* device)
-{
-    std::string adapterName = device->getInfo().adapterName;
-    std::transform(
-        adapterName.begin(),
-        adapterName.end(),
-        adapterName.begin(),
-        [](unsigned char c) { return std::tolower(c); }
-    );
-    return adapterName.find("swiftshader") != std::string::npos;
-}
-
 slang::IGlobalSession* getSlangGlobalSession()
 {
     static slang::IGlobalSession* slangGlobalSession = []()


### PR DESCRIPTION
The Vulkan backend currently has a custom path for loading swift shader which is obsolete. We want to add support for lavapipe but we can load emulated drivers through the Vulkan loader easily, which makes all this code obsolete.