### PR TITLE
Fix MSVC warning C4709: comma operator within a subscript expression

### DIFF
--- a/src/core/reverse-map.h
+++ b/src/core/reverse-map.h
@@ -15,7 +15,9 @@ auto reverseMap(Func func, From min, From max, From defaultValue = From(0))
         std::unordered_map<To, From> map;
         for (int i = int(min); i <= int(max); i++)
         {
-            map[func(From(i))] = From(i);
+            const From fromI = From(i);
+            const To key = func(fromI); // Fixed MSVC warning C4709: comma operator within a subscript expression
+            map[key] = fromI;
         }
         return map;
     }();


### PR DESCRIPTION
Fixed an MSVC warning `C4709`: comma operator within a subscript expression.