### PR TITLE
Fix varLayout assertion failure when importing module with global ConstantBuffer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,6 @@ build/
 external/optix
 
 .vs/
+.idea/
 
 *.nsys-rep

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -928,6 +928,7 @@ if(SLANG_RHI_BUILD_TESTS AND NOT SLANG_RHI_BUILD_SHARED AND NOT EMSCRIPTEN)
         tests/test-fence.cpp
         tests/test-formats.cpp
         tests/test-heap.cpp
+        tests/test-imported-constant-buffer.cpp
         tests/test-link-time-constant.cpp
         tests/test-link-time-default.cpp
         tests/test-link-time-options.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -966,6 +966,7 @@ if(SLANG_RHI_BUILD_TESTS AND NOT SLANG_RHI_BUILD_SHARED AND NOT EMSCRIPTEN)
         tests/test-fence.cpp
         tests/test-formats.cpp
         tests/test-heap.cpp
+        tests/test-imported-constant-buffer.cpp
         tests/test-link-time-constant.cpp
         tests/test-link-time-default.cpp
         tests/test-link-time-options.cpp

--- a/src/cpu/cpu-pipeline.cpp
+++ b/src/cpu/cpu-pipeline.cpp
@@ -23,13 +23,13 @@ Result DeviceImpl::createComputePipeline2(const ComputePipelineDesc& desc, IComp
     uint32_t entryPointIndex = 0;
 
     auto program = checked_cast<ShaderProgramImpl*>(desc.program);
-    auto entryPointLayout = program->slangGlobalScope->getLayout()->getEntryPointByIndex(entryPointIndex);
+    auto entryPointLayout = program->linkedProgram->getLayout()->getEntryPointByIndex(entryPointIndex);
     auto entryPointName = entryPointLayout->getNameOverride();
 
     ComPtr<ISlangSharedLibrary> sharedLibrary;
     ComPtr<ISlangBlob> diagnostics;
     auto compileResult =
-        program->slangGlobalScope
+        program->linkedProgram
             ->getEntryPointHostCallable(entryPointIndex, targetIndex, sharedLibrary.writeRef(), diagnostics.writeRef());
     if (diagnostics)
     {

--- a/src/shader.cpp
+++ b/src/shader.cpp
@@ -56,11 +56,7 @@ Result ShaderProgram::init()
     }
 
     auto session = m_desc.slangGlobalScope ? m_desc.slangGlobalScope->getSession() : nullptr;
-    if (m_desc.linkingStyle == LinkingStyle::SingleProgram && m_desc.slangEntryPointCount == 0)
-    {
-        linkedProgram = m_desc.slangGlobalScope;
-    }
-    else if (m_desc.linkingStyle == LinkingStyle::SingleProgram)
+    if (m_desc.linkingStyle == LinkingStyle::SingleProgram)
     {
         std::vector<slang::IComponentType*> components;
         if (m_desc.slangGlobalScope)

--- a/src/shader.cpp
+++ b/src/shader.cpp
@@ -56,7 +56,11 @@ Result ShaderProgram::init()
     }
 
     auto session = m_desc.slangGlobalScope ? m_desc.slangGlobalScope->getSession() : nullptr;
-    if (m_desc.linkingStyle == LinkingStyle::SingleProgram)
+    if (m_desc.linkingStyle == LinkingStyle::SingleProgram && m_desc.slangEntryPointCount == 0)
+    {
+        linkedProgram = m_desc.slangGlobalScope;
+    }
+    else if (m_desc.linkingStyle == LinkingStyle::SingleProgram)
     {
         std::vector<slang::IComponentType*> components;
         if (m_desc.slangGlobalScope)

--- a/src/shader.cpp
+++ b/src/shader.cpp
@@ -71,9 +71,11 @@ Result ShaderProgram::init()
             }
             components.push_back(m_desc.slangEntryPoints[i]);
         }
+        ComPtr<slang::IComponentType> composedProgram;
         SLANG_RETURN_ON_FAIL(
-            session->createCompositeComponentType(components.data(), components.size(), linkedProgram.writeRef())
+            session->createCompositeComponentType(components.data(), components.size(), composedProgram.writeRef())
         );
