### PR TITLE
Add visual studio 2026 to cmake presets

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -72,6 +72,12 @@
             "inherits": "msvc-base",
             "description": "Visual Studio 2022 project",
             "generator": "Visual Studio 17 2022"
+        },
+        {
+            "name": "vs2026",
+            "inherits": "msvc-base",
+            "description": "Visual Studio 2026 project",
+            "generator": "Visual Studio 18 2026"
         }
     ],
     "buildPresets": [


### PR DESCRIPTION
Adding visual studio 18 2026 as an option to Cmake presets.