### PR TITLE
Allow setting null bindings

### DIFF
--- a/include/slang-rhi.h
+++ b/include/slang-rhi.h
@@ -1549,8 +1549,8 @@ struct Binding
     Binding(IBuffer* buffer, IBuffer* counter, const BufferRange& range = kEntireBuffer) : type(BindingType::BufferWithCounter), resource(buffer), resource2(counter), bufferRange(range) {}
     Binding(const ComPtr<IBuffer>& buffer, const ComPtr<IBuffer>& counter, const BufferRange& range = kEntireBuffer) : type(BindingType::BufferWithCounter), resource(buffer), resource2(counter), bufferRange(range) {}
 
-    Binding(ITexture* texture) : type(BindingType::Texture), resource(texture->getDefaultView()) {}
-    Binding(const ComPtr<ITexture>& texture) : type(BindingType::Texture), resource(texture->getDefaultView()) {}
+    Binding(ITexture* texture) : type(BindingType::Texture), resource(texture ? texture->getDefaultView() : nullptr) {}
+    Binding(const ComPtr<ITexture>& texture) : type(BindingType::Texture), resource(texture ? texture->getDefaultView() : nullptr) {}
 
     Binding(ITextureView* textureView) : type(BindingType::Texture), resource(textureView) {}
     Binding(const ComPtr<ITextureView>& textureView) : type(BindingType::Texture), resource(textureView) {}
@@ -1558,8 +1558,8 @@ struct Binding
     Binding(ISampler* sampler) : type(BindingType::Sampler) , resource(sampler) {}
     Binding(const ComPtr<ISampler>& sampler) : type(BindingType::Sampler) , resource(sampler) {}
 
-    Binding(ITexture* texture, ISampler* sampler) : type(BindingType::CombinedTextureSampler), resource(texture->getDefaultView()), resource2(sampler) {}
-    Binding(const ComPtr<ITexture>& texture, const ComPtr<ISampler>& sampler) : type(BindingType::CombinedTextureSampler), resource(texture->getDefaultView()), resource2(sampler) {}
+    Binding(ITexture* texture, ISampler* sampler) : type(BindingType::CombinedTextureSampler), resource(texture ? texture->getDefaultView() : nullptr), resource2(sampler) {}
+    Binding(const ComPtr<ITexture>& texture, const ComPtr<ISampler>& sampler) : type(BindingType::CombinedTextureSampler), resource(texture ? texture->getDefaultView() : nullptr), resource2(sampler) {}
 
     Binding(ITextureView* textureView, ISampler* sampler) : type(BindingType::CombinedTextureSampler) , resource(textureView), resource2(sampler) {}
     Binding(const ComPtr<ITextureView>& textureView, const ComPtr<ISampler>& sampler) : type(BindingType::CombinedTextureSampler) , resource(textureView), resource2(sampler) {}

