### PR TITLE
Task pool work-stealing

### DIFF
--- a/include/slang-rhi.h
+++ b/include/slang-rhi.h
@@ -3745,6 +3745,9 @@ public:
 
     /// \brief Block the calling thread until a task has finished executing.
     ///
+    /// While waiting, the calling thread may execute pending tasks (work-stealing).
+    /// This makes it safe to call from a task callback without deadlock risk.
+    ///
     /// \param task Task handle to wait on. Must not be null.
     virtual SLANG_NO_THROW void SLANG_MCALL waitTask(TaskHandle task) = 0;
 
@@ -3758,6 +3761,7 @@ public:
     ///
     /// Waits for every task that has been submitted to this pool (and not yet completed)
     /// to finish executing. Does not release any task handles.
+    /// While waiting, the calling thread may execute pending tasks (work-stealing).
     virtual SLANG_NO_THROW void SLANG_MCALL waitAll() = 0;
 
     /// \brief Create a new task group for tracking a set of tasks.
@@ -3770,7 +3774,8 @@ public:
 
     /// \brief Block the calling thread until all tasks in the group have completed.
     ///
-    /// Must not be called from a pool worker thread (deadlock risk).
+    /// While waiting, the calling thread may execute pending tasks (work-stealing).
+    /// This makes it safe to call from a task callback without deadlock risk.
     /// Must not be called while other threads are still submitting tasks to the group
     /// outside of task callbacks.
     /// A group must not be reused after `waitTaskGroup` returns.

--- a/src/core/task-pool.cpp
+++ b/src/core/task-pool.cpp
@@ -9,6 +9,12 @@
 
 namespace rhi {
 
+// Track work-stealing nesting depth per thread.
+// Only the outermost wait call (depth 0) is allowed to steal and execute tasks.
+// This prevents circular steal chains where a stolen task's callback waits on
+// a task that is already in-flight higher up the same thread's call stack.
+static thread_local int tls_stealDepth = 0;
+
 // ----------------------------------------------------------------------------
 // BlockingTaskPool
 // ----------------------------------------------------------------------------
@@ -347,53 +353,63 @@ struct ThreadedTaskPool::Pool
         return task->done.load(std::memory_order_acquire);
     }
 
+    // Work-stealing wait loop. Spins until `isDone` returns true, stealing and
+    // executing queued tasks when possible (only at steal-depth 0 to prevent
+    // circular chains). Falls back to blocking on m_stealCV when no work is
+    // available. At depth > 0 the predicate excludes !m_queue.empty() to avoid
+    // a spin-loop that would starve worker threads.
+    template<typename Pred>
+    void waitWithStealing(Pred isDone)
+    {
+        while (!isDone())
+        {
+            if (tls_stealDepth == 0)
+            {
+                if (Task* stolen = tryDequeue())
+                {
+                    executeTask(stolen);
+                    continue;
+                }
+            }
+            std::unique_lock<std::mutex> lock(m_queueMutex);
+            if (tls_stealDepth == 0)
+            {
+                m_stealCV.wait(
+                    lock,
+                    [&]
+                    {
+                        return isDone() || !m_queue.empty();
+                    }
+                );
+            }
+            else
+            {
+                m_stealCV.wait(lock, isDone);
+            }
+        }
+    }
+
     void waitTask(Task* task)
     {
         SLANG_RHI_ASSERT(task);
         SLANG_RHI_ASSERT(task->pool == this);
 
-        while (!task->done.load(std::memory_order_acquire))
-        {
-            // Try to steal and execute a task from the queue.
-            if (Task* stolen = tryDequeue())
+        waitWithStealing(
+            [task]
             {
-                executeTask(stolen);
-                continue;
+                return task->done.load(std::memory_order_acquire);
             }
-            // Queue is empty; wait for either a new task to be enqueued
-            // or the target task to complete.
-            std::unique_lock<std::mutex> lock(m_queueMutex);
-            m_stealCV.wait(
-                lock,
-                [this, task]
-                {
-                    return task->done.load(std::memory_order_acquire) || !m_queue.empty();
-                }
-            );
-        }
+        );
     }
 
     void waitAll()
     {
-        while (m_tasksRemaining.load(std::memory_order_acquire) != 0)
-        {
-            // Try to steal and execute a task from the queue.
-            if (Task* stolen = tryDequeue())
+        waitWithStealing(
+            [this]
             {
-                executeTask(stolen);
-                continue;
+                return m_tasksRemaining.load(std::memory_order_acquire) == 0;
             }
-            // Queue is empty; wait for either a new task to be enqueued
-            // or all tasks to complete.
-            std::unique_lock<std::mutex> lock(m_queueMutex);
-            m_stealCV.wait(
-                lock,
-                [this]
-                {
-                    return m_tasksRemaining.load(std::memory_order_acquire) == 0 || !m_queue.empty();
-                }
-            );
-        }
+        );
     }
 };
 
