### PR TITLE
Texture access tests

### DIFF
--- a/src/format-conversion.cpp
+++ b/src/format-conversion.cpp
@@ -22,15 +22,15 @@ static const FormatConversionFuncs sFuncs[] = {
     {Format::RGBA8Uint, packUint8<4>, unpackUint8<4>, clampUint8<4>, nullptr, nullptr},
     {Format::RGBA8Sint, packSint8<4>, unpackSint8<4>, clampSint8<4>, nullptr, nullptr},
     {Format::RGBA8Unorm, nullptr, nullptr, nullptr, packUnorm8<4>, unpackUnorm8<4>},
-    {Format::RGBA8UnormSrgb, nullptr, nullptr, nullptr, nullptr, nullptr},
+    {Format::RGBA8UnormSrgb, nullptr, nullptr, nullptr, packRGBA8UnormSrgb, unpackRGBA8UnormSrgb},
     {Format::RGBA8Snorm, nullptr, nullptr, nullptr, packSnorm8<4>, unpackSnorm8<4>},
 
     // TODO flip channels
     {Format::BGRA8Unorm, nullptr, nullptr, nullptr, packBGRA8Unorm, unpackBGRA8Unorm},
-    {Format::BGRA8UnormSrgb, nullptr, nullptr, nullptr, nullptr, nullptr},
+    {Format::BGRA8UnormSrgb, nullptr, nullptr, nullptr, packBGRA8UnormSrgb, unpackBGRA8UnormSrgb},
     // TODO should we discard last channel?
     {Format::BGRX8Unorm, nullptr, nullptr, nullptr, packBGRA8Unorm, unpackBGRA8Unorm},
-    {Format::BGRX8UnormSrgb, nullptr, nullptr, nullptr, nullptr, nullptr},
+    {Format::BGRX8UnormSrgb, nullptr, nullptr, nullptr, packBGRA8UnormSrgb, unpackBGRA8UnormSrgb},
 
     {Format::R16Uint, packUint16<1>, unpackUint16<1>, clampUint16<1>, nullptr, nullptr},
     {Format::R16Sint, packSint16<1>, unpackSint16<1>, clampSint16<1>, nullptr, nullptr},

--- a/src/format-conversion.h
+++ b/src/format-conversion.h
@@ -184,6 +184,38 @@ inline void unpackUnorm8(const void* in, float out[4])
         out[i] = reinterpret_cast<const uint8_t*>(in)[i] / 255.f;
 }
 
+inline float linearToSrgb(float v)
+{
+    if (v <= 0.0031308f)
+        return v * 12.92f;
+    else
+        return 1.055f * ::pow(v, 1.f / 2.4f) - 0.055f;
+}
+
+inline float srgbToLinear(float v)
+{
+    if (v <= 0.04045f)
+        return v / 12.92f;
+    else
+        return ::pow((v + 0.055f) / 1.055f, 2.4f);
+}
+
+inline void packRGBA8UnormSrgb(const float in[4], void* out)
+{
+    reinterpret_cast<uint8_t*>(out)[0] = uint8_t(::floor(linearToSrgb(in[0]) * 255.f + 0.5f));
+    reinterpret_cast<uint8_t*>(out)[1] = uint8_t(::floor(linearToSrgb(in[1]) * 255.f + 0.5f));
+    reinterpret_cast<uint8_t*>(out)[2] = uint8_t(::floor(linearToSrgb(in[2]) * 255.f + 0.5f));
+    reinterpret_cast<uint8_t*>(out)[3] = uint8_t(::floor(in[3] * 255.f + 0.5f));
+}
+
+inline void unpackRGBA8UnormSrgb(const void* in, float out[4])
+{
+    out[0] = srgbToLinear(reinterpret_cast<const uint8_t*>(in)[0] / 255.f);
+    out[1] = srgbToLinear(reinterpret_cast<const uint8_t*>(in)[1] / 255.f);
+    out[2] = srgbToLinear(reinterpret_cast<const uint8_t*>(in)[2] / 255.f);
+    out[3] = reinterpret_cast<const uint8_t*>(in)[3] / 255.f;
+}
+
 inline void packBGRA8Unorm(const float in[4], void* out)
 {
     reinterpret_cast<uint8_t*>(out)[0] = uint8_t(::floor(in[2] * 255.f + 0.5f));
@@ -197,6 +229,22 @@ inline void unpackBGRA8Unorm(const void* in, float out[4])
     out[0] = reinterpret_cast<const uint8_t*>(in)[2] / 255.f;
     out[1] = reinterpret_cast<const uint8_t*>(in)[1] / 255.f;
     out[2] = reinterpret_cast<const uint8_t*>(in)[0] / 255.f;
+    out[3] = reinterpret_cast<const uint8_t*>(in)[3] / 255.f;
+}
+
+inline void packBGRA8UnormSrgb(const float in[4], void* out)
+{
+    reinterpret_cast<uint8_t*>(out)[0] = uint8_t(::floor(linearToSrgb(in[2]) * 255.f + 0.5f));
+    reinterpret_cast<uint8_t*>(out)[1] = uint8_t(::floor(linearToSrgb(in[1]) * 255.f + 0.5f));
+    reinterpret_cast<uint8_t*>(out)[2] = uint8_t(::floor(linearToSrgb(in[0]) * 255.f + 0.5f));
+    reinterpret_cast<uint8_t*>(out)[3] = uint8_t(::floor(in[3] * 255.f + 0.5f));
+}
+
+inline void unpackBGRA8UnormSrgb(const void* in, float out[4])
+{
+    out[0] = srgbToLinear(reinterpret_cast<const uint8_t*>(in)[2] / 255.f);
+    out[1] = srgbToLinear(reinterpret_cast<const uint8_t*>(in)[1] / 255.f);
+    out[2] = srgbToLinear(reinterpret_cast<const uint8_t*>(in)[0] / 255.f);
     out[3] = reinterpret_cast<const uint8_t*>(in)[3] / 255.f;
 }
 

--- a/src/format-conversion.h
+++ b/src/format-conversion.h
@@ -189,15 +189,15 @@ inline float linearToSrgb(float v)
     if (v <= 0.0031308f)
         return v * 12.92f;
     else
-        return 1.055f * ::pow(v, 1.f / 2.4f) - 0.055f;
+        return ::pow(v, 1.f / 2.4f) * 1.055f - 0.055f;
 }
 
 inline float srgbToLinear(float v)
 {
     if (v <= 0.04045f)
-        return v / 12.92f;
+        return v * (1.f / 12.92f);
     else
-        return ::pow((v + 0.055f) / 1.055f, 2.4f);
+        return ::pow((v + 0.055f) * (1.f / 1.055f), 2.4f);
 }
 
 inline void packRGBA8UnormSrgb(const float in[4], void* out)

--- a/tests/test-texture-view.cpp
+++ b/tests/test-texture-view.cpp
@@ -1,6 +1,23 @@
 #include "testing.h"
 #include "texture-test.h"
+#include "format-conversion.h"
 #include <map>
+
+// This series of tests tests reading/writing texture from shaders.
+// The following is covered:
+// - reading from textures using both Load() and the subscript operator
+//   - read-only textures:
+//     - all layers/all mips (Load() only)
+//     - all layers/single mip (Load() and subscript load operator)
+//     - single layer/single mip (Load() and subscript load operator)
+//   - read-write textures:
+//     - all layers/single mip (Load() and subscript load operator)
+//     - single layer/single mip (Load() and subscript load operator)
+// - writing to textures using both Store() and the subscript operator
+//   - all layers/single mip (Store() and subscript store operator)
+//   - single layer/single mip (Store() and subscript store operator)
+
+#define TEST_SPECIFIC_FORMATS 0
 
 using namespace rhi;
 using namespace rhi::testing;
@@ -102,6 +119,7 @@ inline std::string getFormatAttribute(Format format)
     }
 }
 
