### PR TITLE
(Re)enable WARP testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,10 +49,10 @@ jobs:
           # Builds running on GitHub hosted runners (build + tests)
           - { os: macos, platform: "aarch64", compiler: clang, preset: default, config: "Debug", flags: "unit-test,coverage", runs-on: macos-latest }
           - { os: macos, platform: "aarch64", compiler: clang, preset: default, config: "Release", flags: "unit-test", runs-on: macos-latest }
-          # Builds running on GitHub hosted runners (build. disabled tests on WARP as they were failing D3D12)
-          - { os: windows, platform: "x86_64", compiler: clang, preset: clang, config: "Release", runs-on: windows-latest }
-          - { os: windows, platform: "x86_64", compiler: msvc, preset: default, config: "Debug", runs-on: windows-latest }
-          - { os: windows, platform: "aarch64", compiler: msvc, preset: default, config: "Release", runs-on: windows-11-arm }
+          # Builds running on GitHub hosted runners (build + tests on WARP)
+          - { os: windows, platform: "x86_64", compiler: clang, preset: clang, config: "Release", flags: "unit-test", runs-on: windows-latest }
+          - { os: windows, platform: "x86_64", compiler: msvc, preset: default, config: "Debug", flags: "unit-test", runs-on: windows-latest }
+          - { os: windows, platform: "aarch64", compiler: msvc, preset: default, config: "Release", flags: "unit-test", runs-on: windows-11-arm }
           # Raytracing tests are flakey on aarch64/Debug builds, so tests are currently disabled
           - { os: windows, platform: "aarch64", compiler: msvc, preset: default, config: "Debug", flags: "", runs-on: windows-11-arm }
           # Builds running on GitHub hosted runners (build only)


### PR DESCRIPTION
(Re)enable testing on D3D11/D3D12 WARP devices.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enabled unit tests for additional Windows build configurations in CI, expanding automated test coverage across multiple Windows architectures and build types.
  * Updated CI behavior to run those unit tests regularly, improving build reliability and reducing regressions for Windows releases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->