@@ -415,6 +431,11 @@ void ThreadedTaskPool::Pool::executeTask(Task* task)
     // always runs. Without this, an exception would deadlock waiters.
     // NOTE: If a task throws, it is still marked as done and its children
     // will execute. There is currently no failure propagation mechanism.
+    // Increment steal depth so that any waitTask/waitAll/waitTaskGroup called
+    // from the task callback cannot steal tasks. This prevents circular steal
+    // chains where a stolen task's callback waits on a task already in-flight
+    // on the same thread's call stack.
+    tls_stealDepth++;
     try
     {
         task->func(task->payload);
@@ -422,6 +443,7 @@ void ThreadedTaskPool::Pool::executeTask(Task* task)
     {
         SLANG_RHI_ASSERT_FAILURE("Task threw an exception");
     }
+    tls_stealDepth--;
     // Capture the group pointer before we potentially release the task.
     TaskGroup* group = task->group;
     // Mark the task as done and notify child tasks.
@@ -495,25 +517,12 @@ void ThreadedTaskPool::Pool::waitTaskGroup(TaskGroup* group)
 {
     SLANG_RHI_ASSERT(group);
 
-    while (group->pending.load(std::memory_order_acquire) != 0)
-    {
-        // Try to steal and execute a task from the queue.
-        if (Task* stolen = tryDequeue())
+    waitWithStealing(
+        [group]
         {
-            executeTask(stolen);
-            continue;
+            return group->pending.load(std::memory_order_acquire) == 0;
         }
-        // Queue is empty; wait for either a new task to be enqueued
-        // or all group tasks to complete.
-        std::unique_lock<std::mutex> lock(m_queueMutex);
-        m_stealCV.wait(
-            lock,
-            [this, group]
-            {
-                return group->pending.load(std::memory_order_acquire) == 0 || !m_queue.empty();
-            }
-        );
-    }
+    );
 }
 
 ITaskPool* ThreadedTaskPool::getInterface(const Guid& guid)

--- a/src/core/task-pool.cpp
+++ b/src/core/task-pool.cpp
@@ -152,7 +152,12 @@ struct ThreadedTaskPool::Pool
     // Queue of tasks ready for execution.
     std::queue<ThreadedTaskPool::Task*> m_queue;
     std::mutex m_queueMutex;
+    // Condition variable for worker threads (notified when queue gets items or stop).
     std::condition_variable m_queueCV;
+    // Condition variable for work-stealing waiters (notified on enqueue and task completion).
+    // Shares m_queueMutex with m_queueCV but only wakes work-stealing threads, avoiding
+    // thundering herd on worker threads.
+    std::condition_variable m_stealCV;
 
     // Flag to signal worker threads to stop.
     std::atomic<bool> m_stop{false};
@@ -168,6 +173,16 @@ struct ThreadedTaskPool::Pool
     std::condition_variable m_waitCV;
 
     void workerThread();
+
+    // Try to dequeue a ready task from the queue. Returns nullptr if the queue is empty.
+    Task* tryDequeue();
+
+    // Execute a task and perform all completion bookkeeping (done flag, children,
+    // group counter, tasksRemaining counter, reference release). Used by both
+    // workerThread() and work-stealing wait loops.
+    void executeTask(Task* task);
+
+    void waitTaskGroup(TaskGroup* group);
 
     Pool(int workerCount)
     {
@@ -245,6 +260,7 @@ struct ThreadedTaskPool::Pool
             std::lock_guard<std::mutex> lock(m_queueMutex);
             m_queue.push(task);
             m_queueCV.notify_one();
+            m_stealCV.notify_all();
         }
     }
 
@@ -338,28 +354,129 @@ struct ThreadedTaskPool::Pool
         SLANG_RHI_ASSERT(task);
         SLANG_RHI_ASSERT(task->pool == this);
 
