### PR TITLE
Fix running OptiX tests on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,12 +92,12 @@ jobs:
 
       - name: Unit Tests (OptiX 8.0)
         if: contains(matrix.flags, 'unit-test')
-        run: ./slang-rhi-tests -tc=ray-tracing*.cuda -check-devices -optix-version=80000
+        run: ./slang-rhi-tests -tc="ray-tracing*.cuda" -check-devices -optix-version=80000
         working-directory: build/${{matrix.config}}
 
       - name: Unit Tests (OptiX 8.1)
         if: contains(matrix.flags, 'unit-test')
-        run: ./slang-rhi-tests -tc=ray-tracing*.cuda -check-devices -optix-version=80100
+        run: ./slang-rhi-tests -tc="ray-tracing*.cuda" -check-devices -optix-version=80100
         working-directory: build/${{matrix.config}}
 
       - name: Coverage Report


### PR DESCRIPTION
Only run *.cuda tests when testing older OptiX versions.