### PR TITLE
Make slang-rhi depend on copying files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -826,6 +826,7 @@ if(SLANG_RHI_BUILD_EXAMPLES)
 endif()
 
 add_custom_target(slang-rhi-copy-files ALL DEPENDS ${SLANG_RHI_COPY_FILES})
+add_dependencies(slang-rhi slang-rhi-copy-files)
 
 # Add coverage target if coverage is enabled
 if(SLANG_RHI_ENABLE_COVERAGE)


### PR DESCRIPTION
Without this change, the binary files are only copied when building the ALL target. Making slang-rhi-copy-files a dependency of slang-rhi enables copying the files when building slang-rhi.