### PR TITLE
Fix CUDA library discovery on Linux/WSL

### DIFF
--- a/src/cuda-driver-api.cpp
+++ b/src/cuda-driver-api.cpp
@@ -32,6 +32,7 @@ extern "C" bool rhiCudaDriverApiInit()
     };
 #elif SLANG_LINUX_FAMILY
     const char* cudaPaths[] = {
+        "libcuda.so.1",
         "libcuda.so",
         nullptr,
     };

--- a/src/cuda/cuda-nvrtc.cpp
+++ b/src/cuda/cuda-nvrtc.cpp
@@ -77,6 +77,7 @@ inline void findNVRTCPaths(std::vector<std::filesystem::path>& outPaths)
         {
             outPaths.push_back(std::filesystem::path(path) / "lib64");
             outPaths.push_back(std::filesystem::path(path) / "lib");
+            outPaths.push_back(std::filesystem::path(path) / "targets" / "x86_64-linux" / "lib");
         }
     }
     // Next, check default installation paths.
@@ -104,6 +105,11 @@ inline void findNVRTCPaths(std::vector<std::filesystem::path>& outPaths)
             if (std::find(outPaths.begin(), outPaths.end(), path) == outPaths.end())
             {
                 outPaths.push_back(path);
+            }
+            std::filesystem::path targetPath = version / "targets" / "x86_64-linux" / "lib";
+            if (std::find(outPaths.begin(), outPaths.end(), targetPath) == outPaths.end())
+            {
+                outPaths.push_back(targetPath);
             }
         }
     }
@@ -221,6 +227,7 @@ Result NVRTC::initialize(IDebugCallback* debugCallback)
                     "- C:\\Program Files\\NVIDIA GPU Computing Toolkit\\CUDA\\vX.Y\n"
 #elif SLANG_LINUX_FAMILY
                     "- /usr/local/cuda-x.y\n"
+                    "- /usr/local/cuda-x.y/targets/x86_64-linux\n"
                     "- /usr/lib/x86_64-linux-gnu\n"
 #endif
                     ;


### PR DESCRIPTION
## Summary
- try `libcuda.so.1` before `libcuda.so` on Linux so CUDA device creation works on WSL
- search CUDA 12+ `targets/x86_64-linux/lib` locations when discovering NVRTC
- mention the additional Linux search location in the NVRTC error message

## Why
On WSL, the CUDA driver is typically exposed as `libcuda.so.1` rather than `libcuda.so`. Recent CUDA toolkit installs also place `libnvrtc.so` under `targets/x86_64-linux/lib`, which was not part of the Linux search path.

Without these two path updates, CUDA device creation fails even when CUDA on WSL is installed correctly.

## Validation
- rebuilt `slangpy` editable package on WSL
- created a CUDA `slangpy.Device(...)` successfully after the change


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced CUDA driver initialization on Linux to support additional library search paths including versioned shared library names.
  * Extended CUDA NVRTC library discovery on Linux to search additional target directories for improved library resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->