### PR TITLE
Add TaskGroup concept to task pool

### DIFF
--- a/include/slang-rhi.h
+++ b/include/slang-rhi.h
@@ -3695,6 +3695,7 @@ class ITaskPool : public ISlangUnknown
 
 public:
     typedef void* TaskHandle;
+    typedef void* TaskGroupHandle;
 
     /// \brief Submit a new task for execution.
     ///
@@ -3709,13 +3710,15 @@ public:
     /// \param payloadDeleter Optional deleter called with `payload` when the task is destroyed. May be null if no cleanup is needed.
     /// \param deps Array of `TaskHandle`s that must complete before this task runs. May be null if `depsCount` is 0.
     /// \param depsCount Number of entries in `deps`.
+    /// \param group Optional task group handle. If non-null, the task is associated with the group.
     /// \return A handle to the submitted task. The caller must release this with `releaseTask()`.
     virtual SLANG_NO_THROW TaskHandle SLANG_MCALL submitTask(
         void (*func)(void*),
         void* payload,
         void (*payloadDeleter)(void*),
         TaskHandle* deps,
-        size_t depsCount
+        size_t depsCount,
+        TaskGroupHandle group = nullptr
     ) = 0;
 
     /// \brief Get the payload associated with a task.
@@ -3756,6 +3759,32 @@ public:
     /// Waits for every task that has been submitted to this pool (and not yet completed)
     /// to finish executing. Does not release any task handles.
     virtual SLANG_NO_THROW void SLANG_MCALL waitAll() = 0;
+
+    /// \brief Create a new task group for tracking a set of tasks.
+    ///
+    /// A task group tracks a dynamically growing set of tasks. Tasks are associated with a
+    /// group by passing the group handle to `submitTask()`.
+    ///
+    /// \return An opaque handle to the task group.
+    virtual SLANG_NO_THROW TaskGroupHandle SLANG_MCALL createTaskGroup() = 0;
+
+    /// \brief Block the calling thread until all tasks in the group have completed.
+    ///
+    /// Must not be called from a pool worker thread (deadlock risk).
+    /// Must not be called while other threads are still submitting tasks to the group
+    /// outside of task callbacks.
+    /// A group must not be reused after `waitTaskGroup` returns.
+    ///
+    /// \param group Task group handle. Must not be null.
+    virtual SLANG_NO_THROW void SLANG_MCALL waitTaskGroup(TaskGroupHandle group) = 0;
+
+    /// \brief Release a task group.
+    ///
+    /// Must be called exactly once after `waitTaskGroup` returns. Calling with tasks
+    /// still pending is undefined behavior.
+    ///
+    /// \param group Task group handle. Must not be null.
+    virtual SLANG_NO_THROW void SLANG_MCALL releaseTaskGroup(TaskGroupHandle group) = 0;
 };
 
 class IPersistentCache : public ISlangUnknown

--- a/src/core/task-pool.cpp
+++ b/src/core/task-pool.cpp
@@ -1,6 +1,7 @@
 #include "task-pool.h"
 
 #include <condition_variable>
+#include <exception>
 #include <memory>
 #include <mutex>
 #include <queue>
