### PR TITLE
 Fix #640: Add waitUntilCompleted() in retireCommandBuffers() to ensure memory   visibility

### DIFF
--- a/src/metal/metal-command.cpp
+++ b/src/metal/metal-command.cpp
@@ -990,6 +990,10 @@ void CommandQueueImpl::retireCommandBuffers()
         auto status = commandBuffer->m_commandBuffer->status();
         if (status == MTL::CommandBufferStatusCompleted || status == MTL::CommandBufferStatusError)
         {
+            // Ensure memory visibility before retiring.
+            // status() only checks the signal value, but waitUntilCompleted() ensures
+            // all GPU writes are visible to the CPU (required for managed storage mode).
+            commandBuffer->m_commandBuffer->waitUntilCompleted();
             commandBuffer->reset();
         }
         else


### PR DESCRIPTION
## Summary

  Adds `waitUntilCompleted()` call in `retireCommandBuffers()` to fix a race
  condition where command buffers can be retired based on `status()` alone, without
   ensuring memory visibility to the CPU.

  ## The Fix

  Add `waitUntilCompleted()` before retiring command buffers. This ensures all GPU
  writes are visible to the CPU (required for managed storage mode buffers).

  ```cpp
  if (status == MTL::CommandBufferStatusCompleted || status ==
  MTL::CommandBufferStatusError)
  {
      // Ensure memory visibility before retiring.
      commandBuffer->m_commandBuffer->waitUntilCompleted();
      commandBuffer->reset();
  }
  ```

  Alternatives Considered
  Approach: Remove retireCommandBuffers() from submit()
  Tradeoff: Delays cleanup until waitOnHost(), changes behavior

  Choosen Approach: Add waitUntilCompleted() in retireCommandBuffers() 
  Tradeoff: Chosen: ensures memory visibility whenever we retire, correct fix  