-        std::unique_lock<std::mutex> lock(task->waitMutex);
-        task->waitCV.wait(
-            lock,
-            [task]
+        while (!task->done.load(std::memory_order_acquire))
+        {
+            // Try to steal and execute a task from the queue.
+            if (Task* stolen = tryDequeue())
             {
-                return task->done.load(std::memory_order_acquire);
+                executeTask(stolen);
+                continue;
             }
-        );
+            // Queue is empty; wait for either a new task to be enqueued
+            // or the target task to complete.
+            std::unique_lock<std::mutex> lock(m_queueMutex);
+            m_stealCV.wait(
+                lock,
+                [this, task]
+                {
+                    return task->done.load(std::memory_order_acquire) || !m_queue.empty();
+                }
+            );
+        }
     }
 
     void waitAll()
     {
-        std::unique_lock<std::mutex> lock(m_waitMutex);
-        m_waitCV.wait(
-            lock,
-            [this]
+        while (m_tasksRemaining.load(std::memory_order_acquire) != 0)
+        {
+            // Try to steal and execute a task from the queue.
+            if (Task* stolen = tryDequeue())
             {
-                return m_tasksRemaining.load(std::memory_order_acquire) == 0;
+                executeTask(stolen);
+                continue;
             }
-        );
+            // Queue is empty; wait for either a new task to be enqueued
+            // or all tasks to complete.
+            std::unique_lock<std::mutex> lock(m_queueMutex);
+            m_stealCV.wait(
+                lock,
+                [this]
+                {
+                    return m_tasksRemaining.load(std::memory_order_acquire) == 0 || !m_queue.empty();
+                }
+            );
+        }
     }
 };
+
+ThreadedTaskPool::Task* ThreadedTaskPool::Pool::tryDequeue()
+{
+    std::lock_guard<std::mutex> lock(m_queueMutex);
+    if (m_queue.empty())
+        return nullptr;
+    Task* task = m_queue.front();
+    m_queue.pop();
+    return task;
+}
+
+void ThreadedTaskPool::Pool::executeTask(Task* task)
+{
+    // Execute the task function.
+    // Wrap in try/catch to ensure the worker thread survives and the
+    // task-completion bookkeeping (done flag, children, group, counters)
+    // always runs. Without this, an exception would deadlock waiters.
+    try
+    {
+        task->func(task->payload);
+    } catch (...)
+    {
+        SLANG_RHI_ASSERT_FAILURE("Task threw an exception");
+    }
+    // Capture the group pointer before we potentially release the task.
+    TaskGroup* group = task->group;
+    // Mark the task as done and notify child tasks.
+    // We must hold waitMutex around setting done and notifying, so that
+    // waitTask() cannot observe done==true and release the task before
+    // we finish touching it. We must also hold childrenMutex to safely
+    // process the children list.
+    {
+        std::lock_guard<std::mutex> waitLock(task->waitMutex);
+        {
+            std::lock_guard<std::mutex> childLock(task->childrenMutex);
+            task->done.store(true, std::memory_order_release);
+            for (Task* child : task->children)
+            {
+                // Decrement the child's dependency counter.
+                if (child->depsRemaining.fetch_sub(1, std::memory_order_relaxed) == 1)
+                {
+                    // All dependencies satisfied; enqueue the child.
+                    enqueue(child);
+                }
+                // Release the extra reference taken when adding as a dependency.
+                releaseTask(child);
+            }
+            task->children.clear();
+        }
+        // Notify waitTask() waiters.
+        task->waitCV.notify_all();
+    }
+    // Release the pool's reference.
+    // This must happen before decrementing m_tasksRemaining so that
+    // waitAll() only returns after all payload deleters have been called.
+    releaseTask(task);
+    // Decrement the group pending counter and notify waiters.
+    if (group)
+    {
+        if (group->pending.fetch_sub(1, std::memory_order_acq_rel) == 1)
+        {
+            std::lock_guard<std::mutex> lock(group->mutex);
+            group->cv.notify_all();
+        }
+    }
+    // Decrement the remaining task counter and notify waiters.
+    // Notify stealCV so that work-stealing wait loops wake up
+    // and recheck their conditions. Must hold m_queueMutex to prevent
+    // lost wakeups (notification arriving between predicate check and wait).
+    if (m_tasksRemaining.fetch_sub(1, std::memory_order_acq_rel) == 1)
+    {
+        std::lock_guard<std::mutex> lock(m_waitMutex);
+        m_waitCV.notify_all();
+    }
+    {
+        std::lock_guard<std::mutex> lock(m_queueMutex);
+        m_stealCV.notify_all();
+    }
+}
 
 void ThreadedTaskPool::Pool::workerThread()
 {
@@ -381,64 +498,32 @@ void ThreadedTaskPool::Pool::workerThread()
             task = m_queue.front();
             m_queue.pop();
         }