--- a/src/cuda/cuda-shader-object.cpp
+++ b/src/cuda/cuda-shader-object.cpp
@@ -25,10 +25,15 @@ void shaderObjectSetBinding(
     case slang::BindingType::MutableTypedBuffer:
     {
         BufferImpl* buffer = checked_cast<BufferImpl*>(slot.resource.get());
-        void* dataPtr = (uint8_t*)buffer->m_cudaMemory + slot.bufferRange.offset;
-        size_t dataSize = slot.bufferRange.size;
-        if (buffer->m_desc.elementSize > 1)
-            dataSize /= buffer->m_desc.elementSize;
+        void* dataPtr = nullptr;
+        size_t dataSize = 0;
+        if (buffer)
+        {
+            dataPtr = (uint8_t*)buffer->m_cudaMemory + slot.bufferRange.offset;
+            dataSize = slot.bufferRange.size;
+            if (buffer->m_desc.elementSize > 1)
+                dataSize /= buffer->m_desc.elementSize;
+        }
         memcpy(dst + offset.uniformOffset, &dataPtr, sizeof(dataPtr));
         memcpy(dst + offset.uniformOffset + 8, &dataSize, sizeof(dataSize));
         break;
@@ -36,21 +41,33 @@ void shaderObjectSetBinding(
     case slang::BindingType::Texture:
     {
         TextureViewImpl* textureView = checked_cast<TextureViewImpl*>(slot.resource.get());
-        uint64_t handle = textureView->getTexObject();
+        uint64_t handle = 0;
+        if (textureView)
+        {
+            handle = textureView->getTexObject();
+        }
         memcpy(dst + offset.uniformOffset, &handle, sizeof(handle));
         break;
     }
     case slang::BindingType::MutableTexture:
     {
         TextureViewImpl* textureView = checked_cast<TextureViewImpl*>(slot.resource.get());
-        uint64_t handle = textureView->getSurfObject();
+        uint64_t handle = 0;
+        if (textureView)
+        {
+            handle = textureView->getSurfObject();
+        }
         memcpy(dst + offset.uniformOffset, &handle, sizeof(handle));
         break;
     }
     case slang::BindingType::RayTracingAccelerationStructure:
     {
         AccelerationStructureImpl* as = checked_cast<AccelerationStructureImpl*>(slot.resource.get());
-        uint64_t handle = as->m_handle;
+        uint64_t handle = 0;
+        if (as)
+        {
+            handle = as->m_handle;
+        }
         memcpy(dst + offset.uniformOffset, &handle, sizeof(handle));
         break;
     }

--- a/src/shader-object.cpp
+++ b/src/shader-object.cpp
@@ -258,52 +258,77 @@ Result ShaderObject::setBinding(const ShaderOffset& offset, const Binding& bindi
     case BindingType::BufferWithCounter:
     {
         Buffer* buffer = checked_cast<Buffer*>(binding.resource.get());
-        if (!buffer)
-            return SLANG_E_INVALID_ARG;
-        slot.type = BindingType::Buffer;
-        slot.resource = buffer;
-        if (binding.type == BindingType::BufferWithCounter)
-            slot.resource2 = checked_cast<Buffer*>(binding.resource2.get());
-        slot.format = buffer->m_desc.format;
-        slot.bufferRange = buffer->resolveBufferRange(binding.bufferRange);
+        if (buffer)
+        {
+            slot.type = BindingType::Buffer;
+            slot.resource = buffer;
+            if (binding.type == BindingType::BufferWithCounter)
+                slot.resource2 = checked_cast<Buffer*>(binding.resource2.get());
+            slot.format = buffer->m_desc.format;
+            slot.bufferRange = buffer->resolveBufferRange(binding.bufferRange);
+        }
+        else
+        {
+            slot = {};
+        }
         break;
     }
     case BindingType::Texture:
     {
         TextureView* textureView = checked_cast<TextureView*>(binding.resource.get());
-        if (!textureView)
-            return SLANG_E_INVALID_ARG;
-        slot.type = BindingType::Texture;
-        slot.resource = textureView;
+        if (textureView)
+        {
+            slot.type = BindingType::Texture;
+            slot.resource = textureView;
+        }
+        else
+        {
+            slot = {};
+        }
         break;
     }
     case BindingType::Sampler:
     {
         Sampler* sampler = checked_cast<Sampler*>(binding.resource.get());
-        if (!sampler)
-            return SLANG_E_INVALID_ARG;
-        slot.type = BindingType::Sampler;
-        slot.resource = sampler;
+        if (sampler)
+        {
+            slot.type = BindingType::Sampler;
+            slot.resource = sampler;
+        }
+        else
+        {
+            slot = {};
+        }
         break;
     }
     case BindingType::AccelerationStructure:
     {
         AccelerationStructure* accelerationStructure = checked_cast<AccelerationStructure*>(binding.resource.get());
-        if (!accelerationStructure)
-            return SLANG_E_INVALID_ARG;
-        slot.type = BindingType::AccelerationStructure;
-        slot.resource = accelerationStructure;
+        if (accelerationStructure)
+        {
+            slot.type = BindingType::AccelerationStructure;
+            slot.resource = accelerationStructure;
+        }
+        else
+        {
+            slot = {};
+        }
         break;
     }
     case BindingType::CombinedTextureSampler:
     {
         TextureView* textureView = checked_cast<TextureView*>(binding.resource.get());
         Sampler* sampler = checked_cast<Sampler*>(binding.resource2.get());
-        if (!textureView || !sampler)
-            return SLANG_E_INVALID_ARG;
-        slot.type = BindingType::CombinedTextureSampler;
-        slot.resource = textureView;
-        slot.resource2 = sampler;
+        if (textureView && sampler)
+        {
+            slot.type = BindingType::CombinedTextureSampler;
+            slot.resource = textureView;
+            slot.resource2 = sampler;
+        }
+        else
+        {
+            slot = {};
+        }
         break;
     }
     default:

--- a/tests/test-null-views.cpp
+++ b/tests/test-null-views.cpp
@@ -125,16 +125,34 @@ GPU_TEST_CASE("null-views", ALL & ~(D3D11 | CPU | WGPU))
         auto passEncoder = commandEncoder->beginComputePass();
         IShaderObject* rootObject = passEncoder->bindPipeline(pipeline);
         ShaderCursor cursor(rootObject);
-        cursor["buffer2"].setBinding(buffer);
-        cursor["rwBuffer2"].setBinding(rwBuffer);
-        cursor["structuredBuffer2"].setBinding(structuredBuffer);
-        cursor["rwStructuredBuffer2"].setBinding(rwStructuredBuffer);
-        cursor["texture2"].setBinding(texture);
-        cursor["rwTexture2"].setBinding(rwTexture);
-        cursor["textureArray2"].setBinding(textureArray);
-        cursor["rwTextureArray2"].setBinding(rwTextureArray);
-        cursor["samplerState2"].setBinding(sampler);
-        cursor["result"].setBinding(result);
+        REQUIRE_CALL(cursor["buffer1"].setBinding(static_cast<IBuffer*>(nullptr)));
+        REQUIRE_CALL(cursor["buffer2"].setBinding(buffer));
+        // "buffer3" not set explicitly
+        REQUIRE_CALL(cursor["rwBuffer1"].setBinding(static_cast<IBuffer*>(nullptr)));
+        REQUIRE_CALL(cursor["rwBuffer2"].setBinding(rwBuffer));
+        // "rwBuffer3" not set explicitly
+        REQUIRE_CALL(cursor["structuredBuffer1"].setBinding(static_cast<IBuffer*>(nullptr)));
+        REQUIRE_CALL(cursor["structuredBuffer2"].setBinding(structuredBuffer));
+        // "structuredBuffer3" not set explicitly
+        REQUIRE_CALL(cursor["rwStructuredBuffer1"].setBinding(static_cast<IBuffer*>(nullptr)));
+        REQUIRE_CALL(cursor["rwStructuredBuffer2"].setBinding(rwStructuredBuffer));
+        // "rwStructuredBuffer3" not set explicitly
+        REQUIRE_CALL(cursor["texture1"].setBinding(static_cast<ITexture*>(nullptr)));
+        REQUIRE_CALL(cursor["texture2"].setBinding(texture));
+        // "texture3" not set explicitly
+        REQUIRE_CALL(cursor["rwTexture1"].setBinding(static_cast<ITexture*>(nullptr)));
+        REQUIRE_CALL(cursor["rwTexture2"].setBinding(rwTexture));
+        // "rwTexture3" not set explicitly
+        REQUIRE_CALL(cursor["textureArray1"].setBinding(static_cast<ITexture*>(nullptr)));
+        REQUIRE_CALL(cursor["textureArray2"].setBinding(textureArray));
+        // "textureArray3" not set explicitly
+        REQUIRE_CALL(cursor["rwTextureArray1"].setBinding(static_cast<ITexture*>(nullptr)));
+        REQUIRE_CALL(cursor["rwTextureArray2"].setBinding(rwTextureArray));
+        // "rwTextureArray3" not set explicitly
+        REQUIRE_CALL(cursor["samplerState1"].setBinding(static_cast<ISampler*>(nullptr)));
+        REQUIRE_CALL(cursor["samplerState2"].setBinding(sampler));
+        // "samplerState3" not set explicitly
+        REQUIRE_CALL(cursor["result"].setBinding(result));
 
         passEncoder->dispatchCompute(1, 1, 1);
         passEncoder->end();

--- a/tests/test-null-views.slang
+++ b/tests/test-null-views.slang
@@ -47,16 +47,9 @@ void computeMain()
 #endif
     result[2] = structuredBuffer2[0];
     result[3] = rwStructuredBuffer2[0];
-#if !defined(__CUDA__)
     result[4] = texture2.Load(int3(0));
     result[5] = rwTexture2.Load(int2(0));
     result[6] = textureArray2.Load(int4(0));
     result[7] = rwTextureArray2.Load(int3(0));
-#else
-    result[4] = 5.0;
-    result[5] = 6.0;
-    result[6] = 7.0;
-    result[7] = 8.0;
-#endif
     result[8] = texture2.SampleLevel(samplerState2, float2(0), 0.f);
 }


### PR DESCRIPTION
slang-rhi supports having shader object resource bindings left as "unassigned" or "null". Backends can deal with null bindings differently (and may not support them). However, the slang-rhi API was inconsistent in that it allows leaving resources being unassigned, but not allows nulling a previously assigned slot back to it's unassigned state. This PR fixes this by allowing setting null bindings.