@@ -189,6 +190,8 @@ struct ThreadedTaskPool::Pool
 
     ~Pool()
     {
+        // Drain all pending tasks before shutting down.
+        waitAll();
         {
             std::lock_guard<std::mutex> lock(m_queueMutex);
             m_stop.store(true);
@@ -379,7 +382,16 @@ void ThreadedTaskPool::Pool::workerThread()
             m_queue.pop();
         }
         // Execute the task function.
-        task->func(task->payload);
+        // Wrap in try/catch to ensure the worker thread survives and the
+        // task-completion bookkeeping (done flag, children, group, counters)
+        // always runs. Without this, an exception would deadlock waiters.
+        try
+        {
+            task->func(task->payload);
+        } catch (...)
+        {
+            SLANG_RHI_ASSERT_FAILURE("Task threw an exception");
+        }
         // Capture the group pointer before we potentially release the task.
         TaskGroup* group = task->group;
         // Mark the task as done and notify child tasks.

--- a/src/core/task-pool.cpp
+++ b/src/core/task-pool.cpp
@@ -30,7 +30,8 @@ ITaskPool::TaskHandle BlockingTaskPool::submitTask(
     void* payload,
     void (*payloadDeleter)(void*),
     TaskHandle* deps,
-    size_t depsCount
+    size_t depsCount,
+    TaskGroupHandle group
 )
 {
     SLANG_RHI_ASSERT(func);
@@ -83,6 +84,24 @@ bool BlockingTaskPool::isTaskDone(TaskHandle task)
 
 void BlockingTaskPool::waitAll() {}
 
+ITaskPool::TaskGroupHandle BlockingTaskPool::createTaskGroup()
+{
+    static char sentinel;
+    return &sentinel;
+}
+
+void BlockingTaskPool::waitTaskGroup(TaskGroupHandle group)
+{
+    SLANG_RHI_ASSERT(group);
+    SLANG_UNUSED(group);
+}
+
+void BlockingTaskPool::releaseTaskGroup(TaskGroupHandle group)
+{
+    SLANG_RHI_ASSERT(group);
+    SLANG_UNUSED(group);
+}
+
 // ----------------------------------------------------------------------------
 // ThreadedTaskPool
 // ----------------------------------------------------------------------------
@@ -115,6 +134,16 @@ struct ThreadedTaskPool::Task
     // List of tasks that depend on this task.
     std::vector<Task*> children;
     std::mutex childrenMutex;
+
+    // Optional task group this task belongs to.
+    struct TaskGroup* group = nullptr;
+};
+
+struct TaskGroup
+{
+    std::atomic<size_t> pending{0};
+    std::mutex mutex;
+    std::condition_variable cv;
 };
 
 struct ThreadedTaskPool::Pool
@@ -216,7 +245,14 @@ struct ThreadedTaskPool::Pool
         }
     }
 
-    Task* submitTask(void (*func)(void*), void* payload, void (*payloadDeleter)(void*), Task** deps, size_t depsCount)
+    Task* submitTask(
+        void (*func)(void*),
+        void* payload,
+        void (*payloadDeleter)(void*),
+        Task** deps,
+        size_t depsCount,
+        TaskGroup* group
+    )
     {
         SLANG_RHI_ASSERT(func);
         SLANG_RHI_ASSERT(depsCount == 0 || deps);
@@ -228,6 +264,13 @@ struct ThreadedTaskPool::Pool
         task->payloadDeleter = payloadDeleter;
         task->pool = this;
         task->depsRemaining = depsCount;
+        task->group = group;
+
+        // Increment the group counter before enqueuing (critical for correctness).
+        if (group)
+        {
+            group->pending.fetch_add(1, std::memory_order_relaxed);
+        }
 
         // Increment the reference count by 2.
         // One reference is for the pool, the other is for the caller.
@@ -337,6 +380,8 @@ void ThreadedTaskPool::Pool::workerThread()
         }
         // Execute the task function.
         task->func(task->payload);
+        // Capture the group pointer before we potentially release the task.
+        TaskGroup* group = task->group;
         // Mark the task as done and notify child tasks.
         // We must hold waitMutex around setting done and notifying, so that
         // waitTask() cannot observe done==true and release the task before
@@ -367,6 +412,15 @@ void ThreadedTaskPool::Pool::workerThread()
         // This must happen before decrementing m_tasksRemaining so that
         // waitAll() only returns after all payload deleters have been called.
         releaseTask(task);
