### PR TITLE
Check cuda context before switching

### DIFF
--- a/src/cuda/cuda-utils.h
+++ b/src/cuda/cuda-utils.h
@@ -23,6 +23,8 @@ class ContextScope
 public:
     explicit ContextScope(const DeviceImpl* device);
     ~ContextScope();
+
+    bool m_didPush = false;
 };
 
 #define SLANG_CUDA_CTX_SCOPE(device) ::rhi::cuda::ContextScope _context_scope(device)


### PR DESCRIPTION
This is a workaround for perf issues creating by pushing/popping cuda contexts a lot. We now call cuCtxGetCurrent before pushing. This isn't free, and adds overhead when it is found that a push _would_ happen, but massively improves perf with the rhi as it stands.