### PR TITLE
Add spirv_nv capability for Vulkan SER support

### DIFF
--- a/include/slang-rhi/capabilities.h
+++ b/include/slang-rhi/capabilities.h
@@ -150,6 +150,7 @@
     x(spvRayQueryKHR) \
     x(spvRayQueryPositionFetchKHR) \
     x(spvShaderInvocationReorderNV) \
+    x(spirv_nv) \
     x(spvRayTracingClusterAccelerationStructureNV) \
     x(spvRayTracingLinearSweptSpheresGeometryNV) \
     x(spvShaderClockKHR) \

--- a/src/vulkan/vk-device.cpp
+++ b/src/vulkan/vk-device.cpp
@@ -843,6 +843,7 @@ Result DeviceImpl::initVulkanInstanceAndDevice(
                 availableFeatures.push_back(Feature::ShaderExecutionReordering);
                 availableCapabilities.push_back(Capability::SPV_NV_shader_invocation_reorder);
                 availableCapabilities.push_back(Capability::spvShaderInvocationReorderNV);
+                availableCapabilities.push_back(Capability::spirv_nv);
             }
         );
 


### PR DESCRIPTION
Add spirv_nv capability when SER is detected on Vulkan to fix HitObject compilation errors.