### PR TITLE
Fix selected defines for running tests

### DIFF
--- a/tests/testing.h
+++ b/tests/testing.h
@@ -22,8 +22,14 @@ struct Options
     bool verbose = false;
     bool checkDevices = false;
     bool listDevices = false;
-    std::array<bool, kDeviceTypeCount + 1> deviceSelected = {true};
-    std::array<int, kDeviceTypeCount + 1> deviceAdapterIndex = {-1};
+    std::array<bool, kDeviceTypeCount + 1> deviceSelected;
+    std::array<int, kDeviceTypeCount + 1> deviceAdapterIndex;
+
+    Options()
+    {
+        deviceSelected.fill(true);
+        deviceAdapterIndex.fill(-1);
+    }
 };
 
 inline Options& options()


### PR DESCRIPTION
A bug from the adapter PR leads to no tests being run by default, this fixes it.