+#if TEST_SPECIFIC_FORMATS
 static const std::vector<Format> kFormats = {
     // 8-bit / 1-channel formats
     Format::R8Uint,
@@ -117,7 +135,13 @@ static const std::vector<Format> kFormats = {
     Format::RGBA8Uint,
     Format::RGBA8Sint,
     Format::RGBA8Unorm,
+    Format::RGBA8UnormSrgb,
     Format::RGBA8Snorm,
+    Format::BGRA8Unorm,
+    Format::BGRA8UnormSrgb,
+    // These currently fail due to last channel
+    Format::BGRX8Unorm,
+    Format::BGRX8UnormSrgb,
     // 16-bit / 1-channel formats
     Format::R16Uint,
     Format::R16Sint,
@@ -148,183 +172,1271 @@ static const std::vector<Format> kFormats = {
     Format::RGBA32Uint,
     Format::RGBA32Sint,
     Format::RGBA32Float,
+    // Mixed formats
+    Format::BGRA4Unorm,
+    Format::B5G6R5Unorm,
+    Format::BGR5A1Unorm,
+    Format::RGB10A2Uint,
+    Format::RGB10A2Unorm,
+};
+#endif
+
+inline bool shouldSkipFormat(Format format)
+{
+    switch (format)
+    {
+    case Format::RGB9E5Ufloat:
+    case Format::R11G11B10Float:
+        return true;
+    default:
+        return false;
+    }
+}
+
+struct TexelData
+{
+    uint32_t layer;
+    uint32_t mip;
+    uint32_t offset[3];
+    union
+    {
+        float floats[4];
+        int32_t ints[4];
+        uint32_t uints[4];
+    };
+    uint8_t raw[16];
 };
 
-// This test checks texture views for read and read-write access on all basic texture types (1D, 2D, 3D) and formats.
-// It creates a compute shader that copies data from a source texture to a destination texture.
-// The view always targets a single mip-level.
-GPU_TEST_CASE("texture-view-simple", D3D11 | D3D12 | Vulkan | CUDA | Metal)
+static void clearTexelDataValues(span<TexelData> texels)
 {
-    TextureTestOptions options(device);
-    options.addVariants(
-        TTShape::D1 | TTShape::D2 | TTShape::D3,
-        TTArray::Off,     // non-array
-        TTMip::Both,      // with/without mips
-        TTMS::Off,        // without multisampling
-        TTPowerOf2::Both, // test both power-of-2 and non-power-of-2 sizes where possible
-        kFormats
-    );
+    for (TexelData& texel : texels)
+    {
+        memset(texel.floats, 0, 16);
+        memset(texel.raw, 0, 16);
+    }
+}
 
-    struct PipelineKey
+static void compareTexelData(Format format, span<TexelData> a, span<TexelData> b)
+{
+    REQUIRE(a.size() == b.size());
+    const FormatInfo& info = getFormatInfo(format);
+
+    float atol[4] = {0.f, 0.f, 0.f, 0.f};
+    if (info.kind == FormatKind::Normalized)
     {
-        TextureType textureType;
-        Format format;
-        bool operator<(const PipelineKey& other) const
+        int bits = (info.blockSizeInBytes * 8) / info.channelCount;
+        std::array<int, 4> channelBits = {bits, bits, bits, bits};
+        switch (format)
         {
-            return std::tie(textureType, format) < std::tie(other.textureType, other.format);
+        case Format::B5G6R5Unorm:
+            channelBits = {5, 6, 5, 0};
+            break;
+        case Format::BGR5A1Unorm:
+            channelBits = {5, 5, 5, 1};
+            break;
+        case Format::RGB10A2Unorm:
+            channelBits = {10, 10, 10, 2};
+            break;
+        default:
+            break;
         }
-    };
-    std::map<PipelineKey, ComPtr<IComputePipeline>> pipelines;
-    auto getCopyPipeline = [&](TextureType textureType, Format format) -> ComPtr<IComputePipeline>
+        for (int i = 0; i < 4; ++i)
+        {
+            if (channelBits[i] > 0)
+                atol[i] = 1.f / ((1 << channelBits[i]) - 1);
+            if (info.isSigned)
+                atol[i] *= 2;
+            if (info.isSrgb)
+                atol[i] *= 2; // sRGB conversion is not exact
+        }
+    }
+
+    for (size_t i = 0; i < a.size(); ++i)
     {
-        PipelineKey key = {textureType, format};
-        auto it = pipelines.find(key);
-        if (it != pipelines.end())
+        CAPTURE(i);
+        const TexelData& texelA = a[i];
+        const TexelData& texelB = b[i];
+        REQUIRE(texelA.layer == texelB.layer);
+        REQUIRE(texelA.mip == texelB.mip);
+        REQUIRE(texelA.offset[0] == texelB.offset[0]);
+        REQUIRE(texelA.offset[1] == texelB.offset[1]);
+        REQUIRE(texelA.offset[2] == texelB.offset[2]);
+        uint32_t channelCount = info.channelCount;
+        // Ignore last channel for BGRX formats
+        if (format == Format::BGRX8Unorm || format == Format::BGRX8UnormSrgb)
+            channelCount = 3;
+        for (uint32_t c = 0; c < channelCount; ++c)
+        {
+            if (info.kind == FormatKind::Integer && info.isSigned)
+            {
+                CHECK(texelA.ints[c] == texelB.ints[c]);
+            }
+            else if (info.kind == FormatKind::Integer && !info.isSigned)
+            {
+                CHECK(texelA.uints[c] == texelB.uints[c]);
+            }
+            else if (info.kind == FormatKind::Normalized)
+            {
+
+                CHECK(texelA.floats[c] >= texelB.floats[c] - atol[c]);
+                CHECK(texelA.floats[c] <= texelB.floats[c] + atol[c]);
+            }
+            else if (info.kind == FormatKind::Float)
+            {
+                CHECK(texelA.floats[c] == texelB.floats[c]);
+            }
+            else
+            {
+                FAIL("Unsupported format");
+            }
+        }
+    }
+}
+
+enum class TextureViewType
+{
+    ReadOnly,
+    ReadWrite
+};
+
+enum class ReadMethod
+{
+    Load,
+    Subscript
+};
+
+enum class WriteMethod
+{
+    Store,
+    Subscript
+};
+
+class TextureViewTest
+{
+public:
+    IDevice* m_device;
+    ComPtr<ICommandQueue> m_queue;
+    ComPtr<IBuffer> m_buffer;
+    std::unique_ptr<uint8_t[]> m_readbackData;
+    std::unique_ptr<uint8_t[]> m_tmpData;
+    size_t m_tmpDataSize;
+
+    using ReadPipelineKey = std::tuple<TextureViewType, TextureType, Format, ReadMethod>;
+    std::map<ReadPipelineKey, ComPtr<IComputePipeline>> m_readPipelines;
+    using WritePipelineKey = std::tuple<TextureType, Format, WriteMethod>;
+    std::map<WritePipelineKey, ComPtr<IComputePipeline>> m_writePipelines;
+
+    TextureViewTest(IDevice* device)
+        : m_device(device)
+        , m_queue(m_device->getQueue(QueueType::Graphics))
+    {
+        BufferDesc bufferDesc = {};
+        bufferDesc.size = 4 * 1024 * 1024;
+        bufferDesc.usage = BufferUsage::CopySource | BufferUsage::CopyDestination | BufferUsage::ShaderResource |
+                           BufferUsage::UnorderedAccess;
+        m_buffer = device->createBuffer(bufferDesc, nullptr);
+        m_readbackData = std::make_unique<uint8_t[]>(bufferDesc.size);
+        m_tmpDataSize = 1024 * 1024;
+        m_tmpData = std::make_unique<uint8_t[]>(m_tmpDataSize);
+    }
+
+    void writeTexelsRawHost(ITextureView* textureView, span<TexelData> texels)
+    {
+        ITexture* texture = textureView->getTexture();
+        uint32_t baseLayer = textureView->getDesc().subresourceRange.layer;
+        uint32_t baseMip = textureView->getDesc().subresourceRange.mip;
+        ComPtr<ICommandEncoder> commandEncoder = m_queue->createCommandEncoder();
+        for (const TexelData& texel : texels)
+        {
+            SubresourceLayout layout;
+            texture->getSubresourceLayout(baseMip + texel.mip, &layout);
+            Offset3D offset = {texel.offset[0], texel.offset[1], texel.offset[2]};
+            Extent3D extent = {1, 1, 1};
+            SubresourceRange srRange = {baseLayer + texel.layer, 1, baseMip + texel.mip, 1};
+            SLANG_RHI_ASSERT(m_tmpDataSize >= layout.rowPitch);
+            std::memcpy(m_tmpData.get(), texel.raw, 16);
+            SubresourceData srData = {m_tmpData.get(), layout.rowPitch, layout.slicePitch};
+            commandEncoder->uploadTextureData(texture, srRange, offset, extent, &srData, 1);
+        }
+        m_queue->submit(commandEncoder->finish());
+    }
+
+    void writeTexelsHost(ITextureView* textureView, span<TexelData> texels)
+    {
+        // Pack texels to raw data
+        Format format = textureView->getTexture()->getDesc().format;
+        const FormatInfo& info = getFormatInfo(format);
+        FormatConversionFuncs funcs = getFormatConversionFuncs(format);
+        switch (info.kind)
+        {
+        case FormatKind::Integer:
+            for (TexelData& texel : texels)
+            {
+                funcs.packIntFunc(texel.uints, texel.raw);
+            }
+            break;
+        case FormatKind::Normalized:
+        case FormatKind::Float:
+            for (TexelData& texel : texels)
+                funcs.packFloatFunc(texel.floats, texel.raw);
+            break;
+        case FormatKind::DepthStencil:
+            FAIL("Depth/stencil not supported!");
+        }
+        writeTexelsRawHost(textureView, texels);
+    }
+
+    void readTexelsRawHost(ITextureView* textureView, span<TexelData> texels)
+    {
+        REQUIRE(texels.size_bytes() < m_buffer->getDesc().size);
+        ITexture* texture = textureView->getTexture();
+        uint32_t baseLayer = textureView->getDesc().subresourceRange.layer;
+        uint32_t baseMip = textureView->getDesc().subresourceRange.mip;
+        ComPtr<ICommandEncoder> commandEncoder = m_queue->createCommandEncoder();
+        uint64_t offset = 0;
+        for (const TexelData& texel : texels)
+        {
+            SubresourceLayout layout;
+            texture->getSubresourceLayout(baseMip + texel.mip, &layout);
+            Extent3D extent = {1, 1, 1};
+            commandEncoder->copyTextureToBuffer(
+                m_buffer,
+                offset,
+                16,
+                layout.rowPitch,
+                texture,
+                baseLayer + texel.layer,
+                baseMip + texel.mip,
+                Offset3D{texel.offset[0], texel.offset[1], texel.offset[2]},
+                extent
+            );
+            offset += 16;
+        }
+        m_queue->submit(commandEncoder->finish());
+        m_device->readBuffer(m_buffer, 0, texels.size() * 16, m_readbackData.get());
+        offset = 0;
+        for (TexelData& texel : texels)
+        {
+            // Map the raw data back to the texel structure
+            std::memcpy(texel.raw, m_readbackData.get() + offset, 16);
+            offset += 16;
+        }
+    }
+
+    void readTexelsHost(ITextureView* textureView, span<TexelData> texels)
+    {
+        // Unpack raw data to texels
+        Format format = textureView->getTexture()->getDesc().format;
+        const FormatInfo& info = getFormatInfo(format);
+        FormatConversionFuncs funcs = getFormatConversionFuncs(format);
+        readTexelsRawHost(textureView, texels);
+        switch (info.kind)
+        {
+        case FormatKind::Integer:
+            for (TexelData& texel : texels)
+                funcs.unpackIntFunc(texel.raw, texel.uints);
+            break;
+        case FormatKind::Normalized:
+        case FormatKind::Float:
+            for (TexelData& texel : texels)
+                funcs.unpackFloatFunc(texel.raw, texel.floats);
+            break;
+        case FormatKind::DepthStencil:
+            FAIL("Depth/stencil not supported!");
+        }
+    }
+
+    std::string_view getShaderPrelude()
+    {
+        return R"(
+struct TexelData {
+    uint layer;
+    uint mip;
+    uint offset[3];
+    uint values[4];
+    uint raw[4];
+};
+)";
+    }
+
+    ComPtr<IComputePipeline> getWritePipeline(TextureType textureType, Format format, WriteMethod writeMethod)
+    {
+        WritePipelineKey key = {textureType, format, writeMethod};
+        auto it = m_writePipelines.find(key);
+        if (it != m_writePipelines.end())
             return it->second;
 
+        const FormatInfo& info = getFormatInfo(format);
+        std::string formatType = getFormatType(format);
+        std::string slangTextureType =
+            getFormatAttribute(format) + " " + getRWTextureType(textureType) + "<" + formatType + ">";
         std::string source;
-        std::string srcTextureType = getTextureType(textureType) + "<" + getFormatType(format) + ">";
-        std::string dstTextureType =
-            getFormatAttribute(format) + getRWTextureType(textureType) + "<" + getFormatType(format) + ">";
+        source += getShaderPrelude();
         source += "[shader(\"compute\")]\n";
         source += "[numthreads(1,1,1)]\n";
-        source += "void copyTexture(\n";
+        source += "void writeTexels(\n";
         source += "    uint3 tid : SV_DispatchThreadID,\n";
-        source += "    uniform " + srcTextureType + " srcTexture,\n";
-        source += "    uniform " + dstTextureType + " dstTexture)\n";
+        source += "    uniform " + slangTextureType + " texture,\n";
+        source += "    uniform RWStructuredBuffer<TexelData> texelData,\n";
+        source += "    uniform uint texelCount)\n";
         source += "{\n";
-        if (textureType == TextureType::Texture1D || textureType == TextureType::Texture1DArray)
+        source += "    if (tid.x > texelCount)\n";
+        source += "        return;\n";
+        source += "    TexelData texel = texelData[tid.x];\n";
+        source += "    " + formatType + " value;\n";
+        std::string convertFunc = "";
+        switch (info.kind)
         {
-            source += "    uint srcDims;\n";
-            source += "    srcTexture.GetDimensions(srcDims);\n";
-            source += "    uint dstDims;\n";
-            source += "    dstTexture.GetDimensions(dstDims);\n";
-            source += "    if (srcDims != dstDims)\n";
-            source += "        return;\n";
-            source += "    if (tid.x >= srcDims)\n";
-            source += "        return;\n";
-            source += "    dstTexture[tid.x] = srcTexture[tid.x];\n";
+        case FormatKind::Integer:
+            convertFunc = "asuint";
+            break;
+        case FormatKind::Normalized:
+        case FormatKind::Float:
+            convertFunc = "asfloat";
+            break;
+        case FormatKind::DepthStencil:
+            break;
         }
-        else if (textureType == TextureType::Texture2D || textureType == TextureType::Texture2DArray)
+        if (info.channelCount == 1)
         {
-            source += "    uint2 srcDims;\n";
-            source += "    srcTexture.GetDimensions(srcDims.x, srcDims.y);\n";
-            source += "    uint2 dstDims;\n";
-            source += "    dstTexture.GetDimensions(dstDims.x, dstDims.y);\n";
-            source += "    if (any(srcDims != dstDims))\n";
-            source += "        return;\n";
-            source += "    if (any(tid.xy >= dstDims))\n";
-            source += "        return;\n";
-            source += "    dstTexture[tid.xy] = srcTexture[tid.xy];\n";
+            source += "    value = " + convertFunc + "(texel.values[0]);\n";
         }
-        else if (textureType == TextureType::Texture3D)
+        else
         {
-            source += "    uint3 srcDims;\n";
-            source += "    srcTexture.GetDimensions(srcDims.x, srcDims.y, srcDims.z);\n";
-            source += "    uint3 dstDims;\n";
-            source += "    srcTexture.GetDimensions(dstDims.x, dstDims.y, dstDims.z);\n";
-            source += "    if (any(srcDims != dstDims))\n";
-            source += "        return;\n";
-            source += "    if (any(tid >= dstDims))\n";
-            source += "        return;\n";
-            source += "    dstTexture[tid] = srcTexture[tid];\n";
+            for (uint32_t i = 0; i < info.channelCount; ++i)
+            {
+                source += "    value[" + std::to_string(i) + "] = " + convertFunc + "(texel.values[" +
+                          std::to_string(i) + "]);\n";
+            }
+        }
+        if (writeMethod == WriteMethod::Store)
+        {
+            if (textureType == TextureType::Texture1D)
+            {
+                source += "    texture.Store(texel.offset[0], value);\n";
+            }
+            if (textureType == TextureType::Texture1DArray)
+            {
+                source += "    texture.Store(uint2(texel.offset[0], texel.layer), value);\n";
+            }
+            else if (textureType == TextureType::Texture2D)
+            {
+                source += "    texture.Store(uint2(texel.offset[0], texel.offset[1]), value);\n";
+            }
+            else if (textureType == TextureType::Texture2DArray)
+            {
+                source += "    texture.Store(uint3(texel.offset[0], texel.offset[1], texel.layer), value);\n";
+            }
+            else if (textureType == TextureType::Texture3D)
+            {
+                source += "    texture.Store(uint3(texel.offset[0], texel.offset[1], texel.offset[2]), value);\n";
+            }
+        }
+        else if (writeMethod == WriteMethod::Subscript)
+        {
+            if (textureType == TextureType::Texture1D)
+            {
+                source += "    texture[texel.offset[0]] = value;\n";
+            }
+            if (textureType == TextureType::Texture1DArray)
+            {
+                source += "    texture[uint2(texel.offset[0], texel.layer)] = value;\n";
+            }
+            else if (textureType == TextureType::Texture2D)
+            {
+                source += "    texture[uint2(texel.offset[0], texel.offset[1])] = value;\n";
+            }
+            else if (textureType == TextureType::Texture2DArray)
+            {
+                source += "    texture[uint3(texel.offset[0], texel.offset[1], texel.layer)] = value;\n";
+            }
+            else if (textureType == TextureType::Texture3D)
+            {
+                source += "    texture[uint3(texel.offset[0], texel.offset[1], texel.offset[2])] = value;\n";
+            }
         }
         source += "}\n";
-        // fprintf(stderr, "Shader source:\n%s\n", source.c_str());
+        // printf("Shader source:\n%s\n", source.c_str());
 
         ComPtr<IShaderProgram> shaderProgram;
-        REQUIRE_CALL(loadComputeProgramFromSource(device, shaderProgram, source));
+        REQUIRE_CALL(loadComputeProgramFromSource(m_device, shaderProgram, source));
 
         ComPtr<IComputePipeline> pipeline;
         ComputePipelineDesc pipelineDesc = {};
         pipelineDesc.program = shaderProgram;
-        REQUIRE_CALL(device->createComputePipeline(pipelineDesc, pipeline.writeRef()));
-        pipelines[key] = pipeline;
+        REQUIRE_CALL(m_device->createComputePipeline(pipelineDesc, pipeline.writeRef()));
+        m_writePipelines[key] = pipeline;
+        return pipeline;
+    }
+
+    void writeTexelsDevice(ITextureView* textureView, span<TexelData> texels, WriteMethod writeMethod)
+    {
+        REQUIRE(texels.size_bytes() < m_buffer->getDesc().size);
+        const TextureDesc& textureDesc = textureView->getTexture()->getDesc();
+        ComPtr<IComputePipeline> pipeline = getWritePipeline(textureDesc.type, textureDesc.format, writeMethod);
+        ComPtr<ICommandEncoder> commandEncoder = m_queue->createCommandEncoder();
+        commandEncoder->uploadBufferData(m_buffer, 0, texels.size_bytes(), texels.data());
+        auto passEncoder = commandEncoder->beginComputePass();
+        auto rootObject = passEncoder->bindPipeline(pipeline);
+        ShaderCursor cursor(rootObject->getEntryPoint(0));
+        cursor["texture"].setBinding(textureView);
+        cursor["texelData"].setBinding(m_buffer);
+        cursor["texelCount"].setData(uint32_t(texels.size()));
+        passEncoder->dispatchCompute(texels.size(), 1, 1);
+        passEncoder->end();
+        m_queue->submit(commandEncoder->finish());
+        m_device->readBuffer(m_buffer, 0, texels.size_bytes(), texels.data());
+    }
+
+    ComPtr<IComputePipeline> getReadPipeline(
+        TextureViewType textureViewType,
+        TextureType textureType,
+        Format format,
+        ReadMethod readMethod
+    )
+    {
+        ReadPipelineKey key = {textureViewType, textureType, format, readMethod};
+        auto it = m_readPipelines.find(key);
+        if (it != m_readPipelines.end())
+            return it->second;
+
+        const FormatInfo& info = getFormatInfo(format);
+        std::string formatType = getFormatType(format);
+        std::string slangTextureType = getFormatAttribute(format) + " " +
+                                       (textureViewType == TextureViewType::ReadOnly ? getTextureType(textureType)
+                                                                                     : getRWTextureType(textureType)) +
+                                       "<" + formatType + ">";
+        std::string source;
+        source += getShaderPrelude();
+        source += "[shader(\"compute\")]\n";
+        source += "[numthreads(1,1,1)]\n";
+        source += "void readTexels(\n";
+        source += "    uint3 tid : SV_DispatchThreadID,\n";
+        source += "    uniform " + slangTextureType + " texture,\n";
+        source += "    uniform RWStructuredBuffer<TexelData> texelData,\n";
+        source += "    uniform uint texelCount)\n";
+        source += "{\n";
+        source += "    if (tid.x > texelCount)\n";
+        source += "        return;\n";
+        source += "    TexelData texel = texelData[tid.x];\n";
+        source += "    " + formatType + " value;\n";
+        if (textureViewType == TextureViewType::ReadOnly)
+        {
+            if (readMethod == ReadMethod::Load)
+            {
+                if (textureType == TextureType::Texture1D)
+                {
+                    source += "    value = texture.Load(uint2(texel.offset[0], texel.mip));\n";
+                }
+                if (textureType == TextureType::Texture1DArray)
+                {
+                    source += "    value = texture.Load(uint3(texel.offset[0], texel.layer, texel.mip));\n";
+                }
+                else if (textureType == TextureType::Texture2D)
+                {
+                    source += "    value = texture.Load(uint3(texel.offset[0], texel.offset[1], texel.mip));\n";
+                }
+                else if (textureType == TextureType::Texture2DArray)
+                {
+                    source +=
+                        "    value = texture.Load(uint4(texel.offset[0], texel.offset[1], texel.layer, texel.mip));\n";
+                }
+                else if (textureType == TextureType::Texture3D)
+                {
+                    source +=
+                        "    value = texture.Load(uint4(texel.offset[0], texel.offset[1], texel.offset[2], "
+                        "texel.mip));\n";
+                }
+            }
+            else if (readMethod == ReadMethod::Subscript)
+            {
+                if (textureType == TextureType::Texture1D)
+                {
+                    source += "    value = texture[texel.offset[0]];\n";
+                }
+                if (textureType == TextureType::Texture1DArray)
+                {
+                    source += "    value = texture[uint2(texel.offset[0], texel.layer)];\n";
+                }
+                else if (textureType == TextureType::Texture2D)
+                {
+                    source += "    value = texture[uint2(texel.offset[0], texel.offset[1])];\n";
+                }
+                else if (textureType == TextureType::Texture2DArray)
+                {
+                    source += "    value = texture[uint3(texel.offset[0], texel.offset[1], texel.layer)];\n";
+                }
+                else if (textureType == TextureType::Texture3D)
+                {
+                    source += "    value = texture[uint3(texel.offset[0], texel.offset[1], texel.offset[2])];\n";
+                }
+            }
+        }
+        else if (textureViewType == TextureViewType::ReadWrite)
+        {
+            if (readMethod == ReadMethod::Load)
+            {
+                if (textureType == TextureType::Texture1D)
+                {
+                    source += "    value = texture.Load(texel.offset[0]);\n";
+                }
+                if (textureType == TextureType::Texture1DArray)
+                {
+                    source += "    value = texture.Load(uint2(texel.offset[0], texel.layer));\n";
+                }
+                else if (textureType == TextureType::Texture2D)
+                {
+                    source += "    value = texture.Load(uint2(texel.offset[0], texel.offset[1]));\n";
+                }
+                else if (textureType == TextureType::Texture2DArray)
+                {
+                    source += "    value = texture.Load(uint3(texel.offset[0], texel.offset[1], texel.layer));\n";
+                }
+                else if (textureType == TextureType::Texture3D)
+                {
+                    source += "    value = texture.Load(uint3(texel.offset[0], texel.offset[1], texel.offset[2]));\n";
+                }
+            }
+            else if (readMethod == ReadMethod::Subscript)
+            {
+                if (textureType == TextureType::Texture1D)
+                {
+                    source += "    value = texture[texel.offset[0]];\n";
+                }
+                if (textureType == TextureType::Texture1DArray)
+                {
+                    source += "    value = texture[uint2(texel.offset[0], texel.layer)];\n";
+                }
+                else if (textureType == TextureType::Texture2D)
+                {
+                    source += "    value = texture[uint2(texel.offset[0], texel.offset[1])];\n";
+                }
+                else if (textureType == TextureType::Texture2DArray)
+                {
+                    source += "    value = texture[uint3(texel.offset[0], texel.offset[1], texel.layer)];\n";
+                }
+                else if (textureType == TextureType::Texture3D)
+                {
+                    source += "    value = texture[uint3(texel.offset[0], texel.offset[1], texel.offset[2])];\n";
+                }
+            }
+        }
+        if (info.channelCount == 1)
+        {
+            source += "    texel.values[0] = asuint(value);\n";
+        }
+        else
+        {
+            for (uint32_t i = 0; i < info.channelCount; ++i)
+            {
+                source += "    texel.values[" + std::to_string(i) + "] = asuint(value[" + std::to_string(i) + "]);\n";
+            }
+        }
+        source += "    texelData[tid.x] = texel;\n";
+        source += "}\n";
+        // printf("Shader source:\n%s\n", source.c_str());
+
+        ComPtr<IShaderProgram> shaderProgram;
+        REQUIRE_CALL(loadComputeProgramFromSource(m_device, shaderProgram, source));
+
+        ComPtr<IComputePipeline> pipeline;
+        ComputePipelineDesc pipelineDesc = {};
+        pipelineDesc.program = shaderProgram;
+        REQUIRE_CALL(m_device->createComputePipeline(pipelineDesc, pipeline.writeRef()));
+        m_readPipelines[key] = pipeline;
         return pipeline;
     };
+
+    void readTexelsDevice(
+        TextureViewType textureViewType,
+        ITextureView* textureView,
+        span<TexelData> texels,
+        ReadMethod readMethod
+    )
+    {
+        REQUIRE(texels.size_bytes() < m_buffer->getDesc().size);
+        const TextureDesc& textureDesc = textureView->getTexture()->getDesc();
+        ComPtr<IComputePipeline> pipeline =
+            getReadPipeline(textureViewType, textureDesc.type, textureDesc.format, readMethod);
+        ComPtr<ICommandEncoder> commandEncoder = m_queue->createCommandEncoder();
+        commandEncoder->uploadBufferData(m_buffer, 0, texels.size_bytes(), texels.data());
+        auto passEncoder = commandEncoder->beginComputePass();
+        auto rootObject = passEncoder->bindPipeline(pipeline);
+        ShaderCursor cursor(rootObject->getEntryPoint(0));
+        cursor["texture"].setBinding(textureView);
+        cursor["texelData"].setBinding(m_buffer);
+        cursor["texelCount"].setData(uint32_t(texels.size()));
+        passEncoder->dispatchCompute(texels.size(), 1, 1);
+        passEncoder->end();
+        m_queue->submit(commandEncoder->finish());
+        m_device->readBuffer(m_buffer, 0, texels.size_bytes(), texels.data());
+    }
+};
+
+static std::vector<TexelData> generateTexelData(ITextureView* textureView)
+{
+    const TextureDesc& textureDesc = textureView->getTexture()->getDesc();
+    const SubresourceRange& srRange = textureView->getDesc().subresourceRange;
+
+    const FormatInfo& info = getFormatInfo(textureDesc.format);
+
+    std::vector<TexelData> texels;
+
+    uint32_t subresourceCount = srRange.layerCount * srRange.mipCount;
+    uint32_t subresourceIndex = 0;
+
+    for (uint32_t layer = 0; layer < srRange.layerCount; ++layer)
+    {
+        for (uint32_t mip = 0; mip < srRange.mipCount; ++mip)
+        {
+            TexelData texel;
+            texel.layer = layer;
+            texel.mip = mip;
+            texel.offset[0] = 0;
+            texel.offset[1] = 0;
+            texel.offset[2] = 0;
+
+            if (info.kind == FormatKind::Integer && info.isSigned)
+            {
+                texel.ints[0] = -10 - subresourceIndex;
+                texel.ints[1] = -1;
+                texel.ints[2] = 1;
+                texel.ints[3] = 2;
+            }
+            else if (info.kind == FormatKind::Integer && !info.isSigned)
+            {
+                texel.uints[0] = 10 + subresourceIndex;
+                texel.uints[1] = 1;
+                texel.uints[2] = 2;
+                texel.uints[3] = 3;
+            }
+            else if (info.kind == FormatKind::Normalized)
+            {
+                texel.floats[0] = float(subresourceIndex + 1) / subresourceCount;
+                texel.floats[1] = 0.5f;
+                texel.floats[2] = 0.75f;
+                texel.floats[3] = 1.f;
+            }
+            else if (info.kind == FormatKind::Float)
+            {
+                texel.floats[0] = 10.f + subresourceIndex;
+                texel.floats[1] = 20.f;
+                texel.floats[2] = 30.f;
+                texel.floats[3] = 40.f;
+            }
+            else
+            {
+                FAIL("Unsupported format");
+            }
+
+            texels.push_back(texel);
+
+            uint32_t absMip = srRange.mip + mip;
+            uint32_t mipWidth = std::max(1u, textureDesc.size.width >> absMip);
+            uint32_t mipHeight = std::max(1u, textureDesc.size.height >> absMip);
+            uint32_t mipDepth = std::max(1u, textureDesc.size.depth >> absMip);
+            if (mipWidth == 1 && mipHeight == 1 && mipDepth == 1)
+                continue;
+
+            texel.offset[0] = mipWidth - 1;
+            texel.offset[1] = mipHeight - 1;
+            texel.offset[2] = mipDepth - 1;
+
+            if (info.kind == FormatKind::Integer && info.isSigned)
+            {
+                texel.ints[0] = -11 - subresourceIndex;
+                texel.ints[1] = 2;
+                texel.ints[2] = 1;
+                texel.ints[3] = -1;
+            }
+            else if (info.kind == FormatKind::Integer && !info.isSigned)
+            {
+                texel.uints[0] = 11 + subresourceIndex;
+                texel.uints[1] = 3;
+                texel.uints[2] = 2;
+                texel.uints[3] = 1;
+            }
+            else if (info.kind == FormatKind::Normalized)
+            {
+                texel.floats[0] = float(subresourceIndex + 1) / subresourceCount;
+                texel.floats[1] = 1.f;
+                texel.floats[2] = 0.75f;
+                texel.floats[3] = 0.5f;
+            }
+            else if (info.kind == FormatKind::Float)
+            {
+                texel.floats[0] = 11.f + subresourceIndex;
+                texel.floats[1] = 40.f;
+                texel.floats[2] = 30.f;
+                texel.floats[3] = 20.f;
+            }
+
+            texels.push_back(texel);
+
+            subresourceIndex += 1;
+        }
+    }
+
+    return texels;
+}
+
+// Test host write and read-back infrastructure.
+GPU_TEST_CASE("texture-view-host-write-read", D3D12 | Vulkan | CUDA | Metal)
+{
+    TextureViewTest test(device);
+
+    TextureTestOptions options(device);
+    options.addVariants(
+        TTShape::D1 | TTShape::D2 | TTShape::D3,
+        TTArray::Both,        // non-array/array
+        TTMip::Both,          // with/without mips
+        TTMS::Off,            // without multisampling
+        TTPowerOf2::Both,     // test both power-of-2 and non-power-of-2 sizes where possible
+        TTFmtCompressed::Off, // without compressed formats
+        TTFmtDepth::Off       // without depth formats
+#if TEST_SPECIFIC_FORMATS
+        ,
+        kFormats
+#endif
+    );
 
     runTextureTest(
         options,
         [&](TextureTestContext* c)
         {
-            if (device->getDeviceType() == DeviceType::CUDA)
-            {
-                const TextureDesc& desc = c->getTextureData().desc;
-                // Error: surf1Dwrite_convert<float>(((<invalid intrinsic>)), (dstTexture_0), ((_S2)) * 1,
-                // SLANG_CUDA_BOUNDARY_MODE);
-                if (desc.type == TextureType::Texture1D)
-                    return;
-            }
-
-            const TextureData& data = c->getTextureData();
-
-            // Enable this to helpfully log all created textures.
-            // fprintf(stderr, "Created texture %s\n", c->getTexture()->getDesc().label);
-
-            // If texture type couldn't be initialized (eg multisampled or multi-aspect)
-            // then don't check it's contents.
-            if (data.initMode == TextureInitMode::None)
+            const TextureDesc& desc = c->getTexture()->getDesc();
+            if (shouldSkipFormat(desc.format))
                 return;
 
-            ComPtr<ITexture> srcTexture = c->getTexture();
-            TextureDesc dstTextureDesc = srcTexture->getDesc();
-            dstTextureDesc.usage |= TextureUsage::UnorderedAccess;
-            ComPtr<ITexture> dstTexture;
-            REQUIRE_CALL(device->createTexture(dstTextureDesc, nullptr, dstTexture.writeRef()));
+            ComPtr<ITextureView> textureView = c->getTexture()->getDefaultView();
 
-            uint32_t layerCount = c->getTextureData().desc.getLayerCount();
-            uint32_t mipCount = c->getTextureData().desc.mipCount;
+            // Generate reference texel data
+            std::vector<TexelData> refTexels = generateTexelData(textureView);
 
-            for (uint32_t layer = 0; layer < layerCount; ++layer)
+            // Write reference texel data
+            test.writeTexelsHost(textureView, refTexels);
+
+            // Read back the texel data and compare
+            std::vector<TexelData> readTexels = refTexels;
+            clearTexelDataValues(readTexels);
+            test.readTexelsHost(textureView, readTexels);
+            compareTexelData(desc.format, refTexels, readTexels);
+        }
+    );
+
+    device->getQueue(QueueType::Graphics)->waitOnHost();
+}
+
+// Test shader side .Load() on read-only textures with views including all layers and mips.
+GPU_TEST_CASE("texture-view-load-ro-all-layers-all-mips", D3D12 | Vulkan | CUDA | Metal)
+{
+    TextureViewTest test(device);
+
+    TextureTestOptions options(device);
+    options.addVariants(
+        TTShape::D1 | TTShape::D2 | TTShape::D3,
+        TTArray::Both,        // with/without arrays
+        TTMip::Both,          // with/without mips
+        TTMS::Off,            // without multisampling
+        TTPowerOf2::Off,      // without power-of-two sizes (to limit the number of test cases)
+        TTFmtCompressed::Off, // without compressed formats
+        TTFmtDepth::Off,      // without depth formats
+        TextureUsage::ShaderResource
+#if TEST_SPECIFIC_FORMATS
+        ,
+        kFormats
+#endif
+    );
+
+    runTextureTest(
+        options,
+        [&](TextureTestContext* c)
+        {
+            const TextureDesc& desc = c->getTexture()->getDesc();
+            if (shouldSkipFormat(desc.format))
+                return;
+
+            // TODO: Skip CUDA tests due to Slang issues.
+            // CUDA Texture.Load() currently doesn't support mip argument.
+            if (device->getDeviceType() == DeviceType::CUDA &&
+                (desc.type == TextureType::Texture1D || desc.type == TextureType::Texture1DArray ||
+                 desc.arrayLength > 1 || desc.mipCount > 1))
+                return;
+
+            ComPtr<ITextureView> textureView = c->getTexture()->getDefaultView();
+
+            // Generate reference texel data
+            std::vector<TexelData> refTexels = generateTexelData(textureView);
+
+            // Write reference texel data
+            test.writeTexelsHost(textureView, refTexels);
+
+            // Read back the texel data in shader using .Load() and compare
+            std::vector<TexelData> readTexels = refTexels;
+            clearTexelDataValues(readTexels);
+            test.readTexelsDevice(TextureViewType::ReadOnly, textureView, readTexels, ReadMethod::Load);
+            compareTexelData(desc.format, refTexels, readTexels);
+        }
+    );
+
+    device->getQueue(QueueType::Graphics)->waitOnHost();
+}
+
+// Test shader side .Load() and subscript load operator on read-only textures with views including all layers and a
+// single mip.
+GPU_TEST_CASE("texture-view-load-ro-all-layers-single-mip", D3D12 | Vulkan | CUDA | Metal)
+{
+    TextureViewTest test(device);
+
+    TextureTestOptions options(device);
+    options.addVariants(
+        TTShape::D1 | TTShape::D2 | TTShape::D3,
+        TTArray::Both,        // with/without arrays
+        TTMip::Both,          // with/without mips
+        TTMS::Off,            // without multisampling
+        TTPowerOf2::Off,      // without power-of-two sizes (to limit the number of test cases)
+        TTFmtCompressed::Off, // without compressed formats
+        TTFmtDepth::Off,      // without depth formats
+        TextureUsage::ShaderResource
+#if TEST_SPECIFIC_FORMATS
+        ,
+        kFormats
+#endif
+    );
+
+    runTextureTest(
+        options,
+        [&](TextureTestContext* c)
+        {
+            const TextureDesc& desc = c->getTexture()->getDesc();
+            if (shouldSkipFormat(desc.format))
+                return;
+
+            // TODO: Skip CUDA tests due to Slang issues.
+            // CUDA Texture.Load() currently doesn't support mip argument.
+            if (device->getDeviceType() == DeviceType::CUDA &&
+                (desc.type == TextureType::Texture1D || desc.type == TextureType::Texture1DArray ||
+                 desc.arrayLength > 1 || desc.mipCount > 1))
+                return;
+
+            for (uint32_t mip = 0; mip < desc.mipCount; ++mip)
             {
-                for (uint32_t mip = 0; mip < mipCount; ++mip)
+                TextureViewDesc viewDesc = {};
+                viewDesc.subresourceRange.mip = mip;
+                viewDesc.subresourceRange.mipCount = 1;
+                ComPtr<ITextureView> textureView = c->getTexture()->createView(viewDesc);
+
+                // Generate reference texel data
+                std::vector<TexelData> refTexels = generateTexelData(textureView);
+
+                // Write reference texel data
+                test.writeTexelsHost(textureView, refTexels);
+
+                // Read back the texel data in shader using .Load() and compare
                 {
-                    TextureViewDesc srcViewDesc = {};
-                    srcViewDesc.subresourceRange.layer = layer;
-                    srcViewDesc.subresourceRange.layerCount = 1;
-                    srcViewDesc.subresourceRange.mip = mip;
-                    srcViewDesc.subresourceRange.mipCount = 1;
-                    ComPtr<ITextureView> srcView;
-                    REQUIRE_CALL(srcTexture->createView(srcViewDesc, srcView.writeRef()));
-
-                    TextureViewDesc dstViewDesc = {};
-                    dstViewDesc.subresourceRange.layer = layer;
-                    dstViewDesc.subresourceRange.layerCount = 1;
-                    dstViewDesc.subresourceRange.mip = mip;
-                    dstViewDesc.subresourceRange.mipCount = 1;
-                    ComPtr<ITextureView> dstView;
-                    REQUIRE_CALL(dstTexture->createView(dstViewDesc, dstView.writeRef()));
-
-                    ComPtr<IComputePipeline> pipeline = getCopyPipeline(dstTextureDesc.type, dstTextureDesc.format);
-
-                    auto queue = device->getQueue(QueueType::Graphics);
-                    auto commandEncoder = queue->createCommandEncoder();
-
-                    auto passEncoder = commandEncoder->beginComputePass();
-                    auto rootObject = passEncoder->bindPipeline(pipeline);
-                    ShaderCursor cursor(rootObject->getEntryPoint(0));
-                    cursor["srcTexture"].setBinding(srcView);
-                    cursor["dstTexture"].setBinding(dstView);
-                    SubresourceLayout layout;
-                    REQUIRE_CALL(srcTexture->getSubresourceLayout(mip, &layout));
-                    passEncoder->dispatchCompute(layout.size.width, layout.size.height, layout.size.depth);
-                    passEncoder->end();
-
-                    queue->submit(commandEncoder->finish());
+                    std::vector<TexelData> readTexels = refTexels;
+                    clearTexelDataValues(readTexels);
+                    test.readTexelsDevice(TextureViewType::ReadOnly, textureView, readTexels, ReadMethod::Load);
+                    compareTexelData(desc.format, refTexels, readTexels);
                 }
-            }
 
-            // Because signed normalized formats have two binary representations for -1.0,
-            // we need to check the values as converted to floats.
-            const FormatInfo& info = getFormatInfo(dstTextureDesc.format);
-            if (info.kind == FormatKind::Normalized && info.isSigned)
-            {
-                data.checkEqualFloat(dstTexture);
-            }
-            else
-            {
-                data.checkEqual(srcTexture);
+                // Read back the texel data in shader using .subscript() and compare
+                {
+                    std::vector<TexelData> readTexels = refTexels;
+                    clearTexelDataValues(readTexels);
+                    test.readTexelsDevice(TextureViewType::ReadOnly, textureView, readTexels, ReadMethod::Subscript);
+                    compareTexelData(desc.format, refTexels, readTexels);
+                }
             }
         }
     );
+
+    device->getQueue(QueueType::Graphics)->waitOnHost();
+}
+
+// Test shader side .Load() and subscript load operator on read-write textures with views including all layers and a
+// single mip.
+GPU_TEST_CASE("texture-view-load-rw-all-layers-single-mip", D3D12 | Vulkan | CUDA | Metal)
+{
+    TextureViewTest test(device);
+
+    TextureTestOptions options(device);
+    options.addVariants(
+        TTShape::D1 | TTShape::D2 | TTShape::D3,
+        TTArray::Both,        // with/without arrays
+        TTMip::Both,          // with/without mips
+        TTMS::Off,            // without multisampling
+        TTPowerOf2::Off,      // without power-of-two sizes (to limit the number of test cases)
+        TTFmtCompressed::Off, // without compressed formats
+        TTFmtDepth::Off,      // without depth formats
+        TextureUsage::ShaderResource | TextureUsage::UnorderedAccess
+#if TEST_SPECIFIC_FORMATS
+        ,
+        kFormats
+#endif
+    );
+
+    runTextureTest(
+        options,
+        [&](TextureTestContext* c)
+        {
+            const TextureDesc& desc = c->getTexture()->getDesc();
+            if (shouldSkipFormat(desc.format))
+                return;
+
+            // TODO: Skip CUDA tests due to Slang issues.
+            if (device->getDeviceType() == DeviceType::CUDA)
+                return;
+
+            for (uint32_t mip = 0; mip < desc.mipCount; ++mip)
+            {
+                TextureViewDesc viewDesc = {};
+                viewDesc.subresourceRange.mip = mip;
+                viewDesc.subresourceRange.mipCount = 1;
+                ComPtr<ITextureView> textureView = c->getTexture()->createView(viewDesc);
+
+                // Generate reference texel data
+                std::vector<TexelData> refTexels = generateTexelData(textureView);
+
+                // Write reference texel data
+                test.writeTexelsHost(textureView, refTexels);
+
+                // Read back the texel data in shader using .Load() and compare
+                {
+                    std::vector<TexelData> readTexels = refTexels;
+                    clearTexelDataValues(readTexels);
+                    test.readTexelsDevice(TextureViewType::ReadWrite, textureView, readTexels, ReadMethod::Load);
+                    compareTexelData(desc.format, refTexels, readTexels);
+                }
+
+                // Read back the texel data in shader using .subscript() and compare
+                {
+                    std::vector<TexelData> readTexels = refTexels;
+                    clearTexelDataValues(readTexels);
+                    test.readTexelsDevice(TextureViewType::ReadWrite, textureView, readTexels, ReadMethod::Subscript);
+                    compareTexelData(desc.format, refTexels, readTexels);
+                }
+            }
+        }
+    );
+
+    device->getQueue(QueueType::Graphics)->waitOnHost();
+}
+
+// Test shader side .Load() and subscript load operator on read-only textures with views including a single layer and
+// mip.
+GPU_TEST_CASE("texture-view-load-ro-single", D3D12 | Vulkan | CUDA | Metal)
+{
+    TextureViewTest test(device);
+
+    TextureTestOptions options(device);
+    options.addVariants(
+        TTShape::D1 | TTShape::D2 | TTShape::D3,
+        TTArray::Both,        // with/without arrays
+        TTMip::Both,          // with/without mips
+        TTMS::Off,            // without multisampling
+        TTPowerOf2::Off,      // without power-of-two sizes (to limit the number of test cases)
+        TTFmtCompressed::Off, // without compressed formats
+        TTFmtDepth::Off,      // without depth formats
+        TextureUsage::ShaderResource
+#if TEST_SPECIFIC_FORMATS
+        ,
+        kFormats
+#endif
+    );
+
+    runTextureTest(
+        options,
+        [&](TextureTestContext* c)
+        {
+            const TextureDesc& desc = c->getTexture()->getDesc();
+            if (shouldSkipFormat(desc.format))
+                return;
+
+            // TODO: Skip CUDA tests due to Slang issues.
+            if (device->getDeviceType() == DeviceType::CUDA &&
+                (desc.type == TextureType::Texture1D || desc.type == TextureType::Texture1DArray ||
+                 desc.type == TextureType::Texture2DArray))
+                return;
+
+            for (uint32_t layer = 0; layer < desc.arrayLength; ++layer)
+            {
+                for (uint32_t mip = 0; mip < desc.mipCount; ++mip)
+                {
+                    TextureViewDesc viewDesc = {};
+                    viewDesc.subresourceRange.layer = layer;
+                    viewDesc.subresourceRange.layerCount = 1;
+                    viewDesc.subresourceRange.mip = mip;
+                    viewDesc.subresourceRange.mipCount = 1;
+                    ComPtr<ITextureView> textureView = c->getTexture()->createView(viewDesc);
+
+                    // Generate reference texel data
+                    std::vector<TexelData> refTexels = generateTexelData(textureView);
+
+                    // Write reference texel data
+                    test.writeTexelsHost(textureView, refTexels);
+
+                    // Read back the texel data in shader using .Load() and compare
+                    {
+                        std::vector<TexelData> readTexels = refTexels;
+                        clearTexelDataValues(readTexels);
+                        test.readTexelsDevice(TextureViewType::ReadOnly, textureView, readTexels, ReadMethod::Load);
+                        compareTexelData(desc.format, refTexels, readTexels);
+                    }
+
+                    // Read back the texel data in shader using .subscript() and compare
+                    {
+                        std::vector<TexelData> readTexels = refTexels;
+                        clearTexelDataValues(readTexels);
+                        test.readTexelsDevice(
+                            TextureViewType::ReadOnly,
+                            textureView,
+                            readTexels,
+                            ReadMethod::Subscript
+                        );
+                        compareTexelData(desc.format, refTexels, readTexels);
+                    }
+                }
+            }
+        }
+    );
+
+    device->getQueue(QueueType::Graphics)->waitOnHost();
+}
+
+// Test shader side .Load() and subscript load operator on read-write textures with views including a single layer and
+// mip.
+GPU_TEST_CASE("texture-view-load-rw-single", D3D12 | Vulkan | CUDA | Metal)
+{
+    TextureViewTest test(device);
+
+    TextureTestOptions options(device);
+    options.addVariants(
+        TTShape::D1 | TTShape::D2 | TTShape::D3,
+        TTArray::Both,        // with/without arrays
+        TTMip::Both,          // with/without mips
+        TTMS::Off,            // without multisampling
+        TTPowerOf2::Off,      // without power-of-two sizes (to limit the number of test cases)
+        TTFmtCompressed::Off, // without compressed formats
+        TTFmtDepth::Off,      // without depth formats
+        TextureUsage::ShaderResource | TextureUsage::UnorderedAccess,
+        TextureInitMode::None
+#if TEST_SPECIFIC_FORMATS
+        ,
+        kFormats
+#endif
+    );
+
+    runTextureTest(
+        options,
+        [&](TextureTestContext* c)
+        {
+            const TextureDesc& desc = c->getTexture()->getDesc();
+            if (shouldSkipFormat(desc.format))
+                return;
+
+            // TODO: Skip CUDA tests due to Slang issues.
+            if (device->getDeviceType() == DeviceType::CUDA)
+                return;
+
+            for (uint32_t layer = 0; layer < desc.arrayLength; ++layer)
+            {
+                for (uint32_t mip = 0; mip < desc.mipCount; ++mip)
+                {
+                    TextureViewDesc viewDesc = {};
+                    viewDesc.subresourceRange.layer = layer;
+                    viewDesc.subresourceRange.layerCount = 1;
+                    viewDesc.subresourceRange.mip = mip;
+                    viewDesc.subresourceRange.mipCount = 1;
+                    ComPtr<ITextureView> textureView = c->getTexture()->createView(viewDesc);
+
+                    // Generate reference texel data
+                    std::vector<TexelData> refTexels = generateTexelData(textureView);
+
+                    // Write reference texel data
+                    test.writeTexelsHost(textureView, refTexels);
+
+                    // Read back the texel data in shader using .Load() and compare
+                    {
+                        std::vector<TexelData> readTexels = refTexels;
+                        clearTexelDataValues(readTexels);
+                        test.readTexelsDevice(TextureViewType::ReadWrite, textureView, readTexels, ReadMethod::Load);
+                        compareTexelData(desc.format, refTexels, readTexels);
+                    }
+
+                    // Read back the texel data in shader using .subscript() and compare
+                    {
+                        std::vector<TexelData> readTexels = refTexels;
+                        clearTexelDataValues(readTexels);
+                        test.readTexelsDevice(
+                            TextureViewType::ReadWrite,
+                            textureView,
+                            readTexels,
+                            ReadMethod::Subscript
+                        );
+                        compareTexelData(desc.format, refTexels, readTexels);
+                    }
+                }
+            }
+        }
+    );
+
+    device->getQueue(QueueType::Graphics)->waitOnHost();
+}
+
+// Test shader side .Store() and subscript store operator on read-write textures with views including all layers and a
+// single mip.
+GPU_TEST_CASE("texture-view-store-all-layers-single-mip", D3D12 | Vulkan | CUDA | Metal)
+{
+    TextureViewTest test(device);
+
+    TextureTestOptions options(device);
+    options.addVariants(
+        TTShape::D1 | TTShape::D2 | TTShape::D3,
+        TTArray::Both,        // with/without arrays
+        TTMip::Both,          // with/without mips
+        TTMS::Off,            // without multisampling
+        TTPowerOf2::Off,      // without power-of-two sizes (to limit the number of test cases)
+        TTFmtCompressed::Off, // without compressed formats
+        TTFmtDepth::Off,      // without depth formats
+        TextureUsage::UnorderedAccess,
+        TextureInitMode::None
+#if TEST_SPECIFIC_FORMATS
+        ,
+        kFormats
+#endif
+    );
+
+    runTextureTest(
+        options,
+        [&](TextureTestContext* c)
+        {
+            const TextureDesc& desc = c->getTexture()->getDesc();
+            if (shouldSkipFormat(desc.format))
+                return;
+
+            // TODO: Skip CUDA tests due to Slang issues.
+            if (device->getDeviceType() == DeviceType::CUDA)
+                return;
+
+            for (uint32_t mip = 0; mip < desc.mipCount; ++mip)
+            {
+                TextureViewDesc viewDesc = {};
+                viewDesc.subresourceRange.mip = mip;
+                viewDesc.subresourceRange.mipCount = 1;
+                ComPtr<ITextureView> textureView = c->getTexture()->createView(viewDesc);
+
+                // Generate reference texel data
+                std::vector<TexelData> refTexels = generateTexelData(textureView);
+
+                // Write the texel data in shader using .Store() and compare
+                {
+                    test.writeTexelsDevice(textureView, refTexels, WriteMethod::Store);
+                    std::vector<TexelData> readTexels = refTexels;
+                    clearTexelDataValues(readTexels);
+                    test.readTexelsHost(textureView, readTexels);
+                    compareTexelData(desc.format, refTexels, readTexels);
+                }
+
+                // Clear texels.
+                {
+                    std::vector<TexelData> clearTexels = refTexels;
+                    clearTexelDataValues(clearTexels);
+                    test.writeTexelsHost(textureView, clearTexels);
+                }
+
+                // Write the texel data in shader using .Store() and compare
+                {
+                    test.writeTexelsDevice(textureView, refTexels, WriteMethod::Subscript);
+                    std::vector<TexelData> readTexels = refTexels;
+                    clearTexelDataValues(readTexels);
+                    test.readTexelsHost(textureView, readTexels);
+                    compareTexelData(desc.format, refTexels, readTexels);
+                }
+            }
+        }
+    );
+
+    device->getQueue(QueueType::Graphics)->waitOnHost();
+}
+
+// Test shader side .Store() and subscript store operator on read-write textures with views including a single layer and
+// mip.
+GPU_TEST_CASE("texture-view-store-single", D3D12 | Vulkan | CUDA | Metal)
+{
+    TextureViewTest test(device);
+
+    TextureTestOptions options(device);
+    options.addVariants(
+        TTShape::D1 | TTShape::D2 | TTShape::D3,
+        TTArray::Both,        // with/without arrays
+        TTMip::Both,          // with/without mips
+        TTMS::Off,            // without multisampling
+        TTPowerOf2::Off,      // without power-of-two sizes (to limit the number of test cases)
+        TTFmtCompressed::Off, // without compressed formats
+        TTFmtDepth::Off,      // without depth formats
+        TextureUsage::UnorderedAccess,
+        TextureInitMode::None
+#if TEST_SPECIFIC_FORMATS
+        ,
+        kFormats
+#endif
+    );
+
+    runTextureTest(
+        options,
+        [&](TextureTestContext* c)
+        {
+            const TextureDesc& desc = c->getTexture()->getDesc();
+            if (shouldSkipFormat(desc.format))
+                return;
+
+            // TODO: Skip CUDA tests due to Slang issues.
+            if (device->getDeviceType() == DeviceType::CUDA)
+                return;
+
+            for (uint32_t layer = 0; layer < desc.arrayLength; ++layer)
+            {
+                for (uint32_t mip = 0; mip < desc.mipCount; ++mip)
+                {
+                    TextureViewDesc viewDesc = {};
+                    viewDesc.subresourceRange.layer = layer;
+                    viewDesc.subresourceRange.layerCount = 1;
+                    viewDesc.subresourceRange.mip = mip;
+                    viewDesc.subresourceRange.mipCount = 1;
+                    ComPtr<ITextureView> textureView = c->getTexture()->createView(viewDesc);
+
+                    // Generate reference texel data
+                    std::vector<TexelData> refTexels = generateTexelData(textureView);
+
+                    // Write the texel data in shader using .Store() and compare
+                    {
+                        test.writeTexelsDevice(textureView, refTexels, WriteMethod::Store);
+                        std::vector<TexelData> readTexels = refTexels;
+                        clearTexelDataValues(readTexels);
+                        test.readTexelsHost(textureView, readTexels);
+                        compareTexelData(desc.format, refTexels, readTexels);
+                    }
+
+                    // Clear texels.
+                    {
+                        std::vector<TexelData> clearTexels = refTexels;
+                        clearTexelDataValues(clearTexels);
+                        test.writeTexelsHost(textureView, clearTexels);
+                    }
+
+                    // Write the texel data in shader using .Store() and compare
+                    {
+                        test.writeTexelsDevice(textureView, refTexels, WriteMethod::Subscript);
+                        std::vector<TexelData> readTexels = refTexels;
+                        clearTexelDataValues(readTexels);
+                        test.readTexelsHost(textureView, readTexels);
+                        compareTexelData(desc.format, refTexels, readTexels);
+                    }
+                }
+            }
+        }
+    );
+
+    device->getQueue(QueueType::Graphics)->waitOnHost();
 }

--- a/tests/texture-test.cpp
+++ b/tests/texture-test.cpp
@@ -1213,6 +1213,11 @@ void TextureTestOptions::filterFormat(int state, TextureTestVariant variant)
         if (!is_set(support, FormatSupport::Texture))
             return;
 
+        // Skip if format doesn't support UAV access.
+        if (is_set(testTexture.desc.usage, TextureUsage::UnorderedAccess) &&
+            (!is_set(support, FormatSupport::ShaderUavLoad) || !is_set(support, FormatSupport::ShaderUavStore)))
+            return;
+
         const FormatInfo& info = getFormatInfo(format);
 
         // Metal doesn't support writing into depth textures.


### PR DESCRIPTION
Adds a lot of tests for shader side load and store operations on textures.
Tests pass on D3D12/Vulkan/Metal but there issues with CUDA that need to fixed in Slang, so most of the CUDA tests are skipped for now.