### PR TITLE
Cleanup unicode

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,5 +27,4 @@ exclude: |
       build/.*|
       external/.*|
       src/cuda/kernels/.*|
-      tools/.*|
   )$

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,6 +11,13 @@ repos:
   - id: check-symlinks
   - id: check-merge-conflict
   - id: check-yaml
+- repo: local
+  hooks:
+    - id: check-ascii-source
+      name: check-ascii-source
+      entry: python tools/check_ascii_hook.py
+      language: python
+      files: \.(cpp|h|c|py|slang|slangh)$
 - repo: https://github.com/pre-commit/mirrors-clang-format
   rev: v20.1.7
   hooks:

--- a/src/cuda/cuda-device.cpp
+++ b/src/cuda/cuda-device.cpp
@@ -293,7 +293,7 @@ Result DeviceImpl::initialize(const DeviceDesc& desc)
     }
 
     // If no CUDA context is current, set ours so it persists after initialization.
-    // If another context is already current, leave it alone — callers should use
+    // If another context is already current, leave it alone - callers should use
     // setCudaContextCurrent() to explicitly manage the active context.
     {
         CUcontext currentContext = nullptr;

--- a/src/cuda/cuda-heap.cpp
+++ b/src/cuda/cuda-heap.cpp
@@ -23,10 +23,8 @@ namespace rhi::cuda {
 //
 // FREE PATH:
 //   heap->free(allocation)
-//       │
-//       ├─► Same stream + no cross-stream events ──► IMMEDIATE retire
-//       │
-//       └─► Otherwise ──► m_pendingFrees (deferred until GPU done)
+//     Same stream + no cross-stream events -> IMMEDIATE retire
+//     Otherwise -> m_pendingFrees (deferred until GPU done)
 //
 // CROSS-STREAM SYNCHRONIZATION:
 //   When a page is used by a different stream than it was allocated on, we record

--- a/src/debug-layer/debug-command-encoder.cpp
+++ b/src/debug-layer/debug-command-encoder.cpp
@@ -851,7 +851,7 @@ void DebugCommandEncoder::copyBuffer(IBuffer* dst, Offset dstOffset, IBuffer* sr
     }
     if (dst == src)
     {
-        // Check for overlapping ranges — overlapping same-buffer copies are undefined behavior
+        // Check for overlapping ranges - overlapping same-buffer copies are undefined behavior
         // on all major APIs (D3D12, Vulkan, Metal), so skip the call to avoid driver errors.
         if (srcOffset < dstOffset + size && dstOffset < srcOffset + size)
         {

--- a/tests/test-block-allocator.cpp
+++ b/tests/test-block-allocator.cpp
@@ -416,7 +416,7 @@ TEST_CASE("block-allocator-performance")
         auto end = std::chrono::high_resolution_clock::now();
         auto duration = std::chrono::duration_cast<std::chrono::microseconds>(end - start);
 
-        MESSAGE("BlockAllocator: ", numAllocations, " allocations in ", duration.count(), " μs");
+        MESSAGE("BlockAllocator: ", numAllocations, " allocations in ", duration.count(), " us");
     }
 
     SUBCASE("standard-new-delete-performance")
@@ -439,7 +439,7 @@ TEST_CASE("block-allocator-performance")
         auto end = std::chrono::high_resolution_clock::now();
         auto duration = std::chrono::duration_cast<std::chrono::microseconds>(end - start);
 
-        MESSAGE("Standard new/delete: ", numAllocations, " allocations in ", duration.count(), " μs");
+        MESSAGE("Standard new/delete: ", numAllocations, " allocations in ", duration.count(), " us");
     }
 }
 #endif

--- a/tests/test-cuda-external-devices.cpp
+++ b/tests/test-cuda-external-devices.cpp
@@ -209,7 +209,7 @@ GPU_TEST_CASE("cuda-device-scope", CUDA)
     cuCtxGetCurrent(&current);
     CHECK(current == otherContext);
 
-    // Clean up — restore device context before test teardown.
+    // Clean up - restore device context before test teardown.
     cuCtxDestroy(otherContext);
     device->setCudaContextCurrent();
 }