+        // Decrement the group pending counter and notify waiters.
+        if (group)
+        {
+            if (group->pending.fetch_sub(1, std::memory_order_acq_rel) == 1)
+            {
+                std::lock_guard<std::mutex> lock(group->mutex);
+                group->cv.notify_all();
+            }
+        }
         // Decrement the remaining task counter and notify waiters.
         if (m_tasksRemaining.fetch_sub(1, std::memory_order_acq_rel) == 1)
         {
@@ -398,10 +452,11 @@ ITaskPool::TaskHandle ThreadedTaskPool::submitTask(
     void* payload,
     void (*payloadDeleter)(void*),
     TaskHandle* deps,
-    size_t depsCount
+    size_t depsCount,
+    TaskGroupHandle group
 )
 {
-    return m_pool->submitTask(func, payload, payloadDeleter, (Task**)deps, depsCount);
+    return m_pool->submitTask(func, payload, payloadDeleter, (Task**)deps, depsCount, static_cast<TaskGroup*>(group));
 }
 
 void* ThreadedTaskPool::getTaskPayload(TaskHandle task)
@@ -429,6 +484,35 @@ bool ThreadedTaskPool::isTaskDone(TaskHandle task)
 void ThreadedTaskPool::waitAll()
 {
     m_pool->waitAll();
+}
+
+ITaskPool::TaskGroupHandle ThreadedTaskPool::createTaskGroup()
+{
+    return new TaskGroup();
+}
+
+void ThreadedTaskPool::waitTaskGroup(TaskGroupHandle group)
+{
+    SLANG_RHI_ASSERT(group);
+
+    TaskGroup* g = static_cast<TaskGroup*>(group);
+    std::unique_lock<std::mutex> lock(g->mutex);
+    g->cv.wait(
+        lock,
+        [g]
+        {
+            return g->pending.load(std::memory_order_acquire) == 0;
+        }
+    );
+}
+
+void ThreadedTaskPool::releaseTaskGroup(TaskGroupHandle group)
+{
+    SLANG_RHI_ASSERT(group);
+
+    TaskGroup* g = static_cast<TaskGroup*>(group);
+    SLANG_RHI_ASSERT(g->pending.load(std::memory_order_acquire) == 0);
+    delete g;
 }
 
 // ----------------------------------------------------------------------------

--- a/src/core/task-pool.h
+++ b/src/core/task-pool.h
@@ -17,7 +17,8 @@ public:
         void* payload,
         void (*payloadDeleter)(void*),
         TaskHandle* deps,
-        size_t depsCount
+        size_t depsCount,
+        TaskGroupHandle group = nullptr
     ) override;
 
     virtual SLANG_NO_THROW void* SLANG_MCALL getTaskPayload(TaskHandle task) override;
@@ -29,6 +30,12 @@ public:
     virtual SLANG_NO_THROW bool SLANG_MCALL isTaskDone(TaskHandle task) override;
 
     virtual SLANG_NO_THROW void SLANG_MCALL waitAll() override;
+
+    virtual SLANG_NO_THROW TaskGroupHandle SLANG_MCALL createTaskGroup() override;
+
+    virtual SLANG_NO_THROW void SLANG_MCALL waitTaskGroup(TaskGroupHandle group) override;
+
+    virtual SLANG_NO_THROW void SLANG_MCALL releaseTaskGroup(TaskGroupHandle group) override;
 
 private:
     struct Task;
@@ -50,7 +57,8 @@ public:
         void* payload,
         void (*payloadDeleter)(void*),
         TaskHandle* deps,
-        size_t depsCount
+        size_t depsCount,
+        TaskGroupHandle group = nullptr
     ) override;
 
     virtual SLANG_NO_THROW void* SLANG_MCALL getTaskPayload(TaskHandle task) override;
@@ -62,6 +70,12 @@ public:
     virtual SLANG_NO_THROW bool SLANG_MCALL isTaskDone(TaskHandle task) override;
 
     virtual SLANG_NO_THROW void SLANG_MCALL waitAll() override;
