### PR TITLE
Don't set motion options for standard TLAS in ray tracing tests

### DIFF
--- a/tests/test-ray-tracing-common.h
+++ b/tests/test-ray-tracing-common.h
@@ -730,10 +730,6 @@ struct TLAS
 
         AccelerationStructureDesc createDesc{};
         createDesc.size = sizes.accelerationStructureSize;
-        createDesc.flags = AccelerationStructureBuildFlags::CreateMotion;
-
-        createDesc.motionInfo.enabled = true;
-        createDesc.motionInfo.maxInstances = buildInput.instances.instanceCount;
 
         REQUIRE_CALL(device->createAccelerationStructure(createDesc, tlas.writeRef()));
 


### PR DESCRIPTION
The non-motion TLAS is erroneously enabling motion blur in the ray tracing tests, causing validation to fail when the GPU doesn't support motion blur.