### PR TITLE
Update Agility/DXC to latest

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -143,7 +143,7 @@ set(SLANG_RHI_FETCH_SLANG_VERSION "2026.4.1" CACHE STRING "Slang version to fetc
 
 # DirectXShaderCompiler
 if(NOT DEFINED SLANG_RHI_DXC_URL)
-    set(SLANG_RHI_DXC_URL "https://github.com/microsoft/DirectXShaderCompiler/releases/download/v1.8.2407/dxc_2024_07_31.zip")
+    set(SLANG_RHI_DXC_URL "https://github.com/microsoft/DirectXShaderCompiler/releases/download/v1.9.2602/dxc_2026_02_20.zip")
 endif()
 
 # WinPixEventRuntime
@@ -153,7 +153,7 @@ endif()
 
 # Agility SDK
 if(NOT DEFINED SLANG_RHI_AGILITY_SDK_URL)
-    set(SLANG_RHI_AGILITY_SDK_URL "https://www.nuget.org/api/v2/package/Microsoft.Direct3D.D3D12/1.616.1")
+    set(SLANG_RHI_AGILITY_SDK_URL "https://www.nuget.org/api/v2/package/Microsoft.Direct3D.D3D12/1.619.1")
 endif()
 # If using a preview version of Agility SDK, set this to D3D12_PREVIEW_SDK_VERSION
 if(NOT DEFINED SLANG_RHI_AGILITY_SDK_VERSION)


### PR DESCRIPTION
Updating the Agility SDK and DXC to the latest as a preparation for the `linalg`, which is required for the new CoopVec spec.
- https://github.com/microsoft/DirectXShaderCompiler/releases/tag/v1.9.2602
- https://www.nuget.org/packages/Microsoft.Direct3D.D3D12/1.619.1

Related to https://github.com/shader-slang/slang/issues/8711

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated DirectX Shader Compiler (DXC) to v1.9.2602.
  * Updated Direct3D 12 Agility SDK to version 1.619.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->