-        // Execute the task function.
-        // Wrap in try/catch to ensure the worker thread survives and the
-        // task-completion bookkeeping (done flag, children, group, counters)
-        // always runs. Without this, an exception would deadlock waiters.
-        try
+        executeTask(task);
+    }
+}
+
+void ThreadedTaskPool::Pool::waitTaskGroup(TaskGroup* group)
+{
+    SLANG_RHI_ASSERT(group);
+
+    while (group->pending.load(std::memory_order_acquire) != 0)
+    {
+        // Try to steal and execute a task from the queue.
+        if (Task* stolen = tryDequeue())
         {
-            task->func(task->payload);
-        } catch (...)
-        {
-            SLANG_RHI_ASSERT_FAILURE("Task threw an exception");
+            executeTask(stolen);
+            continue;
         }
-        // Capture the group pointer before we potentially release the task.
-        TaskGroup* group = task->group;
-        // Mark the task as done and notify child tasks.
-        // We must hold waitMutex around setting done and notifying, so that
-        // waitTask() cannot observe done==true and release the task before
-        // we finish touching it. We must also hold childrenMutex to safely
-        // process the children list.
-        {
-            std::lock_guard<std::mutex> waitLock(task->waitMutex);
+        // Queue is empty; wait for either a new task to be enqueued
+        // or all group tasks to complete.
+        std::unique_lock<std::mutex> lock(m_queueMutex);
+        m_stealCV.wait(
+            lock,
+            [this, group]
             {
-                std::lock_guard<std::mutex> childLock(task->childrenMutex);
-                task->done.store(true, std::memory_order_release);
-                for (Task* child : task->children)
-                {
-                    // Decrement the child's dependency counter.
-                    if (child->depsRemaining.fetch_sub(1, std::memory_order_relaxed) == 1)
-                    {
-                        // All dependencies satisfied; enqueue the child.
-                        enqueue(child);
-                    }
-                    // Release the extra reference taken when adding as a dependency.
-                    releaseTask(child);
-                }
-                task->children.clear();
+                return group->pending.load(std::memory_order_acquire) == 0 || !m_queue.empty();
             }
-            // Notify waitTask() waiters.
-            task->waitCV.notify_all();
-        }
-        // Release the pool's reference.
-        // This must happen before decrementing m_tasksRemaining so that
-        // waitAll() only returns after all payload deleters have been called.
-        releaseTask(task);
-        // Decrement the group pending counter and notify waiters.
-        if (group)
-        {
-            if (group->pending.fetch_sub(1, std::memory_order_acq_rel) == 1)
-            {
-                std::lock_guard<std::mutex> lock(group->mutex);
-                group->cv.notify_all();
-            }
-        }
-        // Decrement the remaining task counter and notify waiters.
-        if (m_tasksRemaining.fetch_sub(1, std::memory_order_acq_rel) == 1)
-        {
-            std::lock_guard<std::mutex> lock(m_waitMutex);
-            m_waitCV.notify_all();
-        }
+        );
     }
 }
 
@@ -507,15 +592,7 @@ void ThreadedTaskPool::waitTaskGroup(TaskGroupHandle group)
 {
     SLANG_RHI_ASSERT(group);
 
-    TaskGroup* g = static_cast<TaskGroup*>(group);
-    std::unique_lock<std::mutex> lock(g->mutex);
-    g->cv.wait(
-        lock,
-        [g]
-        {
-            return g->pending.load(std::memory_order_acquire) == 0;
-        }
-    );
+    m_pool->waitTaskGroup(static_cast<TaskGroup*>(group));
 }
 
 void ThreadedTaskPool::releaseTaskGroup(TaskGroupHandle group)

--- a/src/core/task-pool.cpp
+++ b/src/core/task-pool.cpp
@@ -128,10 +128,6 @@ struct ThreadedTaskPool::Task
     // Flag indicating the task has finished.
     std::atomic<bool> done{false};
 
-    // Mutex and condition variable for waitTask().
-    std::mutex waitMutex;
-    std::condition_variable waitCV;
-
     // List of tasks that depend on this task.
     std::vector<Task*> children;
     std::mutex childrenMutex;
@@ -143,8 +139,6 @@ struct ThreadedTaskPool::Task
 struct TaskGroup
 {
     std::atomic<size_t> pending{0};
-    std::mutex mutex;
-    std::condition_variable cv;
 };
 
 struct ThreadedTaskPool::Pool
@@ -167,10 +161,6 @@ struct ThreadedTaskPool::Pool
 
     // Total number of tasks not yet completed.
     std::atomic<size_t> m_tasksRemaining{0};
