### PR TITLE
Fail D3D12 Device creation if `setupDebugLayer` fails, otherwise succeed

### DIFF
--- a/src/d3d12/d3d12-device.cpp
+++ b/src/d3d12/d3d12-device.cpp
@@ -313,7 +313,7 @@ Result DeviceImpl::initialize(const DeviceDesc& desc)
     }
 
     SLANG_RETURN_ON_FAIL(setupDebugLayer(d3dModule));
-    
+
     // Get D3D12 entry points.
     {
         m_D3D12CreateDevice = (PFN_D3D12_CREATE_DEVICE)loadProc(d3dModule, "D3D12CreateDevice");


### PR DESCRIPTION
Currently if `setupDebugLayer` succeeds, d3d12 device creation fails.
```
    if (SLANG_SUCCEEDED(setupDebugLayer(d3dModule)))
        return SLANG_FAIL;
```

This has been changed to fail when device creation fails: `SLANG_FAILED`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an initialization logic issue that could prematurely abort device startup when diagnostic setup succeeded. Device initialization now continues correctly on successful diagnostic enablement and only fails for actual setup errors, improving startup reliability and reducing false-negative failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->