+
+    virtual SLANG_NO_THROW TaskGroupHandle SLANG_MCALL createTaskGroup() override;
+
+    virtual SLANG_NO_THROW void SLANG_MCALL waitTaskGroup(TaskGroupHandle group) override;
+
+    virtual SLANG_NO_THROW void SLANG_MCALL releaseTaskGroup(TaskGroupHandle group) override;
 
 private:
     struct Task;

--- a/tests/test-task-pool.cpp
+++ b/tests/test-task-pool.cpp
@@ -272,6 +272,186 @@ void testFibonacci(ITaskPool* pool)
     pool->releaseTask(task);
 }
 
+// Basic group lifecycle: create, submit tasks, wait, release.
+void testGroupBasic(ITaskPool* pool)
+{
+    REQUIRE(pool != nullptr);
+
+    static constexpr size_t N = 100;
+    static std::atomic<size_t> counter;
+    counter = 0;
+
+    auto group = pool->createTaskGroup();
+
+    for (size_t i = 0; i < N; ++i)
+    {
+        ITaskPool::TaskHandle task = pool->submitTask(
+            [](void*)
+            {
+                counter.fetch_add(1, std::memory_order_relaxed);
+            },
+            nullptr,
+            nullptr,
+            nullptr,
+            0,
+            group
+        );
+        pool->releaseTask(task);
+    }
+
+    pool->waitTaskGroup(group);
+    CHECK(counter.load() == N);
+    pool->releaseTaskGroup(group);
+}
+
+// Sub-tasks spawned from callbacks are tracked by the group.
+void testGroupSubTasks(ITaskPool* pool)
+{
+    REQUIRE(pool != nullptr);
+
+    static std::atomic<size_t> counter;
+    counter = 0;
+
+    struct SubTaskPayload
+    {
+        ITaskPool* pool;
+        ITaskPool::TaskGroupHandle group;
+        int depth;
+    };
+
+    auto group = pool->createTaskGroup();
+
+    auto func = [](void* p)
+    {
+        SubTaskPayload* payload = static_cast<SubTaskPayload*>(p);
+        counter.fetch_add(1, std::memory_order_relaxed);
+        if (payload->depth > 0)
+        {
+            // Spawn two sub-tasks in the same group.
+            for (int i = 0; i < 2; ++i)
+            {
+                SubTaskPayload* sub = new SubTaskPayload{payload->pool, payload->group, payload->depth - 1};
+                ITaskPool::TaskHandle task = payload->pool->submitTask(
+                    [](void* p2)
+                    {
+                        SubTaskPayload* sp = static_cast<SubTaskPayload*>(p2);
+                        counter.fetch_add(1, std::memory_order_relaxed);
+                        if (sp->depth > 0)
+                        {
+                            for (int j = 0; j < 2; ++j)
+                            {
+                                SubTaskPayload* sub2 = new SubTaskPayload{sp->pool, sp->group, sp->depth - 1};
+                                ITaskPool::TaskHandle t = sp->pool->submitTask(
+                                    [](void* p3)
+                                    {
+                                        SubTaskPayload* sp2 = static_cast<SubTaskPayload*>(p3);
+                                        counter.fetch_add(1, std::memory_order_relaxed);
+                                        SLANG_UNUSED(sp2);
+                                    },
+                                    sub2,
+                                    [](void* p3)
+                                    {
+                                        delete static_cast<SubTaskPayload*>(p3);
+                                    },
+                                    nullptr,
+                                    0,
+                                    sp->group
+                                );
+                                sp->pool->releaseTask(t);
+                            }
+                        }
+                    },
+                    sub,
+                    [](void* p2)
+                    {
+                        delete static_cast<SubTaskPayload*>(p2);
+                    },
+                    nullptr,
+                    0,
+                    payload->group
+                );
+                payload->pool->releaseTask(task);
+            }
+        }
+    };
+
+    SubTaskPayload* payload = new SubTaskPayload{pool, group, 2};
+    ITaskPool::TaskHandle task = pool->submitTask(
+        func,
+        payload,
+        [](void* p)
+        {
+            delete static_cast<SubTaskPayload*>(p);
+        },
+        nullptr,
+        0,
+        group
+    );
+    pool->releaseTask(task);
+
+    pool->waitTaskGroup(group);
+    // 1 root (depth 2) + 2 children (depth 1) + 4 leaves (depth 0) = 7
+    CHECK(counter.load() == 7);
+    pool->releaseTaskGroup(group);
+}
+
+// Empty group: wait immediately after create.
+void testGroupEmpty(ITaskPool* pool)
+{
+    REQUIRE(pool != nullptr);
+
+    auto group = pool->createTaskGroup();
+    pool->waitTaskGroup(group);
+    pool->releaseTaskGroup(group);
+}
+
+// Group with dependencies: tasks have both a group and dependency handles.
+void testGroupWithDependencies(ITaskPool* pool)
+{
+    REQUIRE(pool != nullptr);
+
+    static std::atomic<size_t> order;
+    order = 0;
+
+    auto group = pool->createTaskGroup();
+
+    // First task in the group.
+    static size_t firstOrder;
+    ITaskPool::TaskHandle first = pool->submitTask(
+        [](void*)
+        {
+            firstOrder = order.fetch_add(1, std::memory_order_relaxed);
+        },
+        nullptr,
+        nullptr,
+        nullptr,
+        0,
+        group
+    );
+
+    // Second task depends on first, also in the group.
+    static size_t secondOrder;
+    ITaskPool::TaskHandle second = pool->submitTask(
+        [](void*)
+        {
+            secondOrder = order.fetch_add(1, std::memory_order_relaxed);
+        },
+        nullptr,
+        nullptr,
+        &first,
+        1,
+        group
+    );
+
+    pool->releaseTask(first);
+    pool->releaseTask(second);
+
+    pool->waitTaskGroup(group);
+    CHECK(firstOrder < secondOrder);
+    CHECK(order.load() == 2);
+    pool->releaseTaskGroup(group);
+}
+
 TEST_CASE("task-pool-blocking")
 {
     ComPtr<ITaskPool> pool(new BlockingTaskPool());
@@ -295,6 +475,22 @@ TEST_CASE("task-pool-blocking")
     SUBCASE("fibonacci")
     {
         testFibonacci(pool);
+    }
+    SUBCASE("group-basic")
+    {
+        testGroupBasic(pool);
+    }
+    SUBCASE("group-sub-tasks")
+    {
+        testGroupSubTasks(pool);
+    }
+    SUBCASE("group-empty")
+    {
+        testGroupEmpty(pool);
+    }
+    SUBCASE("group-with-dependencies")
+    {
+        testGroupWithDependencies(pool);
     }
 }
 
@@ -333,5 +529,33 @@ TEST_CASE("task-pool-threaded")
     SUBCASE("fibonacci")
     {
         testFibonacci(pool);
+    }
+    SUBCASE("group-basic")
+    {
+        for (int i = 0; i < 100; ++i)
+        {
+            testGroupBasic(pool);
+        }
+    }
+    SUBCASE("group-sub-tasks")
+    {
+        for (int i = 0; i < 100; ++i)
+        {
+            testGroupSubTasks(pool);
+        }
+    }
+    SUBCASE("group-empty")
+    {
+        for (int i = 0; i < 100; ++i)
+        {
+            testGroupEmpty(pool);
+        }
+    }
+    SUBCASE("group-with-dependencies")
+    {
+        for (int i = 0; i < 100; ++i)
+        {
+            testGroupWithDependencies(pool);
+        }
     }
 }


### PR DESCRIPTION
Add task groups to the task pool.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Task pools now support task grouping for organizing related tasks and synchronizing on collective completion.
* New task group APIs enable creating groups, associating tasks with groups, and blocking until all group tasks finish execution.
* Enhanced task submission with optional group parameter for flexible task organization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->