### PR TITLE
Add missing D3D12/Vulkan shader table resource state change

### DIFF
--- a/src/d3d12/d3d12-command.cpp
+++ b/src/d3d12/d3d12-command.cpp
@@ -910,6 +910,8 @@ void CommandRecorder::cmdSetRenderState(const commands::SetRenderState& cmd)
         m_cmdList->RSSetScissorRects(state.scissorRectCount, scissorRects);
     }
 
+    commitBarriers();
+
     m_renderStateValid = true;
     m_renderState = state;
 
@@ -1034,6 +1036,8 @@ void CommandRecorder::cmdSetComputeState(const commands::SetComputeState& cmd)
         setBindings(m_bindingData, BindMode::Compute);
     }
 
+    commitBarriers();
+
     m_computeStateValid = true;
 
     m_renderStateValid = false;
@@ -1110,6 +1114,7 @@ void CommandRecorder::cmdSetRayTracingState(const commands::SetRayTracingState& 
             m_rayTracingStateValid = false;
             return;
         }
+        requireBufferState(shaderTablePipelineData->buffer, ResourceState::ShaderResource);
         DeviceAddress shaderTableAddr = shaderTablePipelineData->buffer->getDeviceAddress();
 
         m_dispatchRaysDesc = {};
@@ -1147,6 +1152,8 @@ void CommandRecorder::cmdSetRayTracingState(const commands::SetRayTracingState& 
             m_dispatchRaysDesc.CallableShaderTable.StrideInBytes = shaderTablePipelineData->callableRecordStride;
         }
     }
+
+    commitBarriers();
 
     m_rayTracingStateValid = true;
 
@@ -1627,6 +1634,8 @@ void CommandRecorder::setBindings(BindingDataImpl* bindingData, BindMode bindMod
             textureState.state
         );
     }
+
+    // We need barriers to be committed before setting root parameters.
     commitBarriers();
 
     // Then we bind the root parameters.

--- a/src/vulkan/vk-command.cpp
+++ b/src/vulkan/vk-command.cpp
@@ -1026,9 +1026,10 @@ void CommandRecorder::cmdSetComputeState(const commands::SetComputeState& cmd)
     {
         m_bindingData = static_cast<BindingDataImpl*>(cmd.bindingData);
         requireBindingStates(m_bindingData);
-        commitBarriers();
         setBindings(m_bindingData, VK_PIPELINE_BIND_POINT_COMPUTE);
     }
+
+    commitBarriers();
 
     m_computeStateValid = true;
 
@@ -1088,7 +1089,6 @@ void CommandRecorder::cmdSetRayTracingState(const commands::SetRayTracingState& 
     {
         m_bindingData = static_cast<BindingDataImpl*>(cmd.bindingData);
         requireBindingStates(m_bindingData);
-        commitBarriers();
         setBindings(m_bindingData, VK_PIPELINE_BIND_POINT_RAY_TRACING_KHR);
     }
 
@@ -1101,6 +1101,7 @@ void CommandRecorder::cmdSetRayTracingState(const commands::SetRayTracingState& 
             m_rayTracingStateValid = false;
             return;
         }
+        requireBufferState(m_shaderTablePipelineData->buffer, ResourceState::ShaderResource);
         DeviceAddress shaderTableAddr = m_shaderTablePipelineData->buffer->getDeviceAddress();
 
         // Raygen address, stride, and size are set at dispatch time since each raygen
@@ -1119,6 +1120,8 @@ void CommandRecorder::cmdSetRayTracingState(const commands::SetRayTracingState& 
         m_callableSBT.stride = m_shaderTablePipelineData->callableRecordStride;
         m_callableSBT.size = m_shaderTablePipelineData->callableTableSize;
     }
+
+    commitBarriers();
 
     m_rayTracingStateValid = true;
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed resource state transition ordering in graphics command processing to ensure correct rendering behavior across different graphics APIs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->