### PR TITLE
Add AccelerationStructureKind to AccelerationStructureDesc

### DIFF
--- a/include/slang-rhi.h
+++ b/include/slang-rhi.h
@@ -1446,11 +1446,22 @@ struct AccelerationStructureMotionCreateInfo
     uint32_t maxInstances = 0;
 };
 
+enum class AccelerationStructureKind
+{
+    /// Unknown kind. On Vulkan, creates the acceleration structure with
+    /// VK_ACCELERATION_STRUCTURE_TYPE_GENERIC_KHR. Note that Vulkan validation may reject
+    /// GENERIC acceleration structures used as BLAS instance references.
+    Unknown,
+    BottomLevel,
+    TopLevel,
+};
+
 struct AccelerationStructureDesc
 {
     StructType structType = StructType::AccelerationStructureDesc;
     const void* next = nullptr;
 
+    AccelerationStructureKind kind = AccelerationStructureKind::Unknown;
     uint64_t size;
     AccelerationStructureBuildFlags flags = AccelerationStructureBuildFlags::None;
 

--- a/include/slang-rhi.h
+++ b/include/slang-rhi.h
@@ -1475,6 +1475,7 @@ class IAccelerationStructure : public IResource
     SLANG_COM_INTERFACE(0x38b056d5, 0x63de, 0x49ca, {0xa0, 0xed, 0x62, 0xa1, 0xbe, 0xc3, 0xd4, 0x65});
 
 public:
+    virtual SLANG_NO_THROW const AccelerationStructureDesc& SLANG_MCALL getDesc() = 0;
     virtual SLANG_NO_THROW AccelerationStructureHandle SLANG_MCALL getHandle() = 0;
     virtual SLANG_NO_THROW DeviceAddress SLANG_MCALL getDeviceAddress() = 0;
     virtual SLANG_NO_THROW Result SLANG_MCALL getDescriptorHandle(DescriptorHandle* outHandle) = 0;

--- a/include/slang-rhi.h
+++ b/include/slang-rhi.h
@@ -1448,9 +1448,6 @@ struct AccelerationStructureMotionCreateInfo
 
 enum class AccelerationStructureKind
 {
-    /// Unknown kind. On Vulkan, creates the acceleration structure with
-    /// VK_ACCELERATION_STRUCTURE_TYPE_GENERIC_KHR. Note that Vulkan validation may reject
-    /// GENERIC acceleration structures used as BLAS instance references.
     Unknown,
     BottomLevel,
     TopLevel,

--- a/src/debug-layer/debug-command-encoder.cpp
+++ b/src/debug-layer/debug-command-encoder.cpp
@@ -1516,6 +1516,24 @@ void DebugCommandEncoder::buildAccelerationStructure(
     }
     validateAccelerationStructureBuildDesc(ctx, desc);
 
+    AccelerationStructureKind dstKind = dst->getDesc().kind;
+    if (desc.inputs[0].type == AccelerationStructureBuildInputType::Instances)
+    {
+        if (dstKind != AccelerationStructureKind::TopLevel && dstKind != AccelerationStructureKind::Unknown)
+        {
+            RHI_VALIDATION_ERROR("Destination acceleration structure must be of kind TopLevel or Unknown.");
+            return;
+        }
+    }
+    else
+    {
+        if (dstKind != AccelerationStructureKind::BottomLevel && dstKind != AccelerationStructureKind::Unknown)
+        {
+            RHI_VALIDATION_ERROR("Destination acceleration structure must be of kind BottomLevel or Unknown.");
+            return;
+        }
+    }
+
     baseObject->buildAccelerationStructure(desc, dst, src, scratchBuffer, propertyQueryCount, innerQueryDescs.data());
 }
 

--- a/src/debug-layer/debug-command-encoder.cpp
+++ b/src/debug-layer/debug-command-encoder.cpp
@@ -1504,18 +1504,10 @@ void DebugCommandEncoder::buildAccelerationStructure(
         RHI_VALIDATION_ERROR("'queryDescs' must not be null when 'propertyQueryCount' > 0.");
         return;
     }
-
-    std::vector<AccelerationStructureQueryDesc> innerQueryDescs;
-    for (uint32_t i = 0; i < propertyQueryCount; ++i)
+    if (SLANG_FAILED(validateAccelerationStructureBuildDesc(ctx, desc)))
     {
-        innerQueryDescs.push_back(queryDescs[i]);
+        return;
     }
-    for (auto& innerQueryDesc : innerQueryDescs)
-    {
-        innerQueryDesc.queryPool = getInnerObj(innerQueryDesc.queryPool);
-    }
-    validateAccelerationStructureBuildDesc(ctx, desc);
-
     AccelerationStructureKind dstKind = dst->getDesc().kind;
     if (desc.inputs[0].type == AccelerationStructureBuildInputType::Instances)
     {
@@ -1532,6 +1524,16 @@ void DebugCommandEncoder::buildAccelerationStructure(
             RHI_VALIDATION_ERROR("Destination acceleration structure must be of kind BottomLevel or Unknown.");
             return;
         }
+    }
+
+    std::vector<AccelerationStructureQueryDesc> innerQueryDescs;
+    for (uint32_t i = 0; i < propertyQueryCount; ++i)
+    {
+        innerQueryDescs.push_back(queryDescs[i]);
+    }
+    for (auto& innerQueryDesc : innerQueryDescs)
+    {
+        innerQueryDesc.queryPool = getInnerObj(innerQueryDesc.queryPool);
     }
 
     baseObject->buildAccelerationStructure(desc, dst, src, scratchBuffer, propertyQueryCount, innerQueryDescs.data());

--- a/src/debug-layer/debug-device.cpp
+++ b/src/debug-layer/debug-device.cpp
@@ -755,6 +755,11 @@ Result DebugDevice::createAccelerationStructure(
         RHI_VALIDATION_ERROR("'outAccelerationStructure' must not be null.");
         return SLANG_E_INVALID_ARG;
     }
+    if (!isValidAccelerationStructureKind(desc.kind))
+    {
+        RHI_VALIDATION_ERROR("Invalid acceleration structure kind.");
+        return SLANG_E_INVALID_ARG;
+    }
     if (desc.size == 0)
     {
         RHI_VALIDATION_ERROR("Acceleration structure size must be greater than 0.");

--- a/src/debug-layer/debug-helper-functions.cpp
+++ b/src/debug-layer/debug-helper-functions.cpp
@@ -102,7 +102,7 @@ std::string createSamplerLabel(const SamplerDesc& desc)
 
 std::string createAccelerationStructureLabel(const AccelerationStructureDesc& desc)
 {
-    return string::format("Unnamed acceleration structure (size=%llu)", desc.size);
+    return string::format("Unnamed acceleration structure (kind=%s, size=%llu)", enumToString(desc.kind), desc.size);
 }
 
 std::string createFenceLabel(const FenceDesc& desc)

--- a/src/debug-layer/debug-helper-functions.h
+++ b/src/debug-layer/debug-helper-functions.h
@@ -230,6 +230,11 @@ inline bool isValidQueryType(QueryType value)
     return isValidEnum<QueryType, QueryType::AccelerationStructureCurrentSize>(value);
 }
 
+inline bool isValidAccelerationStructureKind(AccelerationStructureKind value)
+{
+    return isValidEnum<AccelerationStructureKind, AccelerationStructureKind::TopLevel>(value);
+}
+
 inline bool isValidAccelerationStructureCopyMode(AccelerationStructureCopyMode value)
 {
     return isValidEnum<AccelerationStructureCopyMode, AccelerationStructureCopyMode::Compact>(value);

--- a/src/enum-strings.cpp
+++ b/src/enum-strings.cpp
@@ -377,6 +377,20 @@ const char* enumToString(PrimitiveTopology value)
     return S_INVALID;
 }
 
+const char* enumToString(AccelerationStructureKind value)
+{
+    switch (value)
+    {
+    case AccelerationStructureKind::Unknown:
+        return S_AccelerationStructureKind_Unknown;
+    case AccelerationStructureKind::BottomLevel:
+        return S_AccelerationStructureKind_BottomLevel;
+    case AccelerationStructureKind::TopLevel:
+        return S_AccelerationStructureKind_TopLevel;
+    }
+    return S_INVALID;
+}
+
 const char* enumToString(QueryType value)
 {
     switch (value)

--- a/src/enum-strings.h
+++ b/src/enum-strings.h
@@ -23,6 +23,7 @@ const char* enumToString(ComparisonFunc value);
 const char* enumToString(TextureReductionOp value);
 const char* enumToString(InputSlotClass value);
 const char* enumToString(PrimitiveTopology value);
+const char* enumToString(AccelerationStructureKind value);
 const char* enumToString(QueryType value);
 const char* enumToString(CooperativeVectorMatrixLayout value);
 const char* enumToString(CooperativeVectorComponentType value);

--- a/src/rhi-shared.cpp
+++ b/src/rhi-shared.cpp
@@ -65,12 +65,6 @@ BufferRange Buffer::resolveBufferRange(const BufferRange& range)
     return resolved;
 }
 
-Result Buffer::getNativeHandle(NativeHandle* outHandle)
-{
-    *outHandle = {};
-    return SLANG_E_NOT_AVAILABLE;
-}
-
 Result Buffer::getSharedHandle(NativeHandle* outHandle)
 {
     *outHandle = {};
@@ -83,6 +77,12 @@ Result Buffer::getDescriptorHandle(
     BufferRange range,
     DescriptorHandle* outHandle
 )
+{
+    *outHandle = {};
+    return SLANG_E_NOT_AVAILABLE;
+}
+
+Result Buffer::getNativeHandle(NativeHandle* outHandle)
 {
     *outHandle = {};
     return SLANG_E_NOT_AVAILABLE;
@@ -185,12 +185,6 @@ bool Texture::isEntireTexture(const SubresourceRange& range)
     return true;
 }
 
-Result Texture::getNativeHandle(NativeHandle* outHandle)
-{
-    *outHandle = {};
-    return SLANG_E_NOT_AVAILABLE;
-}
-
 Result Texture::getSharedHandle(NativeHandle* outHandle)
 {
     *outHandle = {};
@@ -217,6 +211,12 @@ Result Texture::createView(const TextureViewDesc& desc, ITextureView** outTextur
     return m_device->createTextureView(this, desc, outTextureView);
 }
 
+Result Texture::getNativeHandle(NativeHandle* outHandle)
+{
+    *outHandle = {};
+    return SLANG_E_NOT_AVAILABLE;
+}
+
 // ----------------------------------------------------------------------------
 // TextureView
 // ----------------------------------------------------------------------------
@@ -236,12 +236,6 @@ TextureView::TextureView(Device* device, const TextureViewDesc& desc)
     m_sampler = checked_cast<Sampler*>(m_desc.sampler);
 }
 
-Result TextureView::getNativeHandle(NativeHandle* outHandle)
-{
-    *outHandle = {};
-    return SLANG_E_NOT_AVAILABLE;
-}
-
 Result TextureView::getDescriptorHandle(DescriptorHandleAccess access, DescriptorHandle* outHandle)
 {
     *outHandle = {};
@@ -249,6 +243,12 @@ Result TextureView::getDescriptorHandle(DescriptorHandleAccess access, Descripto
 }
 
 Result TextureView::getCombinedTextureSamplerDescriptorHandle(DescriptorHandle* outHandle)
+{
+    *outHandle = {};
+    return SLANG_E_NOT_AVAILABLE;
+}
+
+Result TextureView::getNativeHandle(NativeHandle* outHandle)
 {
     *outHandle = {};
     return SLANG_E_NOT_AVAILABLE;
@@ -270,11 +270,6 @@ Sampler::Sampler(Device* device, const SamplerDesc& desc)
     , m_desc(desc)
 {
     m_descHolder.holdString(m_desc.label);
-}
-
-const SamplerDesc& Sampler::getDesc()
-{
-    return m_desc;
 }
 
 Result Sampler::getDescriptorHandle(DescriptorHandle* outHandle)

--- a/src/rhi-shared.h
+++ b/src/rhi-shared.h
@@ -78,7 +78,6 @@ public:
 
     // IBuffer interface
     virtual SLANG_NO_THROW BufferDesc& SLANG_MCALL getDesc() override { return m_desc; }
-    virtual SLANG_NO_THROW Result SLANG_MCALL getNativeHandle(NativeHandle* outHandle) override;
     virtual SLANG_NO_THROW Result SLANG_MCALL getSharedHandle(NativeHandle* outHandle) override;
     virtual SLANG_NO_THROW Result SLANG_MCALL getDescriptorHandle(
         DescriptorHandleAccess access,
@@ -86,6 +85,9 @@ public:
         BufferRange range,
         DescriptorHandle* outHandle
     ) override;
+
+    // IResource interface
+    virtual SLANG_NO_THROW Result SLANG_MCALL getNativeHandle(NativeHandle* outHandle) override;
 
 public:
     BufferDesc m_desc;
@@ -138,7 +140,6 @@ public:
 
     // ITexture interface
     virtual SLANG_NO_THROW TextureDesc& SLANG_MCALL getDesc() override { return m_desc; };
-    virtual SLANG_NO_THROW Result SLANG_MCALL getNativeHandle(NativeHandle* outHandle) override;
     virtual SLANG_NO_THROW Result SLANG_MCALL getSharedHandle(NativeHandle* outHandle) override;
     virtual SLANG_NO_THROW Result SLANG_MCALL createView(
         const TextureViewDesc& desc,
@@ -153,6 +154,9 @@ public:
     {
         return getSubresourceRegionLayout(mip, {0, 0, 0}, Extent3D::kWholeTexture, rowAlignment, outLayout);
     }
+
+    // IResource interface
+    virtual SLANG_NO_THROW Result SLANG_MCALL getNativeHandle(NativeHandle* outHandle) override;
 
 public:
     TextureDesc m_desc;
@@ -171,7 +175,6 @@ public:
     TextureView(Device* device, const TextureViewDesc& desc);
 
     // ITextureView interface
-    virtual SLANG_NO_THROW Result SLANG_MCALL getNativeHandle(NativeHandle* outHandle) override;
     virtual SLANG_NO_THROW const TextureViewDesc& SLANG_MCALL getDesc() override { return m_desc; }
     virtual SLANG_NO_THROW Result getDescriptorHandle(
         DescriptorHandleAccess access,
@@ -180,6 +183,9 @@ public:
     virtual SLANG_NO_THROW Result SLANG_MCALL getCombinedTextureSamplerDescriptorHandle(
         DescriptorHandle* outHandle
     ) override;
+
+    // IResource interface
+    virtual SLANG_NO_THROW Result SLANG_MCALL getNativeHandle(NativeHandle* outHandle) override;
 
 public:
     TextureViewDesc m_desc;
@@ -197,7 +203,7 @@ public:
     Sampler(Device* device, const SamplerDesc& desc);
 
     // ISampler interface
-    virtual SLANG_NO_THROW const SamplerDesc& SLANG_MCALL getDesc() override;
+    virtual SLANG_NO_THROW const SamplerDesc& SLANG_MCALL getDesc() override { return m_desc; }
     virtual SLANG_NO_THROW Result SLANG_MCALL getDescriptorHandle(DescriptorHandle* outHandle) override;
 
     // IResource interface
@@ -218,6 +224,7 @@ public:
     AccelerationStructure(Device* device, const AccelerationStructureDesc& desc);
 
     // IAccelerationStructure interface
+    virtual SLANG_NO_THROW const AccelerationStructureDesc& SLANG_MCALL getDesc() override { return m_desc; }
     virtual SLANG_NO_THROW AccelerationStructureHandle SLANG_MCALL getHandle() override;
     virtual SLANG_NO_THROW Result SLANG_MCALL getDescriptorHandle(DescriptorHandle* outHandle) override;
 

--- a/src/strings.h
+++ b/src/strings.h
@@ -146,6 +146,11 @@
 #define S_PrimitiveTopology_TriangleStrip "TriangleStrip"
 #define S_PrimitiveTopology_PatchList "PatchList"
 
+// AccelerationStructureKind
+#define S_AccelerationStructureKind_Unknown "Unknown"
+#define S_AccelerationStructureKind_BottomLevel "BottomLevel"
+#define S_AccelerationStructureKind_TopLevel "TopLevel"
+
 // QueryType
 #define S_QueryType_Timestamp "Timestamp"
 #define S_QueryType_AccelerationStructureCompactedSize "AccelerationStructureCompactedSize"

--- a/src/vulkan/vk-device.cpp
+++ b/src/vulkan/vk-device.cpp
@@ -1777,7 +1777,18 @@ Result DeviceImpl::createAccelerationStructure(
     createInfo.buffer = result->m_buffer->m_buffer.m_buffer;
     createInfo.offset = 0;
     createInfo.size = desc.size;
-    createInfo.type = VK_ACCELERATION_STRUCTURE_TYPE_GENERIC_KHR;
+    switch (desc.kind)
+    {
+    case AccelerationStructureKind::BottomLevel:
+        createInfo.type = VK_ACCELERATION_STRUCTURE_TYPE_BOTTOM_LEVEL_KHR;
+        break;
+    case AccelerationStructureKind::TopLevel:
+        createInfo.type = VK_ACCELERATION_STRUCTURE_TYPE_TOP_LEVEL_KHR;
+        break;
+    default:
+        createInfo.type = VK_ACCELERATION_STRUCTURE_TYPE_GENERIC_KHR;
+        break;
+    }
     if (is_set(desc.flags, AccelerationStructureBuildFlags::CreateMotion))
     {
         createInfo.createFlags |= VK_ACCELERATION_STRUCTURE_CREATE_MOTION_BIT_NV;

--- a/src/vulkan/vk-device.cpp
+++ b/src/vulkan/vk-device.cpp
@@ -1777,18 +1777,7 @@ Result DeviceImpl::createAccelerationStructure(
     createInfo.buffer = result->m_buffer->m_buffer.m_buffer;
     createInfo.offset = 0;
     createInfo.size = desc.size;
-    switch (desc.kind)
-    {
-    case AccelerationStructureKind::BottomLevel:
-        createInfo.type = VK_ACCELERATION_STRUCTURE_TYPE_BOTTOM_LEVEL_KHR;
-        break;
-    case AccelerationStructureKind::TopLevel:
-        createInfo.type = VK_ACCELERATION_STRUCTURE_TYPE_TOP_LEVEL_KHR;
-        break;
-    default:
-        createInfo.type = VK_ACCELERATION_STRUCTURE_TYPE_GENERIC_KHR;
-        break;
-    }
+    createInfo.type = translateAccelerationStructureKind(desc.kind);
     if (is_set(desc.flags, AccelerationStructureBuildFlags::CreateMotion))
     {
         createInfo.createFlags |= VK_ACCELERATION_STRUCTURE_CREATE_MOTION_BIT_NV;

--- a/src/vulkan/vk-utils.cpp
+++ b/src/vulkan/vk-utils.cpp
@@ -970,6 +970,21 @@ VkSamplerReductionMode translateReductionOp(TextureReductionOp op)
     return VkSamplerReductionMode(0);
 }
 
+VkAccelerationStructureTypeKHR translateAccelerationStructureKind(AccelerationStructureKind kind)
+{
+    switch (kind)
+    {
+    case AccelerationStructureKind::BottomLevel:
+        return VK_ACCELERATION_STRUCTURE_TYPE_BOTTOM_LEVEL_KHR;
+    case AccelerationStructureKind::TopLevel:
+        return VK_ACCELERATION_STRUCTURE_TYPE_TOP_LEVEL_KHR;
+    default:
+        return VK_ACCELERATION_STRUCTURE_TYPE_GENERIC_KHR;
+    }
+    SLANG_RHI_ASSERT_FAILURE("Invalid AccelerationStructureKind value");
+    return VK_ACCELERATION_STRUCTURE_TYPE_GENERIC_KHR;
+}
+
 VkComponentTypeKHR translateCooperativeVectorComponentType(CooperativeVectorComponentType type)
 {
     switch (type)

--- a/src/vulkan/vk-utils.cpp
+++ b/src/vulkan/vk-utils.cpp
@@ -974,12 +974,12 @@ VkAccelerationStructureTypeKHR translateAccelerationStructureKind(AccelerationSt
 {
     switch (kind)
     {
+    case AccelerationStructureKind::Unknown:
+        return VK_ACCELERATION_STRUCTURE_TYPE_GENERIC_KHR;
     case AccelerationStructureKind::BottomLevel:
         return VK_ACCELERATION_STRUCTURE_TYPE_BOTTOM_LEVEL_KHR;
     case AccelerationStructureKind::TopLevel:
         return VK_ACCELERATION_STRUCTURE_TYPE_TOP_LEVEL_KHR;
-    default:
-        return VK_ACCELERATION_STRUCTURE_TYPE_GENERIC_KHR;
     }
     SLANG_RHI_ASSERT_FAILURE("Invalid AccelerationStructureKind value");
     return VK_ACCELERATION_STRUCTURE_TYPE_GENERIC_KHR;

--- a/src/vulkan/vk-utils.h
+++ b/src/vulkan/vk-utils.h
@@ -98,6 +98,8 @@ VkStencilOpState translateStencilState(DepthStencilOpDesc desc);
 
 VkSamplerReductionMode translateReductionOp(TextureReductionOp op);
 
+VkAccelerationStructureTypeKHR translateAccelerationStructureKind(AccelerationStructureKind kind);
+
 VkComponentTypeKHR translateCooperativeVectorComponentType(CooperativeVectorComponentType type);
 CooperativeVectorComponentType translateCooperativeVectorComponentType(VkComponentTypeKHR type);
 VkCooperativeVectorMatrixLayoutNV translateCooperativeVectorMatrixLayout(CooperativeVectorMatrixLayout layout);

--- a/tests/test-acceleration-structure-creation-with-validation.cpp
+++ b/tests/test-acceleration-structure-creation-with-validation.cpp
@@ -72,6 +72,7 @@ GPU_TEST_CASE_EX("acceleration-structure-creation-with-validation", Vulkan, kDeb
         // Build acceleration structure.
         ComPtr<IAccelerationStructure> draftAS;
         AccelerationStructureDesc draftDesc = {};
+        draftDesc.kind = AccelerationStructureKind::BottomLevel;
         draftDesc.size = accelerationStructureSizes.accelerationStructureSize;
         m_device->createAccelerationStructure(draftDesc, draftAS.writeRef());
 
@@ -88,6 +89,7 @@ GPU_TEST_CASE_EX("acceleration-structure-creation-with-validation", Vulkan, kDeb
         uint64_t compactedSize = 0;
         compactedSizeQuery->getResult(0, 1, &compactedSize);
         AccelerationStructureDesc finalDesc;
+        finalDesc.kind = AccelerationStructureKind::BottomLevel;
         finalDesc.size = compactedSize;
         m_device->createAccelerationStructure(finalDesc, m_bottomLevelAccelerationStructure.writeRef());
 
@@ -155,6 +157,7 @@ GPU_TEST_CASE_EX("acceleration-structure-creation-with-validation", Vulkan, kDeb
         ComPtr<IBuffer> scratchBuffer = m_device->createBuffer(scratchBufferDesc);
 
         AccelerationStructureDesc createDesc = {};
+        createDesc.kind = AccelerationStructureKind::TopLevel;
         createDesc.size = accelerationStructureSizes.accelerationStructureSize;
         m_device->createAccelerationStructure(createDesc, m_topLevelAccelerationStructure.writeRef());
 

--- a/tests/test-ray-tracing-clusters.cpp
+++ b/tests/test-ray-tracing-clusters.cpp
@@ -583,6 +583,7 @@ static void testClusterTracing(
     ComPtr<IBuffer> tlasScratch = device->createBuffer(tlasScratchDesc);
 
     AccelerationStructureDesc createDesc = {};
+    createDesc.kind = AccelerationStructureKind::TopLevel;
     createDesc.size = tlasSizes.accelerationStructureSize;
     ComPtr<IAccelerationStructure> TLAS;
     REQUIRE_CALL(device->createAccelerationStructure(createDesc, TLAS.writeRef()));

--- a/tests/test-ray-tracing-common.h
+++ b/tests/test-ray-tracing-common.h
@@ -90,6 +90,7 @@ struct TriangleBLAS
 
         ComPtr<IAccelerationStructure> draftAS;
         AccelerationStructureDesc draftCreateDesc;
+        draftCreateDesc.kind = AccelerationStructureKind::BottomLevel;
         draftCreateDesc.size = sizes.accelerationStructureSize;
         REQUIRE_CALL(device->createAccelerationStructure(draftCreateDesc, draftAS.writeRef()));
 
@@ -107,6 +108,7 @@ struct TriangleBLAS
         uint64_t compactedSize = 0;
         compactedSizeQuery->getResult(0, 1, &compactedSize);
         AccelerationStructureDesc createDesc;
+        createDesc.kind = AccelerationStructureKind::BottomLevel;
         createDesc.size = compactedSize;
         REQUIRE_CALL(device->createAccelerationStructure(createDesc, blas.writeRef()));
 
@@ -249,6 +251,7 @@ struct SphereBLAS
 
         ComPtr<IAccelerationStructure> draftAS;
         AccelerationStructureDesc draftCreateDesc;
+        draftCreateDesc.kind = AccelerationStructureKind::BottomLevel;
         draftCreateDesc.size = sizes.accelerationStructureSize;
         REQUIRE_CALL(device->createAccelerationStructure(draftCreateDesc, draftAS.writeRef()));
 
@@ -266,6 +269,7 @@ struct SphereBLAS
         uint64_t compactedSize = 0;
         compactedSizeQuery->getResult(0, 1, &compactedSize);
         AccelerationStructureDesc createDesc;
+        createDesc.kind = AccelerationStructureKind::BottomLevel;
         createDesc.size = compactedSize;
         REQUIRE_CALL(device->createAccelerationStructure(createDesc, blas.writeRef()));
 
@@ -363,6 +367,7 @@ struct SingleCustomGeometryBLAS
 
         ComPtr<IAccelerationStructure> draftAS;
         AccelerationStructureDesc draftCreateDesc;
+        draftCreateDesc.kind = AccelerationStructureKind::BottomLevel;
         draftCreateDesc.size = sizes.accelerationStructureSize;
         REQUIRE_CALL(device->createAccelerationStructure(draftCreateDesc, draftAS.writeRef()));
 
@@ -380,6 +385,7 @@ struct SingleCustomGeometryBLAS
         uint64_t compactedSize = 0;
         compactedSizeQuery->getResult(0, 1, &compactedSize);
         AccelerationStructureDesc createDesc;
+        createDesc.kind = AccelerationStructureKind::BottomLevel;
         createDesc.size = compactedSize;
         REQUIRE_CALL(device->createAccelerationStructure(createDesc, blas.writeRef()));
 
@@ -478,6 +484,7 @@ struct SingleTriangleVertexMotionBLAS
 
         ComPtr<IAccelerationStructure> draftAS;
         AccelerationStructureDesc draftCreateDesc;
+        draftCreateDesc.kind = AccelerationStructureKind::BottomLevel;
         draftCreateDesc.size = sizes.accelerationStructureSize;
         REQUIRE_CALL(device->createAccelerationStructure(draftCreateDesc, draftAS.writeRef()));
 
@@ -495,6 +502,7 @@ struct SingleTriangleVertexMotionBLAS
         uint64_t compactedSize = 0;
         compactedSizeQuery->getResult(0, 1, &compactedSize);
         AccelerationStructureDesc createDesc;
+        createDesc.kind = AccelerationStructureKind::BottomLevel;
         createDesc.size = compactedSize;
         REQUIRE_CALL(device->createAccelerationStructure(createDesc, blas.writeRef()));
 
@@ -588,6 +596,7 @@ struct LssBLAS
 
         ComPtr<IAccelerationStructure> draftAS;
         AccelerationStructureDesc draftCreateDesc;
+        draftCreateDesc.kind = AccelerationStructureKind::BottomLevel;
         draftCreateDesc.size = sizes.accelerationStructureSize;
         REQUIRE_CALL(device->createAccelerationStructure(draftCreateDesc, draftAS.writeRef()));
 
@@ -605,6 +614,7 @@ struct LssBLAS
         uint64_t compactedSize = 0;
         compactedSizeQuery->getResult(0, 1, &compactedSize);
         AccelerationStructureDesc createDesc;
+        createDesc.kind = AccelerationStructureKind::BottomLevel;
         createDesc.size = compactedSize;
         REQUIRE_CALL(device->createAccelerationStructure(createDesc, blas.writeRef()));
 
@@ -729,6 +739,7 @@ struct TLAS
         ComPtr<IBuffer> scratchBuffer = device->createBuffer(scratchBufferDesc);
 
         AccelerationStructureDesc createDesc{};
+        createDesc.kind = AccelerationStructureKind::TopLevel;
         createDesc.size = sizes.accelerationStructureSize;
 
         REQUIRE_CALL(device->createAccelerationStructure(createDesc, tlas.writeRef()));
@@ -808,6 +819,7 @@ struct VertexMotionInstanceTLAS
         ComPtr<IBuffer> scratchBuffer = device->createBuffer(scratchBufferDesc);
 
         AccelerationStructureDesc createDesc;
+        createDesc.kind = AccelerationStructureKind::TopLevel;
         createDesc.size = sizes.accelerationStructureSize;
 
         createDesc.motionInfo.enabled = true;
@@ -888,6 +900,7 @@ struct MatrixMotionInstanceTLAS
         ComPtr<IBuffer> scratchBuffer = device->createBuffer(scratchBufferDesc);
 
         AccelerationStructureDesc createDesc{};
+        createDesc.kind = AccelerationStructureKind::TopLevel;
         createDesc.size = sizes.accelerationStructureSize;
         createDesc.flags = AccelerationStructureBuildFlags::CreateMotion;
 
@@ -968,6 +981,7 @@ struct SrtMotionInstanceTLAS
         ComPtr<IBuffer> scratchBuffer = device->createBuffer(scratchBufferDesc);
 
         AccelerationStructureDesc createDesc{};
+        createDesc.kind = AccelerationStructureKind::TopLevel;
         createDesc.size = sizes.accelerationStructureSize;
         createDesc.flags = AccelerationStructureBuildFlags::CreateMotion;
 


### PR DESCRIPTION
This is to resolve the slang-rhi test caused by PR #622.

Vulkan GPU-assisted validation enforces VUID-vkCmdBuildAccelerationStructuresKHR-pInfos-12281, which requires that acceleration structures referenced as BLAS instances must have been created with VK_ACCELERATION_STRUCTURE_TYPE_BOTTOM_LEVEL_KHR, not VK_ACCELERATION_STRUCTURE_TYPE_GENERIC_KHR.

The Vulkan backend was previously always creating acceleration structures with GENERIC_KHR, which was caught by the new GPU-AV test added in PR #622.

Fix by adding AccelerationStructureKind enum (Unknown/BottomLevel/TopLevel) and a kind field to AccelerationStructureDesc. The Vulkan backend now maps kind to the correct VkAccelerationStructureTypeKHR at creation time (defaulting to GENERIC_KHR for Unknown, preserving backward compatibility). All tests are updated to set the correct kind.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Acceleration structures can be designated as BottomLevel or TopLevel and their creation descriptor can be queried.
* **Behavior Changes**
  * GPU creation now respects the declared structure kind when constructing acceleration structures.
* **Bug Fixes / Validation**
  * New validation rejects invalid kinds and prevents mismatched build types with clear errors.
* **Tests & Debug**
  * Tests now set kinds explicitly; debug labels and messages include the structure kind.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->