--- a/tests/test-ray-tracing-intrinsics.cpp
+++ b/tests/test-ray-tracing-intrinsics.cpp
@@ -17,7 +17,7 @@ struct RayIntrinsicResult
     float rayTCurrent;
     uint32_t rayFlags;
     uint32_t geometryIndex;
-    float triangleVertices[9]; // 3 vertices × 3 components
+    float triangleVertices[9]; // 3 vertices x 3 components
     float rayCurrentTime;
     uint32_t instanceID;
     uint32_t instanceIndex;

--- a/tools/check_ascii_hook.py
+++ b/tools/check_ascii_hook.py
@@ -1,0 +1,155 @@
+#!/usr/bin/env python
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+from __future__ import annotations
+
+import sys
+import unicodedata
+from pathlib import Path
+
+REPLACEMENTS = {
+    # Invisible / zero-width
+    "\ufeff": "",  # BOM (byte order mark)
+    "\u00ad": "",  # soft hyphen
+    "\u200b": "",  # zero-width space
+    "\u200c": "",  # zero-width non-joiner
+    "\u200d": "",  # zero-width joiner
+    # Spaces
+    "\u00a0": " ",  # non-breaking space
+    "\u2000": " ",  # en quad
+    "\u2001": " ",  # em quad
+    "\u2002": " ",  # en space
+    "\u2003": " ",  # em space
+    "\u2004": " ",  # three-per-em space
+    "\u2005": " ",  # four-per-em space
+    "\u2006": " ",  # six-per-em space
+    "\u2007": " ",  # figure space
+    "\u2008": " ",  # punctuation space
+    "\u2009": " ",  # thin space
+    "\u200a": " ",  # hair space
+    "\u202f": " ",  # narrow no-break space
+    # Dashes
+    "\u2010": "-",  # hyphen
+    "\u2011": "-",  # non-breaking hyphen
+    "\u2012": "-",  # figure dash
+    "\u2013": "-",  # en dash
+    "\u2014": "-",  # em dash
+    "\u2015": "-",  # horizontal bar
+    # Quotes
+    "\u2018": "'",  # left single quotation mark
+    "\u2019": "'",  # right single quotation mark
+    "\u201a": "'",  # single low-9 quotation mark
+    "\u201c": '"',  # left double quotation mark
+    "\u201d": '"',  # right double quotation mark
+    "\u201e": '"',  # double low-9 quotation mark
+    "\u2032": "'",  # prime
+    "\u2033": '"',  # double prime
+    "\u00ab": "<<",  # left guillemet
+    "\u00bb": ">>",  # right guillemet
+    "\u2039": "<",  # single left angle quotation mark
+    "\u203a": ">",  # single right angle quotation mark
+    # Symbols
+    "\u2026": "...",  # ellipsis
+    "\u2022": "*",  # bullet
+    "\u00b0": "deg",  # degree sign
+    "\u00b7": ".",  # middle dot
+    "\u00d7": "x",  # multiplication sign
+    "\u00f7": "/",  # division sign
+    "\u00ac": "!",  # not sign
+    "\u00b1": "+/-",  # plus-minus sign
+    "\u00b5": "u",  # micro sign
+    "\u03bc": "u",  # greek mu
+    "\u00a9": "(c)",  # copyright
+    "\u00ae": "(R)",  # registered
+    "\u2122": "(TM)",  # trademark
+    "\u2713": "Y",  # check mark
+    "\u2714": "Y",  # heavy check mark
+    "\u2717": "X",  # ballot X
+    "\u2718": "X",  # heavy ballot X
+    # Math / arrows
+    "\u03c0": "pi",  # pi
+    "\u00b9": "1",  # superscript one
+    "\u221a": "sqrt",  # square root
+    "\u221e": "inf",  # infinity
+    "\u2248": "~=",  # approximately equal
+    "\u2260": "!=",  # not equal
+    "\u2264": "<=",  # less-than or equal
+    "\u2265": ">=",  # greater-than or equal
+    "\u2190": "<-",  # left arrow
+    "\u2192": "->",  # right arrow
+}
+
+
+def write_text_preserve_newlines(path: Path, text: str) -> None:
+    with path.open("w", encoding="utf-8", newline="") as f:
+        f.write(text)
+
+
+def main() -> int:
+    had_error = False
+    for raw_path in sys.argv[1:]:
+
+        # Read the file
+        path = Path(raw_path)
+        try:
+            data = path.read_bytes()
+        except UnicodeDecodeError as exc:
+            print(f"{path}: not valid UTF-8 ({exc})", file=sys.stderr)
+            had_error = True
+            continue
+        except OSError as exc:
+            print(f"{path}: failed to read file ({exc})", file=sys.stderr)
+            had_error = True
+            continue
+
+        # If ASCII-only, no decoding or detailed scan.
+        if data.isascii():
+            continue
+
+        # Contains unicode, so decode it
+        try:
+            text = data.decode("utf-8")
+        except UnicodeDecodeError as exc:
+            print(f"{path}: not valid UTF-8 ({exc})", file=sys.stderr)
+            had_error = True
+            continue
+
+        # Fix each line with explicit replacements first, then Unicode normalization.
+        changed = False
+        unresolved_lines: list[int] = []
+        lines = text.splitlines(keepends=True)
+        fixed_lines: list[str] = []
+        for line_no, line in enumerate(lines, start=1):
+            replaced = line
+            for src, dst in REPLACEMENTS.items():
+                replaced = replaced.replace(src, dst)
+            normalized = unicodedata.normalize("NFKD", replaced)
+            fixed_line = normalized.encode("ascii", "ignore").decode("ascii")
+            if fixed_line != line:
+                changed = True
+                print(
+                    f"{path}:{line_no}: replaced non-ASCII characters with ASCII equivalents",
+                    file=sys.stderr,
+                )
+            if any(ord(ch) > 127 for ch in normalized):
+                unresolved_lines.append(line_no)
+
+            fixed_lines.append(fixed_line)
+
+        # If changes, write out the fixed file
+        if changed:
+            write_text_preserve_newlines(path, "".join(fixed_lines))
+
+        # If any lines still contain non-ASCII after fixing, report them as errors.
+        for line_no in unresolved_lines:
+            print(
+                f"{path}:{line_no}: line still contains non-ASCII characters after automatic fixing",
+                file=sys.stderr,
+            )
+            had_error = True
+
+    return 1 if had_error else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/check_ascii_hook.py
+++ b/tools/check_ascii_hook.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 from __future__ import annotations
 

