### PR TITLE
Improve debug layer

### DIFF
--- a/src/debug-layer/debug-command-buffer.h
+++ b/src/debug-layer/debug-command-buffer.h
@@ -8,11 +8,11 @@ class DebugCommandBuffer : public DebugObject<ICommandBuffer>
 {
 public:
     SLANG_COM_OBJECT_IUNKNOWN_ALL;
+    ICommandBuffer* getInterface(const Guid& guid);
 
     SLANG_RHI_DEBUG_OBJECT_CONSTRUCTOR(DebugCommandBuffer);
 
 public:
-    ICommandBuffer* getInterface(const Guid& guid);
     virtual SLANG_NO_THROW const CommandBufferDesc& SLANG_MCALL getDesc() override;
     virtual SLANG_NO_THROW Result SLANG_MCALL getNativeHandle(NativeHandle* outHandle) override;
 };

--- a/src/debug-layer/debug-command-encoder.cpp
+++ b/src/debug-layer/debug-command-encoder.cpp
@@ -759,10 +759,14 @@ IRenderPassEncoder* DebugCommandEncoder::beginRenderPass(const RenderPassDesc& d
     if (hasErrors)
         return nullptr;
 
+    auto innerEncoder = baseObject->beginRenderPass(desc);
+    if (!innerEncoder)
+        return nullptr;
+
     m_passState = PassState::RenderPass;
     m_renderPassEncoder.m_pipelineBound = false;
     m_renderPassEncoder.m_indexBufferBound = false;
-    m_renderPassEncoder.baseObject = baseObject->beginRenderPass(desc);
+    m_renderPassEncoder.baseObject = innerEncoder;
 
     return &m_renderPassEncoder;
 }
@@ -773,9 +777,14 @@ IComputePassEncoder* DebugCommandEncoder::beginComputePass()
 
     requireOpen();
     requireNoPass();
+
+    auto innerEncoder = baseObject->beginComputePass();
+    if (!innerEncoder)
+        return nullptr;
+
     m_passState = PassState::ComputePass;
     m_computePassEncoder.m_pipelineBound = false;
-    m_computePassEncoder.baseObject = baseObject->beginComputePass();
+    m_computePassEncoder.baseObject = innerEncoder;
 
     return &m_computePassEncoder;
 }
@@ -786,9 +795,14 @@ IRayTracingPassEncoder* DebugCommandEncoder::beginRayTracingPass()
 
     requireOpen();
     requireNoPass();
+
+    auto innerEncoder = baseObject->beginRayTracingPass();
+    if (!innerEncoder)
+        return nullptr;
+
     m_passState = PassState::RayTracingPass;
     m_rayTracingPassEncoder.m_pipelineBound = false;
-    m_rayTracingPassEncoder.baseObject = baseObject->beginRayTracingPass();
+    m_rayTracingPassEncoder.baseObject = innerEncoder;
 
     return &m_rayTracingPassEncoder;
 }

