### PR TITLE
Command encoders may leak - add an autorelease pool to ensure cleanup.

### DIFF
--- a/src/metal/metal-command.cpp
+++ b/src/metal/metal-command.cpp
@@ -1010,6 +1010,8 @@ uint64_t CommandQueueImpl::updateLastFinishedID()
 
 Result CommandQueueImpl::createCommandEncoder(ICommandEncoder** outEncoder)
 {
+    AUTORELEASEPOOL
+
     RefPtr<CommandEncoderImpl> encoder = new CommandEncoderImpl(m_device, this);
     SLANG_RETURN_ON_FAIL(encoder->init());
     returnComPtr(outEncoder, encoder);
@@ -1168,6 +1170,8 @@ Result CommandEncoderImpl::getBindingData(RootShaderObject* rootObject, BindingD
 
 Result CommandEncoderImpl::finish(ICommandBuffer** outCommandBuffer)
 {
+    AUTORELEASEPOOL
+
     DeviceImpl* device = getDevice<DeviceImpl>();
     SLANG_RETURN_ON_FAIL(resolvePipelines(device));
     CommandRecorder recorder(device);


### PR DESCRIPTION
I noticed that there's a memory leak when creating command encoders on Metal specifically, and cycling them through.  So I did some digging, and noticed that there was some cleanup that wasn't happening for some reason with command encoders.