-
-    // Mutex and condition variable for waitAll().
-    std::mutex m_waitMutex;
-    std::condition_variable m_waitCV;
 
     void workerThread();
 
@@ -286,6 +276,9 @@ struct ThreadedTaskPool::Pool
         task->group = group;
 
         // Increment the group counter before enqueuing (critical for correctness).
+        // Relaxed ordering is sufficient: the submitting thread has sequenced-before
+        // visibility, and cross-thread synchronization is provided by m_queueMutex
+        // in enqueue()/tryDequeue().
         if (group)
         {
             group->pending.fetch_add(1, std::memory_order_relaxed);
@@ -425,53 +418,38 @@ void ThreadedTaskPool::Pool::executeTask(Task* task)
     // Capture the group pointer before we potentially release the task.
     TaskGroup* group = task->group;
     // Mark the task as done and notify child tasks.
-    // We must hold waitMutex around setting done and notifying, so that
-    // waitTask() cannot observe done==true and release the task before
-    // we finish touching it. We must also hold childrenMutex to safely
-    // process the children list.
+    // We hold childrenMutex to safely process the children list and to
+    // synchronize with submitTask() which checks done under the same lock.
     {
-        std::lock_guard<std::mutex> waitLock(task->waitMutex);
+        std::lock_guard<std::mutex> childLock(task->childrenMutex);
+        task->done.store(true, std::memory_order_release);
+        for (Task* child : task->children)
         {
-            std::lock_guard<std::mutex> childLock(task->childrenMutex);
-            task->done.store(true, std::memory_order_release);
-            for (Task* child : task->children)
+            // Decrement the child's dependency counter.
+            if (child->depsRemaining.fetch_sub(1, std::memory_order_relaxed) == 1)
             {
-                // Decrement the child's dependency counter.
-                if (child->depsRemaining.fetch_sub(1, std::memory_order_relaxed) == 1)
-                {
-                    // All dependencies satisfied; enqueue the child.
-                    enqueue(child);
-                }
-                // Release the extra reference taken when adding as a dependency.
-                releaseTask(child);
+                // All dependencies satisfied; enqueue the child.
+                enqueue(child);
             }
-            task->children.clear();
+            // Release the extra reference taken when adding as a dependency.
+            releaseTask(child);
         }
-        // Notify waitTask() waiters.
-        task->waitCV.notify_all();
+        task->children.clear();
     }
     // Release the pool's reference.
     // This must happen before decrementing m_tasksRemaining so that
     // waitAll() only returns after all payload deleters have been called.
     releaseTask(task);
-    // Decrement the group pending counter and notify waiters.
+    // Decrement the group pending counter.
     if (group)
     {
-        if (group->pending.fetch_sub(1, std::memory_order_acq_rel) == 1)
-        {
-            std::lock_guard<std::mutex> lock(group->mutex);
-            group->cv.notify_all();
-        }
+        group->pending.fetch_sub(1, std::memory_order_acq_rel);
     }
-    // Decrement the remaining task counter and notify waiters.
+    // Decrement the remaining task counter.
+    m_tasksRemaining.fetch_sub(1, std::memory_order_acq_rel);
     // Notify stealCV so that work-stealing wait loops wake up
     // and recheck their conditions. Must hold m_queueMutex to prevent
     // lost wakeups (notification arriving between predicate check and wait).
-    if (m_tasksRemaining.fetch_sub(1, std::memory_order_acq_rel) == 1)
-    {
-        std::lock_guard<std::mutex> lock(m_waitMutex);
-        m_waitCV.notify_all();
-    }
     {
         std::lock_guard<std::mutex> lock(m_queueMutex);
         m_stealCV.notify_all();

--- a/src/core/task-pool.cpp
+++ b/src/core/task-pool.cpp
@@ -87,8 +87,7 @@ void BlockingTaskPool::waitAll() {}
 
 ITaskPool::TaskGroupHandle BlockingTaskPool::createTaskGroup()
 {
-    static char sentinel;
-    return &sentinel;
+    return new char;
 }
 
 void BlockingTaskPool::waitTaskGroup(TaskGroupHandle group)
@@ -100,7 +99,7 @@ void BlockingTaskPool::waitTaskGroup(TaskGroupHandle group)
 void BlockingTaskPool::releaseTaskGroup(TaskGroupHandle group)
 {
     SLANG_RHI_ASSERT(group);
-    SLANG_UNUSED(group);
+    delete static_cast<char*>(group);
 }
 
 // ----------------------------------------------------------------------------
@@ -250,7 +249,10 @@ struct ThreadedTaskPool::Pool
             std::lock_guard<std::mutex> lock(m_queueMutex);
             m_queue.push(task);
             m_queueCV.notify_one();
-            m_stealCV.notify_all();
+            // Only wake one work-stealing waiter per enqueue to avoid thundering herd.
+            // The completion path in executeTask() uses notify_all() to wake all waiters
+            // so they can recheck their specific conditions (done, pending==0, etc.).
+            m_stealCV.notify_one();
         }
     }
 
