### PR TITLE
Support CoopVec feature when using AgilitySDK preview

### DIFF
--- a/src/d3d12/d3d12-device.cpp
+++ b/src/d3d12/d3d12-device.cpp
@@ -848,6 +848,21 @@ Result DeviceImpl::initialize(const DeviceDesc& desc)
         }
     }
 
+#if SLANG_RHI_AGILITY_SDK_VERSION == D3D12_PREVIEW_SDK_VERSION
+#if defined(D3D12_PREVIEW_SDK_VERSION) && (D3D12_PREVIEW_SDK_VERSION >= 713)
+    {
+        // Check for cooperative vector support via native D3D12 Agility PREVIEW SDK.
+        D3D12_FEATURE_DATA_COOPERATIVE_VECTOR coopVecData = {};
+        if (SLANG_SUCCEEDED(
+                m_device->CheckFeatureSupport(D3D12_FEATURE_COOPERATIVE_VECTOR, &coopVecData, sizeof(coopVecData))
+            ))
+        {
+            addFeature(Feature::CooperativeVector);
+        }
+    }
+#endif
+#endif
+
     // Initialize NVAPI
 #if SLANG_RHI_ENABLE_NVAPI
     {


### PR DESCRIPTION
This PR is to support the Cooperative Vector feature when the AgilitySDK "PREVIEW" is used.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added detection of cooperative vector support on compatible D3D12 devices, enabling applications to discover and utilize this hardware capability when available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->