### PR TITLE
Handle the rest of ScalarType for wgpu as Undefined

### DIFF
--- a/src/wgpu/wgpu-shader-object-layout.cpp
+++ b/src/wgpu/wgpu-shader-object-layout.cpp
@@ -20,8 +20,9 @@ inline WGPUTextureViewDimension getViewDimension(SlangResourceShape shape)
     case SLANG_TEXTURE_3D:
         return WGPUTextureViewDimension_3D;
     default:
-        return WGPUTextureViewDimension_Undefined;
+        break;
     }
+    return WGPUTextureViewDimension_Undefined;
 }
 
 inline WGPUTextureSampleType getSampleType(slang::TypeReflection* type)
@@ -52,6 +53,8 @@ inline WGPUTextureSampleType getSampleType(slang::TypeReflection* type)
     case slang::TypeReflection::ScalarType::Float32:
     case slang::TypeReflection::ScalarType::Float64:
         return WGPUTextureSampleType_Float;
+    default:
+        break;
     }
     return WGPUTextureSampleType_Undefined;
 }


### PR DESCRIPTION
We are trying to add more types to ScalarType: IntPtr, UIntPtr and
BFloat16; in https://github.com/shader-slang/slang/pull/10643
And slang-rhi build prints a warning that the new types are not handled
in a switch-statement for WGPU.

Because WGPU cannot represent those types, this PR converts the new
types as Undefined and avoid the compilation warnings, which is treated
an errors on CI machines.