--- a/src/debug-layer/debug-command-encoder.cpp
+++ b/src/debug-layer/debug-command-encoder.cpp
@@ -901,24 +901,24 @@ void DebugCommandEncoder::copyTexture(
     requireNoPass();
 
     const TextureDesc& srcDesc = src->getDesc();
-    if (srcSubresource.layer > srcDesc.getLayerCount())
+    if (srcSubresource.layer >= srcDesc.getLayerCount())
     {
         RHI_VALIDATION_ERROR("Source layer is out of bounds.");
         return;
     }
-    if (srcSubresource.mip > srcDesc.mipCount)
+    if (srcSubresource.mip >= srcDesc.mipCount)
     {
         RHI_VALIDATION_ERROR("Source mip is out of bounds.");
         return;
     }
 
     const TextureDesc& dstDesc = dst->getDesc();
-    if (dstSubresource.layer > dstDesc.getLayerCount())
+    if (dstSubresource.layer >= dstDesc.getLayerCount())
     {
         RHI_VALIDATION_ERROR("Destination layer is out of bounds.");
         return;
     }
-    if (dstSubresource.mip > dstDesc.mipCount)
+    if (dstSubresource.mip >= dstDesc.mipCount)
     {
         RHI_VALIDATION_ERROR("Destination mip is out of bounds.");
         return;

--- a/src/debug-layer/debug-command-encoder.cpp
+++ b/src/debug-layer/debug-command-encoder.cpp
@@ -829,12 +829,12 @@ void DebugCommandEncoder::copyBuffer(IBuffer* dst, Offset dstOffset, IBuffer* sr
         RHI_VALIDATION_WARNING("size is 0.");
         return;
     }
-    if (srcOffset + size > src->getDesc().size)
+    if (!checkSizePlusOffsetInRange(srcOffset, size, src->getDesc().size))
     {
         RHI_VALIDATION_ERROR("Source range out of bounds.");
         return;
     }
-    if (dstOffset + size > dst->getDesc().size)
+    if (!checkSizePlusOffsetInRange(dstOffset, size, dst->getDesc().size))
     {
         RHI_VALIDATION_ERROR("Destination range out of bounds.");
         return;
@@ -885,7 +885,7 @@ Result DebugCommandEncoder::uploadBufferData(IBuffer* dst, Offset offset, Size s
         RHI_VALIDATION_WARNING("size is 0.");
         return SLANG_OK;
     }
-    if (offset + size > dst->getDesc().size)
+    if (!checkSizePlusOffsetInRange(offset, size, dst->getDesc().size))
     {
         RHI_VALIDATION_ERROR("Destination range out of bounds.");
         return SLANG_E_INVALID_ARG;
@@ -1309,12 +1309,12 @@ void DebugCommandEncoder::resolveQuery(
         RHI_VALIDATION_WARNING("count is 0.");
         return;
     }
-    if (index + count > queryPool->getDesc().count)
+    if (!checkSizePlusOffsetInRange(index, count, queryPool->getDesc().count))
     {
         RHI_VALIDATION_ERROR("Query range out of bounds (index + count exceeds query pool size).");
         return;
     }
-    if (offset + count * sizeof(uint64_t) > buffer->getDesc().size)
+    if (!checkSizePlusOffsetInRange(offset, count * sizeof(uint64_t), buffer->getDesc().size))
     {
         RHI_VALIDATION_ERROR(
             "Destination range out of bounds (offset + count * sizeof(uint64_t) exceeds buffer size)."

--- a/src/debug-layer/debug-command-encoder.cpp
+++ b/src/debug-layer/debug-command-encoder.cpp
@@ -829,12 +829,12 @@ void DebugCommandEncoder::copyBuffer(IBuffer* dst, Offset dstOffset, IBuffer* sr
         RHI_VALIDATION_WARNING("size is 0.");
         return;
     }
-    if (!isValidSubrange(srcOffset, size, src->getDesc().size))
+    if (!isValidSubrange(static_cast<uint64_t>(srcOffset), static_cast<uint64_t>(size), src->getDesc().size))
     {
         RHI_VALIDATION_ERROR("Source range out of bounds.");
         return;
     }
-    if (!isValidSubrange(dstOffset, size, dst->getDesc().size))
+    if (!isValidSubrange(static_cast<uint64_t>(dstOffset), static_cast<uint64_t>(size), dst->getDesc().size))
     {
         RHI_VALIDATION_ERROR("Destination range out of bounds.");
         return;
@@ -885,7 +885,7 @@ Result DebugCommandEncoder::uploadBufferData(IBuffer* dst, Offset offset, Size s
         RHI_VALIDATION_WARNING("size is 0.");
         return SLANG_OK;
     }
-    if (!isValidSubrange(offset, size, dst->getDesc().size))
+    if (!isValidSubrange(static_cast<uint64_t>(offset), static_cast<uint64_t>(size), dst->getDesc().size))
     {
         RHI_VALIDATION_ERROR("Destination range out of bounds.");
         return SLANG_E_INVALID_ARG;
@@ -1325,7 +1325,11 @@ void DebugCommandEncoder::resolveQuery(
         RHI_VALIDATION_ERROR("Query range out of bounds (index + count exceeds query pool size).");
         return;
     }
-    if (!isValidSubrange(offset, count * sizeof(uint64_t), buffer->getDesc().size))
+    if (!isValidSubrange(
+            static_cast<uint64_t>(offset),
+            static_cast<uint64_t>(count) * sizeof(uint64_t),
+            buffer->getDesc().size
+        ))
     {
         RHI_VALIDATION_ERROR(
             "Destination range out of bounds (offset + count * sizeof(uint64_t) exceeds buffer size)."

--- a/src/debug-layer/debug-command-encoder.cpp
+++ b/src/debug-layer/debug-command-encoder.cpp
@@ -7,6 +7,10 @@
 
 namespace rhi::debug {
 
+// ----------------------------------------------------------------------------
+// DebugRenderPassEncoder
+// ----------------------------------------------------------------------------
+
 DebugRenderPassEncoder::DebugRenderPassEncoder(DebugContext* ctx, DebugCommandEncoder* commandEncoder)
     : UnownedDebugObject<IRenderPassEncoder>(ctx)
     , m_commandEncoder(commandEncoder)
@@ -20,8 +24,16 @@ IShaderObject* DebugRenderPassEncoder::bindPipeline(IRenderPipeline* pipeline)
 
     m_commandEncoder->requireOpen();
     m_commandEncoder->requireRenderPass();
+
+    if (!pipeline)
+    {
+        RHI_VALIDATION_ERROR("'pipeline' must not be null.");
+        return nullptr;
+    }
+
     m_rootObject->reset();
     m_rootObject->baseObject = baseObject->bindPipeline(pipeline);
+    m_pipelineBound = true;
 
     return m_rootObject;
 }
@@ -33,7 +45,14 @@ void DebugRenderPassEncoder::bindPipeline(IRenderPipeline* pipeline, IShaderObje
     m_commandEncoder->requireOpen();
     m_commandEncoder->requireRenderPass();
 
+    if (!pipeline)
+    {
+        RHI_VALIDATION_ERROR("'pipeline' must not be null.");
+        return;
+    }
+
     baseObject->bindPipeline(pipeline, getInnerObj(rootObject));
+    m_pipelineBound = true;
 }
 
 void DebugRenderPassEncoder::setRenderState(const RenderState& state)
@@ -42,6 +61,46 @@ void DebugRenderPassEncoder::setRenderState(const RenderState& state)
 
     m_commandEncoder->requireOpen();
     m_commandEncoder->requireRenderPass();
+
+    if (state.viewportCount > SLANG_COUNT_OF(state.viewports))
+    {
+        RHI_VALIDATION_ERROR("Too many viewports (max 16).");
+        return;
+    }
+    if (state.scissorRectCount > SLANG_COUNT_OF(state.scissorRects))
+    {
+        RHI_VALIDATION_ERROR("Too many scissor rects (max 16).");
+        return;
+    }
+    if (state.vertexBufferCount > SLANG_COUNT_OF(state.vertexBuffers))
+    {
+        RHI_VALIDATION_ERROR("Too many vertex buffers (max 16).");
+        return;
+    }
+
+    for (uint32_t i = 0; i < state.viewportCount; ++i)
+    {
+        if (state.viewports[i].extentX <= 0.0f || state.viewports[i].extentY <= 0.0f)
+        {
+            RHI_VALIDATION_WARNING("Viewport has non-positive width or height.");
+        }
+    }
+
+    for (uint32_t i = 0; i < state.vertexBufferCount; ++i)
+    {
+        if (!state.vertexBuffers[i].buffer)
+        {
+            RHI_VALIDATION_WARNING("Vertex buffer binding is null.");
+        }
+    }
+
+    if (!isValidIndexFormat(state.indexFormat))
+    {
+        RHI_VALIDATION_ERROR("Invalid index format.");
+        return;
+    }
+
+    m_indexBufferBound = (state.indexBuffer.buffer != nullptr);
 
     baseObject->setRenderState(state);
 }
@@ -53,6 +112,16 @@ void DebugRenderPassEncoder::draw(const DrawArguments& args)
     m_commandEncoder->requireOpen();
     m_commandEncoder->requireRenderPass();
 
+    if (!m_pipelineBound)
+    {
+        RHI_VALIDATION_ERROR("No pipeline bound.");
+        return;
+    }
+    if (args.instanceCount == 0)
+    {
+        RHI_VALIDATION_WARNING("instanceCount is 0.");
+    }
+
     baseObject->draw(args);
 }
 
@@ -62,6 +131,21 @@ void DebugRenderPassEncoder::drawIndexed(const DrawArguments& args)
 
     m_commandEncoder->requireOpen();
     m_commandEncoder->requireRenderPass();
+
+    if (!m_pipelineBound)
+    {
+        RHI_VALIDATION_ERROR("No pipeline bound.");
+        return;
+    }
+    if (!m_indexBufferBound)
+    {
+        RHI_VALIDATION_ERROR("No index buffer bound.");
+        return;
+    }
+    if (args.instanceCount == 0)
+    {
+        RHI_VALIDATION_WARNING("instanceCount is 0.");
+    }
 
     baseObject->drawIndexed(args);
 }
@@ -77,6 +161,21 @@ void DebugRenderPassEncoder::drawIndirect(
     m_commandEncoder->requireOpen();
     m_commandEncoder->requireRenderPass();
 
+    if (!m_pipelineBound)
+    {
+        RHI_VALIDATION_ERROR("No pipeline bound.");
+        return;
+    }
+    if (!argBuffer.buffer)
+    {
+        RHI_VALIDATION_ERROR("'argBuffer' must not be null.");
+        return;
+    }
+    if (maxDrawCount == 0)
+    {
+        RHI_VALIDATION_WARNING("maxDrawCount is 0.");
+    }
+
     baseObject->drawIndirect(maxDrawCount, argBuffer, countBuffer);
 }
 
@@ -91,6 +190,26 @@ void DebugRenderPassEncoder::drawIndexedIndirect(
     m_commandEncoder->requireOpen();
     m_commandEncoder->requireRenderPass();
 
+    if (!m_pipelineBound)
+    {
+        RHI_VALIDATION_ERROR("No pipeline bound.");
+        return;
+    }
+    if (!m_indexBufferBound)
+    {
+        RHI_VALIDATION_ERROR("No index buffer bound.");
+        return;
+    }
+    if (!argBuffer.buffer)
+    {
+        RHI_VALIDATION_ERROR("'argBuffer' must not be null.");
+        return;
+    }
+    if (maxDrawCount == 0)
+    {
+        RHI_VALIDATION_WARNING("maxDrawCount is 0.");
+    }
+
     baseObject->drawIndexedIndirect(maxDrawCount, argBuffer, countBuffer);
 }
 
@@ -100,6 +219,16 @@ void DebugRenderPassEncoder::drawMeshTasks(uint32_t x, uint32_t y, uint32_t z)
 
     m_commandEncoder->requireOpen();
     m_commandEncoder->requireRenderPass();
+
+    if (!m_pipelineBound)
+    {
+        RHI_VALIDATION_ERROR("No pipeline bound.");
+        return;
+    }
+    if (x == 0 || y == 0 || z == 0)
+    {
+        RHI_VALIDATION_WARNING("One or more dimensions are 0 (no-op dispatch).");
+    }
 
     baseObject->drawMeshTasks(x, y, z);
 }
@@ -141,6 +270,17 @@ void DebugRenderPassEncoder::writeTimestamp(IQueryPool* queryPool, uint32_t quer
     m_commandEncoder->requireOpen();
     m_commandEncoder->requireRenderPass();
 
+    if (!queryPool)
+    {
+        RHI_VALIDATION_ERROR("'queryPool' must not be null.");
+        return;
+    }
+    if (queryIndex >= queryPool->getDesc().count)
+    {
+        RHI_VALIDATION_ERROR("'queryIndex' is out of range.");
+        return;
+    }
+
     baseObject->writeTimestamp(getInnerObj(queryPool), queryIndex);
 }
 
@@ -155,6 +295,10 @@ void DebugRenderPassEncoder::end()
     baseObject->end();
 }
 
+// ----------------------------------------------------------------------------
+// DebugComputePassEncoder
+// ----------------------------------------------------------------------------
+
 DebugComputePassEncoder::DebugComputePassEncoder(DebugContext* ctx, DebugCommandEncoder* commandEncoder)
     : UnownedDebugObject<IComputePassEncoder>(ctx)
     , m_commandEncoder(commandEncoder)
@@ -168,8 +312,16 @@ IShaderObject* DebugComputePassEncoder::bindPipeline(IComputePipeline* pipeline)
 
     m_commandEncoder->requireOpen();
     m_commandEncoder->requireComputePass();
+
+    if (!pipeline)
+    {
+        RHI_VALIDATION_ERROR("'pipeline' must not be null.");
+        return nullptr;
+    }
+
     m_rootObject->reset();
     m_rootObject->baseObject = baseObject->bindPipeline(pipeline);
+    m_pipelineBound = true;
 
     return m_rootObject;
 }
@@ -181,7 +333,14 @@ void DebugComputePassEncoder::bindPipeline(IComputePipeline* pipeline, IShaderOb
     m_commandEncoder->requireOpen();
     m_commandEncoder->requireComputePass();
 
+    if (!pipeline)
+    {
+        RHI_VALIDATION_ERROR("'pipeline' must not be null.");
+        return;
+    }
+
     baseObject->bindPipeline(pipeline, getInnerObj(rootObject));
+    m_pipelineBound = true;
 }
 
 void DebugComputePassEncoder::dispatchCompute(uint32_t x, uint32_t y, uint32_t z)
@@ -190,6 +349,16 @@ void DebugComputePassEncoder::dispatchCompute(uint32_t x, uint32_t y, uint32_t z
 
     m_commandEncoder->requireOpen();
     m_commandEncoder->requireComputePass();
+
+    if (!m_pipelineBound)
+    {
+        RHI_VALIDATION_ERROR("No pipeline bound.");
+        return;
+    }
+    if (x == 0 || y == 0 || z == 0)
+    {
+        RHI_VALIDATION_WARNING("One or more group dimensions is 0.");
+    }
 
     baseObject->dispatchCompute(x, y, z);
 }
@@ -200,6 +369,17 @@ void DebugComputePassEncoder::dispatchComputeIndirect(BufferOffsetPair argBuffer
 
     m_commandEncoder->requireOpen();
     m_commandEncoder->requireComputePass();
+
+    if (!m_pipelineBound)
+    {
+        RHI_VALIDATION_ERROR("No pipeline bound.");
+        return;
+    }
+    if (!argBuffer.buffer)
+    {
+        RHI_VALIDATION_ERROR("'argBuffer' must not be null.");
+        return;
+    }
 
     baseObject->dispatchComputeIndirect(argBuffer);
 }
@@ -241,6 +421,17 @@ void DebugComputePassEncoder::writeTimestamp(IQueryPool* queryPool, uint32_t que
     m_commandEncoder->requireOpen();
     m_commandEncoder->requireComputePass();
 
+    if (!queryPool)
+    {
+        RHI_VALIDATION_ERROR("'queryPool' must not be null.");
+        return;
+    }
+    if (queryIndex >= queryPool->getDesc().count)
+    {
+        RHI_VALIDATION_ERROR("'queryIndex' is out of range.");
+        return;
+    }
+
     baseObject->writeTimestamp(getInnerObj(queryPool), queryIndex);
 }
 
@@ -255,6 +446,10 @@ void DebugComputePassEncoder::end()
     baseObject->end();
 }
 
+// ----------------------------------------------------------------------------
+// DebugRayTracingPassEncoder
+// ----------------------------------------------------------------------------
+
 DebugRayTracingPassEncoder::DebugRayTracingPassEncoder(DebugContext* ctx, DebugCommandEncoder* commandEncoder)
     : UnownedDebugObject<IRayTracingPassEncoder>(ctx)
     , m_commandEncoder(commandEncoder)
@@ -268,8 +463,21 @@ IShaderObject* DebugRayTracingPassEncoder::bindPipeline(IRayTracingPipeline* pip
 
     m_commandEncoder->requireOpen();
     m_commandEncoder->requireRayTracingPass();
+
+    if (!pipeline)
+    {
+        RHI_VALIDATION_ERROR("'pipeline' must not be null.");
+        return nullptr;
+    }
+    if (!shaderTable)
+    {
+        RHI_VALIDATION_ERROR("'shaderTable' must not be null.");
+        return nullptr;
+    }
+
     m_rootObject->reset();
     m_rootObject->baseObject = baseObject->bindPipeline(pipeline, shaderTable);
+    m_pipelineBound = true;
 
     return m_rootObject;
 }
@@ -285,7 +493,19 @@ void DebugRayTracingPassEncoder::bindPipeline(
     m_commandEncoder->requireOpen();
     m_commandEncoder->requireRayTracingPass();
 
+    if (!pipeline)
+    {
+        RHI_VALIDATION_ERROR("'pipeline' must not be null.");
+        return;
+    }
+    if (!shaderTable)
+    {
+        RHI_VALIDATION_ERROR("'shaderTable' must not be null.");
+        return;
+    }
+
     baseObject->bindPipeline(pipeline, shaderTable, getInnerObj(rootObject));
+    m_pipelineBound = true;
 }
 
 void DebugRayTracingPassEncoder::dispatchRays(
@@ -299,6 +519,16 @@ void DebugRayTracingPassEncoder::dispatchRays(
 
     m_commandEncoder->requireOpen();
     m_commandEncoder->requireRayTracingPass();
+
+    if (!m_pipelineBound)
+    {
+        RHI_VALIDATION_ERROR("No pipeline bound.");
+        return;
+    }
+    if (width == 0 || height == 0 || depth == 0)
+    {
+        RHI_VALIDATION_WARNING("One or more dispatch dimensions is 0.");
+    }
 
     baseObject->dispatchRays(rayGenShaderIndex, width, height, depth);
 }
@@ -340,6 +570,17 @@ void DebugRayTracingPassEncoder::writeTimestamp(IQueryPool* queryPool, uint32_t 
     m_commandEncoder->requireOpen();
     m_commandEncoder->requireRayTracingPass();
 
+    if (!queryPool)
+    {
+        RHI_VALIDATION_ERROR("'queryPool' must not be null.");
+        return;
+    }
+    if (queryIndex >= queryPool->getDesc().count)
+    {
+        RHI_VALIDATION_ERROR("'queryIndex' is out of range.");
+        return;
+    }
+
     baseObject->writeTimestamp(getInnerObj(queryPool), queryIndex);
 }
 
@@ -353,6 +594,10 @@ void DebugRayTracingPassEncoder::end()
 
     baseObject->end();
 }
+
+// ----------------------------------------------------------------------------
+// DebugCommandEncoder
+// ----------------------------------------------------------------------------
 
 DebugCommandEncoder::DebugCommandEncoder(DebugContext* ctx)
     : DebugObject<ICommandEncoder>(ctx)
@@ -373,7 +618,150 @@ IRenderPassEncoder* DebugCommandEncoder::beginRenderPass(const RenderPassDesc& d
 
     requireOpen();
     requireNoPass();
+
+    bool hasErrors = false;
+
+    // Validate color attachment count.
+    if (desc.colorAttachmentCount > 8)
+    {
+        RHI_VALIDATION_ERROR("Too many color attachments (max 8).");
+        return nullptr;
+    }
+
+    // Track sample count consistency across all attachments.
+    uint32_t commonSampleCount = 0;
+
+    auto checkSampleCount = [&](uint32_t sc, const char* attachmentName)
+    {
+        if (commonSampleCount == 0)
+            commonSampleCount = sc;
+        else if (sc != commonSampleCount)
+        {
+            RHI_VALIDATION_ERROR_FORMAT(
+                "Sample count mismatch across attachments (%s has %u, expected %u).",
+                attachmentName,
+                sc,
+                commonSampleCount
+            );
+            hasErrors = true;
+        }
+    };
+
+    // Validate color attachments.
+    for (uint32_t i = 0; i < desc.colorAttachmentCount; ++i)
+    {
+        const auto& attachment = desc.colorAttachments[i];
+        if (!attachment.view)
+            continue;
+
+        if (!isValidLoadOp(attachment.loadOp))
+        {
+            RHI_VALIDATION_ERROR_FORMAT("Color attachment %u has invalid loadOp.", i);
+            hasErrors = true;
+        }
+        if (!isValidStoreOp(attachment.storeOp))
+        {
+            RHI_VALIDATION_ERROR_FORMAT("Color attachment %u has invalid storeOp.", i);
+            hasErrors = true;
+        }
+
+        ITexture* texture = attachment.view->getTexture();
+        if (texture)
+        {
+            const TextureDesc& texDesc = texture->getDesc();
+
+            // Check usage.
+            if (!is_set(texDesc.usage, TextureUsage::RenderTarget))
+            {
+                RHI_VALIDATION_ERROR_FORMAT("Color attachment %u texture does not have RenderTarget usage.", i);
+                hasErrors = true;
+            }
+
+            // Determine effective format (view format overrides texture format if not Undefined).
+            Format effectiveFormat = attachment.view->getDesc().format;
+            if (effectiveFormat == Format::Undefined)
+                effectiveFormat = texDesc.format;
+
+            // Check that it's not a depth/stencil format.
+            const FormatInfo& formatInfo = getFormatInfo(effectiveFormat);
+            if (formatInfo.hasDepth || formatInfo.hasStencil)
+            {
+                RHI_VALIDATION_ERROR_FORMAT(
+                    "Color attachment %u uses a depth/stencil format; use depthStencilAttachment instead.",
+                    i
+                );
+                hasErrors = true;
+            }
+
+            // Check sample count consistency.
+            char name[32];
+            snprintf(name, sizeof(name), "color attachment %u", i);
+            checkSampleCount(texDesc.sampleCount, name);
+        }
+    }
+
+    // Validate depth/stencil attachment.
+    if (desc.depthStencilAttachment && desc.depthStencilAttachment->view)
+    {
+        const auto& dsAttachment = *desc.depthStencilAttachment;
+
+        if (!isValidLoadOp(dsAttachment.depthLoadOp))
+        {
+            RHI_VALIDATION_ERROR("Depth/stencil attachment has invalid depthLoadOp.");
+            hasErrors = true;
+        }
+        if (!isValidStoreOp(dsAttachment.depthStoreOp))
+        {
+            RHI_VALIDATION_ERROR("Depth/stencil attachment has invalid depthStoreOp.");
+            hasErrors = true;
+        }
+        if (!isValidLoadOp(dsAttachment.stencilLoadOp))
+        {
+            RHI_VALIDATION_ERROR("Depth/stencil attachment has invalid stencilLoadOp.");
+            hasErrors = true;
+        }
+        if (!isValidStoreOp(dsAttachment.stencilStoreOp))
+        {
+            RHI_VALIDATION_ERROR("Depth/stencil attachment has invalid stencilStoreOp.");
+            hasErrors = true;
+        }
+
+        ITexture* texture = dsAttachment.view->getTexture();
+        if (texture)
+        {
+            const TextureDesc& texDesc = texture->getDesc();
+
+            // Check usage.
+            if (!is_set(texDesc.usage, TextureUsage::DepthStencil))
+            {
+                RHI_VALIDATION_ERROR("Depth/stencil attachment texture does not have DepthStencil usage.");
+                hasErrors = true;
+            }
+
+            // Determine effective format.
+            Format effectiveFormat = dsAttachment.view->getDesc().format;
+            if (effectiveFormat == Format::Undefined)
+                effectiveFormat = texDesc.format;
+
+            // Check that it's a depth/stencil format.
+            const FormatInfo& formatInfo = getFormatInfo(effectiveFormat);
+            if (!formatInfo.hasDepth && !formatInfo.hasStencil)
+            {
+                RHI_VALIDATION_ERROR("Depth/stencil attachment format is not a depth/stencil format.");
+                hasErrors = true;
+            }
+
+            // Check sample count consistency.
+            checkSampleCount(texDesc.sampleCount, "depth/stencil attachment");
+        }
+    }
+
+    if (hasErrors)
+        return nullptr;
+
     m_passState = PassState::RenderPass;
+    m_renderPassEncoder.m_pipelineBound = false;
+    m_renderPassEncoder.m_indexBufferBound = false;
     m_renderPassEncoder.baseObject = baseObject->beginRenderPass(desc);
 
     return &m_renderPassEncoder;
@@ -386,6 +774,7 @@ IComputePassEncoder* DebugCommandEncoder::beginComputePass()
     requireOpen();
     requireNoPass();
     m_passState = PassState::ComputePass;
+    m_computePassEncoder.m_pipelineBound = false;
     m_computePassEncoder.baseObject = baseObject->beginComputePass();
 
     return &m_computePassEncoder;
@@ -398,6 +787,7 @@ IRayTracingPassEncoder* DebugCommandEncoder::beginRayTracingPass()
     requireOpen();
     requireNoPass();
     m_passState = PassState::RayTracingPass;
+    m_rayTracingPassEncoder.m_pipelineBound = false;
     m_rayTracingPassEncoder.baseObject = baseObject->beginRayTracingPass();
 
     return &m_rayTracingPassEncoder;
@@ -410,6 +800,52 @@ void DebugCommandEncoder::copyBuffer(IBuffer* dst, Offset dstOffset, IBuffer* sr
     requireOpen();
     requireNoPass();
 
+    if (!dst)
+    {
+        RHI_VALIDATION_ERROR("'dst' must not be null.");
+        return;
+    }
+    if (!src)
+    {
+        RHI_VALIDATION_ERROR("'src' must not be null.");
+        return;
+    }
+    if (size == 0)
+    {
+        RHI_VALIDATION_WARNING("size is 0.");
+        return;
+    }
+    if (srcOffset + size > src->getDesc().size)
+    {
+        RHI_VALIDATION_ERROR("Source range out of bounds.");
+        return;
+    }
+    if (dstOffset + size > dst->getDesc().size)
+    {
+        RHI_VALIDATION_ERROR("Destination range out of bounds.");
+        return;
+    }
+    if (!is_set(src->getDesc().usage, BufferUsage::CopySource))
+    {
+        RHI_VALIDATION_ERROR("Source buffer does not have CopySource usage flag.");
+        return;
+    }
+    if (!is_set(dst->getDesc().usage, BufferUsage::CopyDestination))
+    {
+        RHI_VALIDATION_ERROR("Destination buffer does not have CopyDestination usage flag.");
+        return;
+    }
+    if (dst == src)
+    {
+        // Check for overlapping ranges — overlapping same-buffer copies are undefined behavior
+        // on all major APIs (D3D12, Vulkan, Metal), so skip the call to avoid driver errors.
+        if (srcOffset < dstOffset + size && dstOffset < srcOffset + size)
+        {
+            RHI_VALIDATION_WARNING("Overlapping source and destination ranges on same buffer.");
+            return;
+        }
+    }
+
     baseObject->copyBuffer(dst, dstOffset, src, srcOffset, size);
 }
 
@@ -419,6 +855,32 @@ Result DebugCommandEncoder::uploadBufferData(IBuffer* dst, Offset offset, Size s
 
     requireOpen();
     requireNoPass();
+
+    if (!dst)
+    {
+        RHI_VALIDATION_ERROR("'dst' must not be null.");
+        return SLANG_E_INVALID_ARG;
+    }
+    if (!data)
+    {
+        RHI_VALIDATION_ERROR("'data' must not be null.");
+        return SLANG_E_INVALID_ARG;
+    }
+    if (size == 0)
+    {
+        RHI_VALIDATION_WARNING("size is 0.");
+        return SLANG_OK;
+    }
+    if (offset + size > dst->getDesc().size)
+    {
+        RHI_VALIDATION_ERROR("Destination range out of bounds.");
+        return SLANG_E_INVALID_ARG;
+    }
+    if (!is_set(dst->getDesc().usage, BufferUsage::CopyDestination))
+    {
+        RHI_VALIDATION_ERROR("Destination buffer does not have CopyDestination usage flag.");
+        return SLANG_E_INVALID_ARG;
+    }
 
     return baseObject->uploadBufferData(dst, offset, size, data);
 }
@@ -441,48 +903,48 @@ void DebugCommandEncoder::copyTexture(
     const TextureDesc& srcDesc = src->getDesc();
     if (srcSubresource.layer > srcDesc.getLayerCount())
     {
-        RHI_VALIDATION_ERROR("Src layer is out of bounds.");
+        RHI_VALIDATION_ERROR("Source layer is out of bounds.");
         return;
     }
     if (srcSubresource.mip > srcDesc.mipCount)
     {
-        RHI_VALIDATION_ERROR("Src mip is out of bounds.");
+        RHI_VALIDATION_ERROR("Source mip is out of bounds.");
         return;
     }
 
     const TextureDesc& dstDesc = dst->getDesc();
     if (dstSubresource.layer > dstDesc.getLayerCount())
     {
-        RHI_VALIDATION_ERROR("Dest layer is out of bounds.");
+        RHI_VALIDATION_ERROR("Destination layer is out of bounds.");
         return;
     }
     if (dstSubresource.mip > dstDesc.mipCount)
     {
-        RHI_VALIDATION_ERROR("Dest mip is out of bounds.");
+        RHI_VALIDATION_ERROR("Destination mip is out of bounds.");
         return;
     }
 
     if (srcSubresource.layerCount != dstSubresource.layerCount)
     {
-        RHI_VALIDATION_ERROR("Src and dest layer count must match.");
+        RHI_VALIDATION_ERROR("Source and destination layer count must match.");
         return;
     }
 
     if (srcSubresource.mipCount != dstSubresource.mipCount)
     {
-        RHI_VALIDATION_ERROR("Src and dest mip count must match.");
+        RHI_VALIDATION_ERROR("Source and destination mip count must match.");
         return;
     }
 
     if (srcSubresource.layerCount == 0 && srcDesc.getLayerCount() != dstDesc.getLayerCount())
     {
-        RHI_VALIDATION_ERROR("Copy layer count is 0, so src and dest texture layer count must match.");
+        RHI_VALIDATION_ERROR("Copy layer count is 0, so source and destination texture layer count must match.");
         return;
     }
 
     if (srcSubresource.mipCount == 0 && srcDesc.mipCount != dstDesc.mipCount)
     {
-        RHI_VALIDATION_ERROR("Copy mip count is 0, so src and dest texture mip count must match.");
+        RHI_VALIDATION_ERROR("Copy mip count is 0, so source and destination texture mip count must match.");
         return;
     }
 
@@ -490,13 +952,13 @@ void DebugCommandEncoder::copyTexture(
     {
         if (!srcOffset.isZero() || !dstOffset.isZero())
         {
-            RHI_VALIDATION_ERROR("Copying multiple mip levels at once requires offset to be 0");
+            RHI_VALIDATION_ERROR("Copying multiple mip levels at once requires offset to be 0.");
             return;
         }
 
         if (!extent.isWholeTexture())
         {
-            RHI_VALIDATION_ERROR("Copying multiple mip levels at once requires extent to be Extent3D::kWholeTexture");
+            RHI_VALIDATION_ERROR("Copying multiple mip levels at once requires extent to be Extent3D::kWholeTexture.");
             return;
         }
     }
@@ -505,7 +967,9 @@ void DebugCommandEncoder::copyTexture(
     {
         if (srcOffset.x != dstOffset.x)
         {
-            RHI_VALIDATION_ERROR("Copying the remaining texture requires src and dst offset to be the same");
+            RHI_VALIDATION_ERROR(
+                "Copying the remaining texture requires source and destination offset to be the same."
+            );
             return;
         }
     }
@@ -513,7 +977,9 @@ void DebugCommandEncoder::copyTexture(
     {
         if (srcOffset.y != dstOffset.y)
         {
-            RHI_VALIDATION_ERROR("Copying the remaining texture requires src and dst offset to be the same");
+            RHI_VALIDATION_ERROR(
+                "Copying the remaining texture requires source and destination offset to be the same."
+            );
             return;
         }
     }
@@ -521,7 +987,9 @@ void DebugCommandEncoder::copyTexture(
     {
         if (srcOffset.z != dstOffset.z)
         {
-            RHI_VALIDATION_ERROR("Copying the remaining texture requires src and dst offset to be the same");
+            RHI_VALIDATION_ERROR(
+                "Copying the remaining texture requires source and destination offset to be the same."
+            );
             return;
         }
     }
@@ -559,14 +1027,16 @@ Result DebugCommandEncoder::uploadTextureData(
     {
         if (offset.x != 0 || offset.y != 0 || offset.z != 0)
         {
-            RHI_VALIDATION_ERROR("Uploading multiple mip levels at once requires offset to be 0");
+            RHI_VALIDATION_ERROR("Uploading multiple mip levels at once requires offset to be 0.");
             return SLANG_E_INVALID_ARG;
         }
 
         if (extent.width != kRemainingTextureSize || extent.height != kRemainingTextureSize ||
             extent.depth != kRemainingTextureSize)
         {
-            RHI_VALIDATION_ERROR("Uploading multiple mip levels at once requires extent to be Extent3D::kWholeTexture");
+            RHI_VALIDATION_ERROR(
+                "Uploading multiple mip levels at once requires extent to be Extent3D::kWholeTexture."
+            );
             return SLANG_E_INVALID_ARG;
         }
     }
@@ -607,6 +1077,35 @@ void DebugCommandEncoder::clearTextureFloat(ITexture* texture, SubresourceRange 
     requireOpen();
     requireNoPass();
 
+    if (!texture)
+    {
+        RHI_VALIDATION_ERROR("'texture' must not be null.");
+        return;
+    }
+    const TextureDesc& desc = texture->getDesc();
+    if (!validateSubresourceRange(subresourceRange, desc))
+    {
+        RHI_VALIDATION_ERROR("Subresource range out of bounds.");
+        return;
+    }
+    const FormatInfo& formatInfo = getFormatInfo(desc.format);
+    if (formatInfo.hasDepth || formatInfo.hasStencil)
+    {
+        RHI_VALIDATION_ERROR(
+            "clearTextureFloat cannot be used with depth/stencil formats; use clearTextureDepthStencil."
+        );
+        return;
+    }
+    if (!is_set(desc.usage, TextureUsage::RenderTarget) && !is_set(desc.usage, TextureUsage::UnorderedAccess))
+    {
+        RHI_VALIDATION_ERROR("Texture must have RenderTarget or UnorderedAccess usage.");
+        return;
+    }
+    if (formatInfo.kind != FormatKind::Float && formatInfo.kind != FormatKind::Normalized)
+    {
+        RHI_VALIDATION_WARNING("clearTextureFloat called on a non-float/non-normalized format.");
+    }
+
     baseObject->clearTextureFloat(texture, subresourceRange, clearValue);
 }
 
@@ -617,6 +1116,35 @@ void DebugCommandEncoder::clearTextureUint(ITexture* texture, SubresourceRange s
     requireOpen();
     requireNoPass();
 
+    if (!texture)
+    {
+        RHI_VALIDATION_ERROR("'texture' must not be null.");
+        return;
+    }
+    const TextureDesc& desc = texture->getDesc();
+    if (!validateSubresourceRange(subresourceRange, desc))
+    {
+        RHI_VALIDATION_ERROR("Subresource range out of bounds.");
+        return;
+    }
+    const FormatInfo& formatInfo = getFormatInfo(desc.format);
+    if (formatInfo.hasDepth || formatInfo.hasStencil)
+    {
+        RHI_VALIDATION_ERROR(
+            "clearTextureUint cannot be used with depth/stencil formats; use clearTextureDepthStencil."
+        );
+        return;
+    }
+    if (!is_set(desc.usage, TextureUsage::RenderTarget) && !is_set(desc.usage, TextureUsage::UnorderedAccess))
+    {
+        RHI_VALIDATION_ERROR("Texture must have RenderTarget or UnorderedAccess usage.");
+        return;
+    }
+    if (formatInfo.kind != FormatKind::Integer || formatInfo.isSigned)
+    {
+        RHI_VALIDATION_WARNING("clearTextureUint called on a non-unsigned-integer format.");
+    }
+
     baseObject->clearTextureUint(texture, subresourceRange, clearValue);
 }
 
@@ -626,6 +1154,35 @@ void DebugCommandEncoder::clearTextureSint(ITexture* texture, SubresourceRange s
 
     requireOpen();
     requireNoPass();
+
+    if (!texture)
+    {
+        RHI_VALIDATION_ERROR("'texture' must not be null.");
+        return;
+    }
+    const TextureDesc& desc = texture->getDesc();
+    if (!validateSubresourceRange(subresourceRange, desc))
+    {
+        RHI_VALIDATION_ERROR("Subresource range out of bounds.");
+        return;
+    }
+    const FormatInfo& formatInfo = getFormatInfo(desc.format);
+    if (formatInfo.hasDepth || formatInfo.hasStencil)
+    {
+        RHI_VALIDATION_ERROR(
+            "clearTextureSint cannot be used with depth/stencil formats; use clearTextureDepthStencil."
+        );
+        return;
+    }
+    if (!is_set(desc.usage, TextureUsage::RenderTarget) && !is_set(desc.usage, TextureUsage::UnorderedAccess))
+    {
+        RHI_VALIDATION_ERROR("Texture must have RenderTarget or UnorderedAccess usage.");
+        return;
+    }
+    if (formatInfo.kind != FormatKind::Integer || !formatInfo.isSigned)
+    {
+        RHI_VALIDATION_WARNING("clearTextureSint called on a non-signed-integer format.");
+    }
 
     baseObject->clearTextureSint(texture, subresourceRange, clearValue);
 }
@@ -643,37 +1200,65 @@ void DebugCommandEncoder::clearTextureDepthStencil(
 
     requireOpen();
     requireNoPass();
-    const FormatInfo& formatInfo = getFormatInfo(texture->getDesc().format);
+    if (!texture)
+    {
+        RHI_VALIDATION_ERROR("'texture' must not be null.");
+        return;
+    }
+    const TextureDesc& desc = texture->getDesc();
+    if (!validateSubresourceRange(subresourceRange, desc))
+    {
+        RHI_VALIDATION_ERROR("Subresource range out of bounds.");
+        return;
+    }
+    const FormatInfo& formatInfo = getFormatInfo(desc.format);
     if (!formatInfo.hasDepth && !formatInfo.hasStencil)
     {
-        RHI_VALIDATION_ERROR("Texture format does not have depth or stencil");
+        RHI_VALIDATION_ERROR("Texture format does not have depth or stencil.");
         return;
+    }
+    if (!clearDepth && !clearStencil)
+    {
+        RHI_VALIDATION_WARNING("Both clearDepth and clearStencil are false; nothing to clear.");
+        return;
+    }
+    if (clearDepth && !formatInfo.hasDepth)
+    {
+        RHI_VALIDATION_WARNING("clearDepth is true but texture format has no depth component.");
+    }
+    if (clearStencil && !formatInfo.hasStencil)
+    {
+        RHI_VALIDATION_WARNING("clearStencil is true but texture format has no stencil component.");
+    }
+    if (clearDepth && (depthValue < 0.0f || depthValue > 1.0f))
+    {
+        RHI_VALIDATION_WARNING("depthValue is outside [0, 1] range.");
     }
     switch (ctx->deviceType)
     {
     case DeviceType::D3D11:
     case DeviceType::D3D12:
-        if (!is_set(texture->getDesc().usage, TextureUsage::DepthStencil))
+        if (!is_set(desc.usage, TextureUsage::DepthStencil))
         {
-            RHI_VALIDATION_ERROR("Texture needs to have usage flag DepthStencil");
+            RHI_VALIDATION_ERROR("Texture needs to have usage flag DepthStencil.");
             return;
         }
         break;
     case DeviceType::Vulkan:
-        if (!is_set(texture->getDesc().usage, TextureUsage::CopyDestination))
+        if (!is_set(desc.usage, TextureUsage::CopyDestination))
         {
-            RHI_VALIDATION_ERROR("Texture needs to have usage flag CopyDestination");
+            RHI_VALIDATION_ERROR("Texture needs to have usage flag CopyDestination.");
             return;
         }
         break;
     case DeviceType::Metal:
         break;
     case DeviceType::WGPU:
-        RHI_VALIDATION_ERROR("Not implemented");
+        RHI_VALIDATION_ERROR("Not implemented.");
         return;
     case DeviceType::CPU:
     case DeviceType::CUDA:
-        RHI_VALIDATION_ERROR("Not supported");
+        RHI_VALIDATION_ERROR("Not supported.");
         return;
     default:
         break;
@@ -694,6 +1279,34 @@ void DebugCommandEncoder::resolveQuery(
 
     requireOpen();
     requireNoPass();
+
+    if (!queryPool)
+    {
+        RHI_VALIDATION_ERROR("'queryPool' must not be null.");
+        return;
+    }
+    if (!buffer)
+    {
+        RHI_VALIDATION_ERROR("'buffer' must not be null.");
+        return;
+    }
+    if (count == 0)
+    {
+        RHI_VALIDATION_WARNING("count is 0.");
+        return;
+    }
+    if (index + count > queryPool->getDesc().count)
+    {
+        RHI_VALIDATION_ERROR("Query range out of bounds (index + count exceeds query pool size).");
+        return;
+    }
+    if (offset + count * sizeof(uint64_t) > buffer->getDesc().size)
+    {
+        RHI_VALIDATION_ERROR(
+            "Destination range out of bounds (offset + count * sizeof(uint64_t) exceeds buffer size)."
+        );
+        return;
+    }
 
     baseObject->resolveQuery(getInnerObj(queryPool), index, count, buffer, offset);
 }
@@ -719,12 +1332,12 @@ void DebugCommandEncoder::copyTextureToBuffer(
 
     if (srcLayer >= desc.getLayerCount())
     {
-        RHI_VALIDATION_ERROR("Src layer is out of bounds.");
+        RHI_VALIDATION_ERROR("Source layer is out of bounds.");
         return;
     }
     if (srcMip >= desc.mipCount)
     {
-        RHI_VALIDATION_ERROR("Src mip is out of bounds.");
+        RHI_VALIDATION_ERROR("Source mip is out of bounds.");
         return;
     }
 
@@ -802,6 +1415,22 @@ void DebugCommandEncoder::copyAccelerationStructure(
     requireOpen();
     requireNoPass();
 
+    if (!dst)
+    {
+        RHI_VALIDATION_ERROR("'dst' must not be null.");
+        return;
+    }
+    if (!src)
+    {
+        RHI_VALIDATION_ERROR("'src' must not be null.");
+        return;
+    }
+    if (!isValidAccelerationStructureCopyMode(mode))
+    {
+        RHI_VALIDATION_ERROR("Invalid acceleration structure copy mode.");
+        return;
+    }
+
     baseObject->copyAccelerationStructure(dst, src, mode);
 }
 
@@ -841,6 +1470,17 @@ void DebugCommandEncoder::serializeAccelerationStructure(BufferOffsetPair dst, I
     requireOpen();
     requireNoPass();
 
+    if (!src)
+    {
+        RHI_VALIDATION_ERROR("'src' must not be null.");
+        return;
+    }
+    if (!dst.buffer)
+    {
+        RHI_VALIDATION_ERROR("'dst.buffer' must not be null.");
+        return;
+    }
+
     baseObject->serializeAccelerationStructure(dst, src);
 }
 
@@ -850,6 +1490,17 @@ void DebugCommandEncoder::deserializeAccelerationStructure(IAccelerationStructur
 
     requireOpen();
     requireNoPass();
+
+    if (!dst)
+    {
+        RHI_VALIDATION_ERROR("'dst' must not be null.");
+        return;
+    }
+    if (!src.buffer)
+    {
+        RHI_VALIDATION_ERROR("'src.buffer' must not be null.");
+        return;
+    }
 
     baseObject->deserializeAccelerationStructure(dst, src);
 }
@@ -867,22 +1518,22 @@ void DebugCommandEncoder::executeClusterOperation(const ClusterOperationDesc& de
     }
     if (!desc.argCountBuffer && desc.params.maxArgCount == 0)
     {
-        RHI_VALIDATION_ERROR("argCountBuffer is not provided and params.maxArgCount is 0");
+        RHI_VALIDATION_ERROR("'argCountBuffer' is not provided and 'params.maxArgCount' is 0.");
         return;
     }
     if (!desc.argsBuffer)
     {
-        RHI_VALIDATION_ERROR("argsBuffer must be provided");
+        RHI_VALIDATION_ERROR("'argsBuffer' must not be null.");
         return;
     }
     if (desc.argsBufferStride == 0)
     {
-        RHI_VALIDATION_ERROR("argsBufferStride must not be 0");
+        RHI_VALIDATION_ERROR("'argsBufferStride' must not be 0.");
         return;
     }
     if (!desc.scratchBuffer)
     {
-        RHI_VALIDATION_ERROR("scratchBuffer must be provided");
+        RHI_VALIDATION_ERROR("'scratchBuffer' must not be null.");
         return;
     }
     switch (desc.params.mode)
@@ -890,42 +1541,46 @@ void DebugCommandEncoder::executeClusterOperation(const ClusterOperationDesc& de
     case ClusterOperationMode::ImplicitDestinations:
         if (!desc.addressesBuffer)
         {
-            RHI_VALIDATION_ERROR("addressesBuffer must be provided in ClusterOperationMode::ImplicitDestinations mode");
+            RHI_VALIDATION_ERROR(
+                "'addressesBuffer' must not be null in ClusterOperationMode::ImplicitDestinations mode."
+            );
             return;
         }
         if (!desc.resultBuffer)
         {
-            RHI_VALIDATION_ERROR("resultBuffer must be provided in ClusterOperationMode::ImplicitDestinations mode");
+            RHI_VALIDATION_ERROR("'resultBuffer' must not be null in ClusterOperationMode::ImplicitDestinations mode.");
             return;
         }
         break;
     case ClusterOperationMode::ExplicitDestinations:
         if (!desc.addressesBuffer)
         {
-            RHI_VALIDATION_ERROR("addressesBuffer must be provided in ClusterOperationMode::ExplicitDestinations mode");
+            RHI_VALIDATION_ERROR(
+                "'addressesBuffer' must not be null in ClusterOperationMode::ExplicitDestinations mode."
+            );
             return;
         }
         break;
     case ClusterOperationMode::GetSizes:
         if (!desc.sizesBuffer)
         {
-            RHI_VALIDATION_ERROR("sizesBuffer must be provided in ClusterOperationMode::GetSizes mode");
+            RHI_VALIDATION_ERROR("'sizesBuffer' must not be null in ClusterOperationMode::GetSizes mode.");
             return;
         }
         break;
     default:
-        RHI_VALIDATION_ERROR("Unknown cluster operation mode");
+        RHI_VALIDATION_ERROR("Unknown cluster operation mode.");
         return;
     }
 
     if (desc.addressesBufferStride != 0 && desc.addressesBufferStride < 8)
     {
-        RHI_VALIDATION_ERROR("addressesBufferStride must be 0 or >= 8");
+        RHI_VALIDATION_ERROR("'addressesBufferStride' must be 0 or >= 8.");
         return;
     }
     if (desc.sizesBufferStride != 0 && desc.sizesBufferStride < 4)
     {
-        RHI_VALIDATION_ERROR("sizesBufferStride must be 0 or >= 4");
+        RHI_VALIDATION_ERROR("'sizesBufferStride' must be 0 or >= 4.");
         return;
     }
 
@@ -947,12 +1602,12 @@ void DebugCommandEncoder::convertCooperativeVectorMatrix(
 
     if (!dstBuffer)
     {
-        RHI_VALIDATION_ERROR("Destination buffer must be valid");
+        RHI_VALIDATION_ERROR("'dstBuffer' must not be null.");
         return;
     }
     if (!srcBuffer)
     {
-        RHI_VALIDATION_ERROR("Source buffer must be valid");
+        RHI_VALIDATION_ERROR("'srcBuffer' must not be null.");
         return;
     }
 
@@ -975,6 +1630,22 @@ void DebugCommandEncoder::setBufferState(IBuffer* buffer, ResourceState state)
     requireOpen();
     requireNoPass();
 
+    if (!buffer)
+    {
+        RHI_VALIDATION_ERROR("'buffer' must not be null.");
+        return;
+    }
+    if (!isValidResourceState(state))
+    {
+        RHI_VALIDATION_ERROR("Invalid resource state.");
+        return;
+    }
+    if (state == ResourceState::Undefined)
+    {
+        RHI_VALIDATION_WARNING("Setting buffer state to Undefined.");
+        return;
+    }
+
     baseObject->setBufferState(buffer, state);
 }
 
@@ -984,6 +1655,27 @@ void DebugCommandEncoder::setTextureState(ITexture* texture, SubresourceRange su
 
     requireOpen();
     requireNoPass();
+
+    if (!texture)
+    {
+        RHI_VALIDATION_ERROR("'texture' must not be null.");
+        return;
+    }
+    if (!isValidResourceState(state))
+    {
+        RHI_VALIDATION_ERROR("Invalid resource state.");
+        return;
+    }
+    if (!validateSubresourceRange(subresourceRange, texture->getDesc()))
+    {
+        RHI_VALIDATION_ERROR("Subresource range out of bounds.");
+        return;
+    }
+    if (state == ResourceState::Undefined)
+    {
+        RHI_VALIDATION_WARNING("Setting texture state to Undefined.");
+        return;
+    }
 
     baseObject->setTextureState(texture, subresourceRange, state);
 }
@@ -1033,6 +1725,17 @@ void DebugCommandEncoder::writeTimestamp(IQueryPool* pool, uint32_t index)
     SLANG_RHI_DEBUG_API(ICommandEncoder, writeTimestamp);
 
     requireOpen();
+
+    if (!pool)
+    {
+        RHI_VALIDATION_ERROR("'queryPool' must not be null.");
+        return;
+    }
+    if (index >= pool->getDesc().count)
+    {
+        RHI_VALIDATION_ERROR("'queryIndex' is out of range.");
+        return;
+    }
 
     baseObject->writeTimestamp(getInnerObj(pool), index);
 }

--- a/src/debug-layer/debug-command-encoder.cpp
+++ b/src/debug-layer/debug-command-encoder.cpp
@@ -914,6 +914,17 @@ void DebugCommandEncoder::copyTexture(
     requireOpen();
     requireNoPass();
 
+    if (!src)
+    {
+        RHI_VALIDATION_ERROR("'src' must not be null.");
+        return;
+    }
+    if (!dst)
+    {
+        RHI_VALIDATION_ERROR("'dst' must not be null.");
+        return;
+    }
+
     const TextureDesc& srcDesc = src->getDesc();
     if (srcSubresource.layer >= srcDesc.getLayerCount())
     {
@@ -1342,6 +1353,17 @@ void DebugCommandEncoder::copyTextureToBuffer(
     requireOpen();
     requireNoPass();
 
+    if (!src)
+    {
+        RHI_VALIDATION_ERROR("'src' must not be null.");
+        return;
+    }
+    if (!dst)
+    {
+        RHI_VALIDATION_ERROR("'dst' must not be null.");
+        return;
+    }
+
     const TextureDesc& desc = src->getDesc();
 
     if (srcLayer >= desc.getLayerCount())
@@ -1374,6 +1396,17 @@ void DebugCommandEncoder::copyBufferToTexture(
 
     requireOpen();
     requireNoPass();
+
+    if (!dst)
+    {
+        RHI_VALIDATION_ERROR("'dst' must not be null.");
+        return;
+    }
+    if (!src)
+    {
+        RHI_VALIDATION_ERROR("'src' must not be null.");
+        return;
+    }
 
     const TextureDesc& desc = dst->getDesc();
 

--- a/src/debug-layer/debug-command-encoder.cpp
+++ b/src/debug-layer/debug-command-encoder.cpp
@@ -961,6 +961,36 @@ void DebugCommandEncoder::copyTexture(
         return;
     }
 
+    if (srcSubresource.layerCount != 0)
+    {
+        if (srcSubresource.layer + srcSubresource.layerCount > srcDesc.getLayerCount())
+        {
+            RHI_VALIDATION_ERROR("Source layer range (layer + layerCount) exceeds source texture layer count.");
+            return;
+        }
+        if (dstSubresource.layer + dstSubresource.layerCount > dstDesc.getLayerCount())
+        {
+            RHI_VALIDATION_ERROR(
+                "Destination layer range (layer + layerCount) exceeds destination texture layer count."
+            );
+            return;
+        }
+    }
+
+    if (srcSubresource.mipCount != 0)
+    {
+        if (srcSubresource.mip + srcSubresource.mipCount > srcDesc.mipCount)
+        {
+            RHI_VALIDATION_ERROR("Source mip range (mip + mipCount) exceeds source texture mip count.");
+            return;
+        }
+        if (dstSubresource.mip + dstSubresource.mipCount > dstDesc.mipCount)
+        {
+            RHI_VALIDATION_ERROR("Destination mip range (mip + mipCount) exceeds destination texture mip count.");
+            return;
+        }
+    }
+
     if (srcSubresource.layerCount == 0 && srcDesc.getLayerCount() != dstDesc.getLayerCount())
     {
         RHI_VALIDATION_ERROR("Copy layer count is 0, so source and destination texture layer count must match.");

--- a/src/debug-layer/debug-command-encoder.cpp
+++ b/src/debug-layer/debug-command-encoder.cpp
@@ -829,12 +829,12 @@ void DebugCommandEncoder::copyBuffer(IBuffer* dst, Offset dstOffset, IBuffer* sr
         RHI_VALIDATION_WARNING("size is 0.");
         return;
     }
-    if (!checkSizePlusOffsetInRange(srcOffset, size, src->getDesc().size))
+    if (!isValidSubrange(srcOffset, size, src->getDesc().size))
     {
         RHI_VALIDATION_ERROR("Source range out of bounds.");
         return;
     }
-    if (!checkSizePlusOffsetInRange(dstOffset, size, dst->getDesc().size))
+    if (!isValidSubrange(dstOffset, size, dst->getDesc().size))
     {
         RHI_VALIDATION_ERROR("Destination range out of bounds.");
         return;
@@ -885,7 +885,7 @@ Result DebugCommandEncoder::uploadBufferData(IBuffer* dst, Offset offset, Size s
         RHI_VALIDATION_WARNING("size is 0.");
         return SLANG_OK;
     }
-    if (!checkSizePlusOffsetInRange(offset, size, dst->getDesc().size))
+    if (!isValidSubrange(offset, size, dst->getDesc().size))
     {
         RHI_VALIDATION_ERROR("Destination range out of bounds.");
         return SLANG_E_INVALID_ARG;
@@ -1309,12 +1309,12 @@ void DebugCommandEncoder::resolveQuery(
         RHI_VALIDATION_WARNING("count is 0.");
         return;
     }
-    if (!checkSizePlusOffsetInRange(index, count, queryPool->getDesc().count))
+    if (!isValidSubrange(index, count, queryPool->getDesc().count))
     {
         RHI_VALIDATION_ERROR("Query range out of bounds (index + count exceeds query pool size).");
         return;
     }
-    if (!checkSizePlusOffsetInRange(offset, count * sizeof(uint64_t), buffer->getDesc().size))
+    if (!isValidSubrange(offset, count * sizeof(uint64_t), buffer->getDesc().size))
     {
         RHI_VALIDATION_ERROR(
             "Destination range out of bounds (offset + count * sizeof(uint64_t) exceeds buffer size)."

--- a/src/debug-layer/debug-command-encoder.h
+++ b/src/debug-layer/debug-command-encoder.h
@@ -13,12 +13,10 @@ public:
     virtual SLANG_NO_THROW uint32_t SLANG_MCALL addRef() override { return 1; }
     virtual SLANG_NO_THROW uint32_t SLANG_MCALL release() override { return 1; }
 
-public:
-    DebugCommandEncoder* m_commandEncoder;
-    RefPtr<DebugRootShaderObject> m_rootObject;
-
     DebugRenderPassEncoder(DebugContext* ctx, DebugCommandEncoder* commandEncoder);
 
+public:
+    // IRenderPassEncoder implementation
     virtual SLANG_NO_THROW IShaderObject* SLANG_MCALL bindPipeline(IRenderPipeline* pipeline) override;
     virtual SLANG_NO_THROW void SLANG_MCALL bindPipeline(IRenderPipeline* pipeline, IShaderObject* rootObject) override;
 
@@ -44,6 +42,12 @@ public:
     virtual SLANG_NO_THROW void SLANG_MCALL writeTimestamp(IQueryPool* queryPool, uint32_t queryIndex) override;
 
     virtual SLANG_NO_THROW void SLANG_MCALL end() override;
+
+public:
+    DebugCommandEncoder* m_commandEncoder;
+    RefPtr<DebugRootShaderObject> m_rootObject;
+    bool m_pipelineBound = false;
+    bool m_indexBufferBound = false;
 };
 
 class DebugComputePassEncoder : public UnownedDebugObject<IComputePassEncoder>
@@ -54,12 +58,10 @@ public:
     virtual SLANG_NO_THROW uint32_t SLANG_MCALL addRef() override { return 1; }
     virtual SLANG_NO_THROW uint32_t SLANG_MCALL release() override { return 1; }
 
-public:
-    DebugCommandEncoder* m_commandEncoder;
-    RefPtr<DebugRootShaderObject> m_rootObject;
-
     DebugComputePassEncoder(DebugContext* ctx, DebugCommandEncoder* commandEncoder);
 
+public:
+    // IComputePassEncoder implementation
     virtual SLANG_NO_THROW IShaderObject* SLANG_MCALL bindPipeline(IComputePipeline* pipeline) override;
     virtual SLANG_NO_THROW void SLANG_MCALL bindPipeline(
         IComputePipeline* pipeline,
@@ -76,6 +78,11 @@ public:
     virtual SLANG_NO_THROW void SLANG_MCALL writeTimestamp(IQueryPool* queryPool, uint32_t queryIndex) override;
 
     virtual SLANG_NO_THROW void SLANG_MCALL end() override;
+
+public:
+    DebugCommandEncoder* m_commandEncoder;
+    RefPtr<DebugRootShaderObject> m_rootObject;
+    bool m_pipelineBound = false;
 };
 
 class DebugRayTracingPassEncoder : public UnownedDebugObject<IRayTracingPassEncoder>
@@ -86,12 +93,10 @@ public:
     virtual SLANG_NO_THROW uint32_t SLANG_MCALL addRef() override { return 1; }
     virtual SLANG_NO_THROW uint32_t SLANG_MCALL release() override { return 1; }
 
-public:
-    DebugCommandEncoder* m_commandEncoder;
-    RefPtr<DebugRootShaderObject> m_rootObject;
-
     DebugRayTracingPassEncoder(DebugContext* ctx, DebugCommandEncoder* commandEncoder);
 
+public:
+    // IRayTracingPassEncoder implementation
     virtual SLANG_NO_THROW IShaderObject* SLANG_MCALL bindPipeline(
         IRayTracingPipeline* pipeline,
         IShaderTable* shaderTable
@@ -116,6 +121,11 @@ public:
     virtual SLANG_NO_THROW void SLANG_MCALL writeTimestamp(IQueryPool* queryPool, uint32_t queryIndex) override;
 
     virtual SLANG_NO_THROW void SLANG_MCALL end() override;
+
+public:
+    DebugCommandEncoder* m_commandEncoder;
+    RefPtr<DebugRootShaderObject> m_rootObject;
+    bool m_pipelineBound = false;
 };
 
 class DebugCommandEncoder : public DebugObject<ICommandEncoder>
@@ -124,9 +134,10 @@ public:
     SLANG_COM_OBJECT_IUNKNOWN_ALL;
     ICommandEncoder* getInterface(const Guid& guid);
 
-public:
     DebugCommandEncoder(DebugContext* ctx);
 
+public:
+    // ICommandEncoder implementation
     virtual SLANG_NO_THROW const CommandEncoderDesc& SLANG_MCALL getDesc() override;
 
     virtual SLANG_NO_THROW IRenderPassEncoder* SLANG_MCALL beginRenderPass(const RenderPassDesc& desc) override;

--- a/src/debug-layer/debug-command-queue.cpp
+++ b/src/debug-layer/debug-command-queue.cpp
@@ -36,7 +36,7 @@ Result DebugCommandQueue::submit(const SubmitDesc& desc)
     {
         if (!desc.commandBuffers[i])
         {
-            RHI_VALIDATION_ERROR("Command buffer is null.");
+            RHI_VALIDATION_ERROR_FORMAT("'desc.commandBuffers[%u]' must not be null.", i);
             return SLANG_E_INVALID_ARG;
         }
         innerCommandBuffers.push_back(getInnerObj(desc.commandBuffers[i]));

--- a/src/debug-layer/debug-command-queue.h
+++ b/src/debug-layer/debug-command-queue.h
@@ -8,11 +8,12 @@ class DebugCommandQueue : public DebugObject<ICommandQueue>
 {
 public:
     SLANG_COM_OBJECT_IUNKNOWN_ALL;
+    ICommandQueue* getInterface(const Guid& guid);
 
     SLANG_RHI_DEBUG_OBJECT_CONSTRUCTOR(DebugCommandQueue);
 
 public:
-    ICommandQueue* getInterface(const Guid& guid);
+    // ICommandQueue implementation
     virtual SLANG_NO_THROW QueueType SLANG_MCALL getType() override;
     virtual SLANG_NO_THROW Result SLANG_MCALL createCommandEncoder(
         const CommandEncoderDesc& desc,

--- a/src/debug-layer/debug-device.cpp
+++ b/src/debug-layer/debug-device.cpp
@@ -1005,12 +1005,12 @@ Result DebugDevice::readTexture(
 
     const TextureDesc& desc = texture->getDesc();
 
-    if (layer > desc.getLayerCount())
+    if (layer >= desc.getLayerCount())
     {
         RHI_VALIDATION_ERROR("Layer out of bounds.");
         return SLANG_E_INVALID_ARG;
     }
-    if (mip > desc.mipCount)
+    if (mip >= desc.mipCount)
     {
         RHI_VALIDATION_ERROR("Mip out of bounds.");
         return SLANG_E_INVALID_ARG;
@@ -1055,12 +1055,12 @@ Result DebugDevice::readTexture(
 
     const TextureDesc& desc = texture->getDesc();
 
-    if (layer > desc.getLayerCount())
+    if (layer >= desc.getLayerCount())
     {
         RHI_VALIDATION_ERROR("Layer out of bounds.");
         return SLANG_E_INVALID_ARG;
     }
-    if (mip > desc.mipCount)
+    if (mip >= desc.mipCount)
     {
         RHI_VALIDATION_ERROR("Mip out of bounds.");
         return SLANG_E_INVALID_ARG;

--- a/src/debug-layer/debug-device.cpp
+++ b/src/debug-layer/debug-device.cpp
@@ -7,6 +7,7 @@
 #include "debug-shader-object.h"
 
 #include "core/short_vector.h"
+#include "resource-desc-utils.h"
 
 #if SLANG_RHI_ENABLE_CUDA
 #include <slang-rhi/cuda-driver-api.h>
@@ -107,39 +108,69 @@ Result DebugDevice::createTexture(const TextureDesc& desc, const SubresourceData
 
     validateCudaContext();
 
-    if (uint32_t(desc.type) > uint32_t(TextureType::TextureCubeArray))
+    if (!outTexture)
     {
-        RHI_VALIDATION_ERROR("Invalid texture type");
+        RHI_VALIDATION_ERROR("'outTexture' must not be null.");
         return SLANG_E_INVALID_ARG;
     }
-    if (desc.size.width < 1)
+    if (!isValidTextureType(desc.type))
     {
-        RHI_VALIDATION_ERROR("Texture width must be at least 1");
+        RHI_VALIDATION_ERROR("Invalid texture type.");
         return SLANG_E_INVALID_ARG;
     }
-    if (desc.size.height < 1)
+    if (!isValidFormat(desc.format))
     {
-        RHI_VALIDATION_ERROR("Texture height must be at least 1");
-        return SLANG_E_INVALID_ARG;
-    }
-    if (desc.size.depth < 1)
-    {
-        RHI_VALIDATION_ERROR("Texture depth must be at least 1");
-        return SLANG_E_INVALID_ARG;
-    }
-    if (desc.arrayLength < 1)
-    {
-        RHI_VALIDATION_ERROR("Texture array length must be at least 1");
-        return SLANG_E_INVALID_ARG;
-    }
-    if (desc.mipCount < 1)
-    {
-        RHI_VALIDATION_ERROR("Texture mip count must be at least 1");
+        RHI_VALIDATION_ERROR("Invalid texture format.");
         return SLANG_E_INVALID_ARG;
     }
     if (desc.format == Format::Undefined)
     {
-        RHI_VALIDATION_ERROR("Texture format must be specified");
+        RHI_VALIDATION_ERROR("Texture format must be specified.");
+        return SLANG_E_INVALID_ARG;
+    }
+    if (!isValidTextureUsage(desc.usage))
+    {
+        RHI_VALIDATION_ERROR("Texture usage contains invalid flags.");
+        return SLANG_E_INVALID_ARG;
+    }
+    if (desc.usage == TextureUsage::None)
+    {
+        RHI_VALIDATION_ERROR("Texture usage must be specified.");
+        return SLANG_E_INVALID_ARG;
+    }
+    if (!isValidMemoryType(desc.memoryType))
+    {
+        RHI_VALIDATION_ERROR("Invalid memory type.");
+        return SLANG_E_INVALID_ARG;
+    }
+    if (desc.defaultState != ResourceState::Undefined && !isValidResourceState(desc.defaultState))
+    {
+        RHI_VALIDATION_ERROR("Invalid default resource state.");
+        return SLANG_E_INVALID_ARG;
+    }
+    if (desc.size.width < 1)
+    {
+        RHI_VALIDATION_ERROR("Texture width must be at least 1.");
+        return SLANG_E_INVALID_ARG;
+    }
+    if (desc.size.height < 1)
+    {
+        RHI_VALIDATION_ERROR("Texture height must be at least 1.");
+        return SLANG_E_INVALID_ARG;
+    }
+    if (desc.size.depth < 1)
+    {
+        RHI_VALIDATION_ERROR("Texture depth must be at least 1.");
+        return SLANG_E_INVALID_ARG;
+    }
+    if (desc.arrayLength < 1)
+    {
+        RHI_VALIDATION_ERROR("Texture array length must be at least 1.");
+        return SLANG_E_INVALID_ARG;
+    }
+    if (desc.mipCount < 1 && desc.mipCount != kAllMips)
+    {
+        RHI_VALIDATION_ERROR("Texture mip count must be at least 1 (or kAllMips).");
         return SLANG_E_INVALID_ARG;
     }
 
@@ -147,7 +178,36 @@ Result DebugDevice::createTexture(const TextureDesc& desc, const SubresourceData
         desc.type != TextureType::Texture2DMSArray && desc.type != TextureType::TextureCubeArray &&
         desc.arrayLength > 1)
     {
-        RHI_VALIDATION_ERROR("Texture array length must be 1 for non-array textures");
+        RHI_VALIDATION_ERROR("Texture array length must be 1 for non-array textures.");
+        return SLANG_E_INVALID_ARG;
+    }
+
+    // Validate mip count does not exceed the maximum for the texture size.
+    if (desc.mipCount != kAllMips)
+    {
+        uint32_t maxMips = calcMipCount(desc);
+        if (maxMips > 0 && desc.mipCount > maxMips)
+        {
+            RHI_VALIDATION_ERROR_FORMAT(
+                "Texture mip count (%d) exceeds maximum mip count (%d) for texture size.",
+                desc.mipCount,
+                maxMips
+            );
+            return SLANG_E_INVALID_ARG;
+        }
+    }
+
+    // Validate mutually exclusive usage flags.
+    if (is_set(desc.usage, TextureUsage::RenderTarget) && is_set(desc.usage, TextureUsage::DepthStencil))
+    {
+        RHI_VALIDATION_ERROR("Texture usage cannot have both RenderTarget and DepthStencil.");
+        return SLANG_E_INVALID_ARG;
+    }
+
+    // Validate depth/stencil usage with compatible format.
+    if (is_set(desc.usage, TextureUsage::DepthStencil) && !isDepthFormat(desc.format))
+    {
+        RHI_VALIDATION_ERROR("Texture with DepthStencil usage must use a depth format.");
         return SLANG_E_INVALID_ARG;
     }
 
@@ -158,34 +218,43 @@ Result DebugDevice::createTexture(const TextureDesc& desc, const SubresourceData
     {
         if (desc.sampleCount < 1)
         {
-            RHI_VALIDATION_ERROR("Texture sample count must be at least 1");
+            RHI_VALIDATION_ERROR("Texture sample count must be at least 1.");
+            return SLANG_E_INVALID_ARG;
+        }
+        if ((desc.sampleCount & (desc.sampleCount - 1)) != 0)
+        {
+            RHI_VALIDATION_ERROR("Texture sample count must be a power of 2.");
             return SLANG_E_INVALID_ARG;
         }
         if (initData)
         {
-            RHI_VALIDATION_ERROR("Texture with multisample type cannot have initial data");
+            RHI_VALIDATION_ERROR("Texture with multisample type cannot have initial data.");
             return SLANG_E_INVALID_ARG;
         }
-        if (desc.mipCount != 1)
+        if (desc.mipCount != 1 && desc.mipCount != kAllMips)
         {
-            RHI_VALIDATION_ERROR("Texture with multisample type cannot have mip levels");
+            RHI_VALIDATION_ERROR("Texture with multisample type cannot have multiple mip levels.");
             return SLANG_E_INVALID_ARG;
         }
         if (ctx->deviceType == DeviceType::WGPU && desc.sampleCount != 4)
         {
-            RHI_VALIDATION_ERROR("WebGPU only supports sample count of 4");
+            RHI_VALIDATION_ERROR("WebGPU only supports sample count of 4.");
             return SLANG_E_INVALID_ARG;
         }
         if (ctx->deviceType == DeviceType::WGPU && desc.arrayLength != 1)
         {
-            RHI_VALIDATION_ERROR("WebGPU doesn't support multisampled texture arrays");
+            RHI_VALIDATION_ERROR("WebGPU does not support multisampled texture arrays.");
             return SLANG_E_INVALID_ARG;
         }
-
 
         break;
     }
     default:
+        if (desc.sampleCount != 1)
+        {
+            RHI_VALIDATION_ERROR("Non-multisample texture types must have sample count of 1.");
+            return SLANG_E_INVALID_ARG;
+        }
         break;
     }
 
@@ -195,7 +264,7 @@ Result DebugDevice::createTexture(const TextureDesc& desc, const SubresourceData
     case TextureType::Texture1DArray:
         if (desc.size.height != 1 || desc.size.depth != 1)
         {
-            RHI_VALIDATION_ERROR("1D textures must have height and depth set to 1");
+            RHI_VALIDATION_ERROR("1D textures must have height and depth set to 1.");
             return SLANG_E_INVALID_ARG;
         }
         break;
@@ -205,7 +274,7 @@ Result DebugDevice::createTexture(const TextureDesc& desc, const SubresourceData
     case TextureType::Texture2DMSArray:
         if (desc.size.depth != 1)
         {
-            RHI_VALIDATION_ERROR("2D textures must have depth set to 1");
+            RHI_VALIDATION_ERROR("2D textures must have depth set to 1.");
             return SLANG_E_INVALID_ARG;
         }
         break;
@@ -215,12 +284,12 @@ Result DebugDevice::createTexture(const TextureDesc& desc, const SubresourceData
     case TextureType::TextureCubeArray:
         if (desc.size.width != desc.size.height)
         {
-            RHI_VALIDATION_ERROR("Cube textures must have width equal to height");
+            RHI_VALIDATION_ERROR("Cube textures must have width equal to height.");
             return SLANG_E_INVALID_ARG;
         }
         if (desc.size.depth != 1)
         {
-            RHI_VALIDATION_ERROR("Cube textures must have depth set to 1");
+            RHI_VALIDATION_ERROR("Cube textures must have depth set to 1.");
             return SLANG_E_INVALID_ARG;
         }
         break;
@@ -241,6 +310,12 @@ Result DebugDevice::createTextureFromNativeHandle(NativeHandle handle, const Tex
 {
     SLANG_RHI_DEBUG_API(IDevice, createTextureFromNativeHandle);
 
+    if (!outTexture)
+    {
+        RHI_VALIDATION_ERROR("'outTexture' must not be null.");
+        return SLANG_E_INVALID_ARG;
+    }
+
     return baseObject->createTextureFromNativeHandle(handle, desc, outTexture);
 }
 
@@ -253,6 +328,12 @@ Result DebugDevice::createTextureFromSharedHandle(
 {
     SLANG_RHI_DEBUG_API(IDevice, createTextureFromSharedHandle);
 
+    if (!outTexture)
+    {
+        RHI_VALIDATION_ERROR("'outTexture' must not be null.");
+        return SLANG_E_INVALID_ARG;
+    }
+
     return baseObject->createTextureFromSharedHandle(handle, desc, size, outTexture);
 }
 
@@ -261,6 +342,36 @@ Result DebugDevice::createBuffer(const BufferDesc& desc, const void* initData, I
     SLANG_RHI_DEBUG_API(IDevice, createBuffer);
 
     validateCudaContext();
+
+    if (!outBuffer)
+    {
+        RHI_VALIDATION_ERROR("'outBuffer' must not be null.");
+        return SLANG_E_INVALID_ARG;
+    }
+    if (desc.size == 0)
+    {
+        RHI_VALIDATION_ERROR("Buffer size must be greater than 0.");
+        return SLANG_E_INVALID_ARG;
+    }
+    if (desc.usage == BufferUsage::None)
+    {
+        RHI_VALIDATION_ERROR("Buffer usage must be specified.");
+        return SLANG_E_INVALID_ARG;
+    }
+    if (!isValidBufferUsage(desc.usage))
+    {
+        RHI_VALIDATION_ERROR("Buffer usage contains invalid flags.");
+        return SLANG_E_INVALID_ARG;
+    }
+    if (!isValidMemoryType(desc.memoryType))
+    {
+        RHI_VALIDATION_ERROR("Invalid memory type.");
+        return SLANG_E_INVALID_ARG;
+    }
+    if (desc.elementSize > 0 && desc.size % desc.elementSize != 0)
+    {
+        RHI_VALIDATION_WARNING("Buffer size is not a multiple of element size.");
+    }
 
     BufferDesc patchedDesc = desc;
     std::string label;
@@ -277,12 +388,24 @@ Result DebugDevice::createBufferFromNativeHandle(NativeHandle handle, const Buff
 {
     SLANG_RHI_DEBUG_API(IDevice, createBufferFromNativeHandle);
 
+    if (!outBuffer)
+    {
+        RHI_VALIDATION_ERROR("'outBuffer' must not be null.");
+        return SLANG_E_INVALID_ARG;
+    }
+
     return baseObject->createBufferFromNativeHandle(handle, desc, outBuffer);
 }
 
 Result DebugDevice::createBufferFromSharedHandle(NativeHandle handle, const BufferDesc& desc, IBuffer** outBuffer)
 {
     SLANG_RHI_DEBUG_API(IDevice, createBufferFromSharedHandle);
+
+    if (!outBuffer)
+    {
+        RHI_VALIDATION_ERROR("'outBuffer' must not be null.");
+        return SLANG_E_INVALID_ARG;
+    }
 
     return baseObject->createBufferFromSharedHandle(handle, desc, outBuffer);
 }
@@ -291,35 +414,74 @@ Result DebugDevice::mapBuffer(IBuffer* buffer, CpuAccessMode mode, void** outDat
 {
     SLANG_RHI_DEBUG_API(IDevice, mapBuffer);
 
+    if (!buffer)
+    {
+        RHI_VALIDATION_ERROR("'buffer' must not be null.");
+        return SLANG_E_INVALID_ARG;
+    }
+    if (!outData)
+    {
+        RHI_VALIDATION_ERROR("'outData' must not be null.");
+        return SLANG_E_INVALID_ARG;
+    }
+    if (!isValidCpuAccessMode(mode))
+    {
+        RHI_VALIDATION_ERROR("Invalid CpuAccessMode.");
+        return SLANG_E_INVALID_ARG;
+    }
+
     switch (mode)
     {
     case CpuAccessMode::Read:
         if (buffer->getDesc().memoryType != MemoryType::ReadBack)
         {
-            RHI_VALIDATION_ERROR("Buffer must be created with MemoryType::ReadBack to map with CpuAccessMode::Read");
+            RHI_VALIDATION_ERROR("Buffer must be created with MemoryType::ReadBack to map with CpuAccessMode::Read.");
             return SLANG_E_INVALID_ARG;
         }
         break;
     case CpuAccessMode::Write:
         if (buffer->getDesc().memoryType != MemoryType::Upload)
         {
-            RHI_VALIDATION_ERROR("Buffer must be created with MemoryType::Upload to map with CpuAccessMode::Write");
+            RHI_VALIDATION_ERROR("Buffer must be created with MemoryType::Upload to map with CpuAccessMode::Write.");
             return SLANG_E_INVALID_ARG;
         }
         break;
     default:
-        RHI_VALIDATION_ERROR("Invalid CpuAccessMode");
+        break;
+    }
+
+    if (m_mappedBuffers.count(buffer))
+    {
+        RHI_VALIDATION_ERROR("Buffer is already mapped.");
         return SLANG_E_INVALID_ARG;
     }
 
-    return baseObject->mapBuffer(buffer, mode, outData);
+    Result result = baseObject->mapBuffer(buffer, mode, outData);
+    if (SLANG_SUCCEEDED(result))
+    {
+        m_mappedBuffers.insert(buffer);
+    }
+    return result;
 }
 
 Result DebugDevice::unmapBuffer(IBuffer* buffer)
 {
     SLANG_RHI_DEBUG_API(IDevice, unmapBuffer);
 
-    return baseObject->unmapBuffer(buffer);
+    if (!buffer)
+    {
+        RHI_VALIDATION_ERROR("'buffer' must not be null.");
+        return SLANG_E_INVALID_ARG;
+    }
+    if (!m_mappedBuffers.count(buffer))
+    {
+        RHI_VALIDATION_ERROR("Buffer is not mapped.");
+        return SLANG_E_INVALID_ARG;
+    }
+
+    Result result = baseObject->unmapBuffer(buffer);
+    m_mappedBuffers.erase(buffer);
+    return result;
 }
 
 Result DebugDevice::createSampler(const SamplerDesc& desc, ISampler** outSampler)
@@ -328,79 +490,100 @@ Result DebugDevice::createSampler(const SamplerDesc& desc, ISampler** outSampler
 
     validateCudaContext();
 
-    if (desc.minFilter > TextureFilteringMode::Linear)
+    if (!outSampler)
     {
-        RHI_VALIDATION_ERROR("Invalid min filter mode");
+        RHI_VALIDATION_ERROR("'outSampler' must not be null.");
         return SLANG_E_INVALID_ARG;
     }
-    if (desc.magFilter > TextureFilteringMode::Linear)
+    if (!isValidTextureFilteringMode(desc.minFilter))
     {
-        RHI_VALIDATION_ERROR("Invalid mag filter mode");
+        RHI_VALIDATION_ERROR("Invalid min filter mode.");
         return SLANG_E_INVALID_ARG;
     }
-    if (desc.mipFilter > TextureFilteringMode::Linear)
+    if (!isValidTextureFilteringMode(desc.magFilter))
     {
-        RHI_VALIDATION_ERROR("Invalid mip filter mode");
+        RHI_VALIDATION_ERROR("Invalid mag filter mode.");
         return SLANG_E_INVALID_ARG;
     }
-    if (desc.reductionOp > TextureReductionOp::Maximum)
+    if (!isValidTextureFilteringMode(desc.mipFilter))
     {
-        RHI_VALIDATION_ERROR("Invalid reduction op");
+        RHI_VALIDATION_ERROR("Invalid mip filter mode.");
         return SLANG_E_INVALID_ARG;
     }
-    if (desc.addressU > TextureAddressingMode::MirrorOnce)
+    if (!isValidTextureReductionOp(desc.reductionOp))
     {
-        RHI_VALIDATION_ERROR("Invalid address U mode");
+        RHI_VALIDATION_ERROR("Invalid reduction op.");
         return SLANG_E_INVALID_ARG;
     }
-    if (desc.addressV > TextureAddressingMode::MirrorOnce)
+    if (!isValidTextureAddressingMode(desc.addressU))
     {
-        RHI_VALIDATION_ERROR("Invalid address V mode");
+        RHI_VALIDATION_ERROR("Invalid address U mode.");
         return SLANG_E_INVALID_ARG;
     }
-    if (desc.addressW > TextureAddressingMode::MirrorOnce)
+    if (!isValidTextureAddressingMode(desc.addressV))
     {
-        RHI_VALIDATION_ERROR("Invalid address W mode");
+        RHI_VALIDATION_ERROR("Invalid address V mode.");
+        return SLANG_E_INVALID_ARG;
+    }
+    if (!isValidTextureAddressingMode(desc.addressW))
+    {
+        RHI_VALIDATION_ERROR("Invalid address W mode.");
+        return SLANG_E_INVALID_ARG;
+    }
+    if (!isValidComparisonFunc(desc.comparisonFunc))
+    {
+        RHI_VALIDATION_ERROR("Invalid comparison func.");
         return SLANG_E_INVALID_ARG;
     }
     if (ctx->deviceType == DeviceType::WGPU && (desc.addressU == TextureAddressingMode::ClampToBorder ||
                                                 desc.addressV == TextureAddressingMode::ClampToBorder ||
                                                 desc.addressW == TextureAddressingMode::ClampToBorder))
     {
-        RHI_VALIDATION_ERROR("WebGPU doesn't support ClampToBorder mode");
+        RHI_VALIDATION_ERROR("WebGPU does not support ClampToBorder mode.");
         return SLANG_E_INVALID_ARG;
     }
     if (ctx->deviceType == DeviceType::WGPU &&
         (desc.addressU == TextureAddressingMode::MirrorOnce || desc.addressV == TextureAddressingMode::MirrorOnce ||
          desc.addressW == TextureAddressingMode::MirrorOnce))
     {
-        RHI_VALIDATION_ERROR("WebGPU doesn't support MirrorOnce mode");
+        RHI_VALIDATION_ERROR("WebGPU does not support MirrorOnce mode.");
         return SLANG_E_INVALID_ARG;
     }
-    if (desc.comparisonFunc > ComparisonFunc::Always)
+    if (desc.maxAnisotropy == 0)
     {
-        RHI_VALIDATION_ERROR("Invalid comparison func");
+        RHI_VALIDATION_ERROR("maxAnisotropy must be at least 1.");
+        return SLANG_E_INVALID_ARG;
+    }
+    if (desc.maxAnisotropy > 16)
+    {
+        RHI_VALIDATION_ERROR("maxAnisotropy exceeds maximum supported value of 16.");
         return SLANG_E_INVALID_ARG;
     }
     if (desc.maxAnisotropy > 1 &&
-        (desc.minFilter == TextureFilteringMode::Point || desc.minFilter == TextureFilteringMode::Point))
+        (desc.minFilter == TextureFilteringMode::Point || desc.magFilter == TextureFilteringMode::Point))
     {
-        RHI_VALIDATION_WARNING("maxAnisotropy > 1 can only be set when neither min and mag filter is Point");
+        RHI_VALIDATION_ERROR("maxAnisotropy > 1 requires Linear min and mag filters.");
+        return SLANG_E_INVALID_ARG;
+    }
+    if (desc.minLOD > desc.maxLOD)
+    {
+        RHI_VALIDATION_ERROR("minLOD must not be greater than maxLOD.");
+        return SLANG_E_INVALID_ARG;
+    }
+    if (desc.mipLODBias < -16.f || desc.mipLODBias > 15.99f)
+    {
+        RHI_VALIDATION_ERROR("mipLODBias is outside the supported range [-16, 15.99].");
+        return SLANG_E_INVALID_ARG;
     }
 
     if (desc.addressU == TextureAddressingMode::ClampToBorder ||
         desc.addressV == TextureAddressingMode::ClampToBorder || desc.addressW == TextureAddressingMode::ClampToBorder)
     {
-        if (ctx->deviceType == DeviceType::WGPU)
-        {
-            RHI_VALIDATION_WARNING("WebGPU doesn't support ClampToBorder addressing mode");
-        }
-
         const float* color = desc.borderColor;
         if (color[0] < 0.f || color[0] > 1.f || color[1] < 0.f || color[1] > 1.f || color[2] < 0.f || color[2] > 1.f ||
             color[3] < 0.f || color[3] > 1.f)
         {
-            RHI_VALIDATION_ERROR("Invalid border color (must be in range [0, 1])");
+            RHI_VALIDATION_ERROR("Invalid border color (must be in range [0, 1]).");
             return SLANG_E_INVALID_ARG;
         }
 
@@ -432,6 +615,32 @@ Result DebugDevice::createTextureView(ITexture* texture, const TextureViewDesc& 
     SLANG_RHI_DEBUG_API(IDevice, createTextureView);
 
     validateCudaContext();
+
+    if (!outView)
+    {
+        RHI_VALIDATION_ERROR("'outView' must not be null.");
+        return SLANG_E_INVALID_ARG;
+    }
+    if (!texture)
+    {
+        RHI_VALIDATION_ERROR("'texture' must not be null.");
+        return SLANG_E_INVALID_ARG;
+    }
+    if (!isValidTextureAspect(desc.aspect))
+    {
+        RHI_VALIDATION_ERROR("Invalid texture aspect.");
+        return SLANG_E_INVALID_ARG;
+    }
+    if (desc.format != Format::Undefined && !isValidFormat(desc.format))
+    {
+        RHI_VALIDATION_ERROR("Invalid format.");
+        return SLANG_E_INVALID_ARG;
+    }
+    if (!validateSubresourceRange(desc.subresourceRange, texture->getDesc()))
+    {
+        RHI_VALIDATION_ERROR("Subresource range is out of bounds for the texture.");
+        return SLANG_E_INVALID_ARG;
+    }
 
     TextureViewDesc patchedDesc = desc;
     std::string label;
@@ -474,6 +683,34 @@ Result DebugDevice::createAccelerationStructure(
 
     validateCudaContext();
 
+    if (!outAccelerationStructure)
+    {
+        RHI_VALIDATION_ERROR("'outAccelerationStructure' must not be null.");
+        return SLANG_E_INVALID_ARG;
+    }
+    if (desc.size == 0)
+    {
+        RHI_VALIDATION_ERROR("Acceleration structure size must be greater than 0.");
+        return SLANG_E_INVALID_ARG;
+    }
+    if (!isValidAccelerationStructureBuildFlags(desc.flags))
+    {
+        RHI_VALIDATION_ERROR("Acceleration structure build flags contain invalid flags.");
+        return SLANG_E_INVALID_ARG;
+    }
+    if (is_set(desc.flags, AccelerationStructureBuildFlags::CreateMotion) &&
+        !baseObject->hasFeature(Feature::RayTracingMotionBlur))
+    {
+        RHI_VALIDATION_ERROR("Acceleration structure with CreateMotion flag requires RayTracingMotionBlur feature.");
+        return SLANG_E_INVALID_ARG;
+    }
+    if (is_set(desc.flags, AccelerationStructureBuildFlags::CreateMotion) && desc.motionInfo.enabled &&
+        desc.motionInfo.maxInstances == 0)
+    {
+        RHI_VALIDATION_ERROR("Motion-enabled acceleration structure requires maxInstances > 0.");
+        return SLANG_E_INVALID_ARG;
+    }
+
     AccelerationStructureDesc patchedDesc = desc;
     std::string label;
     if (!patchedDesc.label)
@@ -499,6 +736,46 @@ Result DebugDevice::createSurface(WindowHandle windowHandle, ISurface** outSurfa
 Result DebugDevice::createInputLayout(const InputLayoutDesc& desc, IInputLayout** outLayout)
 {
     SLANG_RHI_DEBUG_API(IDevice, createInputLayout);
+
+    if (!outLayout)
+    {
+        RHI_VALIDATION_ERROR("'outLayout' must not be null.");
+        return SLANG_E_INVALID_ARG;
+    }
+    if (desc.inputElementCount > 0 && desc.inputElements == nullptr)
+    {
+        RHI_VALIDATION_ERROR("'inputElements' is null but 'inputElementCount' > 0.");
+        return SLANG_E_INVALID_ARG;
+    }
+    if (desc.vertexStreamCount > 0 && desc.vertexStreams == nullptr)
+    {
+        RHI_VALIDATION_ERROR("'vertexStreams' is null but 'vertexStreamCount' > 0.");
+        return SLANG_E_INVALID_ARG;
+    }
+    for (uint32_t i = 0; i < desc.inputElementCount; ++i)
+    {
+        const InputElementDesc& element = desc.inputElements[i];
+        if (element.bufferSlotIndex >= desc.vertexStreamCount)
+        {
+            RHI_VALIDATION_ERROR_FORMAT(
+                "Input element %u 'bufferSlotIndex' (%u) is out of range ('vertexStreamCount' = %u).",
+                i,
+                element.bufferSlotIndex,
+                desc.vertexStreamCount
+            );
+            return SLANG_E_INVALID_ARG;
+        }
+        if (!isValidFormat(element.format))
+        {
+            RHI_VALIDATION_ERROR_FORMAT("Input element %u has invalid format.", i);
+            return SLANG_E_INVALID_ARG;
+        }
+        if (element.format == Format::Undefined)
+        {
+            RHI_VALIDATION_ERROR_FORMAT("Input element %u format must be specified.", i);
+            return SLANG_E_INVALID_ARG;
+        }
+    }
 
     return baseObject->createInputLayout(desc, outLayout);
 }
@@ -574,6 +851,22 @@ Result DebugDevice::createShaderProgram(
 
     validateCudaContext();
 
+    if (!outProgram)
+    {
+        RHI_VALIDATION_ERROR("'outProgram' must not be null.");
+        return SLANG_E_INVALID_ARG;
+    }
+    if (desc.slangGlobalScope == nullptr && desc.slangEntryPointCount == 0)
+    {
+        RHI_VALIDATION_ERROR("Shader program requires at least a global scope or entry point.");
+        return SLANG_E_INVALID_ARG;
+    }
+    if (desc.slangEntryPointCount > 0 && desc.slangEntryPoints == nullptr)
+    {
+        RHI_VALIDATION_ERROR("'slangEntryPoints' is null but 'slangEntryPointCount' > 0.");
+        return SLANG_E_INVALID_ARG;
+    }
+
     ShaderProgramDesc patchedDesc = desc;
     std::string label;
     if (!patchedDesc.label)
@@ -593,17 +886,17 @@ Result DebugDevice::createRenderPipeline(const RenderPipelineDesc& desc, IRender
 
     if (desc.program == nullptr)
     {
-        RHI_VALIDATION_ERROR("Program must be specified");
+        RHI_VALIDATION_ERROR("Program must be specified.");
         return SLANG_E_INVALID_ARG;
     }
     if (ctx->deviceType == DeviceType::WGPU && desc.primitiveTopology == PrimitiveTopology::PatchList)
     {
-        RHI_VALIDATION_ERROR("WebGPU doesn't support PatchList topology");
+        RHI_VALIDATION_ERROR("WebGPU does not support PatchList topology.");
         return SLANG_E_INVALID_ARG;
     }
     if (ctx->deviceType == DeviceType::Metal && desc.primitiveTopology == PrimitiveTopology::PatchList)
     {
-        RHI_VALIDATION_ERROR("Metal doesn't support PatchList topology");
+        RHI_VALIDATION_ERROR("Metal does not support PatchList topology.");
         return SLANG_E_INVALID_ARG;
     }
 
@@ -626,7 +919,7 @@ Result DebugDevice::createComputePipeline(const ComputePipelineDesc& desc, IComp
 
     if (desc.program == nullptr)
     {
-        RHI_VALIDATION_ERROR("Program must be specified");
+        RHI_VALIDATION_ERROR("Program must be specified.");
         return SLANG_E_INVALID_ARG;
     }
 
@@ -649,7 +942,7 @@ Result DebugDevice::createRayTracingPipeline(const RayTracingPipelineDesc& desc,
 
     if (desc.program == nullptr)
     {
-        RHI_VALIDATION_ERROR("Program must be specified");
+        RHI_VALIDATION_ERROR("Program must be specified.");
         return SLANG_E_INVALID_ARG;
     }
 
@@ -687,12 +980,12 @@ Result DebugDevice::readTexture(
 
     if (layer > desc.getLayerCount())
     {
-        RHI_VALIDATION_ERROR("Layer out of bounds");
+        RHI_VALIDATION_ERROR("Layer out of bounds.");
         return SLANG_E_INVALID_ARG;
     }
     if (mip > desc.mipCount)
     {
-        RHI_VALIDATION_ERROR("Mip out of bounds");
+        RHI_VALIDATION_ERROR("Mip out of bounds.");
         return SLANG_E_INVALID_ARG;
     }
 
@@ -700,7 +993,7 @@ Result DebugDevice::readTexture(
     {
     case TextureType::Texture2DMS:
     case TextureType::Texture2DMSArray:
-        RHI_VALIDATION_ERROR("Multisample textures cannot be read");
+        RHI_VALIDATION_ERROR("Multisample textures cannot be read.");
         return SLANG_E_INVALID_ARG;
     default:
         break;
@@ -714,7 +1007,7 @@ Result DebugDevice::readTexture(
         layout.sizeInBytes != expectedLayout.sizeInBytes || layout.blockWidth != expectedLayout.blockWidth ||
         layout.blockHeight != expectedLayout.blockHeight || layout.rowCount != expectedLayout.rowCount)
     {
-        RHI_VALIDATION_ERROR("Layout does not match the expected layout");
+        RHI_VALIDATION_ERROR("Layout does not match the expected layout.");
         return SLANG_E_INVALID_ARG;
     }
 
@@ -737,12 +1030,12 @@ Result DebugDevice::readTexture(
 
     if (layer > desc.getLayerCount())
     {
-        RHI_VALIDATION_ERROR("Layer out of bounds");
+        RHI_VALIDATION_ERROR("Layer out of bounds.");
         return SLANG_E_INVALID_ARG;
     }
     if (mip > desc.mipCount)
     {
-        RHI_VALIDATION_ERROR("Mip out of bounds");
+        RHI_VALIDATION_ERROR("Mip out of bounds.");
         return SLANG_E_INVALID_ARG;
     }
 
@@ -750,7 +1043,7 @@ Result DebugDevice::readTexture(
     {
     case TextureType::Texture2DMS:
     case TextureType::Texture2DMSArray:
-        RHI_VALIDATION_ERROR("Multisample textures cannot be read");
+        RHI_VALIDATION_ERROR("Multisample textures cannot be read.");
         return SLANG_E_INVALID_ARG;
     default:
         break;
@@ -765,6 +1058,27 @@ Result DebugDevice::readBuffer(IBuffer* buffer, Offset offset, Size size, void* 
 
     validateCudaContext();
 
+    if (!buffer)
+    {
+        RHI_VALIDATION_ERROR("'buffer' must not be null.");
+        return SLANG_E_INVALID_ARG;
+    }
+    if (!outData)
+    {
+        RHI_VALIDATION_ERROR("'outData' must not be null.");
+        return SLANG_E_INVALID_ARG;
+    }
+    if (size == 0)
+    {
+        RHI_VALIDATION_ERROR("Read size must be greater than 0.");
+        return SLANG_E_INVALID_ARG;
+    }
+    if (offset + size > buffer->getDesc().size)
+    {
+        RHI_VALIDATION_ERROR("Read range (offset + size) exceeds buffer size.");
+        return SLANG_E_INVALID_ARG;
+    }
+
     return baseObject->readBuffer(buffer, offset, size, outData);
 }
 
@@ -773,6 +1087,27 @@ Result DebugDevice::readBuffer(IBuffer* buffer, size_t offset, size_t size, ISla
     SLANG_RHI_DEBUG_API(IDevice, readBuffer);
 
     validateCudaContext();
+
+    if (!buffer)
+    {
+        RHI_VALIDATION_ERROR("'buffer' must not be null.");
+        return SLANG_E_INVALID_ARG;
+    }
+    if (!outBlob)
+    {
+        RHI_VALIDATION_ERROR("'outBlob' must not be null.");
+        return SLANG_E_INVALID_ARG;
+    }
+    if (size == 0)
+    {
+        RHI_VALIDATION_ERROR("Read size must be greater than 0.");
+        return SLANG_E_INVALID_ARG;
+    }
+    if (offset + size > buffer->getDesc().size)
+    {
+        RHI_VALIDATION_ERROR("Read range (offset + size) exceeds buffer size.");
+        return SLANG_E_INVALID_ARG;
+    }
 
     return baseObject->readBuffer(buffer, offset, size, outBlob);
 }
@@ -789,6 +1124,22 @@ Result DebugDevice::createQueryPool(const QueryPoolDesc& desc, IQueryPool** outP
     SLANG_RHI_DEBUG_API(IDevice, createQueryPool);
 
     validateCudaContext();
+
+    if (!outPool)
+    {
+        RHI_VALIDATION_ERROR("'outPool' must not be null.");
+        return SLANG_E_INVALID_ARG;
+    }
+    if (desc.count == 0)
+    {
+        RHI_VALIDATION_ERROR("Query pool count must be greater than 0.");
+        return SLANG_E_INVALID_ARG;
+    }
+    if (!isValidQueryType(desc.type))
+    {
+        RHI_VALIDATION_ERROR("Invalid query type.");
+        return SLANG_E_INVALID_ARG;
+    }
 
     QueryPoolDesc patchedDesc = desc;
     std::string label;
@@ -810,6 +1161,12 @@ Result DebugDevice::createFence(const FenceDesc& desc, IFence** outFence)
     SLANG_RHI_DEBUG_API(IDevice, createFence);
 
     validateCudaContext();
+
+    if (!outFence)
+    {
+        RHI_VALIDATION_ERROR("'outFence' must not be null.");
+        return SLANG_E_INVALID_ARG;
+    }
 
     FenceDesc patchedDesc = desc;
     std::string label;
@@ -907,12 +1264,12 @@ Result DebugDevice::getCooperativeVectorMatrixSize(
 
     if (rowCount < 1 || rowCount > 128)
     {
-        RHI_VALIDATION_ERROR("Row count must be in the range [1, 128]");
+        RHI_VALIDATION_ERROR("Row count must be in the range [1, 128].");
         return SLANG_E_INVALID_ARG;
     }
     if (colCount < 1 || colCount > 128)
     {
-        RHI_VALIDATION_ERROR("Column count must be in the range [1, 128]");
+        RHI_VALIDATION_ERROR("Column count must be in the range [1, 128].");
         return SLANG_E_INVALID_ARG;
     }
     switch (layout)
@@ -924,12 +1281,12 @@ Result DebugDevice::getCooperativeVectorMatrixSize(
     case CooperativeVectorMatrixLayout::TrainingOptimal:
         if (rowColumnStride != 0)
         {
-            RHI_VALIDATION_ERROR("Row/Column stride must be zero for optimal layouts");
+            RHI_VALIDATION_ERROR("Row/Column stride must be zero for optimal layouts.");
             return SLANG_E_INVALID_ARG;
         }
         break;
     default:
-        RHI_VALIDATION_ERROR("Invalid matrix layout");
+        RHI_VALIDATION_ERROR("Invalid matrix layout.");
         return SLANG_E_INVALID_ARG;
     }
 
@@ -951,12 +1308,12 @@ Result DebugDevice::convertCooperativeVectorMatrix(
 
     if (!dstBuffer)
     {
-        RHI_VALIDATION_ERROR("Destination buffer must be valid");
+        RHI_VALIDATION_ERROR("'dstBuffer' must not be null.");
         return SLANG_E_INVALID_ARG;
     }
     if (!srcBuffer)
     {
-        RHI_VALIDATION_ERROR("Source buffer must be valid");
+        RHI_VALIDATION_ERROR("'srcBuffer' must not be null.");
         return SLANG_E_INVALID_ARG;
     }
 
@@ -978,6 +1335,37 @@ Result DebugDevice::convertCooperativeVectorMatrix(
 Result DebugDevice::createShaderTable(const ShaderTableDesc& desc, IShaderTable** outTable)
 {
     SLANG_RHI_DEBUG_API(IDevice, createShaderTable);
+
+    if (!outTable)
+    {
+        RHI_VALIDATION_ERROR("'outTable' must not be null.");
+        return SLANG_E_INVALID_ARG;
+    }
+    if (desc.program == nullptr)
+    {
+        RHI_VALIDATION_ERROR("'program' must not be null.");
+        return SLANG_E_INVALID_ARG;
+    }
+    if (desc.rayGenShaderCount > 0 && desc.rayGenShaderEntryPointNames == nullptr)
+    {
+        RHI_VALIDATION_ERROR("'rayGenShaderEntryPointNames' is null but 'rayGenShaderCount' > 0.");
+        return SLANG_E_INVALID_ARG;
+    }
+    if (desc.missShaderCount > 0 && desc.missShaderEntryPointNames == nullptr)
+    {
+        RHI_VALIDATION_ERROR("'missShaderEntryPointNames' is null but 'missShaderCount' > 0.");
+        return SLANG_E_INVALID_ARG;
+    }
+    if (desc.hitGroupCount > 0 && desc.hitGroupNames == nullptr)
+    {
+        RHI_VALIDATION_ERROR("'hitGroupNames' is null but 'hitGroupCount' > 0.");
+        return SLANG_E_INVALID_ARG;
+    }
+    if (desc.callableShaderCount > 0 && desc.callableShaderEntryPointNames == nullptr)
+    {
+        RHI_VALIDATION_ERROR("'callableShaderEntryPointNames' is null but 'callableShaderCount' > 0.");
+        return SLANG_E_INVALID_ARG;
+    }
 
     return baseObject->createShaderTable(desc, outTable);
 }

--- a/src/debug-layer/debug-device.cpp
+++ b/src/debug-layer/debug-device.cpp
@@ -461,19 +461,18 @@ Result DebugDevice::mapBuffer(IBuffer* buffer, CpuAccessMode mode, void** outDat
             RHI_VALIDATION_ERROR("Buffer is already mapped.");
             return SLANG_E_INVALID_ARG;
         }
-
-        Result result = baseObject->mapBuffer(buffer, mode, outData);
-
-        if (SLANG_SUCCEEDED(result))
-        {
-            m_mappedBuffers.insert(buffer);
-        }
-
-        return result;
     }
-#else
-    return baseObject->mapBuffer(buffer, mode, outData);
 #endif
+    Result result = baseObject->mapBuffer(buffer, mode, outData);
+#if SLANG_RHI_DEBUG_ENABLE_BUFFER_MAP_VALIDATION
+    if (SLANG_SUCCEEDED(result))
+    {
+        std::lock_guard<std::mutex> lock(m_mappedBuffersMutex);
+        m_mappedBuffers.insert(buffer);
+    }
+#endif
+
+    return result;
 }
 
 Result DebugDevice::unmapBuffer(IBuffer* buffer)
@@ -494,19 +493,18 @@ Result DebugDevice::unmapBuffer(IBuffer* buffer)
             RHI_VALIDATION_ERROR("Buffer is not mapped.");
             return SLANG_E_INVALID_ARG;
         }
-
-        Result result = baseObject->unmapBuffer(buffer);
-
-        if (SLANG_SUCCEEDED(result))
-        {
-            m_mappedBuffers.erase(buffer);
-        }
-
-        return result;
     }
-#else
-    return baseObject->unmapBuffer(buffer);
 #endif
+    Result result = baseObject->unmapBuffer(buffer);
+#if SLANG_RHI_DEBUG_ENABLE_BUFFER_MAP_VALIDATION
+    if (SLANG_SUCCEEDED(result))
+    {
+        std::lock_guard<std::mutex> lock(m_mappedBuffersMutex);
+        m_mappedBuffers.erase(buffer);
+    }
+#endif
+
+    return result;
 }
 
 Result DebugDevice::createSampler(const SamplerDesc& desc, ISampler** outSampler)

--- a/src/debug-layer/debug-device.cpp
+++ b/src/debug-layer/debug-device.cpp
@@ -461,20 +461,19 @@ Result DebugDevice::mapBuffer(IBuffer* buffer, CpuAccessMode mode, void** outDat
             RHI_VALIDATION_ERROR("Buffer is already mapped.");
             return SLANG_E_INVALID_ARG;
         }
+
+        Result result = baseObject->mapBuffer(buffer, mode, outData);
+
+        if (SLANG_SUCCEEDED(result))
+        {
+            m_mappedBuffers.insert(buffer);
+        }
+
+        return result;
     }
+#else
+    return baseObject->mapBuffer(buffer, mode, outData);
 #endif
-
-    Result result = baseObject->mapBuffer(buffer, mode, outData);
-
-#if SLANG_RHI_DEBUG_ENABLE_BUFFER_MAP_VALIDATION
-    if (SLANG_SUCCEEDED(result))
-    {
-        std::lock_guard<std::mutex> lock(m_mappedBuffersMutex);
-        m_mappedBuffers.insert(buffer);
-    }
-#endif
-
-    return result;
 }
 
 Result DebugDevice::unmapBuffer(IBuffer* buffer)
@@ -495,20 +494,19 @@ Result DebugDevice::unmapBuffer(IBuffer* buffer)
             RHI_VALIDATION_ERROR("Buffer is not mapped.");
             return SLANG_E_INVALID_ARG;
         }
+
+        Result result = baseObject->unmapBuffer(buffer);
+
+        if (SLANG_SUCCEEDED(result))
+        {
+            m_mappedBuffers.erase(buffer);
+        }
+
+        return result;
     }
+#else
+    return baseObject->unmapBuffer(buffer);
 #endif
-
-    Result result = baseObject->unmapBuffer(buffer);
-
-#if SLANG_RHI_DEBUG_ENABLE_BUFFER_MAP_VALIDATION
-    if (SLANG_SUCCEEDED(result))
-    {
-        std::lock_guard<std::mutex> lock(m_mappedBuffersMutex);
-        m_mappedBuffers.erase(buffer);
-    }
-#endif
-
-    return result;
 }
 
 Result DebugDevice::createSampler(const SamplerDesc& desc, ISampler** outSampler)
@@ -586,6 +584,8 @@ Result DebugDevice::createSampler(const SamplerDesc& desc, ISampler** outSampler
         RHI_VALIDATION_ERROR("maxAnisotropy exceeds maximum supported value of 16.");
         return SLANG_E_INVALID_ARG;
     }
+    // Anisotropic filtering replaces both min and mag filters, so both must be linear.
+    // This is required by D3D12 and Vulkan specs.
     if (desc.maxAnisotropy > 1 &&
         (desc.minFilter == TextureFilteringMode::Point || desc.magFilter == TextureFilteringMode::Point))
     {

--- a/src/debug-layer/debug-device.cpp
+++ b/src/debug-layer/debug-device.cpp
@@ -90,6 +90,9 @@ Result DebugDevice::getFormatSupport(Format format, FormatSupport* outFormatSupp
 DebugDevice::DebugDevice(DeviceType deviceType, IDebugCallback* debugCallback)
     : DebugObject(&m_ctx)
 {
+    // Devices are created through IRHI::createDevice.
+    SLANG_RHI_DEBUG_API(IRHI, createDevice);
+
     ctx->deviceType = deviceType;
     ctx->debugCallback = debugCallback;
     RHI_VALIDATION_INFO("Debug layer is enabled.");
@@ -450,17 +453,27 @@ Result DebugDevice::mapBuffer(IBuffer* buffer, CpuAccessMode mode, void** outDat
         break;
     }
 
-    if (m_mappedBuffers.count(buffer))
+#if SLANG_RHI_DEBUG_ENABLE_BUFFER_MAP_VALIDATION
     {
-        RHI_VALIDATION_ERROR("Buffer is already mapped.");
-        return SLANG_E_INVALID_ARG;
+        std::lock_guard<std::mutex> lock(m_mappedBuffersMutex);
+        if (m_mappedBuffers.count(buffer))
+        {
+            RHI_VALIDATION_ERROR("Buffer is already mapped.");
+            return SLANG_E_INVALID_ARG;
+        }
     }
+#endif
 
     Result result = baseObject->mapBuffer(buffer, mode, outData);
+
+#if SLANG_RHI_DEBUG_ENABLE_BUFFER_MAP_VALIDATION
     if (SLANG_SUCCEEDED(result))
     {
+        std::lock_guard<std::mutex> lock(m_mappedBuffersMutex);
         m_mappedBuffers.insert(buffer);
     }
+#endif
+
     return result;
 }
 
@@ -473,14 +486,28 @@ Result DebugDevice::unmapBuffer(IBuffer* buffer)
         RHI_VALIDATION_ERROR("'buffer' must not be null.");
         return SLANG_E_INVALID_ARG;
     }
-    if (!m_mappedBuffers.count(buffer))
+
+#if SLANG_RHI_DEBUG_ENABLE_BUFFER_MAP_VALIDATION
     {
-        RHI_VALIDATION_ERROR("Buffer is not mapped.");
-        return SLANG_E_INVALID_ARG;
+        std::lock_guard<std::mutex> lock(m_mappedBuffersMutex);
+        if (!m_mappedBuffers.count(buffer))
+        {
+            RHI_VALIDATION_ERROR("Buffer is not mapped.");
+            return SLANG_E_INVALID_ARG;
+        }
     }
+#endif
 
     Result result = baseObject->unmapBuffer(buffer);
-    m_mappedBuffers.erase(buffer);
+
+#if SLANG_RHI_DEBUG_ENABLE_BUFFER_MAP_VALIDATION
+    if (SLANG_SUCCEEDED(result))
+    {
+        std::lock_guard<std::mutex> lock(m_mappedBuffersMutex);
+        m_mappedBuffers.erase(buffer);
+    }
+#endif
+
     return result;
 }
 

--- a/src/debug-layer/debug-device.h
+++ b/src/debug-layer/debug-device.h
@@ -2,6 +2,8 @@
 
 #include "debug-base.h"
 
+#include <unordered_set>
+
 namespace rhi::debug {
 
 class DebugDevice : public DebugObject<IDevice>
@@ -10,10 +12,12 @@ public:
     Result SLANG_MCALL queryInterface(const SlangUUID& uuid, void** outObject) noexcept override;
     SLANG_COM_OBJECT_IUNKNOWN_ADD_REF;
     SLANG_COM_OBJECT_IUNKNOWN_RELEASE;
+    IDevice* getInterface(const Guid& guid);
+
+    DebugDevice(DeviceType deviceType, IDebugCallback* debugCallback);
 
 public:
-    DebugDevice(DeviceType deviceType, IDebugCallback* debugCallback);
-    IDevice* getInterface(const Guid& guid);
+    // IDevice implementation
     virtual SLANG_NO_THROW Result SLANG_MCALL getNativeDeviceHandles(DeviceNativeHandles* outHandles) override;
     virtual SLANG_NO_THROW Result SLANG_MCALL getFeatures(uint32_t* outFeatureCount, Feature* outFeatures) override;
     virtual SLANG_NO_THROW bool SLANG_MCALL hasFeature(Feature feature) override;
@@ -194,9 +198,13 @@ public:
     virtual SLANG_NO_THROW Result SLANG_MCALL pushCudaContext() override;
     virtual SLANG_NO_THROW Result SLANG_MCALL popCudaContext() override;
 
+public:
     /// Validate that the correct CUDA context is current (CUDA devices only).
     /// Emits a warning if the wrong context or no context is active.
     void validateCudaContext();
+
+    /// Set of currently mapped buffers for double-map/double-unmap detection.
+    std::unordered_set<IBuffer*> m_mappedBuffers;
 
 private:
     DebugContext m_ctx;

--- a/src/debug-layer/debug-device.h
+++ b/src/debug-layer/debug-device.h
@@ -4,6 +4,10 @@
 
 #include <unordered_set>
 
+/// Enabling this will add validation to track mapped buffers and warn on double maps/unmaps.
+/// This is disabled by default as it adds overhead to map/unmap calls and requires storing a pointer in a set.
+#define SLANG_RHI_DEBUG_ENABLE_BUFFER_MAP_VALIDATION 0
+
 namespace rhi::debug {
 
 class DebugDevice : public DebugObject<IDevice>
@@ -203,8 +207,11 @@ public:
     /// Emits a warning if the wrong context or no context is active.
     void validateCudaContext();
 
+#if SLANG_RHI_DEBUG_ENABLE_BUFFER_MAP_VALIDATION
     /// Set of currently mapped buffers for double-map/double-unmap detection.
     std::unordered_set<IBuffer*> m_mappedBuffers;
+    std::mutex m_mappedBuffersMutex;
+#endif
 
 private:
     DebugContext m_ctx;

--- a/src/debug-layer/debug-device.h
+++ b/src/debug-layer/debug-device.h
@@ -6,7 +6,9 @@
 
 /// Enabling this will add validation to track mapped buffers and warn on double maps/unmaps.
 /// This is disabled by default as it adds overhead to map/unmap calls and requires storing a pointer in a set.
+#ifndef SLANG_RHI_DEBUG_ENABLE_BUFFER_MAP_VALIDATION
 #define SLANG_RHI_DEBUG_ENABLE_BUFFER_MAP_VALIDATION 0
+#endif
 
 namespace rhi::debug {
 

--- a/src/debug-layer/debug-fence.h
+++ b/src/debug-layer/debug-fence.h
@@ -8,11 +8,12 @@ class DebugFence : public DebugObject<IFence>
 {
 public:
     SLANG_COM_OBJECT_IUNKNOWN_ALL;
+    IFence* getInterface(const Guid& guid);
 
     SLANG_RHI_DEBUG_OBJECT_CONSTRUCTOR(DebugFence);
 
 public:
-    IFence* getInterface(const Guid& guid);
+    // IFence implementation
     virtual SLANG_NO_THROW Result SLANG_MCALL getCurrentValue(uint64_t* outValue) override;
     virtual SLANG_NO_THROW Result SLANG_MCALL setCurrentValue(uint64_t value) override;
     virtual SLANG_NO_THROW Result SLANG_MCALL getNativeHandle(NativeHandle* outHandle) override;

--- a/src/debug-layer/debug-heap.cpp
+++ b/src/debug-layer/debug-heap.cpp
@@ -3,16 +3,38 @@
 
 namespace rhi::debug {
 
-Result DebugHeap::allocate(const HeapAllocDesc& desc, HeapAlloc* allocation)
+Result DebugHeap::allocate(const HeapAllocDesc& desc, HeapAlloc* outAllocation)
 {
     SLANG_RHI_DEBUG_API(IHeap, allocate);
 
-    return baseObject->allocate(desc, allocation);
+    if (!outAllocation)
+    {
+        RHI_VALIDATION_ERROR("'outAllocation' must not be null.");
+        return SLANG_E_INVALID_ARG;
+    }
+    if (desc.size == 0)
+    {
+        RHI_VALIDATION_ERROR("Heap allocation size must be greater than 0.");
+        return SLANG_E_INVALID_ARG;
+    }
+    if (desc.alignment != 0 && (desc.alignment & (desc.alignment - 1)) != 0)
+    {
+        RHI_VALIDATION_ERROR("Heap allocation alignment must be 0 or a power of 2.");
+        return SLANG_E_INVALID_ARG;
+    }
+
+    return baseObject->allocate(desc, outAllocation);
 }
 
 Result DebugHeap::free(HeapAlloc allocation)
 {
     SLANG_RHI_DEBUG_API(IHeap, free);
+
+    if (!allocation.isValid())
+    {
+        RHI_VALIDATION_WARNING("Allocation is not valid.");
+        return SLANG_OK;
+    }
 
     return baseObject->free(allocation);
 }

--- a/src/debug-layer/debug-heap.h
+++ b/src/debug-layer/debug-heap.h
@@ -8,20 +8,16 @@ class DebugHeap : public DebugObject<IHeap>
 {
 public:
     SLANG_COM_OBJECT_IUNKNOWN_ALL;
+    IHeap* getInterface(const Guid& guid);
 
     SLANG_RHI_DEBUG_OBJECT_CONSTRUCTOR(DebugHeap);
 
-    IHeap* getInterface(const Guid& guid);
-
 public:
-    virtual SLANG_NO_THROW Result SLANG_MCALL allocate(const HeapAllocDesc& desc, HeapAlloc* allocation) override;
-
+    // IHeap implementation
+    virtual SLANG_NO_THROW Result SLANG_MCALL allocate(const HeapAllocDesc& desc, HeapAlloc* outAllocation) override;
     virtual SLANG_NO_THROW Result SLANG_MCALL free(HeapAlloc allocation) override;
-
     virtual SLANG_NO_THROW Result SLANG_MCALL report(HeapReport* outReport) override;
-
     virtual SLANG_NO_THROW Result SLANG_MCALL flush() override;
-
     virtual SLANG_NO_THROW Result SLANG_MCALL removeEmptyPages() override;
 };
 

--- a/src/debug-layer/debug-helper-functions.cpp
+++ b/src/debug-layer/debug-helper-functions.cpp
@@ -786,8 +786,30 @@ Result validateConvertCooperativeVectorMatrix(
             break;
         }
 
-        minDstBufferSize = std::max(minDstBufferSize, dstDescs[i].offset + dstDescs[i].size);
-        minSrcBufferSize = std::max(minSrcBufferSize, srcDescs[i].offset + srcDescs[i].size);
+        {
+            size_t dstEnd = dstDescs[i].offset + dstDescs[i].size;
+            if (dstDescs[i].offset > dstEnd)
+            {
+                RHI_VALIDATION_ERROR_FORMAT("dstDescs[%d].offset + dstDescs[%d].size overflows.", i, i);
+                valid = false;
+            }
+            else
+            {
+                minDstBufferSize = std::max(minDstBufferSize, dstEnd);
+            }
+        }
+        {
+            size_t srcEnd = srcDescs[i].offset + srcDescs[i].size;
+            if (srcDescs[i].offset > srcEnd)
+            {
+                RHI_VALIDATION_ERROR_FORMAT("srcDescs[%d].offset + srcDescs[%d].size overflows.", i, i);
+                valid = false;
+            }
+            else
+            {
+                minSrcBufferSize = std::max(minSrcBufferSize, srcEnd);
+            }
+        }
     }
 
     if (dstBufferSize < minDstBufferSize)

--- a/src/debug-layer/debug-helper-functions.cpp
+++ b/src/debug-layer/debug-helper-functions.cpp
@@ -185,6 +185,12 @@ Result validateAccelerationStructureBuildDesc(DebugContext* ctx, const Accelerat
         return SLANG_E_INVALID_ARG;
     }
 
+    if (!buildDesc.inputs)
+    {
+        RHI_VALIDATION_ERROR("AccelerationStructureBuildDesc::inputs must not be null.");
+        return SLANG_E_INVALID_ARG;
+    }
+
     AccelerationStructureBuildInputType type = buildDesc.inputs[0].type;
     for (uint32_t i = 1; i < buildDesc.inputCount; ++i)
     {

--- a/src/debug-layer/debug-helper-functions.cpp
+++ b/src/debug-layer/debug-helper-functions.cpp
@@ -181,7 +181,7 @@ Result validateAccelerationStructureBuildDesc(DebugContext* ctx, const Accelerat
 {
     if (buildDesc.inputCount < 1)
     {
-        RHI_VALIDATION_WARNING("AccelerationStructureBuildDesc::inputCount must be >= 1.");
+        RHI_VALIDATION_ERROR("AccelerationStructureBuildDesc::inputCount must be >= 1.");
         return SLANG_E_INVALID_ARG;
     }
 
@@ -190,7 +190,7 @@ Result validateAccelerationStructureBuildDesc(DebugContext* ctx, const Accelerat
     {
         if (type != buildDesc.inputs[i].type)
         {
-            RHI_VALIDATION_WARNING("AccelerationStructureBuildDesc::inputs must have the same type.");
+            RHI_VALIDATION_ERROR("AccelerationStructureBuildDesc::inputs must have the same type.");
             return SLANG_E_INVALID_ARG;
         }
     }
@@ -215,7 +215,7 @@ Result validateAccelerationStructureBuildDesc(DebugContext* ctx, const Accelerat
             if (!instances.instanceBuffer.buffer)
             {
                 RHI_VALIDATION_ERROR_FORMAT(
-                    "AccelerationStructureBuildDesc::inputs[%d].instances.instanceBuffer cannot be null.",
+                    "AccelerationStructureBuildDesc::inputs[%d].instances.instanceBuffer must not be null.",
                     i
                 );
                 valid = false;
@@ -223,7 +223,7 @@ Result validateAccelerationStructureBuildDesc(DebugContext* ctx, const Accelerat
             if (instances.instanceStride == 0)
             {
                 RHI_VALIDATION_ERROR_FORMAT(
-                    "AccelerationStructureBuildDesc::inputs[%d].instances.instanceStride cannot be 0.",
+                    "AccelerationStructureBuildDesc::inputs[%d].instances.instanceStride must not be 0.",
                     i
                 );
                 valid = false;
@@ -245,7 +245,7 @@ Result validateAccelerationStructureBuildDesc(DebugContext* ctx, const Accelerat
                 break;
             default:
                 RHI_VALIDATION_ERROR_FORMAT(
-                    "AccelerationStructureBuildDesc::inputs[%d].triangles.vertexFormat is unsupported. "
+                    "AccelerationStructureBuildDesc::inputs[%d].triangles.vertexFormat is not supported. "
                     "Valid values are RGB32Float, RG32Float, RGBA16Float, RG16Float, RGBA16Snorm or RG16Snorm.",
                     i
                 );
@@ -260,7 +260,7 @@ Result validateAccelerationStructureBuildDesc(DebugContext* ctx, const Accelerat
                     break;
                 default:
                     RHI_VALIDATION_ERROR_FORMAT(
-                        "AccelerationStructureBuildDesc::inputs[%d].triangles.indexFormat is unsupported. "
+                        "AccelerationStructureBuildDesc::inputs[%d].triangles.indexFormat is not supported. "
                         "Valid values are Uint16 and Uint32.",
                         i
                     );
@@ -269,7 +269,7 @@ Result validateAccelerationStructureBuildDesc(DebugContext* ctx, const Accelerat
                 if (!triangles.indexBuffer.buffer)
                 {
                     RHI_VALIDATION_ERROR_FORMAT(
-                        "AccelerationStructureBuildDesc::inputs[%d].triangles.indexBuffer.buffer cannot be null if "
+                        "AccelerationStructureBuildDesc::inputs[%d].triangles.indexBuffer.buffer must not be null if "
                         "indexCount is not 0.",
                         i
                     );
@@ -279,7 +279,7 @@ Result validateAccelerationStructureBuildDesc(DebugContext* ctx, const Accelerat
             if (triangles.vertexBufferCount < 1)
             {
                 RHI_VALIDATION_ERROR_FORMAT(
-                    "AccelerationStructureBuildDesc::inputs[%d].triangles.vertexBufferCount cannot be <= 1.",
+                    "AccelerationStructureBuildDesc::inputs[%d].triangles.vertexBufferCount must not be < 1.",
                     i
                 );
                 valid = false;
@@ -289,7 +289,7 @@ Result validateAccelerationStructureBuildDesc(DebugContext* ctx, const Accelerat
                 if (!triangles.vertexBuffers[j].buffer)
                 {
                     RHI_VALIDATION_ERROR_FORMAT(
-                        "AccelerationStructureBuildDesc::inputs[%d].triangles.vertexBuffers.buffer cannot be null.",
+                        "AccelerationStructureBuildDesc::inputs[%d].triangles.vertexBuffers.buffer must not be null.",
                         i
                     );
                     valid = false;
@@ -319,7 +319,7 @@ Result validateAccelerationStructureBuildDesc(DebugContext* ctx, const Accelerat
                 break;
             default:
                 RHI_VALIDATION_ERROR_FORMAT(
-                    "AccelerationStructureBuildDesc::inputs[%d].spheres.vertexPositionFormat is unsupported. "
+                    "AccelerationStructureBuildDesc::inputs[%d].spheres.vertexPositionFormat is not supported. "
                     "Valid values are RGB32Float, RG32Float, RGBA16Float, RG16Float, RGBA16Snorm or RG16Snorm.",
                     i
                 );
@@ -333,7 +333,7 @@ Result validateAccelerationStructureBuildDesc(DebugContext* ctx, const Accelerat
                 break;
             default:
                 RHI_VALIDATION_ERROR_FORMAT(
-                    "AccelerationStructureBuildDesc::inputs[%d].spheres.vertexRadiusFormat is unsupported. "
+                    "AccelerationStructureBuildDesc::inputs[%d].spheres.vertexRadiusFormat is not supported. "
                     "Valid values are R32Float or R16Float.",
                     i
                 );
@@ -486,7 +486,7 @@ Result validateAccelerationStructureBuildDesc(DebugContext* ctx, const Accelerat
             if (linearSweptSpheres.vertexBufferCount < 1)
             {
                 RHI_VALIDATION_ERROR_FORMAT(
-                    "AccelerationStructureBuildDesc::inputs[%d].linearSweptSpheres.vertexBufferCount cannot be <= 1.",
+                    "AccelerationStructureBuildDesc::inputs[%d].linearSweptSpheres.vertexBufferCount must not be < 1.",
                     i
                 );
                 valid = false;
@@ -496,8 +496,8 @@ Result validateAccelerationStructureBuildDesc(DebugContext* ctx, const Accelerat
                 if (!linearSweptSpheres.vertexPositionBuffers[j].buffer)
                 {
                     RHI_VALIDATION_ERROR_FORMAT(
-                        "AccelerationStructureBuildDesc::inputs[%d].linearSweptSpheres.vertexBuffers[%d].buffer cannot "
-                        "be null.",
+                        "AccelerationStructureBuildDesc::inputs[%d].linearSweptSpheres.vertexPositionBuffers[%d]."
+                        "buffer must not be null.",
                         i,
                         j
                     );
@@ -509,7 +509,7 @@ Result validateAccelerationStructureBuildDesc(DebugContext* ctx, const Accelerat
         }
         default:
             RHI_VALIDATION_ERROR_FORMAT(
-                "AccelerationStructureBuildDesc::inputs[%d].type is not supported. ",
+                "AccelerationStructureBuildDesc::inputs[%d].type is not supported. "
                 "Valid values are Instances, Triangles, ProceduralPrimitives, Spheres and LinearSweptSpheres.",
                 i
             );
@@ -531,7 +531,7 @@ Result validateClusterOperationParams(DebugContext* ctx, const ClusterOperationP
     case ClusterOperationType::MoveObjects:
         if (ctx->deviceType == DeviceType::CUDA)
         {
-            RHI_VALIDATION_ERROR("ClusterOperationType::MoveObjects is not supported on CUDA (OptiX limitation)");
+            RHI_VALIDATION_ERROR("ClusterOperationType::MoveObjects is not supported on CUDA (OptiX limitation).");
             valid = false;
         }
         break;
@@ -548,7 +548,7 @@ Result validateClusterOperationParams(DebugContext* ctx, const ClusterOperationP
         validateClasParams = true;
         break;
     default:
-        RHI_VALIDATION_ERROR("ClusterOperationParams::type is invalid");
+        RHI_VALIDATION_ERROR("ClusterOperationParams::type is invalid.");
         valid = false;
         break;
     }
@@ -562,7 +562,7 @@ Result validateClusterOperationParams(DebugContext* ctx, const ClusterOperationP
     case ClusterOperationMode::GetSizes:
         break;
     default:
-        RHI_VALIDATION_ERROR("ClusterOperationParams::mode is invalid");
+        RHI_VALIDATION_ERROR("ClusterOperationParams::mode is invalid.");
         valid = false;
         break;
     }
@@ -656,17 +656,17 @@ Result validateConvertCooperativeVectorMatrix(
 {
     if (!dstDescs)
     {
-        RHI_VALIDATION_ERROR("Destination descriptions must be valid");
+        RHI_VALIDATION_ERROR("'dstDescs' must not be null.");
         return SLANG_E_INVALID_ARG;
     }
     if (!srcDescs)
     {
-        RHI_VALIDATION_ERROR("Source descriptions must be valid");
+        RHI_VALIDATION_ERROR("'srcDescs' must not be null.");
         return SLANG_E_INVALID_ARG;
     }
     if (matrixCount == 0)
     {
-        RHI_VALIDATION_ERROR("Matrix count must be non-zero");
+        RHI_VALIDATION_ERROR("Matrix count must not be zero.");
         return SLANG_E_INVALID_ARG;
     }
 
@@ -677,28 +677,28 @@ Result validateConvertCooperativeVectorMatrix(
     {
         if (dstDescs[i].rowCount != srcDescs[i].rowCount)
         {
-            RHI_VALIDATION_ERROR_FORMAT("dstDescs[%d].rowCount must match srcDescs[%d].rowCount", i, i);
+            RHI_VALIDATION_ERROR_FORMAT("dstDescs[%d].rowCount must match srcDescs[%d].rowCount.", i, i);
             valid = false;
         }
         if (dstDescs[i].colCount != srcDescs[i].colCount)
         {
-            RHI_VALIDATION_ERROR_FORMAT("dstDescs[%d].colCount must match srcDescs[%d].colCount", i, i);
+            RHI_VALIDATION_ERROR_FORMAT("dstDescs[%d].colCount must match srcDescs[%d].colCount.", i, i);
             valid = false;
         }
 
         if (dstDescs[i].rowCount < 1 || dstDescs[i].rowCount > 128)
         {
-            RHI_VALIDATION_ERROR_FORMAT("dstDescs[%d].rowCount must be in the range [1, 128]", i);
+            RHI_VALIDATION_ERROR_FORMAT("dstDescs[%d].rowCount must be in the range [1, 128].", i);
             valid = false;
         }
         if (dstDescs[i].colCount < 1 || dstDescs[i].colCount > 128)
         {
-            RHI_VALIDATION_ERROR_FORMAT("dstDescs[%d].colCount must be in the range [1, 128]", i);
+            RHI_VALIDATION_ERROR_FORMAT("dstDescs[%d].colCount must be in the range [1, 128].", i);
             valid = false;
         }
         if (dstDescs[i].size == 0)
         {
-            RHI_VALIDATION_ERROR_FORMAT("dstDescs[%d].size must not be zero", i);
+            RHI_VALIDATION_ERROR_FORMAT("dstDescs[%d].size must not be zero.", i);
             valid = false;
         }
         switch (dstDescs[i].layout)
@@ -708,8 +708,7 @@ Result validateConvertCooperativeVectorMatrix(
             if (dstDescs[i].rowColumnStride == 0)
             {
                 RHI_VALIDATION_ERROR_FORMAT(
-                    "dstDescs[%d].rowColumnStride must must not be zero for row-major and column-major layouts"
-                    "layouts",
+                    "dstDescs[%d].rowColumnStride must not be zero for row-major and column-major layouts.",
                     i
                 );
                 valid = false;
@@ -719,34 +718,34 @@ Result validateConvertCooperativeVectorMatrix(
         case CooperativeVectorMatrixLayout::TrainingOptimal:
             if (dstDescs[i].offset % 64 != 0)
             {
-                RHI_VALIDATION_ERROR_FORMAT("dstDescs[%d].offset must be a multiple of 64 bytes", i);
+                RHI_VALIDATION_ERROR_FORMAT("dstDescs[%d].offset must be a multiple of 64 bytes.", i);
                 valid = false;
             }
             if (dstDescs[i].rowColumnStride != 0)
             {
-                RHI_VALIDATION_ERROR_FORMAT("dstDescs[%d].rowColumnStride must be zero for optimal layouts", i);
+                RHI_VALIDATION_ERROR_FORMAT("dstDescs[%d].rowColumnStride must be zero for optimal layouts.", i);
                 valid = false;
             }
             break;
         default:
-            RHI_VALIDATION_ERROR_FORMAT("dstDescs[%d].layout is invalid", i);
+            RHI_VALIDATION_ERROR_FORMAT("dstDescs[%d].layout is invalid.", i);
             valid = false;
             break;
         }
 
         if (srcDescs[i].rowCount < 1 || srcDescs[i].rowCount > 128)
         {
-            RHI_VALIDATION_ERROR_FORMAT("srcDescs[%d].rowCount must be in the range [1, 128]", i);
+            RHI_VALIDATION_ERROR_FORMAT("srcDescs[%d].rowCount must be in the range [1, 128].", i);
             valid = false;
         }
         if (srcDescs[i].colCount < 1 || srcDescs[i].colCount > 128)
         {
-            RHI_VALIDATION_ERROR_FORMAT("srcDescs[%d].colCount must be in the range [1, 128]", i);
+            RHI_VALIDATION_ERROR_FORMAT("srcDescs[%d].colCount must be in the range [1, 128].", i);
             valid = false;
         }
         if (srcDescs[i].size == 0)
         {
-            RHI_VALIDATION_ERROR_FORMAT("srcDescs[%d].size must not be zero", i);
+            RHI_VALIDATION_ERROR_FORMAT("srcDescs[%d].size must not be zero.", i);
             valid = false;
         }
         switch (srcDescs[i].layout)
@@ -756,8 +755,7 @@ Result validateConvertCooperativeVectorMatrix(
             if (srcDescs[i].rowColumnStride == 0)
             {
                 RHI_VALIDATION_ERROR_FORMAT(
-                    "srcDescs[%d].rowColumnStride must must not be zero for row-major and column-major layouts"
-                    "layouts",
+                    "srcDescs[%d].rowColumnStride must not be zero for row-major and column-major layouts.",
                     i
                 );
                 valid = false;
@@ -767,17 +765,17 @@ Result validateConvertCooperativeVectorMatrix(
         case CooperativeVectorMatrixLayout::TrainingOptimal:
             if (srcDescs[i].offset % 64 != 0)
             {
-                RHI_VALIDATION_ERROR_FORMAT("srcDescs[%d].offset must be a multiple of 64 bytes", i);
+                RHI_VALIDATION_ERROR_FORMAT("srcDescs[%d].offset must be a multiple of 64 bytes.", i);
                 valid = false;
             }
             if (srcDescs[i].rowColumnStride != 0)
             {
-                RHI_VALIDATION_ERROR_FORMAT("srcDescs[%d].rowColumnStride must be zero for optimal layouts", i);
+                RHI_VALIDATION_ERROR_FORMAT("srcDescs[%d].rowColumnStride must be zero for optimal layouts.", i);
                 valid = false;
             }
             break;
         default:
-            RHI_VALIDATION_ERROR_FORMAT("srcDescs[%d].layout is invalid", i);
+            RHI_VALIDATION_ERROR_FORMAT("srcDescs[%d].layout is invalid.", i);
             valid = false;
             break;
         }
@@ -789,7 +787,7 @@ Result validateConvertCooperativeVectorMatrix(
     if (dstBufferSize < minDstBufferSize)
     {
         RHI_VALIDATION_ERROR_FORMAT(
-            "Destination buffer size (%zu) is smaller than the required minimum size (%zu)",
+            "Destination buffer size (%zu) is smaller than the required minimum size (%zu).",
             dstBufferSize,
             minDstBufferSize
         );
@@ -798,7 +796,7 @@ Result validateConvertCooperativeVectorMatrix(
     if (srcBufferSize < minSrcBufferSize)
     {
         RHI_VALIDATION_ERROR_FORMAT(
-            "Source buffer size (%zu) is smaller than the required minimum size (%zu)",
+            "Source buffer size (%zu) is smaller than the required minimum size (%zu).",
             srcBufferSize,
             minSrcBufferSize
         );

--- a/src/debug-layer/debug-helper-functions.h
+++ b/src/debug-layer/debug-helper-functions.h
@@ -153,4 +153,173 @@ Result validateConvertCooperativeVectorMatrix(
     uint32_t matrixCount
 );
 
+// ----------------------------------------------------------------------------
+// Enum validation helpers
+// ----------------------------------------------------------------------------
+
+/// Check that a sequential enum value is in [0, LastValue].
+template<typename E, E LastValue>
+inline bool isValidEnum(E value)
+{
+    return static_cast<int>(value) >= 0 && static_cast<int>(value) <= static_cast<int>(LastValue);
+}
+
+inline bool isValidFormat(Format value)
+{
+    return isValidEnum<Format, Format::BC7UnormSrgb>(value);
+}
+
+inline bool isValidIndexFormat(IndexFormat value)
+{
+    return isValidEnum<IndexFormat, IndexFormat::Uint32>(value);
+}
+
+inline bool isValidMemoryType(MemoryType value)
+{
+    return isValidEnum<MemoryType, MemoryType::ReadBack>(value);
+}
+
+inline bool isValidCpuAccessMode(CpuAccessMode value)
+{
+    return isValidEnum<CpuAccessMode, CpuAccessMode::Write>(value);
+}
+
+inline bool isValidTextureType(TextureType value)
+{
+    return isValidEnum<TextureType, TextureType::TextureCubeArray>(value);
+}
+
+inline bool isValidTextureAspect(TextureAspect value)
+{
+    return isValidEnum<TextureAspect, TextureAspect::StencilOnly>(value);
+}
+
+inline bool isValidResourceState(ResourceState value)
+{
+    return isValidEnum<ResourceState, ResourceState::AccelerationStructureBuildInput>(value);
+}
+
+inline bool isValidLoadOp(LoadOp value)
+{
+    return isValidEnum<LoadOp, LoadOp::DontCare>(value);
+}
+
+inline bool isValidStoreOp(StoreOp value)
+{
+    return isValidEnum<StoreOp, StoreOp::DontCare>(value);
+}
+
+inline bool isValidQueryType(QueryType value)
+{
+    return isValidEnum<QueryType, QueryType::AccelerationStructureCurrentSize>(value);
+}
+
+inline bool isValidAccelerationStructureCopyMode(AccelerationStructureCopyMode value)
+{
+    return isValidEnum<AccelerationStructureCopyMode, AccelerationStructureCopyMode::Compact>(value);
+}
+
+inline bool isValidComparisonFunc(ComparisonFunc value)
+{
+    return isValidEnum<ComparisonFunc, ComparisonFunc::Always>(value);
+}
+
+inline bool isValidTextureFilteringMode(TextureFilteringMode value)
+{
+    return isValidEnum<TextureFilteringMode, TextureFilteringMode::Linear>(value);
+}
+
+inline bool isValidTextureAddressingMode(TextureAddressingMode value)
+{
+    return isValidEnum<TextureAddressingMode, TextureAddressingMode::MirrorOnce>(value);
+}
+
+inline bool isValidTextureReductionOp(TextureReductionOp value)
+{
+    return isValidEnum<TextureReductionOp, TextureReductionOp::Maximum>(value);
+}
+
+inline bool isValidPrimitiveTopology(PrimitiveTopology value)
+{
+    return isValidEnum<PrimitiveTopology, PrimitiveTopology::PatchList>(value);
+}
+
+// ----------------------------------------------------------------------------
+// Flags validation helpers
+// ----------------------------------------------------------------------------
+
+/// Check that a bitmask enum value has no bits set outside allValidBits.
+template<typename E>
+inline bool isValidFlags(E value, E allValidBits)
+{
+    using U = std::underlying_type_t<E>;
+    return (static_cast<U>(value) & ~static_cast<U>(allValidBits)) == 0;
+}
+
+inline bool isValidBufferUsage(BufferUsage value)
+{
+    const BufferUsage allValidBits =
+        BufferUsage::VertexBuffer | BufferUsage::IndexBuffer | BufferUsage::ConstantBuffer |
+        BufferUsage::ShaderResource | BufferUsage::UnorderedAccess | BufferUsage::IndirectArgument |
+        BufferUsage::CopySource | BufferUsage::CopyDestination | BufferUsage::AccelerationStructure |
+        BufferUsage::AccelerationStructureBuildInput | BufferUsage::ShaderTable | BufferUsage::Shared;
+    return isValidFlags(value, allValidBits);
+}
+
+inline bool isValidTextureUsage(TextureUsage value)
+{
+    const TextureUsage allValidBits =
+        TextureUsage::ShaderResource | TextureUsage::UnorderedAccess | TextureUsage::RenderTarget |
+        TextureUsage::DepthStencil | TextureUsage::Present | TextureUsage::CopySource | TextureUsage::CopyDestination |
+        TextureUsage::ResolveSource | TextureUsage::ResolveDestination | TextureUsage::Typeless | TextureUsage::Shared;
+    return isValidFlags(value, allValidBits);
+}
+
+inline bool isValidHeapUsage(HeapUsage value)
+{
+    const HeapUsage allValidBits = HeapUsage::Shared;
+    return isValidFlags(value, allValidBits);
+}
+
+inline bool isValidAccelerationStructureBuildFlags(AccelerationStructureBuildFlags value)
+{
+    const AccelerationStructureBuildFlags allValidBits =
+        AccelerationStructureBuildFlags::AllowUpdate | AccelerationStructureBuildFlags::AllowCompaction |
+        AccelerationStructureBuildFlags::PreferFastTrace | AccelerationStructureBuildFlags::PreferFastBuild |
+        AccelerationStructureBuildFlags::MinimizeMemory | AccelerationStructureBuildFlags::CreateMotion;
+    return isValidFlags(value, allValidBits);
+}
+
+// ----------------------------------------------------------------------------
+// Subresource range validation
+// ----------------------------------------------------------------------------
+
+/// Validate a SubresourceRange against a TextureDesc.
+/// Returns true if the range is valid. Resolves sentinel values (kAllMips, kAllLayers)
+/// and checks that the range is within the texture bounds.
+inline bool validateSubresourceRange(const SubresourceRange& range, const TextureDesc& desc)
+{
+    uint32_t totalMips = desc.mipCount;
+    uint32_t totalLayers = desc.getLayerCount();
+
+    // Resolve sentinel values.
+    uint32_t mipCount = (range.mipCount == kAllMips) ? (totalMips - min(range.mip, totalMips)) : range.mipCount;
+    uint32_t layerCount =
+        (range.layerCount == kAllLayers) ? (totalLayers - min(range.layer, totalLayers)) : range.layerCount;
+
+    // Check mip bounds.
+    if (range.mip >= totalMips)
+        return false;
+    if (mipCount == 0 || range.mip + mipCount > totalMips)
+        return false;
+
+    // Check layer bounds.
+    if (range.layer >= totalLayers)
+        return false;
+    if (layerCount == 0 || range.layer + layerCount > totalLayers)
+        return false;
+
+    return true;
+}
+
 } // namespace rhi::debug

--- a/src/debug-layer/debug-helper-functions.h
+++ b/src/debug-layer/debug-helper-functions.h
@@ -166,7 +166,7 @@ inline bool isValidEnum(E value)
 
 inline bool isValidFormat(Format value)
 {
-    return isValidEnum<Format, Format::BC7UnormSrgb>(value);
+    return isValidEnum<Format, static_cast<Format>(static_cast<int>(Format::_Count) - 1)>(value);
 }
 
 inline bool isValidIndexFormat(IndexFormat value)

--- a/src/debug-layer/debug-helper-functions.h
+++ b/src/debug-layer/debug-helper-functions.h
@@ -154,6 +154,22 @@ Result validateConvertCooperativeVectorMatrix(
 );
 
 // ----------------------------------------------------------------------------
+// Validation helpers
+// ----------------------------------------------------------------------------
+
+/// Check that offset and size are within the total size while avoiding overlow.
+/// Returns true if the offset and size are valid.
+template<typename T>
+bool checkSizePlusOffsetInRange(T offset, T size, T totalSize)
+{
+    if (offset > totalSize)
+        return false;
+    if (size > totalSize - offset)
+        return false;
+    return true;
+}
+
+// ----------------------------------------------------------------------------
 // Enum validation helpers
 // ----------------------------------------------------------------------------
 

--- a/src/debug-layer/debug-helper-functions.h
+++ b/src/debug-layer/debug-helper-functions.h
@@ -157,10 +157,10 @@ Result validateConvertCooperativeVectorMatrix(
 // Validation helpers
 // ----------------------------------------------------------------------------
 
-/// Check that offset and size are within the total size while avoiding overlow.
+/// Check that a subrange [offset, offset+size) is within the total size while avoiding overflow.
 /// Returns true if the offset and size are valid.
 template<typename T>
-bool checkSizePlusOffsetInRange(T offset, T size, T totalSize)
+bool isValidSubrange(T offset, T size, T totalSize)
 {
     if (offset > totalSize)
         return false;

--- a/src/debug-layer/debug-pipeline.cpp
+++ b/src/debug-layer/debug-pipeline.cpp
@@ -3,6 +3,10 @@
 
 namespace rhi::debug {
 
+// ----------------------------------------------------------------------------
+// DebugRenderPipeline
+// ----------------------------------------------------------------------------
+
 Result DebugRenderPipeline::getNativeHandle(NativeHandle* outHandle)
 {
     SLANG_RHI_DEBUG_API(IRenderPipeline, getNativeHandle);
@@ -10,12 +14,20 @@ Result DebugRenderPipeline::getNativeHandle(NativeHandle* outHandle)
     return baseObject->getNativeHandle(outHandle);
 }
 
+// ----------------------------------------------------------------------------
+// DebugComputePipeline
+// ----------------------------------------------------------------------------
+
 Result DebugComputePipeline::getNativeHandle(NativeHandle* outHandle)
 {
     SLANG_RHI_DEBUG_API(IComputePipeline, getNativeHandle);
 
     return baseObject->getNativeHandle(outHandle);
 }
+
+// ----------------------------------------------------------------------------
+// DebugRayTracingPipeline
+// ----------------------------------------------------------------------------
 
 Result DebugRayTracingPipeline::getNativeHandle(NativeHandle* outHandle)
 {

--- a/src/debug-layer/debug-pipeline.h
+++ b/src/debug-layer/debug-pipeline.h
@@ -8,22 +8,21 @@ class DebugPipeline : public DebugObject<IPipeline>
 {
 public:
     SLANG_COM_OBJECT_IUNKNOWN_ALL;
+    IPipeline* getInterface(const Guid& guid);
 
     SLANG_RHI_DEBUG_OBJECT_CONSTRUCTOR(DebugPipeline);
-
-public:
-    IPipeline* getInterface(const Guid& guid);
 };
 
 class DebugRenderPipeline : public DebugObject<IRenderPipeline>
 {
 public:
     SLANG_COM_OBJECT_IUNKNOWN_ALL;
+    IRenderPipeline* getInterface(const Guid& guid);
 
     SLANG_RHI_DEBUG_OBJECT_CONSTRUCTOR(DebugRenderPipeline);
 
 public:
-    IRenderPipeline* getInterface(const Guid& guid);
+    // IRenderPipeline implementation
     virtual SLANG_NO_THROW Result SLANG_MCALL getNativeHandle(NativeHandle* outHandle) override;
 };
 
@@ -31,11 +30,12 @@ class DebugComputePipeline : public DebugObject<IComputePipeline>
 {
 public:
     SLANG_COM_OBJECT_IUNKNOWN_ALL;
+    IComputePipeline* getInterface(const Guid& guid);
 
     SLANG_RHI_DEBUG_OBJECT_CONSTRUCTOR(DebugComputePipeline);
 
 public:
-    IComputePipeline* getInterface(const Guid& guid);
+    // IComputePipeline implementation
     virtual SLANG_NO_THROW Result SLANG_MCALL getNativeHandle(NativeHandle* outHandle) override;
 };
 
@@ -43,11 +43,12 @@ class DebugRayTracingPipeline : public DebugObject<IRayTracingPipeline>
 {
 public:
     SLANG_COM_OBJECT_IUNKNOWN_ALL;
+    IRayTracingPipeline* getInterface(const Guid& guid);
 
     SLANG_RHI_DEBUG_OBJECT_CONSTRUCTOR(DebugRayTracingPipeline);
 
 public:
-    IRayTracingPipeline* getInterface(const Guid& guid);
+    // IRayTracingPipeline implementation
     virtual SLANG_NO_THROW Result SLANG_MCALL getNativeHandle(NativeHandle* outHandle) override;
 };
 

--- a/src/debug-layer/debug-query.cpp
+++ b/src/debug-layer/debug-query.cpp
@@ -14,9 +14,10 @@ Result DebugQueryPool::getResult(uint32_t queryIndex, uint32_t count, uint64_t* 
 {
     SLANG_RHI_DEBUG_API(IQueryPool, getResult);
 
-    if (queryIndex + count > baseObject->getDesc().count)
+    if (!checkSizePlusOffsetInRange(queryIndex, count, baseObject->getDesc().count))
     {
-        RHI_VALIDATION_ERROR("'queryIndex' is out of bounds.");
+        RHI_VALIDATION_ERROR("'queryIndex' and 'count' must specify a valid range within the query pool.");
+        return SLANG_E_INVALID_ARG;
     }
 
     return baseObject->getResult(queryIndex, count, data);

--- a/src/debug-layer/debug-query.cpp
+++ b/src/debug-layer/debug-query.cpp
@@ -16,7 +16,7 @@ Result DebugQueryPool::getResult(uint32_t queryIndex, uint32_t count, uint64_t* 
 
     if (queryIndex + count > baseObject->getDesc().count)
     {
-        RHI_VALIDATION_ERROR("index is out of bounds.");
+        RHI_VALIDATION_ERROR("'queryIndex' is out of bounds.");
     }
 
     return baseObject->getResult(queryIndex, count, data);

--- a/src/debug-layer/debug-query.cpp
+++ b/src/debug-layer/debug-query.cpp
@@ -14,7 +14,7 @@ Result DebugQueryPool::getResult(uint32_t queryIndex, uint32_t count, uint64_t* 
 {
     SLANG_RHI_DEBUG_API(IQueryPool, getResult);
 
-    if (!checkSizePlusOffsetInRange(queryIndex, count, baseObject->getDesc().count))
+    if (!isValidSubrange(queryIndex, count, baseObject->getDesc().count))
     {
         RHI_VALIDATION_ERROR("'queryIndex' and 'count' must specify a valid range within the query pool.");
         return SLANG_E_INVALID_ARG;

--- a/src/debug-layer/debug-query.h
+++ b/src/debug-layer/debug-query.h
@@ -8,11 +8,12 @@ class DebugQueryPool : public DebugObject<IQueryPool>
 {
 public:
     SLANG_COM_OBJECT_IUNKNOWN_ALL;
+    IQueryPool* getInterface(const Guid& guid);
 
     SLANG_RHI_DEBUG_OBJECT_CONSTRUCTOR(DebugQueryPool);
 
 public:
-    IQueryPool* getInterface(const Guid& guid);
+    // IQueryPool implementation
     virtual SLANG_NO_THROW const QueryPoolDesc& SLANG_MCALL getDesc() override;
     virtual SLANG_NO_THROW Result SLANG_MCALL getResult(uint32_t queryIndex, uint32_t count, uint64_t* data) override;
     virtual SLANG_NO_THROW Result SLANG_MCALL reset() override;

--- a/src/debug-layer/debug-shader-object.cpp
+++ b/src/debug-layer/debug-shader-object.cpp
@@ -55,7 +55,7 @@ Result DebugShaderObject::setData(const ShaderOffset& offset, const void* data, 
 {
     SLANG_RHI_DEBUG_API(IShaderObject, setData);
 
-    checkNotFinalized();
+    SLANG_RETURN_ON_FAIL(checkNotFinalized());
 
     return baseObject->setData(offset, data, size);
 }
@@ -64,7 +64,7 @@ Result DebugShaderObject::reserveData(const ShaderOffset& offset, Size size, voi
 {
     SLANG_RHI_DEBUG_API(IShaderObject, reserveData);
 
-    checkNotFinalized();
+    SLANG_RETURN_ON_FAIL(checkNotFinalized());
 
     return baseObject->reserveData(offset, size, outData);
 }
@@ -101,7 +101,7 @@ Result DebugShaderObject::setObject(const ShaderOffset& offset, IShaderObject* o
 {
     SLANG_RHI_DEBUG_API(IShaderObject, setObject);
 
-    checkNotFinalized();
+    SLANG_RETURN_ON_FAIL(checkNotFinalized());
 
     auto objectImpl = getDebugObj(object);
     m_objects[ShaderOffsetKey{offset}] = objectImpl;
@@ -116,7 +116,7 @@ Result DebugShaderObject::setBinding(const ShaderOffset& offset, const Binding& 
 {
     SLANG_RHI_DEBUG_API(IShaderObject, setBinding);
 
-    checkNotFinalized();
+    SLANG_RETURN_ON_FAIL(checkNotFinalized());
 
     // TODO(shaderobject): Implement better validation for bindings but make that optional as it's expensive.
     // m_bindings[ShaderOffsetKey{offset}] = binding;
@@ -129,7 +129,7 @@ Result DebugShaderObject::setDescriptorHandle(const ShaderOffset& offset, const 
 {
     SLANG_RHI_DEBUG_API(IShaderObject, setDescriptorHandle);
 
-    checkNotFinalized();
+    SLANG_RETURN_ON_FAIL(checkNotFinalized());
 
     return baseObject->setDescriptorHandle(offset, handle);
 }
@@ -142,7 +142,7 @@ Result DebugShaderObject::setSpecializationArgs(
 {
     SLANG_RHI_DEBUG_API(IShaderObject, setSpecializationArgs);
 
-    checkNotFinalized();
+    SLANG_RETURN_ON_FAIL(checkNotFinalized());
 
     return baseObject->setSpecializationArgs(offset, args, count);
 }
@@ -165,7 +165,7 @@ Result DebugShaderObject::setConstantBufferOverride(IBuffer* constantBuffer)
 {
     SLANG_RHI_DEBUG_API(IShaderObject, setConstantBufferOverride);
 
-    checkNotFinalized();
+    SLANG_RETURN_ON_FAIL(checkNotFinalized());
 
     return baseObject->setConstantBufferOverride(constantBuffer);
 }
@@ -210,12 +210,14 @@ void DebugShaderObject::checkCompleteness()
     // }
 }
 
-void DebugShaderObject::checkNotFinalized()
+Result DebugShaderObject::checkNotFinalized()
 {
     if (baseObject->isFinalized())
     {
         RHI_VALIDATION_ERROR("The shader object is finalized and must not be modified.");
+        return SLANG_E_INVALID_ARG;
     }
+    return SLANG_OK;
 }
 
 // ----------------------------------------------------------------------------
@@ -230,7 +232,7 @@ Result DebugRootShaderObject::setSpecializationArgs(
 {
     SLANG_RHI_DEBUG_API(IShaderObject, setSpecializationArgs);
 
-    checkNotFinalized();
+    SLANG_RETURN_ON_FAIL(checkNotFinalized());
 
     return baseObject->setSpecializationArgs(offset, args, count);
 }

--- a/src/debug-layer/debug-shader-object.cpp
+++ b/src/debug-layer/debug-shader-object.cpp
@@ -3,47 +3,22 @@
 
 namespace rhi::debug {
 
-ShaderObjectContainerType DebugShaderObject::getContainerType()
-{
-    SLANG_RHI_DEBUG_API(IShaderObject, getContainerType);
-
-    return baseObject->getContainerType();
-}
-
-void DebugShaderObject::checkCompleteness()
-{
-    // TODO(shaderobject): Implement better validation for bindings but make that optional as it's expensive.
-    // auto layout = baseObject->getElementTypeLayout();
-    // for (SlangInt i = 0; i < layout->getBindingRangeCount(); i++)
-    // {
-    //     if (layout->getBindingRangeBindingCount(i) != 0)
-    //     {
-    //         if (!m_initializedBindingRanges.count(i))
-    //         {
-    //             auto var = layout->getBindingRangeLeafVariable(i);
-    //             RHI_VALIDATION_ERROR_FORMAT(
-    //                 "shader parameter '%s' is not initialized in the shader object of type '%s'.",
-    //                 var->getName(),
-    //                 m_slangType->getName()
-    //             );
-    //         }
-    //     }
-    // }
-}
-
-void DebugShaderObject::checkNotFinalized()
-{
-    if (baseObject->isFinalized())
-    {
-        RHI_VALIDATION_ERROR("The shader object is finalized and must not be modified.");
-    }
-}
+// ----------------------------------------------------------------------------
+// DebugShaderObject
+// ----------------------------------------------------------------------------
 
 slang::TypeLayoutReflection* DebugShaderObject::getElementTypeLayout()
 {
     SLANG_RHI_DEBUG_API(IShaderObject, getElementTypeLayout);
 
     return baseObject->getElementTypeLayout();
+}
+
+ShaderObjectContainerType DebugShaderObject::getContainerType()
+{
+    SLANG_RHI_DEBUG_API(IShaderObject, getContainerType);
+
+    return baseObject->getContainerType();
 }
 
 uint32_t DebugShaderObject::getEntryPointCount()
@@ -66,9 +41,9 @@ Result DebugShaderObject::getEntryPoint(uint32_t index, IShaderObject** entryPoi
             m_entryPoints.push_back(entryPointObj);
         }
     }
-    if (index > m_entryPoints.size())
+    if (index >= m_entryPoints.size())
     {
-        RHI_VALIDATION_ERROR("`index` must not exceed `entryPointCount`.");
+        RHI_VALIDATION_ERROR("'index' must not exceed 'entryPointCount'.");
         return SLANG_FAIL;
     }
 
@@ -213,6 +188,39 @@ bool DebugShaderObject::isFinalized()
 
     return baseObject->isFinalized();
 }
+
+void DebugShaderObject::checkCompleteness()
+{
+    // TODO(shaderobject): Implement better validation for bindings but make that optional as it's expensive.
+    // auto layout = baseObject->getElementTypeLayout();
+    // for (SlangInt i = 0; i < layout->getBindingRangeCount(); i++)
+    // {
+    //     if (layout->getBindingRangeBindingCount(i) != 0)
+    //     {
+    //         if (!m_initializedBindingRanges.count(i))
+    //         {
+    //             auto var = layout->getBindingRangeLeafVariable(i);
+    //             RHI_VALIDATION_ERROR_FORMAT(
+    //                 "shader parameter '%s' is not initialized in the shader object of type '%s'.",
+    //                 var->getName(),
+    //                 m_slangType->getName()
+    //             );
+    //         }
+    //     }
+    // }
+}
+
+void DebugShaderObject::checkNotFinalized()
+{
+    if (baseObject->isFinalized())
+    {
+        RHI_VALIDATION_ERROR("The shader object is finalized and must not be modified.");
+    }
+}
+
+// ----------------------------------------------------------------------------
+// DebugRootShaderObject
+// ----------------------------------------------------------------------------
 
 Result DebugRootShaderObject::setSpecializationArgs(
     const ShaderOffset& offset,

--- a/src/debug-layer/debug-shader-object.h
+++ b/src/debug-layer/debug-shader-object.h
@@ -76,7 +76,7 @@ public:
 
 public:
     void checkCompleteness();
-    void checkNotFinalized();
+    Result checkNotFinalized();
 
     // Type name of an ordinary shader object.
     std::string m_typeName;

--- a/src/debug-layer/debug-shader-object.h
+++ b/src/debug-layer/debug-shader-object.h
@@ -34,15 +34,12 @@ class DebugShaderObject : public DebugObject<IShaderObject>
 {
 public:
     SLANG_COM_OBJECT_IUNKNOWN_ALL;
+    IShaderObject* getInterface(const Guid& guid);
 
     SLANG_RHI_DEBUG_OBJECT_CONSTRUCTOR(DebugShaderObject);
 
-    void checkCompleteness();
-    void checkFinalized();
-    void checkNotFinalized();
-
 public:
-    IShaderObject* getInterface(const Guid& guid);
+    // IShaderObject implementation
     virtual SLANG_NO_THROW slang::TypeLayoutReflection* SLANG_MCALL getElementTypeLayout() override;
     virtual SLANG_NO_THROW ShaderObjectContainerType SLANG_MCALL getContainerType() override;
     virtual SLANG_NO_THROW uint32_t SLANG_MCALL getEntryPointCount() override;
@@ -78,6 +75,9 @@ public:
     virtual SLANG_NO_THROW bool SLANG_MCALL isFinalized() override;
 
 public:
+    void checkCompleteness();
+    void checkNotFinalized();
+
     // Type name of an ordinary shader object.
     std::string m_typeName;
 
@@ -109,11 +109,15 @@ public:
     {
     }
 
+public:
+    // IShaderObject implementation
     virtual SLANG_NO_THROW Result SLANG_MCALL setSpecializationArgs(
         const ShaderOffset& offset,
         const slang::SpecializationArg* args,
         uint32_t count
     ) override;
+
+public:
     void reset();
 };
 

--- a/src/debug-layer/debug-surface.cpp
+++ b/src/debug-layer/debug-surface.cpp
@@ -28,28 +28,28 @@ Result DebugSurface::configure(const SurfaceConfig& config)
     // format must be Format::Undefined (selecting preferred format) or any of the supported formats.
     if (config.format != Format::Undefined && !contains(info.formats, info.formatCount, config.format))
     {
-        RHI_VALIDATION_ERROR("Unsupported format");
+        RHI_VALIDATION_ERROR("Format is not supported.");
         return SLANG_E_INVALID_ARG;
     }
 
     // usage must be subset of supported usage.
     if (config.usage != (config.usage & info.supportedUsage))
     {
-        RHI_VALIDATION_ERROR("Unsupported usage");
+        RHI_VALIDATION_ERROR("Usage is not supported.");
         return SLANG_E_INVALID_ARG;
     }
 
     // width and height must be greater than 0.
     if (config.width == 0 || config.height == 0)
     {
-        RHI_VALIDATION_ERROR("Invalid size");
+        RHI_VALIDATION_ERROR("Invalid size.");
         return SLANG_E_INVALID_ARG;
     }
 
     // desiredImageCount must be greater than 0.
     if (config.desiredImageCount == 0)
     {
-        RHI_VALIDATION_ERROR("Invalid desired image count");
+        RHI_VALIDATION_ERROR("Invalid desired image count.");
         return SLANG_E_INVALID_ARG;
     }
 
@@ -95,7 +95,7 @@ Result DebugSurface::acquireNextImage(ITexture** outTexture)
 
     if (m_state == State::ImageAcquired)
     {
-        RHI_VALIDATION_ERROR("Image already aquired. Image needs to be presented before acquiring a new one.");
+        RHI_VALIDATION_ERROR("Image already acquired. Image needs to be presented before acquiring a new one.");
         return SLANG_FAIL;
     }
 

--- a/src/debug-layer/debug-surface.h
+++ b/src/debug-layer/debug-surface.h
@@ -8,10 +8,17 @@ class DebugSurface : public DebugObject<ISurface>
 {
 public:
     SLANG_COM_OBJECT_IUNKNOWN_ALL;
+    ISurface* getInterface(const Guid& guid);
 
     SLANG_RHI_DEBUG_OBJECT_CONSTRUCTOR(DebugSurface);
 
-    ISurface* getInterface(const Guid& guid);
+public:
+    virtual SLANG_NO_THROW const SurfaceInfo& SLANG_MCALL getInfo() override;
+    virtual SLANG_NO_THROW const SurfaceConfig* SLANG_MCALL getConfig() override;
+    virtual SLANG_NO_THROW Result SLANG_MCALL configure(const SurfaceConfig& config) override;
+    virtual SLANG_NO_THROW Result SLANG_MCALL unconfigure() override;
+    virtual SLANG_NO_THROW Result SLANG_MCALL acquireNextImage(ITexture** outTexture) override;
+    virtual SLANG_NO_THROW Result SLANG_MCALL present() override;
 
 public:
     bool m_configured = false;
@@ -24,13 +31,6 @@ public:
     };
 
     State m_state = State::Initial;
-
-    virtual SLANG_NO_THROW const SurfaceInfo& SLANG_MCALL getInfo() override;
-    virtual SLANG_NO_THROW const SurfaceConfig* SLANG_MCALL getConfig() override;
-    virtual SLANG_NO_THROW Result SLANG_MCALL configure(const SurfaceConfig& config) override;
-    virtual SLANG_NO_THROW Result SLANG_MCALL unconfigure() override;
-    virtual SLANG_NO_THROW Result SLANG_MCALL acquireNextImage(ITexture** outTexture) override;
-    virtual SLANG_NO_THROW Result SLANG_MCALL present() override;
 };
 
 } // namespace rhi::debug

--- a/src/staging-heap.cpp
+++ b/src/staging-heap.cpp
@@ -7,17 +7,6 @@ namespace rhi {
 
 const std::thread::id NO_THREAD_ID;
 
-StagingHeap::~StagingHeap()
-{
-    // Unmap all pages.
-    for (auto& page_pair : m_pages)
-    {
-        Page* page = page_pair.second;
-        if (page->getMapped())
-            page->unmap(m_device);
-    }
-}
-
 void StagingHeap::initialize(Device* device, Size pageSize, MemoryType memoryType)
 {
     std::lock_guard<std::mutex> lock(m_mutex);

--- a/src/staging-heap.cpp
+++ b/src/staging-heap.cpp
@@ -7,6 +7,17 @@ namespace rhi {
 
 const std::thread::id NO_THREAD_ID;
 
+StagingHeap::~StagingHeap()
+{
+    // Unmap all pages.
+    for (auto& page_pair : m_pages)
+    {
+        Page* page = page_pair.second;
+        if (page->getMapped())
+            page->unmap(m_device);
+    }
+}
+
 void StagingHeap::initialize(Device* device, Size pageSize, MemoryType memoryType)
 {
     std::lock_guard<std::mutex> lock(m_mutex);

--- a/src/staging-heap.h
+++ b/src/staging-heap.h
@@ -128,6 +128,9 @@ public:
         Allocation m_allocation;
     };
 
+    // Destructor.
+    ~StagingHeap();
+
     // Initialize with device pointer.
     void initialize(Device* device, Size pageSize, MemoryType memoryType);
 

--- a/src/staging-heap.h
+++ b/src/staging-heap.h
@@ -128,9 +128,6 @@ public:
         Allocation m_allocation;
     };
 
-    // Destructor.
-    ~StagingHeap();
-
     // Initialize with device pointer.
     void initialize(Device* device, Size pageSize, MemoryType memoryType);
 

--- a/tests/test-ray-tracing-shader-table-multi-pipeline.cpp
+++ b/tests/test-ray-tracing-shader-table-multi-pipeline.cpp
@@ -42,6 +42,7 @@ GPU_TEST_CASE("ray-tracing-shader-table-multi-pipeline", ALL)
     {
         ShaderTableDesc shaderTableDesc = {};
         const char* rayGenNames[] = {"rayGen"};
+        shaderTableDesc.program = programA;
         shaderTableDesc.rayGenShaderCount = SLANG_COUNT_OF(rayGenNames);
         shaderTableDesc.rayGenShaderEntryPointNames = rayGenNames;
         REQUIRE_CALL(device->createShaderTable(shaderTableDesc, shaderTable.writeRef()));

--- a/tests/test-texture-view-3d.cpp
+++ b/tests/test-texture-view-3d.cpp
@@ -184,9 +184,7 @@ struct TestTextureViews
             // Texture size
             Extent3D size = {16 /*width*/, 16 /*height*/, 16 /*depth*/};
             // This subrange/textureView will give a 8x8x8 texture and verifies a fix for issue #220
-            // We use 3 for layer as this was previously used for FirstWSlice and we want
-            // to verify that selecting a subset of depth slices is not currently supported.
-            SubresourceRange range = {3 /*layer*/, 1 /*layerCount*/, 1 /*mip*/, 4 /*mipCount*/};
+            SubresourceRange range = {0 /*layer*/, 1 /*layerCount*/, 1 /*mip*/, 4 /*mipCount*/};
             testTextureViewUnorderedAccess(type, 5 /*mipCount*/, size, range, subData);
         }
     }


### PR DESCRIPTION
This PR improves the RHI debug layer by adding a lot of new validations.
This also revealed some issues:
- `StagingHeap` did not unmap pages on destruction (hit in unit tests)
- `ray-tracing-shader-table-multi-pipeline` created shader table without specifying a `program`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed surface error message typo ("aquired" → "acquired") and improved many validation/error messages for clearer diagnostics.
  * Prevented several invalid/no-op operations by adding stronger argument and bounds checks (now return errors instead of proceeding).

* **Refactor**
  * Strengthened the debug validation layer with broader runtime checks and clearer public interface organization.
  * Added optional buffer-map validation and safer resource-creation validation.

* **Tests**
  * Adjusted shader-table and 3D texture-view test inputs for correctness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->