+        SLANG_RETURN_ON_FAIL(composedProgram->link(linkedProgram.writeRef()));
     }
     else
     {

--- a/tests/test-imported-constant-buffer-data.slang
+++ b/tests/test-imported-constant-buffer-data.slang
@@ -1,0 +1,9 @@
+// Module with global ConstantBuffer — triggers varLayout assertion when imported.
+module "test-imported-constant-buffer-data";
+
+public struct MyData
+{
+    public float4 value;
+};
+
+public ConstantBuffer<MyData> gData;

--- a/tests/test-imported-constant-buffer-data.slang
+++ b/tests/test-imported-constant-buffer-data.slang
@@ -1,4 +1,4 @@
-// Module with global ConstantBuffer — triggers varLayout assertion when imported.
+// Module with global ConstantBuffer - triggers varLayout assertion when imported.
 module "test-imported-constant-buffer-data";
 
 public struct MyData

--- a/tests/test-imported-constant-buffer.cpp
+++ b/tests/test-imported-constant-buffer.cpp
@@ -3,7 +3,7 @@
 using namespace rhi;
 using namespace rhi::testing;
 
-GPU_TEST_CASE("imported-constant-buffer", ALL)
+GPU_TEST_CASE("imported-constant-buffer", ALL & ~CPU)
 {
     ComPtr<IShaderProgram> shaderProgram;
     REQUIRE_CALL(loadProgram(device, "test-imported-constant-buffer", "computeMain", shaderProgram.writeRef()));

--- a/tests/test-imported-constant-buffer.cpp
+++ b/tests/test-imported-constant-buffer.cpp
@@ -5,26 +5,8 @@ using namespace rhi::testing;
 
 GPU_TEST_CASE("imported-constant-buffer", ALL)
 {
-    ComPtr<slang::ISession> slangSession;
-    REQUIRE_CALL(device->getSlangSession(slangSession.writeRef()));
-
-    ComPtr<slang::IBlob> diagnosticsBlob;
-    slang::IModule* module = slangSession->loadModule("test-imported-constant-buffer", diagnosticsBlob.writeRef());
-    diagnoseIfNeeded(diagnosticsBlob);
-    REQUIRE(module);
-
-    ComPtr<slang::IEntryPoint> entryPoint;
-    REQUIRE_CALL(module->findEntryPointByName("computeMain", entryPoint.writeRef()));
-
-    slang::IComponentType* entryPoints[] = {entryPoint.get()};
-
-    ShaderProgramDesc desc = {};
-    desc.slangGlobalScope = module;
-    desc.slangEntryPoints = entryPoints;
-    desc.slangEntryPointCount = 1;
-
     ComPtr<IShaderProgram> shaderProgram;
-    REQUIRE_CALL(device->createShaderProgram(desc, shaderProgram.writeRef()));
+    REQUIRE_CALL(loadProgram(device, "test-imported-constant-buffer", "computeMain", shaderProgram.writeRef()));
 
     ComputePipelineDesc pipelineDesc = {};
     pipelineDesc.program = shaderProgram.get();

--- a/tests/test-imported-constant-buffer.cpp
+++ b/tests/test-imported-constant-buffer.cpp
@@ -1,0 +1,89 @@
+#include "testing.h"
+
+using namespace rhi;
+using namespace rhi::testing;
+
+GPU_TEST_CASE("imported-constant-buffer", ALL)
+{
+    ComPtr<slang::ISession> slangSession;
+    REQUIRE_CALL(device->getSlangSession(slangSession.writeRef()));
+
+    ComPtr<slang::IBlob> diagnosticsBlob;
+    slang::IModule* module = slangSession->loadModule("test-imported-constant-buffer", diagnosticsBlob.writeRef());
+    diagnoseIfNeeded(diagnosticsBlob);
+    REQUIRE(module);
+
+    ComPtr<slang::IEntryPoint> entryPoint;
+    REQUIRE_CALL(module->findEntryPointByName("computeMain", entryPoint.writeRef()));
+
+    slang::IComponentType* entryPoints[] = {entryPoint.get()};
+
+    ShaderProgramDesc desc = {};
+    desc.slangGlobalScope = module;
+    desc.slangEntryPoints = entryPoints;
+    desc.slangEntryPointCount = 1;
+
+    ComPtr<IShaderProgram> shaderProgram;
+    REQUIRE_CALL(device->createShaderProgram(desc, shaderProgram.writeRef()));
+
+    ComputePipelineDesc pipelineDesc = {};
+    pipelineDesc.program = shaderProgram.get();
+    ComPtr<IComputePipeline> pipeline;
+    REQUIRE_CALL(device->createComputePipeline(pipelineDesc, pipeline.writeRef()));
+
+    float initialData[] = {0.0f, 0.0f, 0.0f, 0.0f};
+    BufferDesc bufferDesc = {};
+    bufferDesc.size = sizeof(initialData);
+    bufferDesc.format = Format::Undefined;
+    bufferDesc.elementSize = sizeof(float) * 4;
+    bufferDesc.usage = BufferUsage::ShaderResource | BufferUsage::UnorderedAccess | BufferUsage::CopyDestination |
+                       BufferUsage::CopySource;
+    bufferDesc.defaultState = ResourceState::UnorderedAccess;
+    bufferDesc.memoryType = MemoryType::DeviceLocal;
+
+    ComPtr<IBuffer> resultBuffer;
+    REQUIRE_CALL(device->createBuffer(bufferDesc, initialData, resultBuffer.writeRef()));
+
+    ComPtr<IShaderObject> rootObject;
+    REQUIRE_CALL(device->createRootShaderObject(shaderProgram, rootObject.writeRef()));
+    ShaderCursor cursor(rootObject);
+
+    struct Float4
+    {
+        float x, y, z, w;
+    };
+
+    auto slangReflection = shaderProgram->findTypeByName("MyData");
+    REQUIRE(slangReflection);
+
+    ComPtr<IShaderObject> dataObject;
+    REQUIRE_CALL(device->createShaderObject(
+        nullptr,
+        slangReflection,
+        ShaderObjectContainerType::None,
+        dataObject.writeRef()
+    ));
+    {
+        ShaderCursor dataCursor(dataObject);
+        dataCursor["value"].setData(Float4{1.0f, 2.0f, 3.0f, 4.0f});
+        dataObject->finalize();
+    }
+
+    cursor["gData"].setObject(dataObject);
+    cursor["resultBuffer"].setBinding(resultBuffer);
+
+    {
+        auto queue = device->getQueue(QueueType::Graphics);
+        auto commandEncoder = queue->createCommandEncoder();
+
+        auto passEncoder = commandEncoder->beginComputePass();
+        passEncoder->bindPipeline(pipeline, rootObject);
+        passEncoder->dispatchCompute(1, 1, 1);
+        passEncoder->end();
+
+        queue->submit(commandEncoder->finish());
+        queue->waitOnHost();
+    }
+
+    compareComputeResult(device, resultBuffer, makeArray<float>(1.0f, 2.0f, 3.0f, 4.0f));
+}

--- a/tests/test-imported-constant-buffer.cpp
+++ b/tests/test-imported-constant-buffer.cpp
@@ -39,12 +39,9 @@ GPU_TEST_CASE("imported-constant-buffer", ALL & ~CPU)
     REQUIRE(slangReflection);
 
     ComPtr<IShaderObject> dataObject;
-    REQUIRE_CALL(device->createShaderObject(
-        nullptr,
-        slangReflection,
-        ShaderObjectContainerType::None,
-        dataObject.writeRef()
-    ));
+    REQUIRE_CALL(
+        device->createShaderObject(nullptr, slangReflection, ShaderObjectContainerType::None, dataObject.writeRef())
+    );
     {
         ShaderCursor dataCursor(dataObject);
         dataCursor["value"].setData(Float4{1.0f, 2.0f, 3.0f, 4.0f});

--- a/tests/test-imported-constant-buffer.slang
+++ b/tests/test-imported-constant-buffer.slang
@@ -1,0 +1,10 @@
+import "test-imported-constant-buffer-data";
+
+RWStructuredBuffer<float4> resultBuffer;
+
+[shader("compute")]
+[numthreads(1, 1, 1)]
+void computeMain(uint3 tid : SV_DispatchThreadID)
+{
+    resultBuffer[tid.x] = gData.value;
+}

--- a/tests/testing.cpp
+++ b/tests/testing.cpp
@@ -247,45 +247,53 @@ static Result loadProgram(
     if (!module)
         return SLANG_FAIL;
 
-    std::vector<slang::IComponentType*> componentTypes;
-    componentTypes.push_back(module);
-
-    // Find all entry points
+    std::vector<ComPtr<slang::IEntryPoint>> entryPoints;
+    std::vector<slang::IComponentType*> entryPointComponents;
     for (const char* entryPointName : entryPointNames)
     {
         ComPtr<slang::IEntryPoint> entryPoint;
         SLANG_RETURN_ON_FAIL(module->findEntryPointByName(entryPointName, entryPoint.writeRef()));
-        componentTypes.push_back(entryPoint);
+        entryPointComponents.push_back(entryPoint.get());
+        entryPoints.push_back(entryPoint);
     }
 
-    // Create composite component type
-    ComPtr<slang::IComponentType> composedProgram;
-    Result result = slangSession->createCompositeComponentType(
-        componentTypes.data(),
-        componentTypes.size(),
-        composedProgram.writeRef(),
-        diagnosticsBlob.writeRef()
-    );
-    diagnoseIfNeeded(diagnosticsBlob);
-    SLANG_RETURN_ON_FAIL(result);
-
-    slang::IComponentType* programToUse = composedProgram.get();
+    ShaderProgramDesc shaderProgramDesc = {};
     ComPtr<slang::IComponentType> linkedProgram;
 
     if (performLinking)
     {
+        std::vector<slang::IComponentType*> componentTypes;
+        componentTypes.push_back(module);
+        for (auto* ep : entryPointComponents)
+            componentTypes.push_back(ep);
+
+        ComPtr<slang::IComponentType> composedProgram;
+        Result result = slangSession->createCompositeComponentType(
+            componentTypes.data(),
+            componentTypes.size(),
+            composedProgram.writeRef(),
+            diagnosticsBlob.writeRef()
+        );
+        diagnoseIfNeeded(diagnosticsBlob);
+        SLANG_RETURN_ON_FAIL(result);
+
         result = composedProgram->link(linkedProgram.writeRef(), diagnosticsBlob.writeRef());
         diagnoseIfNeeded(diagnosticsBlob);
         SLANG_RETURN_ON_FAIL(result);
 
-        programToUse = linkedProgram.get();
         if (outSlangReflection)
             *outSlangReflection = linkedProgram->getLayout();
+
+        shaderProgramDesc.slangGlobalScope = linkedProgram.get();
+    }
+    else
+    {
+        shaderProgramDesc.slangGlobalScope = module;
+        shaderProgramDesc.slangEntryPoints = entryPointComponents.data();
+        shaderProgramDesc.slangEntryPointCount = (uint32_t)entryPointComponents.size();
     }
 
-    ShaderProgramDesc shaderProgramDesc = {};
-    shaderProgramDesc.slangGlobalScope = programToUse;
-    result = device->createShaderProgram(shaderProgramDesc, outShaderProgram, diagnosticsBlob.writeRef());
+    Result result = device->createShaderProgram(shaderProgramDesc, outShaderProgram, diagnosticsBlob.writeRef());
     diagnoseIfNeeded(diagnosticsBlob);
     return result;
 }


### PR DESCRIPTION
## Problem

`IDevice::createShaderProgram` crashes with `assert failure: varLayout` when a shader imports a module that declares a global `ConstantBuffer<T>` variable. The same shader code compiles successfully with `slangc`.

**Reproduction:**
```slang
// MyData.slang (imported module)
public struct MyData { public float4 value; };
public ConstantBuffer<MyData> gData;

// Main.slang
import MyData;
[shader("compute")] [numthreads(1,1,1)]
void computeMain(uint3 tid : SV_DispatchThreadID) { ... gData.value ... }
```

```cpp
ShaderProgramDesc desc = {};
desc.slangGlobalScope = module;
desc.slangEntryPoints = entryPoints;
desc.slangEntryPointCount = 1;
device->createShaderProgram(desc, program.writeRef()); // crash
```

```
FATAL ERROR: [Error] [Slang] error[E99999]: Slang compilation
aborted due to an exception of class Slang::InternalError assert failure: varLayout
For assistance, file an issue on GitHub (https://github.com/shader-slang/slang/issues) or join the Slang Discord (https:
//khr.io/slangdiscord)

FATAL ERROR: REQUIRE( !((device->createCo
mputePipeline(pipelineDesc, pipeline.writeRef())) < 0) ) THREW exception: "unknown exception"
```

## Root Cause

`ShaderProgram::init()` creates a composite component type from the module and entry points via `createCompositeComponentType`, but never calls `link()` on it. When the Slang compiler later performs layout reflection or code generation on this unlinked composite, it hits an internal assertion because variable layout information has not been resolved.

## Fix

**`src/shader.cpp`**: Call `link()` on the composite program after `createCompositeComponentType` in the `SingleProgram` linking path.

## Test

Added `tests/test-imported-constant-buffer.cpp` with corresponding `.slang` files that reproduce the original crash.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved shader program linking and handling of composite programs to avoid linking/reflect issues.
  * CPU pipeline creation now uses the linked program for entry-point layout and host callable lookup.

* **Tests**
  * Added GPU tests for imported constant-buffer behavior, including a compute shader that validates buffer binding and results.

* **Chores**
  * Updated .gitignore to exclude JetBrains IDE metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->