@@ -265,6 +267,7 @@ struct ThreadedTaskPool::Pool
     {
         SLANG_RHI_ASSERT(func);
         SLANG_RHI_ASSERT(depsCount == 0 || deps);
+        SLANG_RHI_ASSERT(!m_stop.load(std::memory_order_relaxed));
 
         Task* task = new Task();
 
@@ -316,6 +319,8 @@ struct ThreadedTaskPool::Pool
                     else
                     {
                         // Dependency is already done, decrement the counter.
+                        // Relaxed ordering is safe here because dep->childrenMutex provides
+                        // the necessary acquire/release synchronization.
                         if (task->depsRemaining.fetch_sub(1, std::memory_order_relaxed) == 1)
                         {
                             readyToEnqueue = true;
@@ -408,6 +413,8 @@ void ThreadedTaskPool::Pool::executeTask(Task* task)
     // Wrap in try/catch to ensure the worker thread survives and the
     // task-completion bookkeeping (done flag, children, group, counters)
     // always runs. Without this, an exception would deadlock waiters.
+    // NOTE: If a task throws, it is still marked as done and its children
+    // will execute. There is currently no failure propagation mechanism.
     try
     {
         task->func(task->payload);
@@ -441,6 +448,10 @@ void ThreadedTaskPool::Pool::executeTask(Task* task)
     // waitAll() only returns after all payload deleters have been called.
     releaseTask(task);
     // Decrement the group pending counter.
+    // Safety: group is user-managed, but this is safe because waitTaskGroup()
+    // only returns when pending==0, which requires ALL tasks in the group to
+    // have completed this fetch_sub. Therefore no task can still be accessing
+    // the group when the user calls releaseTaskGroup() after waitTaskGroup().
     if (group)
     {
         group->pending.fetch_sub(1, std::memory_order_acq_rel);

--- a/tests/test-task-pool.cpp
+++ b/tests/test-task-pool.cpp
@@ -559,3 +559,203 @@ TEST_CASE("task-pool-threaded")
         }
     }
 }
+
+// Work-stealing tests: use a single worker thread to force scenarios that
+// would deadlock without work-stealing in wait functions.
+
+// A task callback calls waitTask on another task. With 1 worker thread and
+// no work-stealing, the worker blocks and the waited-on task never runs.
+void testWorkStealingWaitTaskFromCallback(ITaskPool* pool)
+{
+    REQUIRE(pool != nullptr);
+
+    std::atomic<int> result{0};
+
+    // Task A: sets result to 1.
+    auto taskA = pool->submitTask(
+        [](void* p)
+        {
+            static_cast<std::atomic<int>*>(p)->store(1, std::memory_order_relaxed);
+        },
+        &result,
+        nullptr,
+        nullptr,
+        0
+    );
+
+    // Task B: waits on A from inside its callback, then sets result to 2.
+    struct Payload
+    {
+        ITaskPool* pool;
+        ITaskPool::TaskHandle taskA;
+        std::atomic<int>* result;
+    };
+    Payload payload{pool, taskA, &result};
+
+    auto taskB = pool->submitTask(
+        [](void* p)
+        {
+            auto* ctx = static_cast<Payload*>(p);
+            ctx->pool->waitTask(ctx->taskA);
+            CHECK(ctx->result->load(std::memory_order_relaxed) == 1);
+            ctx->result->store(2, std::memory_order_relaxed);
+        },
+        &payload,
+        nullptr,
+        nullptr,
+        0
+    );
+
+    pool->waitTask(taskB);
+    CHECK(result.load() == 2);
+
+    pool->releaseTask(taskA);
+    pool->releaseTask(taskB);
+}
+
+// Nested wait chain: task C waits on B, B waits on A. With 1 worker thread,
+// this requires two levels of work-stealing to avoid deadlock.
+void testWorkStealingNestedWait(ITaskPool* pool)
+{
+    REQUIRE(pool != nullptr);
+
+    std::atomic<int> order{0};
+
+    auto taskA = pool->submitTask(
+        [](void* p)
+        {
+            static_cast<std::atomic<int>*>(p)->fetch_add(1, std::memory_order_relaxed);
+        },
+        &order,
+        nullptr,
+        nullptr,
+        0
+    );
+
+    struct WaitPayload
+    {
+        ITaskPool* pool;
+        ITaskPool::TaskHandle dep;
+        std::atomic<int>* order;
+    };
+    WaitPayload payloadB{pool, taskA, &order};
+
+    auto taskB = pool->submitTask(
+        [](void* p)
+        {
+            auto* ctx = static_cast<WaitPayload*>(p);
+            ctx->pool->waitTask(ctx->dep);
+            ctx->order->fetch_add(1, std::memory_order_relaxed);
+        },
+        &payloadB,
+        nullptr,
+        nullptr,
+        0
+    );
+
+    WaitPayload payloadC{pool, taskB, &order};
+
+    auto taskC = pool->submitTask(
+        [](void* p)
+        {
+            auto* ctx = static_cast<WaitPayload*>(p);
+            ctx->pool->waitTask(ctx->dep);
+            ctx->order->fetch_add(1, std::memory_order_relaxed);
+        },
+        &payloadC,
+        nullptr,
+        nullptr,
+        0
+    );
+
+    pool->waitTask(taskC);
+    CHECK(order.load() == 3);
+
+    pool->releaseTask(taskA);
+    pool->releaseTask(taskB);
+    pool->releaseTask(taskC);
+}
+
+// A task callback uses waitTaskGroup to wait on sub-tasks it spawns.
+// With 1 worker, the callback's thread must steal sub-tasks to make progress.
+void testWorkStealingWaitGroupFromCallback(ITaskPool* pool)
+{
+    REQUIRE(pool != nullptr);
+
+    std::atomic<int> sum{0};
+
+    struct Payload
+    {
+        ITaskPool* pool;
+        std::atomic<int>* sum;
+    };
+    Payload payload{pool, &sum};
+
+    auto task = pool->submitTask(
+        [](void* p)
+        {
+            auto* ctx = static_cast<Payload*>(p);
+            auto group = ctx->pool->createTaskGroup();
+
+            static constexpr int N = 10;
+            ITaskPool::TaskHandle subtasks[N];
+            for (int i = 0; i < N; ++i)
+            {
+                subtasks[i] = ctx->pool->submitTask(
+                    [](void* p2)
+                    {
+                        static_cast<std::atomic<int>*>(p2)->fetch_add(1, std::memory_order_relaxed);
+                    },
+                    ctx->sum,
+                    nullptr,
+                    nullptr,
+                    0,
+                    group
+                );
+            }
+
+            ctx->pool->waitTaskGroup(group);
+            ctx->pool->releaseTaskGroup(group);
+
+            for (int i = 0; i < N; ++i)
+                ctx->pool->releaseTask(subtasks[i]);
+        },
+        &payload,
+        nullptr,
+        nullptr,
+        0
+    );
+
+    pool->waitTask(task);
+    CHECK(sum.load() == 10);
+    pool->releaseTask(task);
+}
+
+TEST_CASE("task-pool-work-stealing")
+{
+    // Use a single worker thread to force work-stealing in wait functions.
+    // Without work-stealing, these tests would deadlock.
+    ComPtr<ITaskPool> pool(new ThreadedTaskPool(1));
+
+    SUBCASE("wait-task-from-callback")
+    {
+        for (int i = 0; i < 100; ++i)
+        {
+            testWorkStealingWaitTaskFromCallback(pool);
+        }
+    }
+    SUBCASE("nested-wait")
+    {
+        for (int i = 0; i < 100; ++i)
+        {
+            testWorkStealingNestedWait(pool);
+        }
+    }
+    SUBCASE("wait-group-from-callback")
+    {
+        for (int i = 0; i < 100; ++i)
+        {
+            testWorkStealingWaitGroupFromCallback(pool);
+        }
+    }
+}

--- a/tests/test-task-pool.cpp
+++ b/tests/test-task-pool.cpp
@@ -452,76 +452,32 @@ void testGroupWithDependencies(ITaskPool* pool)
     pool->releaseTaskGroup(group);
 }
 
-TEST_CASE("task-pool-blocking")
+void testTaskPool(ITaskPool* pool, int iterations)
 {
-    ComPtr<ITaskPool> pool(new BlockingTaskPool());
-
     SUBCASE("simple")
     {
-        testSimple(pool);
-    }
-    SUBCASE("wait-all")
-    {
-        testWaitAll(pool);
-    }
-    SUBCASE("simple-dependency")
-    {
-        testSimpleDependency(pool);
-    }
-    SUBCASE("recursive-dependency")
-    {
-        testRecursiveDependency(pool);
-    }
-    SUBCASE("fibonacci")
-    {
-        testFibonacci(pool);
-    }
-    SUBCASE("group-basic")
-    {
-        testGroupBasic(pool);
-    }
-    SUBCASE("group-sub-tasks")
-    {
-        testGroupSubTasks(pool);
-    }
-    SUBCASE("group-empty")
-    {
-        testGroupEmpty(pool);
-    }
-    SUBCASE("group-with-dependencies")
-    {
-        testGroupWithDependencies(pool);
-    }
-}
-
-TEST_CASE("task-pool-threaded")
-{
-    ComPtr<ITaskPool> pool(new ThreadedTaskPool());
-
-    SUBCASE("simple")
-    {
-        for (int i = 0; i < 100; ++i)
+        for (int i = 0; i < iterations; ++i)
         {
             testSimple(pool);
         }
     }
     SUBCASE("wait-all")
     {
-        for (int i = 0; i < 100; ++i)
+        for (int i = 0; i < iterations; ++i)
         {
             testWaitAll(pool);
         }
     }
     SUBCASE("simple-dependency")
     {
-        for (int i = 0; i < 100; ++i)
+        for (int i = 0; i < iterations; ++i)
         {
             testSimpleDependency(pool);
         }
     }
     SUBCASE("recursive-dependency")
     {
-        for (int i = 0; i < 100; ++i)
+        for (int i = 0; i < iterations; ++i)
         {
             testRecursiveDependency(pool);
         }
@@ -532,32 +488,50 @@ TEST_CASE("task-pool-threaded")
     }
     SUBCASE("group-basic")
     {
-        for (int i = 0; i < 100; ++i)
+        for (int i = 0; i < iterations; ++i)
         {
             testGroupBasic(pool);
         }
     }
     SUBCASE("group-sub-tasks")
     {
-        for (int i = 0; i < 100; ++i)
+        for (int i = 0; i < iterations; ++i)
         {
             testGroupSubTasks(pool);
         }
     }
     SUBCASE("group-empty")
     {
-        for (int i = 0; i < 100; ++i)
+        for (int i = 0; i < iterations; ++i)
         {
             testGroupEmpty(pool);
         }
     }
     SUBCASE("group-with-dependencies")
     {
-        for (int i = 0; i < 100; ++i)
+        for (int i = 0; i < iterations; ++i)
         {
             testGroupWithDependencies(pool);
         }
     }
+}
+
+TEST_CASE("task-pool-blocking")
+{
+    ComPtr<ITaskPool> pool(new BlockingTaskPool());
+    testTaskPool(pool, 1);
+}
+
+TEST_CASE("task-pool-threaded")
+{
+    ComPtr<ITaskPool> pool(new ThreadedTaskPool());
+    testTaskPool(pool, 10);
+}
+
+TEST_CASE("task-pool-threaded-single-worker")
+{
+    ComPtr<ITaskPool> pool(new ThreadedTaskPool(1));
+    testTaskPool(pool, 1);
 }
 
 // Work-stealing tests: use a single worker thread to force scenarios that

--- a/tests/test-task-pool.cpp
+++ b/tests/test-task-pool.cpp
@@ -713,21 +713,21 @@ TEST_CASE("task-pool-work-stealing")
 
     SUBCASE("wait-task-from-callback")
     {
-        for (int i = 0; i < 100; ++i)
+        for (int i = 0; i < 10000; ++i)
         {
             testWorkStealingWaitTaskFromCallback(pool);
         }
     }
     SUBCASE("nested-wait")
     {
-        for (int i = 0; i < 100; ++i)
+        for (int i = 0; i < 10000; ++i)
         {
             testWorkStealingNestedWait(pool);
         }
     }
     SUBCASE("wait-group-from-callback")
     {
-        for (int i = 0; i < 100; ++i)
+        for (int i = 0; i < 10000; ++i)
         {
             testWorkStealingWaitGroupFromCallback(pool);
         }


### PR DESCRIPTION
Extends the `ThreadedTaskPool` with work-stealing when waiting for tasks or task groups.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved task pool synchronization to avoid deadlocks by allowing waiting threads to run pending tasks (work-stealing), including nested/wait-from-callback scenarios.

* **Documentation**
  * Clarified blocking API docs to describe work-stealing and deadlock-safety behavior during waits.

* **Tests**
  * Added and expanded tests covering work-stealing, nested waits, wait-from-callbacks, single-worker and repeated stress scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->