--- a/tools/check_ascii_hook.py
+++ b/tools/check_ascii_hook.py
@@ -135,17 +135,17 @@ def main() -> int:
 
             fixed_lines.append(fixed_line)
 
-        # If changes, write out the fixed file
-        if changed:
-            write_text_preserve_newlines(path, "".join(fixed_lines))
-
         # If any lines still contain non-ASCII after fixing, report them as errors.
-        for line_no in unresolved_lines:
-            print(
-                f"{path}:{line_no}: line still contains non-ASCII characters after automatic fixing",
-                file=sys.stderr,
-            )
+        if unresolved_lines:
+            for line_no in unresolved_lines:
+                print(
+                    f"{path}:{line_no}: line still contains non-ASCII characters after automatic fixing",
+                    file=sys.stderr,
+                )
             had_error = True
+        elif changed:
+            # Only write the fixed file when all characters were resolved.
+            write_text_preserve_newlines(path, "".join(fixed_lines))
 
     return 1 if had_error else 0
 


### PR DESCRIPTION
We don't want unicode symbols in our source files.
Adds a pre-commit hook for cleaning source from unicode characters.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added a pre-commit hook to enforce ASCII-only source code with automatic character conversion.

* **Style**
  * Updated comments and strings across the codebase to use ASCII-compatible characters, replacing special punctuation and symbols with their ASCII equivalents.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->