### PR TITLE
Fix ray tracing test compilation with ToT slang

### DIFF
--- a/tests/test-ray-tracing-hitobject-intrinsics.slang
+++ b/tests/test-ray-tracing-hitobject-intrinsics.slang
@@ -425,6 +425,10 @@ void rayGenShaderMakeMiss()
     resultBuffer[0].invokeWasSuccess = payload.invokeWasSuccess;
 }
 
+// NOTE: We disable this code under D3D12 because it causes compilation to fail, but it's not clear
+// if it is failing due to a bug in the test or a bug in Slang. Revisit this if/when motion blur
+// support is added to the D3D12 backend.
+#if !defined(__D3D12__)
 [shader("raygeneration")]
 void rayGenShaderMakeMotionMiss()
 {
@@ -448,6 +452,7 @@ void rayGenShaderMakeMotionMiss()
     HitObject.Invoke(sceneBVH, hitObjectMiss, payload);
     resultBuffer[0].invokeWasSuccess = payload.invokeWasSuccess;
 }
+#endif
 
 [shader("raygeneration")]
 void rayGenShaderTraceMotionRay()

--- a/tests/test-ray-tracing-intrinsics.slang
+++ b/tests/test-ray-tracing-intrinsics.slang
@@ -22,11 +22,14 @@ void closestHitNOP(inout RayPayload payload, in BuiltInTriangleIntersectionAttri
     // NOP
 }
 
+// OptiX only allows calling ObjectRayOrigin from any hit or intersection.
+#if !defined(__CUDA__)
 [shader("closesthit")]
 void closestHitWriteObjectRayOrigin(inout RayPayload payload, in BuiltInTriangleIntersectionAttributes attr)
 {
     payload.attribute = ObjectRayOrigin();
 }
+#endif
 
 [shader("anyhit")]
 void anyHitWriteObjectRayOrigin(inout RayPayload payload, in BuiltInTriangleIntersectionAttributes attr)
@@ -40,11 +43,14 @@ void closestHitWriteWorldRayOrigin(inout RayPayload payload, in BuiltInTriangleI
     payload.attribute = WorldRayOrigin();
 }
 
+// OptiX only allows calling ObjectRayDirection from any hit or intersection.
+#if !defined(__CUDA__)
 [shader("closesthit")]
 void closestHitWriteObjectRayDirection(inout RayPayload payload, in BuiltInTriangleIntersectionAttributes attr)
 {
     payload.attribute = ObjectRayDirection();
 }
+#endif
 
 [shader("anyhit")]
 void anyHitWriteObjectRayDirection(inout RayPayload payload, in BuiltInTriangleIntersectionAttributes attr)

--- a/tests/test-ray-tracing.slang
+++ b/tests/test-ray-tracing.slang
@@ -82,7 +82,7 @@ void closestHitShaderIdx1(inout RayPayload payload, in BuiltInTriangleIntersecti
     payload.color = color;
 }
 
-#ifndef __CUDA__
+#if !(defined(__CUDA__) || defined(__D3D12__))
 [shader("raygeneration")]
 void rayGenShaderMotion()
 {
@@ -104,7 +104,9 @@ void rayGenShaderMotion()
 
     resultTexture[pixel] = payload.color;
 }
+#endif // !(defined(__CUDA__) || defined(__D3D12__))
 
+#if !defined(__CUDA__)
 [shader("closesthit")]
 void closestHitShaderMotion(inout RayPayload payload, in BuiltInTriangleIntersectionAttributes attr)
 {


### PR DESCRIPTION
Disable some code that is failing to compile against Slang ToT.

Specifically, ifdef out Slang code that calls ObjectRayOrigin and ObjectRayDirection from closest hit programs. Slang correctly rejects this when targeting CUDA/OptiX, since OptiX disallows those intrinsics in closest hit.

Also disable D3D12 code that calls MakeMotionHit and TraceMotionRay. It's unclear if these are failing due to bugs in Slang, but we don't test them anyway (slang-rhi doesn't support motion blur for D3D12 yet).