### PR TITLE
Cleanup static initialization (part 1)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -630,6 +630,7 @@ endif()
 
 if(SLANG_RHI_ENABLE_CPU)
     target_sources(slang-rhi PRIVATE
+        src/cpu/cpu-backend.cpp
         src/cpu/cpu-buffer.cpp
         src/cpu/cpu-command.cpp
         src/cpu/cpu-device.cpp
@@ -652,6 +653,7 @@ endif()
 
 if(SLANG_RHI_ENABLE_D3D11)
     target_sources(slang-rhi PRIVATE
+        src/d3d11/d3d11-backend.cpp
         src/d3d11/d3d11-buffer.cpp
         src/d3d11/d3d11-command.cpp
         src/d3d11/d3d11-constant-buffer-pool.cpp
@@ -672,6 +674,7 @@ endif()
 if(SLANG_RHI_ENABLE_D3D12)
     target_sources(slang-rhi PRIVATE
         src/d3d12/d3d12-acceleration-structure.cpp
+        src/d3d12/d3d12-backend.cpp
         src/d3d12/d3d12-bindless-descriptor-set.cpp
         src/d3d12/d3d12-buffer.cpp
         src/d3d12/d3d12-command.cpp
@@ -698,6 +701,7 @@ if(SLANG_RHI_ENABLE_VULKAN)
     target_sources(slang-rhi PRIVATE
         src/vulkan/vk-acceleration-structure.cpp
         src/vulkan/vk-api.cpp
+        src/vulkan/vk-backend.cpp
         src/vulkan/vk-bindless-descriptor-set.cpp
         src/vulkan/vk-buffer.cpp
         src/vulkan/vk-command.cpp
@@ -725,6 +729,7 @@ if(SLANG_RHI_ENABLE_METAL)
     target_sources(slang-rhi PRIVATE
         src/metal/metal-acceleration-structure.cpp
         src/metal/metal-api.cpp
+        src/metal/metal-backend.cpp
         src/metal/metal-buffer.cpp
         src/metal/metal-clear-engine.cpp
         src/metal/metal-command.cpp
@@ -749,6 +754,7 @@ endif()
 if(SLANG_RHI_ENABLE_CUDA)
     target_sources(slang-rhi PRIVATE
         src/cuda/cuda-acceleration-structure.cpp
+        src/cuda/cuda-backend.cpp
         src/cuda/cuda-buffer.cpp
         src/cuda/cuda-clear-engine.cpp
         src/cuda/cuda-command.cpp
@@ -781,6 +787,7 @@ endif()
 if(SLANG_RHI_ENABLE_WGPU)
     target_sources(slang-rhi PRIVATE
         src/wgpu/wgpu-api.cpp
+        src/wgpu/wgpu-backend.cpp
         src/wgpu/wgpu-buffer.cpp
         src/wgpu/wgpu-command.cpp
         src/wgpu/wgpu-constant-buffer-pool.cpp

--- a/include/slang-rhi.h
+++ b/include/slang-rhi.h
@@ -3938,6 +3938,11 @@ struct VulkanDeviceExtendedDesc
 /// Get the global interface to the RHI.
 extern "C" SLANG_RHI_API rhi::IRHI* SLANG_STDCALL rhiGetInstance();
 
+/// Destroy the global RHI instance and release all owned resources.
+/// Fails if any devices are currently alive.
+/// After calling this, rhiGetInstance() will create a new instance on next call.
+extern "C" SLANG_RHI_API SlangResult SLANG_STDCALL rhiDestroyInstance();
+
 // Global public functions
 
 namespace rhi {
@@ -3946,6 +3951,14 @@ namespace rhi {
 inline IRHI* getRHI()
 {
     return ::rhiGetInstance();
+}
+
+/// Destroy the global RHI instance and release all owned resources.
+/// Fails if any devices are currently alive.
+/// After calling this, getRHI() will create a new instance on next call.
+inline Result destroyRHI()
+{
+    return rhiDestroyInstance();
 }
 
 inline const FormatInfo& getFormatInfo(Format format)

--- a/src/aftermath.cpp
+++ b/src/aftermath.cpp
@@ -266,10 +266,21 @@ const std::string* AftermathCrashDumper::findMarker(uint64_t hash)
     return nullptr;
 }
 
+static std::mutex s_aftermathCrashDumperMutex;
+static RefPtr<AftermathCrashDumper> s_aftermathCrashDumper;
+
 AftermathCrashDumper* AftermathCrashDumper::getOrCreate()
 {
-    static RefPtr<AftermathCrashDumper> instance = new AftermathCrashDumper();
-    return instance;
+    std::lock_guard lock(s_aftermathCrashDumperMutex);
+    if (!s_aftermathCrashDumper)
+        s_aftermathCrashDumper = new AftermathCrashDumper();
+    return s_aftermathCrashDumper;
+}
+
+void AftermathCrashDumper::clear()
+{
+    std::lock_guard lock(s_aftermathCrashDumperMutex);
+    s_aftermathCrashDumper = nullptr;
 }
 
 void AftermathCrashDumper::waitForDump(int timeoutSeconds)

--- a/src/aftermath.h
+++ b/src/aftermath.h
@@ -97,6 +97,8 @@ public:
 
     /// Get or create the global AftermathCrashDumper instance.
     static AftermathCrashDumper* getOrCreate();
+    /// Clear the global AftermathCrashDumper instance.
+    static void clear();
     /// Wait for a crash dump to be written. Should be called after a crash is triggered.
     static void waitForDump(int timeoutSeconds = 10);
 

--- a/src/backend.h
+++ b/src/backend.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include <slang-rhi.h>
+
+#include "core/smart-pointer.h"
+
+namespace rhi {
+
+class Backend : public RefObject
+{
+public:
+    virtual ~Backend() = default;
+    virtual IAdapter* getAdapter(uint32_t index) = 0;
+    virtual Result createDevice(const DeviceDesc& desc, IDevice** outDevice) = 0;
+};
+
+Result createD3D11Backend(Backend** outBackend);
+Result createD3D12Backend(Backend** outBackend);
+Result createVKBackend(Backend** outBackend);
+Result createMetalBackend(Backend** outBackend);
+Result createCUDABackend(Backend** outBackend);
+Result createCPUBackend(Backend** outBackend);
+Result createWGPUBackend(Backend** outBackend);
+
+} // namespace rhi

--- a/src/backend.h
+++ b/src/backend.h
@@ -4,6 +4,8 @@
 
 #include "core/smart-pointer.h"
 
+#include <mutex>
+
 namespace rhi {
 
 class Backend : public RefObject
@@ -12,6 +14,22 @@ public:
     virtual ~Backend() = default;
     virtual IAdapter* getAdapter(uint32_t index) = 0;
     virtual Result createDevice(const DeviceDesc& desc, IDevice** outDevice) = 0;
+
+protected:
+    virtual Result enumerateAdapters() = 0;
+
+    void ensureAdapters()
+    {
+        std::call_once(
+            m_adaptersOnce,
+            [this]
+            {
+                enumerateAdapters();
+            }
+        );
+    }
+
+    std::once_flag m_adaptersOnce;
 };
 
 Result createD3D11Backend(Backend** outBackend);

--- a/src/core/reverse-map.h
+++ b/src/core/reverse-map.h
@@ -1,30 +1,31 @@
 #pragma once
 
-#include <unordered_map>
+#include <array>
 
 namespace rhi {
 
 /// Given a mapping function, create a reverse map from To to From.
 /// The mapping function func must be bijective.
 /// The reverse map will return defaultValue if the value is not found.
-template<typename From, typename To, typename Func>
-auto reverseMap(Func func, From min, From max, From defaultValue = From(0))
+template<typename From, typename To, From min, From max, typename Func>
+auto reverseMap(Func func, From defaultValue = From(0))
 {
-    static std::unordered_map<To, From> reverseMap = [&]()
+    constexpr size_t size = size_t(max) - size_t(min) + 1;
+    static std::array<std::pair<To, From>, size> data = [&]()
     {
-        std::unordered_map<To, From> map;
-        for (int i = int(min); i <= int(max); i++)
+        std::array<std::pair<To, From>, size> arr{};
+        for (size_t i = 0; i < size; i++)
         {
-            const From fromI = From(i);
-            const To key = func(fromI); // Fixed MSVC warning C4709: comma operator within a subscript expression
-            map[key] = fromI;
+            arr[i] = {func(From(int(min) + int(i))), From(int(min) + int(i))};
         }
-        return map;
+        return arr;
     }();
     return [defaultValue](To value) -> From
     {
-        auto it = reverseMap.find(value);
-        return it == reverseMap.end() ? defaultValue : it->second;
+        for (const auto& [k, v] : data)
+            if (k == value)
+                return v;
+        return defaultValue;
     };
 }
 

--- a/src/cpu/cpu-backend.cpp
+++ b/src/cpu/cpu-backend.cpp
@@ -1,0 +1,45 @@
+#include "cpu-backend.h"
+#include "cpu-device.h"
+#include "../reference.h"
+
+#include "core/string.h"
+
+namespace rhi::cpu {
+
+Result BackendImpl::initialize()
+{
+    AdapterInfo info = {};
+    info.deviceType = DeviceType::CPU;
+    info.adapterType = AdapterType::Software;
+    string::copy_safe(info.name, sizeof(info.name), "Default");
+    m_adapter.m_info = info;
+    m_adapter.m_isDefault = true;
+    return SLANG_OK;
+}
+
+IAdapter* BackendImpl::getAdapter(uint32_t index)
+{
+    return index == 0 ? &m_adapter : nullptr;
+}
+
+Result BackendImpl::createDevice(const DeviceDesc& desc, IDevice** outDevice)
+{
+    RefPtr<DeviceImpl> result = new DeviceImpl();
+    SLANG_RETURN_ON_FAIL(result->initialize(desc, this));
+    returnComPtr(outDevice, result);
+    return SLANG_OK;
+}
+
+} // namespace rhi::cpu
+
+namespace rhi {
+
+Result createCPUBackend(Backend** outBackend)
+{
+    RefPtr<cpu::BackendImpl> backend = new cpu::BackendImpl();
+    SLANG_RETURN_ON_FAIL(backend->initialize());
+    returnRefPtr(outBackend, backend);
+    return SLANG_OK;
+}
+
+} // namespace rhi

--- a/src/cpu/cpu-backend.cpp
+++ b/src/cpu/cpu-backend.cpp
@@ -6,19 +6,9 @@
 
 namespace rhi::cpu {
 
-Result BackendImpl::initialize()
-{
-    AdapterInfo info = {};
-    info.deviceType = DeviceType::CPU;
-    info.adapterType = AdapterType::Software;
-    string::copy_safe(info.name, sizeof(info.name), "Default");
-    m_adapter.m_info = info;
-    m_adapter.m_isDefault = true;
-    return SLANG_OK;
-}
-
 IAdapter* BackendImpl::getAdapter(uint32_t index)
 {
+    ensureAdapters();
     return index == 0 ? &m_adapter : nullptr;
 }
 
@@ -30,6 +20,17 @@ Result BackendImpl::createDevice(const DeviceDesc& desc, IDevice** outDevice)
     return SLANG_OK;
 }
 
+Result BackendImpl::enumerateAdapters()
+{
+    AdapterInfo info = {};
+    info.deviceType = DeviceType::CPU;
+    info.adapterType = AdapterType::Software;
+    string::copy_safe(info.name, sizeof(info.name), "Default");
+    m_adapter.m_info = info;
+    m_adapter.m_isDefault = true;
+    return SLANG_OK;
+}
+
 } // namespace rhi::cpu
 
 namespace rhi {
@@ -37,7 +38,6 @@ namespace rhi {
 Result createCPUBackend(Backend** outBackend)
 {
     RefPtr<cpu::BackendImpl> backend = new cpu::BackendImpl();
-    SLANG_RETURN_ON_FAIL(backend->initialize());
     returnRefPtr(outBackend, backend);
     return SLANG_OK;
 }

--- a/src/cpu/cpu-backend.h
+++ b/src/cpu/cpu-backend.h
@@ -8,12 +8,13 @@ namespace rhi::cpu {
 class BackendImpl : public Backend
 {
 public:
-    Result initialize();
-
     // Backend implementation
 
     IAdapter* getAdapter(uint32_t index) override;
     Result createDevice(const DeviceDesc& desc, IDevice** outDevice) override;
+
+protected:
+    Result enumerateAdapters() override;
 
 private:
     Adapter m_adapter;

--- a/src/cpu/cpu-backend.h
+++ b/src/cpu/cpu-backend.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include "cpu-base.h"
+#include "../backend.h"
+
+namespace rhi::cpu {
+
+class BackendImpl : public Backend
+{
+public:
+    Result initialize();
+
+    // Backend implementation
+
+    IAdapter* getAdapter(uint32_t index) override;
+    Result createDevice(const DeviceDesc& desc, IDevice** outDevice) override;
+
+private:
+    Adapter m_adapter;
+};
+
+} // namespace rhi::cpu

--- a/src/cpu/cpu-base.h
+++ b/src/cpu/cpu-base.h
@@ -13,6 +13,7 @@
 
 namespace rhi::cpu {
 
+class BackendImpl;
 class BufferImpl;
 class TextureImpl;
 class TextureViewImpl;

--- a/src/cpu/cpu-device.cpp
+++ b/src/cpu/cpu-device.cpp
@@ -9,7 +9,7 @@ namespace rhi::cpu {
 
 DeviceImpl::~DeviceImpl() {}
 
-Result DeviceImpl::initialize(const DeviceDesc& desc)
+Result DeviceImpl::initialize(const DeviceDesc& desc, BackendImpl* backend)
 {
     SLANG_RETURN_ON_FAIL(Device::initialize(desc));
 
@@ -139,31 +139,3 @@ void DeviceImpl::customizeShaderObject(ShaderObject* shaderObject)
 }
 
 } // namespace rhi::cpu
-
-namespace rhi {
-
-IAdapter* getCPUAdapter(uint32_t index)
-{
-    static Adapter adapter = []()
-    {
-        Adapter outAdapter;
-        AdapterInfo info = {};
-        info.deviceType = DeviceType::CPU;
-        info.adapterType = AdapterType::Software;
-        string::copy_safe(info.name, sizeof(info.name), "Default");
-        outAdapter.m_info = info;
-        outAdapter.m_isDefault = true;
-        return outAdapter;
-    }();
-    return index == 0 ? &adapter : nullptr;
-}
-
-Result createCPUDevice(const DeviceDesc* desc, IDevice** outDevice)
-{
-    RefPtr<cpu::DeviceImpl> result = new cpu::DeviceImpl();
-    SLANG_RETURN_ON_FAIL(result->initialize(*desc));
-    returnComPtr(outDevice, result);
-    return SLANG_OK;
-}
-
-} // namespace rhi

--- a/src/cpu/cpu-device.h
+++ b/src/cpu/cpu-device.h
@@ -14,7 +14,7 @@ public:
 
     ~DeviceImpl();
 
-    virtual SLANG_NO_THROW Result SLANG_MCALL initialize(const DeviceDesc& desc) override;
+    Result initialize(const DeviceDesc& desc, BackendImpl* backend);
 
     virtual SLANG_NO_THROW Result SLANG_MCALL getTextureRowAlignment(Format format, Size* outAlignment) override;
 
@@ -101,10 +101,3 @@ private:
 };
 
 } // namespace rhi::cpu
-
-namespace rhi {
-
-IAdapter* getCPUAdapter(uint32_t index);
-Result createCPUDevice(const DeviceDesc* desc, IDevice** outDevice);
-
-} // namespace rhi

--- a/src/cuda/cuda-backend.cpp
+++ b/src/cuda/cuda-backend.cpp
@@ -151,6 +151,11 @@ Result BackendImpl::initialize()
     return getAdaptersImpl(m_adapters);
 }
 
+std::span<const AdapterImpl> BackendImpl::getAdapters() const
+{
+    return m_adapters;
+}
+
 IAdapter* BackendImpl::getAdapter(uint32_t index)
 {
     return index < m_adapters.size() ? &m_adapters[index] : nullptr;

--- a/src/cuda/cuda-backend.cpp
+++ b/src/cuda/cuda-backend.cpp
@@ -1,0 +1,179 @@
+#include "cuda-backend.h"
+#include "cuda-device.h"
+#include "cuda-utils.h"
+#include "../reference.h"
+
+namespace rhi::cuda {
+
+static int calcSMCountPerMultiProcessor(int major, int minor)
+{
+    // Defines for GPU Architecture types (using the SM version to determine
+    // the # of cores per SM
+    struct SMInfo
+    {
+        int sm; // 0xMm (hexadecimal notation), M = SM Major version, and m = SM minor version
+        int coreCount;
+    };
+
+    static const SMInfo infos[] = {
+        {0x30, 192},
+        {0x32, 192},
+        {0x35, 192},
+        {0x37, 192},
+        {0x50, 128},
+        {0x52, 128},
+        {0x53, 128},
+        {0x60, 64},
+        {0x61, 128},
+        {0x62, 128},
+        {0x70, 64},
+        {0x72, 64},
+        {0x75, 64}
+    };
+
+    const int sm = ((major << 4) + minor);
+    for (size_t i = 0; i < SLANG_COUNT_OF(infos); ++i)
+    {
+        if (infos[i].sm == sm)
+        {
+            return infos[i].coreCount;
+        }
+    }
+
+    const auto& last = infos[SLANG_COUNT_OF(infos) - 1];
+
+    // It must be newer presumably
+    SLANG_RHI_ASSERT(sm > last.sm);
+
+    // Default to the last entry
+    return last.coreCount;
+}
+
+static Result findMaxFlopsDeviceIndex(int* outDeviceIndex)
+{
+    int smPerMultiproc = 0;
+    int maxPerfDevice = -1;
+    int deviceCount = 0;
+
+    uint64_t maxComputePerf = 0;
+    SLANG_CUDA_RETURN_ON_FAIL(cuDeviceGetCount(&deviceCount));
+
+    // Find the best CUDA capable GPU device
+    for (int currentDevice = 0; currentDevice < deviceCount; ++currentDevice)
+    {
+        CUdevice device;
+        SLANG_CUDA_RETURN_ON_FAIL(cuDeviceGet(&device, currentDevice));
+        int computeMode = -1, major = 0, minor = 0;
+        SLANG_CUDA_RETURN_ON_FAIL(cuDeviceGetAttribute(&computeMode, CU_DEVICE_ATTRIBUTE_COMPUTE_MODE, device));
+        SLANG_CUDA_RETURN_ON_FAIL(cuDeviceGetAttribute(&major, CU_DEVICE_ATTRIBUTE_COMPUTE_CAPABILITY_MAJOR, device));
+        SLANG_CUDA_RETURN_ON_FAIL(cuDeviceGetAttribute(&minor, CU_DEVICE_ATTRIBUTE_COMPUTE_CAPABILITY_MINOR, device));
+
+        // If this GPU is not running on Compute Mode prohibited,
+        // then we can add it to the list
+        if (computeMode != CU_COMPUTEMODE_PROHIBITED)
+        {
+            if (major == 9999 && minor == 9999)
+            {
+                smPerMultiproc = 1;
+            }
+            else
+            {
+                smPerMultiproc = calcSMCountPerMultiProcessor(major, minor);
+            }
+
+            int multiProcessorCount = 0, clockRate = 0;
+            SLANG_CUDA_RETURN_ON_FAIL(
+                cuDeviceGetAttribute(&multiProcessorCount, CU_DEVICE_ATTRIBUTE_MULTIPROCESSOR_COUNT, device)
+            );
+            SLANG_CUDA_RETURN_ON_FAIL(cuDeviceGetAttribute(&clockRate, CU_DEVICE_ATTRIBUTE_CLOCK_RATE, device));
+            uint64_t compute_perf = uint64_t(multiProcessorCount) * smPerMultiproc * clockRate;
+
+            if (compute_perf > maxComputePerf)
+            {
+                maxComputePerf = compute_perf;
+                maxPerfDevice = currentDevice;
+            }
+        }
+    }
+
+    if (maxPerfDevice < 0)
+    {
+        return SLANG_FAIL;
+    }
+
+    *outDeviceIndex = maxPerfDevice;
+    return SLANG_OK;
+}
+
+static Result getAdaptersImpl(std::vector<AdapterImpl>& outAdapters)
+{
+    if (!rhiCudaDriverApiInit())
+    {
+        return SLANG_FAIL;
+    }
+
+    SLANG_CUDA_RETURN_ON_FAIL(cuInit(0));
+
+    int deviceCount;
+    SLANG_CUDA_RETURN_ON_FAIL(cuDeviceGetCount(&deviceCount));
+
+    for (int deviceIndex = 0; deviceIndex < deviceCount; deviceIndex++)
+    {
+        CUdevice device;
+        SLANG_CUDA_RETURN_ON_FAIL(cuDeviceGet(&device, deviceIndex));
+
+        AdapterInfo info = {};
+        info.deviceType = DeviceType::CUDA;
+        info.adapterType = AdapterType::Discrete;
+        SLANG_CUDA_RETURN_ON_FAIL(cuDeviceGetName(info.name, sizeof(info.name), device));
+        info.luid = getAdapterLUID(deviceIndex);
+
+        AdapterImpl adapter;
+        adapter.m_info = info;
+        adapter.m_deviceIndex = deviceIndex;
+        outAdapters.push_back(adapter);
+    }
+
+    // Find the max flops adapter and mark it as the default one.
+    if (!outAdapters.empty())
+    {
+        int defaultDeviceIndex = 0;
+        SLANG_RETURN_ON_FAIL(findMaxFlopsDeviceIndex(&defaultDeviceIndex));
+        SLANG_RHI_ASSERT(defaultDeviceIndex >= 0 && defaultDeviceIndex < (int)outAdapters.size());
+        outAdapters[defaultDeviceIndex].m_isDefault = true;
+    }
+
+    return SLANG_OK;
+}
+
+Result BackendImpl::initialize()
+{
+    return getAdaptersImpl(m_adapters);
+}
+
+IAdapter* BackendImpl::getAdapter(uint32_t index)
+{
+    return index < m_adapters.size() ? &m_adapters[index] : nullptr;
+}
+
+Result BackendImpl::createDevice(const DeviceDesc& desc, IDevice** outDevice)
+{
+    RefPtr<DeviceImpl> result = new DeviceImpl();
+    SLANG_RETURN_ON_FAIL(result->initialize(desc, this));
+    returnComPtr(outDevice, result);
+    return SLANG_OK;
+}
+
+} // namespace rhi::cuda
+
+namespace rhi {
+
+Result createCUDABackend(Backend** outBackend)
+{
+    RefPtr<cuda::BackendImpl> backend = new cuda::BackendImpl();
+    SLANG_RETURN_ON_FAIL(backend->initialize());
+    returnRefPtr(outBackend, backend);
+    return SLANG_OK;
+}
+
+} // namespace rhi

--- a/src/cuda/cuda-backend.cpp
+++ b/src/cuda/cuda-backend.cpp
@@ -28,7 +28,12 @@ static int calcSMCountPerMultiProcessor(int major, int minor)
         {0x62, 128},
         {0x70, 64},
         {0x72, 64},
-        {0x75, 64}
+        {0x75, 64},
+        {0x80, 64},
+        {0x86, 128},
+        {0x87, 128},
+        {0x89, 128},
+        {0x90, 128}
     };
 
     const int sm = ((major << 4) + minor);

--- a/src/cuda/cuda-backend.cpp
+++ b/src/cuda/cuda-backend.cpp
@@ -105,7 +105,27 @@ static Result findMaxFlopsDeviceIndex(int* outDeviceIndex)
     return SLANG_OK;
 }
 
-static Result getAdaptersImpl(std::vector<AdapterImpl>& outAdapters)
+std::span<const AdapterImpl> BackendImpl::getAdapters()
+{
+    ensureAdapters();
+    return m_adapters;
+}
+
+IAdapter* BackendImpl::getAdapter(uint32_t index)
+{
+    ensureAdapters();
+    return index < m_adapters.size() ? &m_adapters[index] : nullptr;
+}
+
+Result BackendImpl::createDevice(const DeviceDesc& desc, IDevice** outDevice)
+{
+    RefPtr<DeviceImpl> result = new DeviceImpl();
+    SLANG_RETURN_ON_FAIL(result->initialize(desc, this));
+    returnComPtr(outDevice, result);
+    return SLANG_OK;
+}
+
+Result BackendImpl::enumerateAdapters()
 {
     if (!rhiCudaDriverApiInit())
     {
@@ -131,41 +151,18 @@ static Result getAdaptersImpl(std::vector<AdapterImpl>& outAdapters)
         AdapterImpl adapter;
         adapter.m_info = info;
         adapter.m_deviceIndex = deviceIndex;
-        outAdapters.push_back(adapter);
+        m_adapters.push_back(adapter);
     }
 
     // Find the max flops adapter and mark it as the default one.
-    if (!outAdapters.empty())
+    if (!m_adapters.empty())
     {
         int defaultDeviceIndex = 0;
         SLANG_RETURN_ON_FAIL(findMaxFlopsDeviceIndex(&defaultDeviceIndex));
-        SLANG_RHI_ASSERT(defaultDeviceIndex >= 0 && defaultDeviceIndex < (int)outAdapters.size());
-        outAdapters[defaultDeviceIndex].m_isDefault = true;
+        SLANG_RHI_ASSERT(defaultDeviceIndex >= 0 && defaultDeviceIndex < (int)m_adapters.size());
+        m_adapters[defaultDeviceIndex].m_isDefault = true;
     }
 
-    return SLANG_OK;
-}
-
-Result BackendImpl::initialize()
-{
-    return getAdaptersImpl(m_adapters);
-}
-
-std::span<const AdapterImpl> BackendImpl::getAdapters() const
-{
-    return m_adapters;
-}
-
-IAdapter* BackendImpl::getAdapter(uint32_t index)
-{
-    return index < m_adapters.size() ? &m_adapters[index] : nullptr;
-}
-
-Result BackendImpl::createDevice(const DeviceDesc& desc, IDevice** outDevice)
-{
-    RefPtr<DeviceImpl> result = new DeviceImpl();
-    SLANG_RETURN_ON_FAIL(result->initialize(desc, this));
-    returnComPtr(outDevice, result);
     return SLANG_OK;
 }
 
@@ -176,7 +173,6 @@ namespace rhi {
 Result createCUDABackend(Backend** outBackend)
 {
     RefPtr<cuda::BackendImpl> backend = new cuda::BackendImpl();
-    SLANG_RETURN_ON_FAIL(backend->initialize());
     returnRefPtr(outBackend, backend);
     return SLANG_OK;
 }

--- a/src/cuda/cuda-backend.h
+++ b/src/cuda/cuda-backend.h
@@ -8,14 +8,15 @@ namespace rhi::cuda {
 class BackendImpl : public Backend
 {
 public:
-    Result initialize();
-
-    std::span<const AdapterImpl> getAdapters() const;
+    std::span<const AdapterImpl> getAdapters();
 
     // Backend implementation
 
     IAdapter* getAdapter(uint32_t index) override;
     Result createDevice(const DeviceDesc& desc, IDevice** outDevice) override;
+
+protected:
+    Result enumerateAdapters() override;
 
 private:
     std::vector<AdapterImpl> m_adapters;

--- a/src/cuda/cuda-backend.h
+++ b/src/cuda/cuda-backend.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include "cuda-base.h"
+#include "../backend.h"
+
+namespace rhi::cuda {
+
+class BackendImpl : public Backend
+{
+public:
+    Result initialize();
+
+    std::vector<AdapterImpl>& getAdapters() { return m_adapters; }
+
+    // Backend implementation
+
+    IAdapter* getAdapter(uint32_t index) override;
+    Result createDevice(const DeviceDesc& desc, IDevice** outDevice) override;
+
+private:
+    std::vector<AdapterImpl> m_adapters;
+};
+
+} // namespace rhi::cuda

--- a/src/cuda/cuda-backend.h
+++ b/src/cuda/cuda-backend.h
@@ -10,7 +10,7 @@ class BackendImpl : public Backend
 public:
     Result initialize();
 
-    std::vector<AdapterImpl>& getAdapters() { return m_adapters; }
+    std::span<const AdapterImpl> getAdapters() const { return m_adapters; }
 
     // Backend implementation
 

--- a/src/cuda/cuda-backend.h
+++ b/src/cuda/cuda-backend.h
@@ -10,7 +10,7 @@ class BackendImpl : public Backend
 public:
     Result initialize();
 
-    std::span<const AdapterImpl> getAdapters() const { return m_adapters; }
+    std::span<const AdapterImpl> getAdapters() const;
 
     // Backend implementation
 

--- a/src/cuda/cuda-base.h
+++ b/src/cuda/cuda-base.h
@@ -14,6 +14,7 @@
 
 namespace rhi::cuda {
 
+class BackendImpl;
 class AdapterImpl;
 class BufferImpl;
 class TextureImpl;

--- a/src/cuda/cuda-device.cpp
+++ b/src/cuda/cuda-device.cpp
@@ -1,4 +1,5 @@
 #include "cuda-device.h"
+#include "cuda-backend.h"
 #include "cuda-command.h"
 #include "cuda-buffer.h"
 #include "cuda-pipeline.h"
@@ -39,155 +40,6 @@ static ComputeCapabilityInfo kKnownComputeCapabilities[] = {
 #undef COMPUTE_CAPABILITY
 };
 
-inline int calcSMCountPerMultiProcessor(int major, int minor)
-{
-    // Defines for GPU Architecture types (using the SM version to determine
-    // the # of cores per SM
-    struct SMInfo
-    {
-        int sm; // 0xMm (hexadecimal notation), M = SM Major version, and m = SM minor version
-        int coreCount;
-    };
-
-    static const SMInfo infos[] = {
-        {0x30, 192},
-        {0x32, 192},
-        {0x35, 192},
-        {0x37, 192},
-        {0x50, 128},
-        {0x52, 128},
-        {0x53, 128},
-        {0x60, 64},
-        {0x61, 128},
-        {0x62, 128},
-        {0x70, 64},
-        {0x72, 64},
-        {0x75, 64}
-    };
-
-    const int sm = ((major << 4) + minor);
-    for (size_t i = 0; i < SLANG_COUNT_OF(infos); ++i)
-    {
-        if (infos[i].sm == sm)
-        {
-            return infos[i].coreCount;
-        }
-    }
-
-    const auto& last = infos[SLANG_COUNT_OF(infos) - 1];
-
-    // It must be newer presumably
-    SLANG_RHI_ASSERT(sm > last.sm);
-
-    // Default to the last entry
-    return last.coreCount;
-}
-
-inline Result findMaxFlopsDeviceIndex(int* outDeviceIndex)
-{
-    int smPerMultiproc = 0;
-    int maxPerfDevice = -1;
-    int deviceCount = 0;
-
-    uint64_t maxComputePerf = 0;
-    SLANG_CUDA_RETURN_ON_FAIL(cuDeviceGetCount(&deviceCount));
-
-    // Find the best CUDA capable GPU device
-    for (int currentDevice = 0; currentDevice < deviceCount; ++currentDevice)
-    {
-        CUdevice device;
-        SLANG_CUDA_RETURN_ON_FAIL(cuDeviceGet(&device, currentDevice));
-        int computeMode = -1, major = 0, minor = 0;
-        SLANG_CUDA_RETURN_ON_FAIL(cuDeviceGetAttribute(&computeMode, CU_DEVICE_ATTRIBUTE_COMPUTE_MODE, device));
-        SLANG_CUDA_RETURN_ON_FAIL(cuDeviceGetAttribute(&major, CU_DEVICE_ATTRIBUTE_COMPUTE_CAPABILITY_MAJOR, device));
-        SLANG_CUDA_RETURN_ON_FAIL(cuDeviceGetAttribute(&minor, CU_DEVICE_ATTRIBUTE_COMPUTE_CAPABILITY_MINOR, device));
-
-        // If this GPU is not running on Compute Mode prohibited,
-        // then we can add it to the list
-        if (computeMode != CU_COMPUTEMODE_PROHIBITED)
-        {
-            if (major == 9999 && minor == 9999)
-            {
-                smPerMultiproc = 1;
-            }
-            else
-            {
-                smPerMultiproc = calcSMCountPerMultiProcessor(major, minor);
-            }
-
-            int multiProcessorCount = 0, clockRate = 0;
-            SLANG_CUDA_RETURN_ON_FAIL(
-                cuDeviceGetAttribute(&multiProcessorCount, CU_DEVICE_ATTRIBUTE_MULTIPROCESSOR_COUNT, device)
-            );
-            SLANG_CUDA_RETURN_ON_FAIL(cuDeviceGetAttribute(&clockRate, CU_DEVICE_ATTRIBUTE_CLOCK_RATE, device));
-            uint64_t compute_perf = uint64_t(multiProcessorCount) * smPerMultiproc * clockRate;
-
-            if (compute_perf > maxComputePerf)
-            {
-                maxComputePerf = compute_perf;
-                maxPerfDevice = currentDevice;
-            }
-        }
-    }
-
-    if (maxPerfDevice < 0)
-    {
-        return SLANG_FAIL;
-    }
-
-    *outDeviceIndex = maxPerfDevice;
-    return SLANG_OK;
-}
-
-inline Result getAdaptersImpl(std::vector<AdapterImpl>& outAdapters)
-{
-    if (!rhiCudaDriverApiInit())
-    {
-        return SLANG_FAIL;
-    }
-
-    SLANG_CUDA_RETURN_ON_FAIL(cuInit(0));
-
-    int deviceCount;
-    SLANG_CUDA_RETURN_ON_FAIL(cuDeviceGetCount(&deviceCount));
-
-    for (int deviceIndex = 0; deviceIndex < deviceCount; deviceIndex++)
-    {
-        CUdevice device;
-        SLANG_CUDA_RETURN_ON_FAIL(cuDeviceGet(&device, deviceIndex));
-
-        AdapterInfo info = {};
-        info.deviceType = DeviceType::CUDA;
-        info.adapterType = AdapterType::Discrete;
-        SLANG_CUDA_RETURN_ON_FAIL(cuDeviceGetName(info.name, sizeof(info.name), device));
-        info.luid = getAdapterLUID(deviceIndex);
-
-        AdapterImpl adapter;
-        adapter.m_info = info;
-        adapter.m_deviceIndex = deviceIndex;
-        outAdapters.push_back(adapter);
-    }
-
-    // Find the max flops adapter and mark it as the default one.
-    if (!outAdapters.empty())
-    {
-        int defaultDeviceIndex = 0;
-        SLANG_RETURN_ON_FAIL(findMaxFlopsDeviceIndex(&defaultDeviceIndex));
-        SLANG_RHI_ASSERT(defaultDeviceIndex >= 0 && defaultDeviceIndex < (int)outAdapters.size());
-        outAdapters[defaultDeviceIndex].m_isDefault = true;
-    }
-
-    return SLANG_OK;
-}
-
-std::vector<AdapterImpl>& getAdapters()
-{
-    static std::vector<AdapterImpl> adapters;
-    static Result initResult = getAdaptersImpl(adapters);
-    SLANG_UNUSED(initResult);
-    return adapters;
-}
-
 DeviceImpl::DeviceImpl() {}
 
 DeviceImpl::~DeviceImpl()
@@ -218,29 +70,7 @@ DeviceImpl::~DeviceImpl()
     }
 }
 
-void DeviceImpl::deferDelete(Resource* resource)
-{
-    SLANG_RHI_ASSERT(m_queue != nullptr);
-    m_queue->deferDelete(resource);
-    resource->breakStrongReferenceToDevice();
-}
-
-Result DeviceImpl::getNativeDeviceHandles(DeviceNativeHandles* outHandles)
-{
-    outHandles->handles[0].type = NativeHandleType::CUdevice;
-    outHandles->handles[0].value = m_ctx.device;
-    outHandles->handles[1] = {};
-    if (m_ctx.optixContext)
-    {
-        outHandles->handles[1].type = NativeHandleType::OptixDeviceContext;
-        outHandles->handles[1].value = (uint64_t)m_ctx.optixContext->getOptixDeviceContext();
-    }
-    outHandles->handles[2].type = NativeHandleType::CUcontext;
-    outHandles->handles[2].value = (uint64_t)m_ctx.context;
-    return SLANG_OK;
-}
-
-Result DeviceImpl::initialize(const DeviceDesc& desc)
+Result DeviceImpl::initialize(const DeviceDesc& desc, BackendImpl* backend)
 {
     SLANG_RETURN_ON_FAIL(Device::initialize(desc));
 
@@ -286,7 +116,7 @@ Result DeviceImpl::initialize(const DeviceDesc& desc)
     {
         // User provided no external handles, so we need to create a device and context.
         AdapterImpl* adapter = nullptr;
-        SLANG_RETURN_ON_FAIL(selectAdapter(this, getAdapters(), desc, adapter));
+        SLANG_RETURN_ON_FAIL(selectAdapter(this, backend->getAdapters(), desc, adapter));
         SLANG_CUDA_RETURN_ON_FAIL_REPORT(cuDeviceGet(&m_ctx.device, adapter->m_deviceIndex), this);
         SLANG_CUDA_RETURN_ON_FAIL_REPORT(cuDevicePrimaryCtxRetain(&m_ctx.context, m_ctx.device), this);
         m_ownsContext = true;
@@ -491,6 +321,28 @@ Result DeviceImpl::initialize(const DeviceDesc& desc)
 
     SLANG_RETURN_ON_FAIL(m_clearEngine.initialize(this));
 
+    return SLANG_OK;
+}
+
+void DeviceImpl::deferDelete(Resource* resource)
+{
+    SLANG_RHI_ASSERT(m_queue != nullptr);
+    m_queue->deferDelete(resource);
+    resource->breakStrongReferenceToDevice();
+}
+
+Result DeviceImpl::getNativeDeviceHandles(DeviceNativeHandles* outHandles)
+{
+    outHandles->handles[0].type = NativeHandleType::CUdevice;
+    outHandles->handles[0].value = m_ctx.device;
+    outHandles->handles[1] = {};
+    if (m_ctx.optixContext)
+    {
+        outHandles->handles[1].type = NativeHandleType::OptixDeviceContext;
+        outHandles->handles[1].value = (uint64_t)m_ctx.optixContext->getOptixDeviceContext();
+    }
+    outHandles->handles[2].type = NativeHandleType::CUcontext;
+    outHandles->handles[2].value = (uint64_t)m_ctx.context;
     return SLANG_OK;
 }
 
@@ -835,21 +687,3 @@ Result DeviceImpl::popCudaContext()
 }
 
 } // namespace rhi::cuda
-
-namespace rhi {
-
-IAdapter* getCUDAAdapter(uint32_t index)
-{
-    std::vector<cuda::AdapterImpl>& adapters = cuda::getAdapters();
-    return index < adapters.size() ? &adapters[index] : nullptr;
-}
-
-Result createCUDADevice(const DeviceDesc* desc, IDevice** outDevice)
-{
-    RefPtr<cuda::DeviceImpl> result = new cuda::DeviceImpl();
-    SLANG_RETURN_ON_FAIL(result->initialize(*desc));
-    returnComPtr(outDevice, result);
-    return SLANG_OK;
-}
-
-} // namespace rhi

--- a/src/cuda/cuda-device.cpp
+++ b/src/cuda/cuda-device.cpp
@@ -115,7 +115,7 @@ Result DeviceImpl::initialize(const DeviceDesc& desc, BackendImpl* backend)
     else
     {
         // User provided no external handles, so we need to create a device and context.
-        AdapterImpl* adapter = nullptr;
+        const AdapterImpl* adapter = nullptr;
         SLANG_RETURN_ON_FAIL(selectAdapter(this, backend->getAdapters(), desc, adapter));
         SLANG_CUDA_RETURN_ON_FAIL_REPORT(cuDeviceGet(&m_ctx.device, adapter->m_deviceIndex), this);
         SLANG_CUDA_RETURN_ON_FAIL_REPORT(cuDevicePrimaryCtxRetain(&m_ctx.context, m_ctx.device), this);

--- a/src/cuda/cuda-device.h
+++ b/src/cuda/cuda-device.h
@@ -35,11 +35,11 @@ public:
     DeviceImpl();
     ~DeviceImpl();
 
+    Result initialize(const DeviceDesc& desc, BackendImpl* backend);
+
     void deferDelete(Resource* resource);
 
     virtual SLANG_NO_THROW Result SLANG_MCALL getNativeDeviceHandles(DeviceNativeHandles* outHandles) override;
-
-    virtual SLANG_NO_THROW Result SLANG_MCALL initialize(const DeviceDesc& desc) override;
 
     virtual SLANG_NO_THROW Result SLANG_MCALL createTexture(
         const TextureDesc& desc,
@@ -209,10 +209,3 @@ public:
 };
 
 } // namespace rhi::cuda
-
-namespace rhi {
-
-IAdapter* getCUDAAdapter(uint32_t index);
-Result createCUDADevice(const DeviceDesc* desc, IDevice** outDevice);
-
-} // namespace rhi

--- a/src/cuda/cuda-surface.cpp
+++ b/src/cuda/cuda-surface.cpp
@@ -109,7 +109,7 @@ public:
     virtual SLANG_NO_THROW Result SLANG_MCALL present() override;
 };
 
-static auto translateVkFormat = reverseMap<Format, VkFormat>(vk::getVkFormat, Format::Undefined, Format::_Count);
+static auto translateVkFormat = reverseMap<Format, VkFormat, Format::Undefined, Format::_Count>(vk::getVkFormat);
 
 SurfaceImpl::~SurfaceImpl()
 {

--- a/src/d3d11/d3d11-backend.cpp
+++ b/src/d3d11/d3d11-backend.cpp
@@ -1,0 +1,62 @@
+#include "d3d11-backend.h"
+#include "d3d11-device.h"
+#include "../d3d/d3d-utils.h"
+#include "../reference.h"
+
+#include "core/string.h"
+
+namespace rhi::d3d11 {
+
+static Result getAdaptersImpl(std::vector<AdapterImpl>& outAdapters)
+{
+    std::vector<ComPtr<IDXGIAdapter>> dxgiAdapters;
+    SLANG_RETURN_ON_FAIL(enumAdapters(dxgiAdapters));
+
+    for (const auto& dxgiAdapter : dxgiAdapters)
+    {
+        AdapterInfo info = getAdapterInfo(dxgiAdapter);
+        info.deviceType = DeviceType::D3D11;
+
+        AdapterImpl adapter;
+        adapter.m_info = info;
+        adapter.m_dxgiAdapter = dxgiAdapter;
+        outAdapters.push_back(adapter);
+    }
+
+    // Mark default adapter (prefer discrete if available).
+    markDefaultAdapter(outAdapters);
+
+    return SLANG_OK;
+}
+
+Result BackendImpl::initialize()
+{
+    return getAdaptersImpl(m_adapters);
+}
+
+IAdapter* BackendImpl::getAdapter(uint32_t index)
+{
+    return index < m_adapters.size() ? &m_adapters[index] : nullptr;
+}
+
+Result BackendImpl::createDevice(const DeviceDesc& desc, IDevice** outDevice)
+{
+    RefPtr<DeviceImpl> result = new DeviceImpl();
+    SLANG_RETURN_ON_FAIL(result->initialize(desc, this));
+    returnComPtr(outDevice, result);
+    return SLANG_OK;
+}
+
+} // namespace rhi::d3d11
+
+namespace rhi {
+
+Result createD3D11Backend(Backend** outBackend)
+{
+    RefPtr<d3d11::BackendImpl> backend = new d3d11::BackendImpl();
+    SLANG_RETURN_ON_FAIL(backend->initialize());
+    returnRefPtr(outBackend, backend);
+    return SLANG_OK;
+}
+
+} // namespace rhi

--- a/src/d3d11/d3d11-backend.cpp
+++ b/src/d3d11/d3d11-backend.cpp
@@ -7,7 +7,27 @@
 
 namespace rhi::d3d11 {
 
-static Result getAdaptersImpl(std::vector<AdapterImpl>& outAdapters)
+std::span<const AdapterImpl> BackendImpl::getAdapters()
+{
+    ensureAdapters();
+    return m_adapters;
+}
+
+IAdapter* BackendImpl::getAdapter(uint32_t index)
+{
+    ensureAdapters();
+    return index < m_adapters.size() ? &m_adapters[index] : nullptr;
+}
+
+Result BackendImpl::createDevice(const DeviceDesc& desc, IDevice** outDevice)
+{
+    RefPtr<DeviceImpl> result = new DeviceImpl();
+    SLANG_RETURN_ON_FAIL(result->initialize(desc, this));
+    returnComPtr(outDevice, result);
+    return SLANG_OK;
+}
+
+Result BackendImpl::enumerateAdapters()
 {
     std::vector<ComPtr<IDXGIAdapter>> dxgiAdapters;
     SLANG_RETURN_ON_FAIL(enumAdapters(dxgiAdapters));
@@ -20,35 +40,12 @@ static Result getAdaptersImpl(std::vector<AdapterImpl>& outAdapters)
         AdapterImpl adapter;
         adapter.m_info = info;
         adapter.m_dxgiAdapter = dxgiAdapter;
-        outAdapters.push_back(adapter);
+        m_adapters.push_back(adapter);
     }
 
     // Mark default adapter (prefer discrete if available).
-    markDefaultAdapter(outAdapters);
+    markDefaultAdapter(m_adapters);
 
-    return SLANG_OK;
-}
-
-Result BackendImpl::initialize()
-{
-    return getAdaptersImpl(m_adapters);
-}
-
-std::span<const AdapterImpl> BackendImpl::getAdapters() const
-{
-    return m_adapters;
-}
-
-IAdapter* BackendImpl::getAdapter(uint32_t index)
-{
-    return index < m_adapters.size() ? &m_adapters[index] : nullptr;
-}
-
-Result BackendImpl::createDevice(const DeviceDesc& desc, IDevice** outDevice)
-{
-    RefPtr<DeviceImpl> result = new DeviceImpl();
-    SLANG_RETURN_ON_FAIL(result->initialize(desc, this));
-    returnComPtr(outDevice, result);
     return SLANG_OK;
 }
 
@@ -59,7 +56,6 @@ namespace rhi {
 Result createD3D11Backend(Backend** outBackend)
 {
     RefPtr<d3d11::BackendImpl> backend = new d3d11::BackendImpl();
-    SLANG_RETURN_ON_FAIL(backend->initialize());
     returnRefPtr(outBackend, backend);
     return SLANG_OK;
 }

--- a/src/d3d11/d3d11-backend.cpp
+++ b/src/d3d11/d3d11-backend.cpp
@@ -34,6 +34,11 @@ Result BackendImpl::initialize()
     return getAdaptersImpl(m_adapters);
 }
 
+std::span<const AdapterImpl> BackendImpl::getAdapters() const
+{
+    return m_adapters;
+}
+
 IAdapter* BackendImpl::getAdapter(uint32_t index)
 {
     return index < m_adapters.size() ? &m_adapters[index] : nullptr;

--- a/src/d3d11/d3d11-backend.h
+++ b/src/d3d11/d3d11-backend.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include "d3d11-base.h"
+#include "../backend.h"
+
+namespace rhi::d3d11 {
+
+class BackendImpl : public Backend
+{
+public:
+    Result initialize();
+
+    std::vector<AdapterImpl>& getAdapters() { return m_adapters; }
+
+    // Backend implementation
+
+    IAdapter* getAdapter(uint32_t index) override;
+    Result createDevice(const DeviceDesc& desc, IDevice** outDevice) override;
+
+private:
+    std::vector<AdapterImpl> m_adapters;
+};
+
+} // namespace rhi::d3d11

--- a/src/d3d11/d3d11-backend.h
+++ b/src/d3d11/d3d11-backend.h
@@ -10,7 +10,7 @@ class BackendImpl : public Backend
 public:
     Result initialize();
 
-    std::vector<AdapterImpl>& getAdapters() { return m_adapters; }
+    std::span<const AdapterImpl> getAdapters() const { return m_adapters; }
 
     // Backend implementation
 

--- a/src/d3d11/d3d11-backend.h
+++ b/src/d3d11/d3d11-backend.h
@@ -10,7 +10,7 @@ class BackendImpl : public Backend
 public:
     Result initialize();
 
-    std::span<const AdapterImpl> getAdapters() const { return m_adapters; }
+    std::span<const AdapterImpl> getAdapters() const;
 
     // Backend implementation
 

--- a/src/d3d11/d3d11-backend.h
+++ b/src/d3d11/d3d11-backend.h
@@ -8,14 +8,15 @@ namespace rhi::d3d11 {
 class BackendImpl : public Backend
 {
 public:
-    Result initialize();
-
-    std::span<const AdapterImpl> getAdapters() const;
+    std::span<const AdapterImpl> getAdapters();
 
     // Backend implementation
 
     IAdapter* getAdapter(uint32_t index) override;
     Result createDevice(const DeviceDesc& desc, IDevice** outDevice) override;
+
+protected:
+    Result enumerateAdapters() override;
 
 private:
     std::vector<AdapterImpl> m_adapters;

--- a/src/d3d11/d3d11-base.h
+++ b/src/d3d11/d3d11-base.h
@@ -12,6 +12,7 @@
 
 namespace rhi::d3d11 {
 
+class BackendImpl;
 class AdapterImpl;
 class DeviceImpl;
 class ShaderProgramImpl;

--- a/src/d3d11/d3d11-device.cpp
+++ b/src/d3d11/d3d11-device.cpp
@@ -58,7 +58,7 @@ Result DeviceImpl::initialize(const DeviceDesc& desc, BackendImpl* backend)
 
     m_dxgiFactory = getDXGIFactory(getRHI()->getDebugLayerOptions(), this);
 
-    AdapterImpl* adapter = nullptr;
+    const AdapterImpl* adapter = nullptr;
     SLANG_RETURN_ON_FAIL(selectAdapter(this, backend->getAdapters(), desc, adapter));
     m_dxgiAdapter = adapter->m_dxgiAdapter;
 

--- a/src/d3d11/d3d11-device.cpp
+++ b/src/d3d11/d3d11-device.cpp
@@ -1,5 +1,6 @@
 #define _CRT_SECURE_NO_WARNINGS
 #include "d3d11-device.h"
+#include "d3d11-backend.h"
 #include "d3d11-buffer.h"
 #include "d3d11-utils.h"
 #include "d3d11-query.h"
@@ -18,41 +19,11 @@
 
 namespace rhi::d3d11 {
 
-inline Result getAdaptersImpl(std::vector<AdapterImpl>& outAdapters)
-{
-    std::vector<ComPtr<IDXGIAdapter>> dxgiAdapters;
-    SLANG_RETURN_ON_FAIL(enumAdapters(dxgiAdapters));
-
-    for (const auto& dxgiAdapter : dxgiAdapters)
-    {
-        AdapterInfo info = getAdapterInfo(dxgiAdapter);
-        info.deviceType = DeviceType::D3D11;
-
-        AdapterImpl adapter;
-        adapter.m_info = info;
-        adapter.m_dxgiAdapter = dxgiAdapter;
-        outAdapters.push_back(adapter);
-    }
-
-    // Mark default adapter (prefer discrete if available).
-    markDefaultAdapter(outAdapters);
-
-    return SLANG_OK;
-}
-
-std::vector<AdapterImpl>& getAdapters()
-{
-    static std::vector<AdapterImpl> adapters;
-    static Result initResult = getAdaptersImpl(adapters);
-    SLANG_UNUSED(initResult);
-    return adapters;
-}
-
 DeviceImpl::DeviceImpl() {}
 
 DeviceImpl::~DeviceImpl() {}
 
-Result DeviceImpl::initialize(const DeviceDesc& desc)
+Result DeviceImpl::initialize(const DeviceDesc& desc, BackendImpl* backend)
 {
     SLANG_RETURN_ON_FAIL(Device::initialize(desc));
 
@@ -88,7 +59,7 @@ Result DeviceImpl::initialize(const DeviceDesc& desc)
     m_dxgiFactory = getDXGIFactory(getRHI()->getDebugLayerOptions(), this);
 
     AdapterImpl* adapter = nullptr;
-    SLANG_RETURN_ON_FAIL(selectAdapter(this, getAdapters(), desc, adapter));
+    SLANG_RETURN_ON_FAIL(selectAdapter(this, backend->getAdapters(), desc, adapter));
     m_dxgiAdapter = adapter->m_dxgiAdapter;
 
     // We will ask for the highest feature level that can be supported.
@@ -665,21 +636,3 @@ Result DeviceImpl::createRootShaderObjectLayout(
 }
 
 } // namespace rhi::d3d11
-
-namespace rhi {
-
-IAdapter* getD3D11Adapter(uint32_t index)
-{
-    std::vector<d3d11::AdapterImpl>& adapters = d3d11::getAdapters();
-    return index < adapters.size() ? &adapters[index] : nullptr;
-}
-
-Result createD3D11Device(const DeviceDesc* desc, IDevice** outDevice)
-{
-    RefPtr<d3d11::DeviceImpl> result = new d3d11::DeviceImpl();
-    SLANG_RETURN_ON_FAIL(result->initialize(*desc));
-    returnComPtr(outDevice, result);
-    return SLANG_OK;
-}
-
-} // namespace rhi

--- a/src/d3d11/d3d11-device.h
+++ b/src/d3d11/d3d11-device.h
@@ -18,7 +18,7 @@ public:
     DeviceImpl();
     ~DeviceImpl();
 
-    virtual SLANG_NO_THROW Result SLANG_MCALL initialize(const DeviceDesc& desc) override;
+    Result initialize(const DeviceDesc& desc, BackendImpl* backend);
 
     virtual SLANG_NO_THROW Result SLANG_MCALL createSurface(WindowHandle windowHandle, ISurface** outSurface) override;
 
@@ -121,10 +121,3 @@ public:
 };
 
 } // namespace rhi::d3d11
-
-namespace rhi {
-
-IAdapter* getD3D11Adapter(uint32_t index);
-Result createD3D11Device(const DeviceDesc* desc, IDevice** outDevice);
-
-} // namespace rhi

--- a/src/d3d12/d3d12-backend.cpp
+++ b/src/d3d12/d3d12-backend.cpp
@@ -7,7 +7,27 @@
 
 namespace rhi::d3d12 {
 
-static Result getAdaptersImpl(std::vector<AdapterImpl>& outAdapters)
+std::span<const AdapterImpl> BackendImpl::getAdapters()
+{
+    ensureAdapters();
+    return m_adapters;
+}
+
+IAdapter* BackendImpl::getAdapter(uint32_t index)
+{
+    ensureAdapters();
+    return index < m_adapters.size() ? &m_adapters[index] : nullptr;
+}
+
+Result BackendImpl::createDevice(const DeviceDesc& desc, IDevice** outDevice)
+{
+    RefPtr<DeviceImpl> result = new DeviceImpl();
+    SLANG_RETURN_ON_FAIL(result->initialize(desc, this));
+    returnComPtr(outDevice, result);
+    return SLANG_OK;
+}
+
+Result BackendImpl::enumerateAdapters()
 {
     std::vector<ComPtr<IDXGIAdapter>> dxgiAdapters;
     SLANG_RETURN_ON_FAIL(enumAdapters(dxgiAdapters));
@@ -20,35 +40,12 @@ static Result getAdaptersImpl(std::vector<AdapterImpl>& outAdapters)
         AdapterImpl adapter;
         adapter.m_info = info;
         adapter.m_dxgiAdapter = dxgiAdapter;
-        outAdapters.push_back(adapter);
+        m_adapters.push_back(adapter);
     }
 
     // Mark default adapter (prefer discrete if available).
-    markDefaultAdapter(outAdapters);
+    markDefaultAdapter(m_adapters);
 
-    return SLANG_OK;
-}
-
-Result BackendImpl::initialize()
-{
-    return getAdaptersImpl(m_adapters);
-}
-
-std::span<const AdapterImpl> BackendImpl::getAdapters() const
-{
-    return m_adapters;
-}
-
-IAdapter* BackendImpl::getAdapter(uint32_t index)
-{
-    return index < m_adapters.size() ? &m_adapters[index] : nullptr;
-}
-
-Result BackendImpl::createDevice(const DeviceDesc& desc, IDevice** outDevice)
-{
-    RefPtr<DeviceImpl> result = new DeviceImpl();
-    SLANG_RETURN_ON_FAIL(result->initialize(desc, this));
-    returnComPtr(outDevice, result);
     return SLANG_OK;
 }
 
@@ -59,7 +56,6 @@ namespace rhi {
 Result createD3D12Backend(Backend** outBackend)
 {
     RefPtr<d3d12::BackendImpl> backend = new d3d12::BackendImpl();
-    SLANG_RETURN_ON_FAIL(backend->initialize());
     returnRefPtr(outBackend, backend);
     return SLANG_OK;
 }

--- a/src/d3d12/d3d12-backend.cpp
+++ b/src/d3d12/d3d12-backend.cpp
@@ -1,0 +1,62 @@
+#include "d3d12-backend.h"
+#include "d3d12-device.h"
+#include "../d3d/d3d-utils.h"
+#include "../reference.h"
+
+#include "core/string.h"
+
+namespace rhi::d3d12 {
+
+static Result getAdaptersImpl(std::vector<AdapterImpl>& outAdapters)
+{
+    std::vector<ComPtr<IDXGIAdapter>> dxgiAdapters;
+    SLANG_RETURN_ON_FAIL(enumAdapters(dxgiAdapters));
+
+    for (const auto& dxgiAdapter : dxgiAdapters)
+    {
+        AdapterInfo info = getAdapterInfo(dxgiAdapter);
+        info.deviceType = DeviceType::D3D12;
+
+        AdapterImpl adapter;
+        adapter.m_info = info;
+        adapter.m_dxgiAdapter = dxgiAdapter;
+        outAdapters.push_back(adapter);
+    }
+
+    // Mark default adapter (prefer discrete if available).
+    markDefaultAdapter(outAdapters);
+
+    return SLANG_OK;
+}
+
+Result BackendImpl::initialize()
+{
+    return getAdaptersImpl(m_adapters);
+}
+
+IAdapter* BackendImpl::getAdapter(uint32_t index)
+{
+    return index < m_adapters.size() ? &m_adapters[index] : nullptr;
+}
+
+Result BackendImpl::createDevice(const DeviceDesc& desc, IDevice** outDevice)
+{
+    RefPtr<DeviceImpl> result = new DeviceImpl();
+    SLANG_RETURN_ON_FAIL(result->initialize(desc, this));
+    returnComPtr(outDevice, result);
+    return SLANG_OK;
+}
+
+} // namespace rhi::d3d12
+
+namespace rhi {
+
+Result createD3D12Backend(Backend** outBackend)
+{
+    RefPtr<d3d12::BackendImpl> backend = new d3d12::BackendImpl();
+    SLANG_RETURN_ON_FAIL(backend->initialize());
+    returnRefPtr(outBackend, backend);
+    return SLANG_OK;
+}
+
+} // namespace rhi

--- a/src/d3d12/d3d12-backend.cpp
+++ b/src/d3d12/d3d12-backend.cpp
@@ -34,6 +34,11 @@ Result BackendImpl::initialize()
     return getAdaptersImpl(m_adapters);
 }
 
+std::span<const AdapterImpl> BackendImpl::getAdapters() const
+{
+    return m_adapters;
+}
+
 IAdapter* BackendImpl::getAdapter(uint32_t index)
 {
     return index < m_adapters.size() ? &m_adapters[index] : nullptr;

--- a/src/d3d12/d3d12-backend.h
+++ b/src/d3d12/d3d12-backend.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include "d3d12-base.h"
+#include "../backend.h"
+
+namespace rhi::d3d12 {
+
+class BackendImpl : public Backend
+{
+public:
+    Result initialize();
+
+    std::vector<AdapterImpl>& getAdapters() { return m_adapters; }
+
+    // Backend implementation
+
+    IAdapter* getAdapter(uint32_t index) override;
+    Result createDevice(const DeviceDesc& desc, IDevice** outDevice) override;
+
+private:
+    std::vector<AdapterImpl> m_adapters;
+};
+
+} // namespace rhi::d3d12

--- a/src/d3d12/d3d12-backend.h
+++ b/src/d3d12/d3d12-backend.h
@@ -10,7 +10,7 @@ class BackendImpl : public Backend
 public:
     Result initialize();
 
-    std::vector<AdapterImpl>& getAdapters() { return m_adapters; }
+    std::span<const AdapterImpl> getAdapters() const { return m_adapters; }
 
     // Backend implementation
 

--- a/src/d3d12/d3d12-backend.h
+++ b/src/d3d12/d3d12-backend.h
@@ -8,14 +8,15 @@ namespace rhi::d3d12 {
 class BackendImpl : public Backend
 {
 public:
-    Result initialize();
-
-    std::span<const AdapterImpl> getAdapters() const;
+    std::span<const AdapterImpl> getAdapters();
 
     // Backend implementation
 
     IAdapter* getAdapter(uint32_t index) override;
     Result createDevice(const DeviceDesc& desc, IDevice** outDevice) override;
+
+protected:
+    Result enumerateAdapters() override;
 
 private:
     std::vector<AdapterImpl> m_adapters;

--- a/src/d3d12/d3d12-backend.h
+++ b/src/d3d12/d3d12-backend.h
@@ -10,7 +10,7 @@ class BackendImpl : public Backend
 public:
     Result initialize();
 
-    std::span<const AdapterImpl> getAdapters() const { return m_adapters; }
+    std::span<const AdapterImpl> getAdapters() const;
 
     // Backend implementation
 

--- a/src/d3d12/d3d12-base.h
+++ b/src/d3d12/d3d12-base.h
@@ -14,6 +14,7 @@
 
 namespace rhi::d3d12 {
 
+class BackendImpl;
 class AdapterImpl;
 class DeviceImpl;
 class BufferImpl;

--- a/src/d3d12/d3d12-device.cpp
+++ b/src/d3d12/d3d12-device.cpp
@@ -330,7 +330,7 @@ Result DeviceImpl::initialize(const DeviceDesc& desc, BackendImpl* backend)
 #endif
 
     m_dxgiFactory = getDXGIFactory(getRHI()->getDebugLayerOptions(), this);
-    AdapterImpl* adapter = nullptr;
+    const AdapterImpl* adapter = nullptr;
 
     if (!desc.existingDeviceHandles.handles[0])
     {

--- a/src/d3d12/d3d12-device.cpp
+++ b/src/d3d12/d3d12-device.cpp
@@ -1,4 +1,5 @@
 #include "d3d12-device.h"
+#include "d3d12-backend.h"
 #include "d3d12-buffer.h"
 #include "d3d12-fence.h"
 #include "d3d12-utils.h"
@@ -85,36 +86,6 @@ inline int getShaderModelFromProfileName(const char* name)
         }
     }
     return -1;
-}
-
-inline Result getAdaptersImpl(std::vector<AdapterImpl>& outAdapters)
-{
-    std::vector<ComPtr<IDXGIAdapter>> dxgiAdapters;
-    SLANG_RETURN_ON_FAIL(enumAdapters(dxgiAdapters));
-
-    for (const auto& dxgiAdapter : dxgiAdapters)
-    {
-        AdapterInfo info = getAdapterInfo(dxgiAdapter);
-        info.deviceType = DeviceType::D3D12;
-
-        AdapterImpl adapter;
-        adapter.m_info = info;
-        adapter.m_dxgiAdapter = dxgiAdapter;
-        outAdapters.push_back(adapter);
-    }
-
-    // Mark default adapter (prefer discrete if available).
-    markDefaultAdapter(outAdapters);
-
-    return SLANG_OK;
-}
-
-std::vector<AdapterImpl>& getAdapters()
-{
-    static std::vector<AdapterImpl> adapters;
-    static Result initResult = getAdaptersImpl(adapters);
-    SLANG_UNUSED(initResult);
-    return adapters;
 }
 
 static void validationMessageCallback(
@@ -278,7 +249,7 @@ inline Result DeviceImpl::setupDebugLayer(SharedLibraryHandle d3dModule)
     return SLANG_OK;
 }
 
-Result DeviceImpl::initialize(const DeviceDesc& desc)
+Result DeviceImpl::initialize(const DeviceDesc& desc, BackendImpl* backend)
 {
     SLANG_RETURN_ON_FAIL(Device::initialize(desc));
 
@@ -363,7 +334,7 @@ Result DeviceImpl::initialize(const DeviceDesc& desc)
 
     if (!desc.existingDeviceHandles.handles[0])
     {
-        SLANG_RETURN_ON_FAIL(selectAdapter(this, getAdapters(), desc, adapter));
+        SLANG_RETURN_ON_FAIL(selectAdapter(this, backend->getAdapters(), desc, adapter));
         m_dxgiAdapter = adapter->m_dxgiAdapter;
 
         const D3D_FEATURE_LEVEL featureLevels[] =
@@ -389,14 +360,14 @@ Result DeviceImpl::initialize(const DeviceDesc& desc)
         m_device = (ID3D12Device*)desc.existingDeviceHandles.handles[0].value;
         AdapterLUID luid = getAdapterLUID(m_device->GetAdapterLuid());
         auto it = std::find_if(
-            getAdapters().begin(),
-            getAdapters().end(),
+            backend->getAdapters().begin(),
+            backend->getAdapters().end(),
             [&](const AdapterImpl& a)
             {
                 return luid == a.m_info.luid;
             }
         );
-        if (it == getAdapters().end())
+        if (it == backend->getAdapters().end())
         {
             return SLANG_FAIL;
         }
@@ -2088,21 +2059,3 @@ void DeviceImpl::deferDelete(Resource* resource)
 }
 
 } // namespace rhi::d3d12
-
-namespace rhi {
-
-IAdapter* getD3D12Adapter(uint32_t index)
-{
-    std::vector<d3d12::AdapterImpl>& adapters = d3d12::getAdapters();
-    return index < adapters.size() ? &adapters[index] : nullptr;
-}
-
-Result createD3D12Device(const DeviceDesc* desc, IDevice** outDevice)
-{
-    RefPtr<d3d12::DeviceImpl> result = new d3d12::DeviceImpl();
-    SLANG_RETURN_ON_FAIL(result->initialize(*desc));
-    returnComPtr(outDevice, result);
-    return SLANG_OK;
-}
-
-} // namespace rhi

--- a/src/d3d12/d3d12-device.h
+++ b/src/d3d12/d3d12-device.h
@@ -82,7 +82,7 @@ public:
 public:
     using Device::readBuffer;
 
-    virtual SLANG_NO_THROW Result SLANG_MCALL initialize(const DeviceDesc& desc) override;
+    Result initialize(const DeviceDesc& desc, BackendImpl* backend);
 
     virtual SLANG_NO_THROW Result SLANG_MCALL getQueue(QueueType type, ICommandQueue** outQueue) override;
     virtual SLANG_NO_THROW Result SLANG_MCALL createSurface(WindowHandle windowHandle, ISurface** outSurface) override;
@@ -273,10 +273,3 @@ private:
 };
 
 } // namespace rhi::d3d12
-
-namespace rhi {
-
-IAdapter* getD3D12Adapter(uint32_t index);
-Result createD3D12Device(const DeviceDesc* desc, IDevice** outDevice);
-
-} // namespace rhi

--- a/src/device.cpp
+++ b/src/device.cpp
@@ -552,15 +552,15 @@ bool Device::hasFeature(Feature feature)
 bool Device::hasFeature(const char* feature)
 {
 #define SLANG_RHI_FEATURES_X(id, name) {name, Feature::id},
-    static const std::unordered_map<std::string_view, Feature> kFeatureNameMap = {
+    static constexpr std::pair<std::string_view, Feature> kFeatureNameMap[] = {
         SLANG_RHI_FEATURES(SLANG_RHI_FEATURES_X)
     };
 #undef SLANG_RHI_FEATURES_X
 
-    auto it = kFeatureNameMap.find(feature);
-    if (it != kFeatureNameMap.end())
+    for (const auto& [name, value] : kFeatureNameMap)
     {
-        return hasFeature(it->second);
+        if (name == feature)
+            return hasFeature(value);
     }
     return false;
 }
@@ -609,15 +609,15 @@ bool Device::hasCapability(Capability capability)
 bool Device::hasCapability(const char* capability)
 {
 #define SLANG_RHI_CAPABILITIES_X(id) {#id, Capability::id},
-    static const std::unordered_map<std::string_view, Capability> kCapabilityMap = {
+    static constexpr std::pair<std::string_view, Capability> kCapabilityMap[] = {
         SLANG_RHI_CAPABILITIES(SLANG_RHI_CAPABILITIES_X)
     };
 #undef SLANG_RHI_CAPABILITIES_X
 
-    auto it = kCapabilityMap.find(capability);
-    if (it != kCapabilityMap.end())
+    for (const auto& [name, value] : kCapabilityMap)
     {
-        return hasCapability(it->second);
+        if (name == capability)
+            return hasCapability(value);
     }
     return false;
 }

--- a/src/device.h
+++ b/src/device.h
@@ -441,7 +441,7 @@ public:
     virtual Result createRayTracingPipeline2(const RayTracingPipelineDesc& desc, IRayTracingPipeline** outPipeline);
 
 protected:
-    virtual SLANG_NO_THROW Result SLANG_MCALL initialize(const DeviceDesc& desc);
+    Result initialize(const DeviceDesc& desc);
 
     void addFeature(Feature feature);
     void addCapability(Capability capability);

--- a/src/device.h
+++ b/src/device.h
@@ -499,7 +499,7 @@ void markDefaultAdapter(std::vector<T>& adapters)
 }
 
 template<typename T>
-Result selectAdapter(Device* device, std::vector<T>& adapters, const DeviceDesc& desc, T*& outAdapter)
+Result selectAdapter(Device* device, std::span<const T> adapters, const DeviceDesc& desc, const T*& outAdapter)
 {
     if (adapters.empty())
     {

--- a/src/metal/metal-backend.cpp
+++ b/src/metal/metal-backend.cpp
@@ -7,7 +7,27 @@
 
 namespace rhi::metal {
 
-static Result getAdaptersImpl(std::vector<AdapterImpl>& outAdapters)
+std::span<const AdapterImpl> BackendImpl::getAdapters()
+{
+    ensureAdapters();
+    return m_adapters;
+}
+
+IAdapter* BackendImpl::getAdapter(uint32_t index)
+{
+    ensureAdapters();
+    return index < m_adapters.size() ? &m_adapters[index] : nullptr;
+}
+
+Result BackendImpl::createDevice(const DeviceDesc& desc, IDevice** outDevice)
+{
+    RefPtr<DeviceImpl> result = new DeviceImpl();
+    SLANG_RETURN_ON_FAIL(result->initialize(desc, this));
+    returnComPtr(outDevice, result);
+    return SLANG_OK;
+}
+
+Result BackendImpl::enumerateAdapters()
 {
     AUTORELEASEPOOL
 
@@ -24,7 +44,7 @@ static Result getAdaptersImpl(std::vector<AdapterImpl>& outAdapters)
         AdapterImpl adapter;
         adapter.m_info = info;
         adapter.m_device = NS::RetainPtr(device);
-        outAdapters.push_back(adapter);
+        m_adapters.push_back(adapter);
     };
 
     NS::Array* devices = MTL::CopyAllDevices();
@@ -44,34 +64,11 @@ static Result getAdaptersImpl(std::vector<AdapterImpl>& outAdapters)
     }
 
     // Make the first adapter the default one.
-    if (!outAdapters.empty())
+    if (!m_adapters.empty())
     {
-        outAdapters[0].m_isDefault = true;
+        m_adapters[0].m_isDefault = true;
     }
 
-    return SLANG_OK;
-}
-
-Result BackendImpl::initialize()
-{
-    return getAdaptersImpl(m_adapters);
-}
-
-std::span<const AdapterImpl> BackendImpl::getAdapters() const
-{
-    return m_adapters;
-}
-
-IAdapter* BackendImpl::getAdapter(uint32_t index)
-{
-    return index < m_adapters.size() ? &m_adapters[index] : nullptr;
-}
-
-Result BackendImpl::createDevice(const DeviceDesc& desc, IDevice** outDevice)
-{
-    RefPtr<DeviceImpl> result = new DeviceImpl();
-    SLANG_RETURN_ON_FAIL(result->initialize(desc, this));
-    returnComPtr(outDevice, result);
     return SLANG_OK;
 }
 
@@ -82,7 +79,6 @@ namespace rhi {
 Result createMetalBackend(Backend** outBackend)
 {
     RefPtr<metal::BackendImpl> backend = new metal::BackendImpl();
-    SLANG_RETURN_ON_FAIL(backend->initialize());
     returnRefPtr(outBackend, backend);
     return SLANG_OK;
 }

--- a/src/metal/metal-backend.cpp
+++ b/src/metal/metal-backend.cpp
@@ -48,7 +48,7 @@ Result BackendImpl::enumerateAdapters()
     };
 
     NS::Array* devices = MTL::CopyAllDevices();
-    if (devices->count() > 0)
+    if (devices && devices->count() > 0)
     {
         for (int i = 0; i < devices->count(); ++i)
         {
@@ -59,9 +59,14 @@ Result BackendImpl::enumerateAdapters()
     else
     {
         MTL::Device* device = MTL::CreateSystemDefaultDevice();
-        addAdapter(device);
-        device->release();
+        if (device)
+        {
+            addAdapter(device);
+            device->release();
+        }
     }
+    if (devices)
+        devices->release();
 
     // Make the first adapter the default one.
     if (!m_adapters.empty())

--- a/src/metal/metal-backend.cpp
+++ b/src/metal/metal-backend.cpp
@@ -56,6 +56,11 @@ Result BackendImpl::initialize()
     return getAdaptersImpl(m_adapters);
 }
 
+std::span<const AdapterImpl> BackendImpl::getAdapters() const
+{
+    return m_adapters;
+}
+
 IAdapter* BackendImpl::getAdapter(uint32_t index)
 {
     return index < m_adapters.size() ? &m_adapters[index] : nullptr;

--- a/src/metal/metal-backend.cpp
+++ b/src/metal/metal-backend.cpp
@@ -1,0 +1,84 @@
+#include "metal-backend.h"
+#include "metal-device.h"
+#include "../reference.h"
+
+#include "core/string.h"
+
+namespace rhi::metal {
+
+static Result getAdaptersImpl(std::vector<AdapterImpl>& outAdapters)
+{
+    AUTORELEASEPOOL
+
+    auto addAdapter = [&](MTL::Device* device)
+    {
+        AdapterInfo info = {};
+        info.deviceType = DeviceType::Metal;
+        info.adapterType = device->hasUnifiedMemory() ? AdapterType::Integrated : AdapterType::Discrete;
+        const char* name = device->name()->cString(NS::ASCIIStringEncoding);
+        string::copy_safe(info.name, sizeof(info.name), name);
+        uint64_t registryID = device->registryID();
+        memcpy(&info.luid.luid[0], &registryID, sizeof(registryID));
+
+        AdapterImpl adapter;
+        adapter.m_info = info;
+        adapter.m_device = NS::RetainPtr(device);
+        outAdapters.push_back(adapter);
+    };
+
+    NS::Array* devices = MTL::CopyAllDevices();
+    if (devices->count() > 0)
+    {
+        for (int i = 0; i < devices->count(); ++i)
+        {
+            MTL::Device* device = static_cast<MTL::Device*>(devices->object(i));
+            addAdapter(device);
+        }
+    }
+    else
+    {
+        MTL::Device* device = MTL::CreateSystemDefaultDevice();
+        addAdapter(device);
+        device->release();
+    }
+
+    // Make the first adapter the default one.
+    if (!outAdapters.empty())
+    {
+        outAdapters[0].m_isDefault = true;
+    }
+
+    return SLANG_OK;
+}
+
+Result BackendImpl::initialize()
+{
+    return getAdaptersImpl(m_adapters);
+}
+
+IAdapter* BackendImpl::getAdapter(uint32_t index)
+{
+    return index < m_adapters.size() ? &m_adapters[index] : nullptr;
+}
+
+Result BackendImpl::createDevice(const DeviceDesc& desc, IDevice** outDevice)
+{
+    RefPtr<DeviceImpl> result = new DeviceImpl();
+    SLANG_RETURN_ON_FAIL(result->initialize(desc, this));
+    returnComPtr(outDevice, result);
+    return SLANG_OK;
+}
+
+} // namespace rhi::metal
+
+namespace rhi {
+
+Result createMetalBackend(Backend** outBackend)
+{
+    RefPtr<metal::BackendImpl> backend = new metal::BackendImpl();
+    SLANG_RETURN_ON_FAIL(backend->initialize());
+    returnRefPtr(outBackend, backend);
+    return SLANG_OK;
+}
+
+} // namespace rhi

--- a/src/metal/metal-backend.cpp
+++ b/src/metal/metal-backend.cpp
@@ -1,5 +1,6 @@
 #include "metal-backend.h"
 #include "metal-device.h"
+#include "metal-utils.h"
 #include "../reference.h"
 
 #include "core/string.h"

--- a/src/metal/metal-backend.h
+++ b/src/metal/metal-backend.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include "metal-base.h"
+#include "../backend.h"
+
+namespace rhi::metal {
+
+class BackendImpl : public Backend
+{
+public:
+    Result initialize();
+
+    std::vector<AdapterImpl>& getAdapters() { return m_adapters; }
+
+    // Backend implementation
+
+    IAdapter* getAdapter(uint32_t index) override;
+    Result createDevice(const DeviceDesc& desc, IDevice** outDevice) override;
+
+private:
+    std::vector<AdapterImpl> m_adapters;
+};
+
+} // namespace rhi::metal

--- a/src/metal/metal-backend.h
+++ b/src/metal/metal-backend.h
@@ -10,7 +10,7 @@ class BackendImpl : public Backend
 public:
     Result initialize();
 
-    std::vector<AdapterImpl>& getAdapters() { return m_adapters; }
+    std::span<const AdapterImpl> getAdapters() const { return m_adapters; }
 
     // Backend implementation
 

--- a/src/metal/metal-backend.h
+++ b/src/metal/metal-backend.h
@@ -8,14 +8,15 @@ namespace rhi::metal {
 class BackendImpl : public Backend
 {
 public:
-    Result initialize();
-
-    std::span<const AdapterImpl> getAdapters() const;
+    std::span<const AdapterImpl> getAdapters();
 
     // Backend implementation
 
     IAdapter* getAdapter(uint32_t index) override;
     Result createDevice(const DeviceDesc& desc, IDevice** outDevice) override;
+
+protected:
+    Result enumerateAdapters() override;
 
 private:
     std::vector<AdapterImpl> m_adapters;

--- a/src/metal/metal-backend.h
+++ b/src/metal/metal-backend.h
@@ -10,7 +10,7 @@ class BackendImpl : public Backend
 public:
     Result initialize();
 
-    std::span<const AdapterImpl> getAdapters() const { return m_adapters; }
+    std::span<const AdapterImpl> getAdapters() const;
 
     // Backend implementation
 

--- a/src/metal/metal-base.h
+++ b/src/metal/metal-base.h
@@ -7,6 +7,7 @@
 
 namespace rhi::metal {
 
+class BackendImpl;
 class AdapterImpl;
 class DeviceImpl;
 class InputLayoutImpl;

--- a/src/metal/metal-device.cpp
+++ b/src/metal/metal-device.cpp
@@ -66,7 +66,7 @@ Result DeviceImpl::initialize(const DeviceDesc& desc, BackendImpl* backend)
     SLANG_RETURN_ON_FAIL(Device::initialize(desc));
 
     const AdapterImpl* adapter = nullptr;
-    selectAdapter(this, backend->getAdapters(), desc, adapter);
+    SLANG_RETURN_ON_FAIL(selectAdapter(this, backend->getAdapters(), desc, adapter));
     m_device = adapter->m_device;
     if (!m_device)
     {

--- a/src/metal/metal-device.cpp
+++ b/src/metal/metal-device.cpp
@@ -1,4 +1,5 @@
 #include "metal-device.h"
+#include "metal-backend.h"
 #include "../resource-desc-utils.h"
 #include "metal-command.h"
 #include "metal-buffer.h"
@@ -19,59 +20,6 @@
 #include <vector>
 
 namespace rhi::metal {
-
-inline Result getAdaptersImpl(std::vector<AdapterImpl>& outAdapters)
-{
-    AUTORELEASEPOOL
-
-    auto addAdapter = [&](MTL::Device* device)
-    {
-        AdapterInfo info = {};
-        info.deviceType = DeviceType::Metal;
-        info.adapterType = device->hasUnifiedMemory() ? AdapterType::Integrated : AdapterType::Discrete;
-        const char* name = device->name()->cString(NS::ASCIIStringEncoding);
-        string::copy_safe(info.name, sizeof(info.name), name);
-        uint64_t registryID = device->registryID();
-        memcpy(&info.luid.luid[0], &registryID, sizeof(registryID));
-
-        AdapterImpl adapter;
-        adapter.m_info = info;
-        adapter.m_device = NS::RetainPtr(device);
-        outAdapters.push_back(adapter);
-    };
-
-    NS::Array* devices = MTL::CopyAllDevices();
-    if (devices->count() > 0)
-    {
-        for (int i = 0; i < devices->count(); ++i)
-        {
-            MTL::Device* device = static_cast<MTL::Device*>(devices->object(i));
-            addAdapter(device);
-        }
-    }
-    else
-    {
-        MTL::Device* device = MTL::CreateSystemDefaultDevice();
-        addAdapter(device);
-        device->release();
-    }
-
-    // Make the first adapter the default one.
-    if (!outAdapters.empty())
-    {
-        outAdapters[0].m_isDefault = true;
-    }
-
-    return SLANG_OK;
-}
-
-std::vector<AdapterImpl>& getAdapters()
-{
-    static std::vector<AdapterImpl> adapters;
-    static Result initResult = getAdaptersImpl(adapters);
-    SLANG_UNUSED(initResult);
-    return adapters;
-}
 
 DeviceImpl::DeviceImpl() {}
 
@@ -111,14 +59,14 @@ Result DeviceImpl::getNativeDeviceHandles(DeviceNativeHandles* outHandles)
     return SLANG_OK;
 }
 
-Result DeviceImpl::initialize(const DeviceDesc& desc)
+Result DeviceImpl::initialize(const DeviceDesc& desc, BackendImpl* backend)
 {
     AUTORELEASEPOOL
 
     SLANG_RETURN_ON_FAIL(Device::initialize(desc));
 
     AdapterImpl* adapter = nullptr;
-    selectAdapter(this, getAdapters(), desc, adapter);
+    selectAdapter(this, backend->getAdapters(), desc, adapter);
     m_device = adapter->m_device;
     if (!m_device)
     {
@@ -507,21 +455,3 @@ Result DeviceImpl::createQueryPool(const QueryPoolDesc& desc, IQueryPool** outPo
 }
 
 } // namespace rhi::metal
-
-namespace rhi {
-
-IAdapter* getMetalAdapter(uint32_t index)
-{
-    std::vector<metal::AdapterImpl>& adapters = metal::getAdapters();
-    return index < adapters.size() ? &adapters[index] : nullptr;
-}
-
-Result SLANG_MCALL createMetalDevice(const DeviceDesc* desc, IDevice** outDevice)
-{
-    RefPtr<metal::DeviceImpl> result = new metal::DeviceImpl();
-    SLANG_RETURN_ON_FAIL(result->initialize(*desc));
-    returnComPtr(outDevice, result);
-    return SLANG_OK;
-}
-
-} // namespace rhi

--- a/src/metal/metal-device.cpp
+++ b/src/metal/metal-device.cpp
@@ -65,7 +65,7 @@ Result DeviceImpl::initialize(const DeviceDesc& desc, BackendImpl* backend)
 
     SLANG_RETURN_ON_FAIL(Device::initialize(desc));
 
-    AdapterImpl* adapter = nullptr;
+    const AdapterImpl* adapter = nullptr;
     selectAdapter(this, backend->getAdapters(), desc, adapter);
     m_device = adapter->m_device;
     if (!m_device)

--- a/src/metal/metal-device.cpp
+++ b/src/metal/metal-device.cpp
@@ -116,8 +116,8 @@ Result DeviceImpl::initialize(const DeviceDesc& desc, BackendImpl* backend)
     {
         m_info.deviceType = DeviceType::Metal;
         m_info.apiName = "Metal";
-        m_info.adapterName = "default";
-        m_info.adapterLUID = {};
+        m_info.adapterName = adapter->m_info.name;
+        m_info.adapterLUID = adapter->m_info.luid;
 
         // TODO: Most limits cannot be queried through the Metal API but are described in
         // https://developer.apple.com/metal/Metal-Feature-Set-Tables.pdf

--- a/src/metal/metal-device.h
+++ b/src/metal/metal-device.h
@@ -18,7 +18,7 @@ class DeviceImpl : public Device
 public:
     using Device::readBuffer;
 
-    virtual SLANG_NO_THROW Result SLANG_MCALL initialize(const DeviceDesc& desc) override;
+    Result initialize(const DeviceDesc& desc, BackendImpl* backend);
     virtual SLANG_NO_THROW Result SLANG_MCALL getQueue(QueueType type, ICommandQueue** outQueue) override;
     virtual SLANG_NO_THROW Result SLANG_MCALL createSurface(WindowHandle windowHandle, ISurface** outSurface) override;
     virtual SLANG_NO_THROW Result SLANG_MCALL createTexture(
@@ -169,10 +169,3 @@ public:
 };
 
 } // namespace rhi::metal
-
-namespace rhi {
-
-IAdapter* getMetalAdapter(uint32_t index);
-Result createMetalDevice(const DeviceDesc* desc, IDevice** outDevice);
-
-} // namespace rhi

--- a/src/rhi.cpp
+++ b/src/rhi.cpp
@@ -379,6 +379,9 @@ Backend* RHI::getBackend(DeviceType type)
     {
         return nullptr;
     }
+
+    std::lock_guard<std::mutex> lock(m_backendsMutex);
+
     if (m_backends[index])
     {
         return m_backends[index];

--- a/src/rhi.cpp
+++ b/src/rhi.cpp
@@ -1,6 +1,7 @@
 #include <slang-rhi.h>
 
 #include "rhi.h"
+#include "backend.h"
 #include "debug-layer/debug-device.h"
 #include "rhi-shared.h"
 
@@ -11,22 +12,6 @@
 #include <vector>
 
 namespace rhi {
-
-IAdapter* getD3D11Adapter(uint32_t index);
-IAdapter* getD3D12Adapter(uint32_t index);
-IAdapter* getVKAdapter(uint32_t index);
-IAdapter* getMetalAdapter(uint32_t index);
-IAdapter* getCUDAAdapter(uint32_t index);
-IAdapter* getCPUAdapter(uint32_t index);
-IAdapter* getWGPUAdapter(uint32_t index);
-
-Result createD3D11Device(const DeviceDesc* desc, IDevice** outDevice);
-Result createD3D12Device(const DeviceDesc* desc, IDevice** outDevice);
-Result createVKDevice(const DeviceDesc* desc, IDevice** outDevice);
-Result createMetalDevice(const DeviceDesc* desc, IDevice** outDevice);
-Result createCUDADevice(const DeviceDesc* desc, IDevice** outDevice);
-Result createCPUDevice(const DeviceDesc* desc, IDevice** outDevice);
-Result createWGPUDevice(const DeviceDesc* desc, IDevice** outDevice);
 
 Result reportD3DLiveObjects();
 
@@ -144,7 +129,13 @@ Result RHI::destroy()
 {
     SLANG_RHI_ASSERT(m_liveDeviceCount == 0);
     if (m_liveDeviceCount != 0)
+    {
         return SLANG_FAIL;
+    }
+    for (auto& backend : m_backends)
+    {
+        backend.setNull();
+    }
     return SLANG_OK;
 }
 
@@ -260,39 +251,8 @@ const char* RHI::getCapabilityName(Capability capability)
 
 IAdapter* RHI::getAdapter(DeviceType type, uint32_t index)
 {
-    switch (type)
-    {
-#if SLANG_RHI_ENABLE_D3D11
-    case DeviceType::D3D11:
-        return getD3D11Adapter(index);
-#endif
-#if SLANG_RHI_ENABLE_D3D12
-    case DeviceType::D3D12:
-        return getD3D12Adapter(index);
-#endif
-#if SLANG_RHI_ENABLE_VULKAN
-    case DeviceType::Vulkan:
-        return getVKAdapter(index);
-#endif
-#if SLANG_RHI_ENABLE_METAL
-    case DeviceType::Metal:
-        return getMetalAdapter(index);
-#endif
-#if SLANG_RHI_ENABLE_CUDA
-    case DeviceType::CUDA:
-        return getCUDAAdapter(index);
-#endif
-#if SLANG_RHI_ENABLE_CPU
-    case DeviceType::CPU:
-        return getCPUAdapter(index);
-#endif
-#if SLANG_RHI_ENABLE_WGPU
-    case DeviceType::WGPU:
-        return getWGPUAdapter(index);
-#endif
-    default:
-        return nullptr;
-    }
+    Backend* backend = getBackend(type);
+    return backend ? backend->getAdapter(index) : nullptr;
 }
 
 Result RHI::getAdapters(DeviceType type, ISlangBlob** outAdaptersBlob)
@@ -314,95 +274,53 @@ Result RHI::getAdapters(DeviceType type, ISlangBlob** outAdaptersBlob)
     return SLANG_OK;
 }
 
-inline Result _createDevice(const DeviceDesc* desc, IDevice** outDevice)
+Result RHI::createDeviceImpl(const DeviceDesc& desc, IDevice** outDevice)
 {
-    switch (desc->deviceType)
+    Backend* backend = getBackend(desc.deviceType);
+    if (!backend)
+        return SLANG_FAIL;
+
+    if (desc.deviceType == DeviceType::Default)
     {
-    case DeviceType::Default:
-    {
-        DeviceDesc newDesc = *desc;
+        DeviceDesc newDesc = desc;
 #if SLANG_WINDOWS_FAMILY
         newDesc.deviceType = DeviceType::D3D12;
-        if (SLANG_SUCCEEDED(_createDevice(&newDesc, outDevice)))
+        if (SLANG_SUCCEEDED(createDeviceImpl(newDesc, outDevice)))
             return SLANG_OK;
         newDesc.deviceType = DeviceType::Vulkan;
-        if (SLANG_SUCCEEDED(_createDevice(&newDesc, outDevice)))
+        if (SLANG_SUCCEEDED(createDeviceImpl(newDesc, outDevice)))
             return SLANG_OK;
 #elif SLANG_LINUX_FAMILY
         newDesc.deviceType = DeviceType::Vulkan;
-        if (SLANG_SUCCEEDED(_createDevice(&newDesc, outDevice)))
+        if (SLANG_SUCCEEDED(createDeviceImpl(newDesc, outDevice)))
             return SLANG_OK;
 #elif SLANG_APPLE_FAMILY
         newDesc.deviceType = DeviceType::Metal;
-        if (SLANG_SUCCEEDED(_createDevice(&newDesc, outDevice)))
+        if (SLANG_SUCCEEDED(createDeviceImpl(newDesc, outDevice)))
             return SLANG_OK;
 #endif
         return SLANG_FAIL;
     }
-    break;
-#if SLANG_RHI_ENABLE_D3D11
-    case DeviceType::D3D11:
-    {
-        return createD3D11Device(desc, outDevice);
-    }
-#endif
-#if SLANG_RHI_ENABLE_D3D12
-    case DeviceType::D3D12:
-    {
-        return createD3D12Device(desc, outDevice);
-    }
-#endif
-#if SLANG_RHI_ENABLE_VULKAN
-    case DeviceType::Vulkan:
-    {
-        return createVKDevice(desc, outDevice);
-    }
-#endif
-#if SLANG_RHI_ENABLE_METAL
-    case DeviceType::Metal:
-    {
-        return createMetalDevice(desc, outDevice);
-    }
-#endif
-#if SLANG_RHI_ENABLE_CUDA
-    case DeviceType::CUDA:
-    {
-        return createCUDADevice(desc, outDevice);
-    }
-#endif
-#if SLANG_RHI_ENABLE_CPU
-    case DeviceType::CPU:
-    {
-        return createCPUDevice(desc, outDevice);
-    }
-#endif
-#if SLANG_RHI_ENABLE_WGPU
-    case DeviceType::WGPU:
-    {
-        return createWGPUDevice(desc, outDevice);
-    }
-#endif
-    default:
-        return SLANG_FAIL;
-    }
+
+    return backend->createDevice(desc, outDevice);
 }
 
 Result RHI::createDevice(const DeviceDesc& desc, IDevice** outDevice)
 {
     ComPtr<IDevice> innerDevice;
-    auto resultCode = _createDevice(&desc, innerDevice.writeRef());
-    if (SLANG_FAILED(resultCode))
-        return resultCode;
+    Result result = createDeviceImpl(desc, innerDevice.writeRef());
+    if (SLANG_FAILED(result))
+        return result;
     if (!desc.enableValidation)
     {
         returnComPtr(outDevice, innerDevice);
-        return resultCode;
+        return result;
     }
     IDebugCallback* debugCallback = checked_cast<Device*>(innerDevice.get())->m_debugCallback;
     RefPtr<debug::DebugDevice> debugDevice = new debug::DebugDevice(innerDevice->getInfo().deviceType, debugCallback);
     debugDevice->baseObject = innerDevice;
     returnComPtr(outDevice, debugDevice);
-    return resultCode;
+    return result;
 }
 
 Result RHI::createBlob(const void* data, size_t size, ISlangBlob** outBlob)
@@ -447,6 +365,68 @@ Result RHI::initTaskPool(int workerCount)
     if (m_liveDeviceCount != 0)
         return SLANG_FAIL;
     return initGlobalTaskPool(workerCount);
+}
+
+Backend* RHI::getBackend(DeviceType type)
+{
+    size_t index = size_t(type);
+    if (index >= std::size(m_backends))
+    {
+        return nullptr;
+    }
+    if (m_backends[index])
+    {
+        return m_backends[index];
+    }
+
+    RefPtr<Backend> backend;
+    Result result = SLANG_FAIL;
+    switch (type)
+    {
+#if SLANG_RHI_ENABLE_D3D11
+    case DeviceType::D3D11:
+        result = createD3D11Backend(backend.writeRef());
+        break;
+#endif
+#if SLANG_RHI_ENABLE_D3D12
+    case DeviceType::D3D12:
+        result = createD3D12Backend(backend.writeRef());
+        break;
+#endif
+#if SLANG_RHI_ENABLE_VULKAN
+    case DeviceType::Vulkan:
+        result = createVKBackend(backend.writeRef());
+        break;
+#endif
+#if SLANG_RHI_ENABLE_METAL
+    case DeviceType::Metal:
+        result = createMetalBackend(backend.writeRef());
+        break;
+#endif
+#if SLANG_RHI_ENABLE_CUDA
+    case DeviceType::CUDA:
+        result = createCUDABackend(backend.writeRef());
+        break;
+#endif
+#if SLANG_RHI_ENABLE_CPU
+    case DeviceType::CPU:
+        result = createCPUBackend(backend.writeRef());
+        break;
+#endif
+#if SLANG_RHI_ENABLE_WGPU
+    case DeviceType::WGPU:
+        result = createWGPUBackend(backend.writeRef());
+        break;
+#endif
+    default:
+        return nullptr;
+    }
+    if (SLANG_FAILED(result))
+    {
+        return nullptr;
+    }
+    m_backends[index] = backend;
+    return backend;
 }
 
 static std::mutex s_instanceMutex;

--- a/src/rhi.cpp
+++ b/src/rhi.cpp
@@ -1,6 +1,7 @@
 #include <slang-rhi.h>
 
 #include "rhi.h"
+#include "aftermath.h"
 #include "backend.h"
 #include "debug-layer/debug-device.h"
 #include "rhi-shared.h"
@@ -142,6 +143,11 @@ Result RHI::destroy()
 
     // Release the global task pool.
     setGlobalTaskPool(nullptr);
+
+    // Release the Aftermath crash dumper.
+#if SLANG_RHI_ENABLE_AFTERMATH
+    AftermathCrashDumper::clear();
+#endif
 
     return SLANG_OK;
 }

--- a/src/rhi.cpp
+++ b/src/rhi.cpp
@@ -127,15 +127,22 @@ inline const FormatInfo& _getFormatInfo(Format format)
 
 Result RHI::destroy()
 {
+    // RHI can only be destroyed if there are no live devices.
     SLANG_RHI_ASSERT(m_liveDeviceCount == 0);
     if (m_liveDeviceCount != 0)
     {
         return SLANG_FAIL;
     }
+
+    // Release all backends.
     for (auto& backend : m_backends)
     {
         backend.setNull();
     }
+
+    // Release the global task pool.
+    setGlobalTaskPool(nullptr);
+
     return SLANG_OK;
 }
 
@@ -146,15 +153,7 @@ void RHI::incrementLiveDeviceCount()
 
 void RHI::decrementLiveDeviceCount()
 {
-    if (m_liveDeviceCount.fetch_sub(1) == 1)
-    {
-        // Last device destroyed - release the global task pool so it
-        // doesn't appear as a leaked object. globalTaskPool() will
-        // lazily re-create it if another device is created later.
-        // TODO: We should address this when allowing explicit control
-        // over the lifetime of the RHI instance itself.
-        setGlobalTaskPool(nullptr);
-    }
+    m_liveDeviceCount--;
 }
 
 void RHI::enableDebugLayers()

--- a/src/rhi.cpp
+++ b/src/rhi.cpp
@@ -142,6 +142,7 @@ inline const FormatInfo& _getFormatInfo(Format format)
 
 Result RHI::destroy()
 {
+    SLANG_RHI_ASSERT(m_liveDeviceCount == 0);
     if (m_liveDeviceCount != 0)
         return SLANG_FAIL;
     return SLANG_OK;
@@ -451,7 +452,7 @@ Result RHI::initTaskPool(int workerCount)
 static std::mutex s_instanceMutex;
 static RHI* s_instance = nullptr;
 
-RHI* getRHIInstance()
+static RHI* getRHIInstance()
 {
     std::lock_guard<std::mutex> lock(s_instanceMutex);
     if (!s_instance)
@@ -459,7 +460,7 @@ RHI* getRHIInstance()
     return s_instance;
 }
 
-Result destroyRHIInstance()
+static Result destroyRHIInstance()
 {
     std::lock_guard<std::mutex> lock(s_instanceMutex);
     if (!s_instance)

--- a/src/rhi.cpp
+++ b/src/rhi.cpp
@@ -281,10 +281,6 @@ Result RHI::getAdapters(DeviceType type, ISlangBlob** outAdaptersBlob)
 
 Result RHI::createDeviceImpl(const DeviceDesc& desc, IDevice** outDevice)
 {
-    Backend* backend = getBackend(desc.deviceType);
-    if (!backend)
-        return SLANG_FAIL;
-
     if (desc.deviceType == DeviceType::Default)
     {
         DeviceDesc newDesc = desc;
@@ -306,6 +302,10 @@ Result RHI::createDeviceImpl(const DeviceDesc& desc, IDevice** outDevice)
 #endif
         return SLANG_FAIL;
     }
+
+    Backend* backend = getBackend(desc.deviceType);
+    if (!backend)
+        return SLANG_FAIL;
 
     return backend->createDevice(desc, outDevice);
 }

--- a/src/rhi.cpp
+++ b/src/rhi.cpp
@@ -140,6 +140,13 @@ inline const FormatInfo& _getFormatInfo(Format format)
     return s_formatInfos[size_t(format)];
 }
 
+Result RHI::destroy()
+{
+    if (m_liveDeviceCount != 0)
+        return SLANG_FAIL;
+    return SLANG_OK;
+}
+
 void RHI::incrementLiveDeviceCount()
 {
     m_liveDeviceCount++;
@@ -441,9 +448,38 @@ Result RHI::initTaskPool(int workerCount)
     return initGlobalTaskPool(workerCount);
 }
 
+static std::mutex s_instanceMutex;
+static RHI* s_instance = nullptr;
+
+RHI* getRHIInstance()
+{
+    std::lock_guard<std::mutex> lock(s_instanceMutex);
+    if (!s_instance)
+        s_instance = new RHI();
+    return s_instance;
+}
+
+Result destroyRHIInstance()
+{
+    std::lock_guard<std::mutex> lock(s_instanceMutex);
+    if (!s_instance)
+        return SLANG_OK;
+    Result result = s_instance->destroy();
+    if (SLANG_FAILED(result))
+        return result;
+    delete s_instance;
+    s_instance = nullptr;
+    return SLANG_OK;
+}
+
 } // namespace rhi
 
 extern "C" SLANG_RHI_API rhi::IRHI* SLANG_STDCALL rhiGetInstance()
 {
-    return rhi::RHI::getInstance();
+    return rhi::getRHIInstance();
+}
+
+extern "C" SLANG_RHI_API SlangResult SLANG_STDCALL rhiDestroyInstance()
+{
+    return rhi::destroyRHIInstance();
 }

--- a/src/rhi.cpp
+++ b/src/rhi.cpp
@@ -437,7 +437,7 @@ Backend* RHI::getBackend(DeviceType type)
 static std::mutex s_instanceMutex;
 static RHI* s_instance = nullptr;
 
-static RHI* getRHIInstance()
+static RHI* getInstance()
 {
     std::lock_guard<std::mutex> lock(s_instanceMutex);
     if (!s_instance)
@@ -445,7 +445,7 @@ static RHI* getRHIInstance()
     return s_instance;
 }
 
-static Result destroyRHIInstance()
+static Result destroyInstance()
 {
     std::lock_guard<std::mutex> lock(s_instanceMutex);
     if (!s_instance)
@@ -462,10 +462,10 @@ static Result destroyRHIInstance()
 
 extern "C" SLANG_RHI_API rhi::IRHI* SLANG_STDCALL rhiGetInstance()
 {
-    return rhi::getRHIInstance();
+    return rhi::getInstance();
 }
 
 extern "C" SLANG_RHI_API SlangResult SLANG_STDCALL rhiDestroyInstance()
 {
-    return rhi::destroyRHIInstance();
+    return rhi::destroyInstance();
 }

--- a/src/rhi.h
+++ b/src/rhi.h
@@ -5,6 +5,7 @@
 #include "core/smart-pointer.h"
 
 #include <atomic>
+#include <mutex>
 
 namespace rhi {
 
@@ -48,6 +49,7 @@ private:
 
     DebugLayerOptions m_debugLayerOptions = {};
     std::atomic<uint32_t> m_liveDeviceCount = 0;
+    std::mutex m_backendsMutex;
     RefPtr<Backend> m_backends[8]; // indexed by DeviceType
 };
 

--- a/src/rhi.h
+++ b/src/rhi.h
@@ -2,6 +2,7 @@
 
 #include <slang-rhi.h>
 #include <atomic>
+#include <mutex>
 
 namespace rhi {
 class RHI : public IRHI
@@ -11,8 +12,12 @@ private:
     std::atomic<uint32_t> m_liveDeviceCount = 0;
 
 public:
+    Result destroy();
+
     void incrementLiveDeviceCount();
     void decrementLiveDeviceCount();
+
+    // IRHI implementation
 
     virtual void enableDebugLayers() override;
     virtual Result setDebugLayerOptions(DebugLayerOptions options) override;
@@ -33,11 +38,6 @@ public:
     virtual Result reportLiveObjects() override;
     virtual Result setTaskPool(ITaskPool* scheduler) override;
     virtual Result initTaskPool(int workerCount) override;
-
-    static RHI* getInstance()
-    {
-        static RHI instance;
-        return &instance;
-    }
 };
+
 } // namespace rhi

--- a/src/rhi.h
+++ b/src/rhi.h
@@ -13,6 +13,8 @@ class Backend;
 class RHI : public IRHI
 {
 public:
+    virtual ~RHI() = default;
+
     Result destroy();
 
     void incrementLiveDeviceCount();

--- a/src/rhi.h
+++ b/src/rhi.h
@@ -2,7 +2,6 @@
 
 #include <slang-rhi.h>
 #include <atomic>
-#include <mutex>
 
 namespace rhi {
 class RHI : public IRHI

--- a/src/rhi.h
+++ b/src/rhi.h
@@ -1,15 +1,17 @@
 #pragma once
 
 #include <slang-rhi.h>
+
+#include "core/smart-pointer.h"
+
 #include <atomic>
 
 namespace rhi {
+
+class Backend;
+
 class RHI : public IRHI
 {
-private:
-    DebugLayerOptions m_debugLayerOptions = {};
-    std::atomic<uint32_t> m_liveDeviceCount = 0;
-
 public:
     Result destroy();
 
@@ -37,6 +39,14 @@ public:
     virtual Result reportLiveObjects() override;
     virtual Result setTaskPool(ITaskPool* scheduler) override;
     virtual Result initTaskPool(int workerCount) override;
+
+private:
+    Backend* getBackend(DeviceType type);
+    Result createDeviceImpl(const DeviceDesc& desc, IDevice** outDevice);
+
+    DebugLayerOptions m_debugLayerOptions = {};
+    std::atomic<uint32_t> m_liveDeviceCount = 0;
+    RefPtr<Backend> m_backends[8]; // indexed by DeviceType
 };
 
 } // namespace rhi

--- a/src/vulkan/vk-backend.cpp
+++ b/src/vulkan/vk-backend.cpp
@@ -1,0 +1,123 @@
+#include "vk-backend.h"
+#include "vk-device.h"
+#include "vk-utils.h"
+#include "../reference.h"
+
+#include "core/deferred.h"
+#include "core/string.h"
+
+namespace rhi::vk {
+
+static Result getAdaptersImpl(std::vector<AdapterImpl>& outAdapters)
+{
+    VulkanModule module;
+    SLANG_RETURN_ON_FAIL(module.init());
+    SLANG_RHI_DEFERRED({ module.destroy(); });
+
+    VulkanApi api;
+    SLANG_RETURN_ON_FAIL(api.initGlobalProcs(module));
+
+    VkInstanceCreateInfo instanceCreateInfo = {VK_STRUCTURE_TYPE_INSTANCE_CREATE_INFO};
+    const char* instanceExtensions[] = {
+        VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME,
+#if SLANG_APPLE_FAMILY
+        VK_KHR_PORTABILITY_ENUMERATION_EXTENSION_NAME,
+#endif
+    };
+    instanceCreateInfo.enabledExtensionCount = SLANG_COUNT_OF(instanceExtensions);
+    instanceCreateInfo.ppEnabledExtensionNames = &instanceExtensions[0];
+#if SLANG_APPLE_FAMILY
+    instanceCreateInfo.flags = VK_INSTANCE_CREATE_ENUMERATE_PORTABILITY_BIT_KHR;
+#endif
+    VkInstance instance;
+    SLANG_VK_RETURN_ON_FAIL(api.vkCreateInstance(&instanceCreateInfo, nullptr, &instance));
+    SLANG_RHI_DEFERRED({ api.vkDestroyInstance(instance, nullptr); });
+
+    // This will fail due to not loading any extensions.
+    api.initInstanceProcs(instance);
+
+    if (!(api.vkEnumeratePhysicalDevices && api.vkGetPhysicalDeviceProperties2 &&
+          api.vkEnumerateDeviceExtensionProperties))
+    {
+        return SLANG_FAIL;
+    }
+
+    uint32_t physicalDeviceCount = 0;
+    SLANG_VK_RETURN_ON_FAIL(api.vkEnumeratePhysicalDevices(instance, &physicalDeviceCount, nullptr));
+    std::vector<VkPhysicalDevice> physicalDevices(physicalDeviceCount);
+    SLANG_VK_RETURN_ON_FAIL(api.vkEnumeratePhysicalDevices(instance, &physicalDeviceCount, physicalDevices.data()));
+
+    for (const auto& physicalDevice : physicalDevices)
+    {
+        VkPhysicalDeviceIDProperties idProps = {VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_ID_PROPERTIES};
+        VkPhysicalDeviceProperties2 props = {VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PROPERTIES_2};
+        props.pNext = &idProps;
+        SLANG_RHI_ASSERT(api.vkGetPhysicalDeviceFeatures2);
+        api.vkGetPhysicalDeviceProperties2(physicalDevice, &props);
+
+        AdapterInfo info = {};
+        info.deviceType = DeviceType::Vulkan;
+        switch (props.properties.deviceType)
+        {
+        case VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU:
+            info.adapterType = AdapterType::Discrete;
+            break;
+        case VK_PHYSICAL_DEVICE_TYPE_INTEGRATED_GPU:
+            info.adapterType = AdapterType::Integrated;
+            break;
+        case VK_PHYSICAL_DEVICE_TYPE_CPU:
+            info.adapterType = AdapterType::Software;
+            break;
+        default:
+            info.adapterType = AdapterType::Unknown;
+            break;
+        }
+        string::copy_safe(info.name, sizeof(info.name), props.properties.deviceName);
+        info.vendorID = props.properties.vendorID;
+        info.deviceID = props.properties.deviceID;
+        info.luid = getAdapterLUID(idProps);
+
+        AdapterImpl adapter;
+        adapter.m_info = info;
+        memcpy(adapter.m_deviceUUID, idProps.deviceUUID, VK_UUID_SIZE);
+
+        outAdapters.push_back(adapter);
+    }
+
+    // Mark default adapter (prefer discrete if available).
+    markDefaultAdapter(outAdapters);
+
+    return SLANG_OK;
+}
+
+Result BackendImpl::initialize()
+{
+    return getAdaptersImpl(m_adapters);
+}
+
+IAdapter* BackendImpl::getAdapter(uint32_t index)
+{
+    return index < m_adapters.size() ? &m_adapters[index] : nullptr;
+}
+
+Result BackendImpl::createDevice(const DeviceDesc& desc, IDevice** outDevice)
+{
+    RefPtr<DeviceImpl> result = new DeviceImpl();
+    SLANG_RETURN_ON_FAIL(result->initialize(desc, this));
+    returnComPtr(outDevice, result);
+    return SLANG_OK;
+}
+
+} // namespace rhi::vk
+
+namespace rhi {
+
+Result createVKBackend(Backend** outBackend)
+{
+    RefPtr<vk::BackendImpl> backend = new vk::BackendImpl();
+    SLANG_RETURN_ON_FAIL(backend->initialize());
+    returnRefPtr(outBackend, backend);
+    return SLANG_OK;
+}
+
+} // namespace rhi

--- a/src/vulkan/vk-backend.cpp
+++ b/src/vulkan/vk-backend.cpp
@@ -95,6 +95,11 @@ Result BackendImpl::initialize()
     return getAdaptersImpl(m_adapters);
 }
 
+std::span<const AdapterImpl> BackendImpl::getAdapters() const
+{
+    return m_adapters;
+}
+
 IAdapter* BackendImpl::getAdapter(uint32_t index)
 {
     return index < m_adapters.size() ? &m_adapters[index] : nullptr;

--- a/src/vulkan/vk-backend.cpp
+++ b/src/vulkan/vk-backend.cpp
@@ -8,7 +8,27 @@
 
 namespace rhi::vk {
 
-static Result getAdaptersImpl(std::vector<AdapterImpl>& outAdapters)
+std::span<const AdapterImpl> BackendImpl::getAdapters()
+{
+    ensureAdapters();
+    return m_adapters;
+}
+
+IAdapter* BackendImpl::getAdapter(uint32_t index)
+{
+    ensureAdapters();
+    return index < m_adapters.size() ? &m_adapters[index] : nullptr;
+}
+
+Result BackendImpl::createDevice(const DeviceDesc& desc, IDevice** outDevice)
+{
+    RefPtr<DeviceImpl> result = new DeviceImpl();
+    SLANG_RETURN_ON_FAIL(result->initialize(desc, this));
+    returnComPtr(outDevice, result);
+    return SLANG_OK;
+}
+
+Result BackendImpl::enumerateAdapters()
 {
     VulkanModule module;
     SLANG_RETURN_ON_FAIL(module.init());
@@ -81,35 +101,12 @@ static Result getAdaptersImpl(std::vector<AdapterImpl>& outAdapters)
         adapter.m_info = info;
         memcpy(adapter.m_deviceUUID, idProps.deviceUUID, VK_UUID_SIZE);
 
-        outAdapters.push_back(adapter);
+        m_adapters.push_back(adapter);
     }
 
     // Mark default adapter (prefer discrete if available).
-    markDefaultAdapter(outAdapters);
+    markDefaultAdapter(m_adapters);
 
-    return SLANG_OK;
-}
-
-Result BackendImpl::initialize()
-{
-    return getAdaptersImpl(m_adapters);
-}
-
-std::span<const AdapterImpl> BackendImpl::getAdapters() const
-{
-    return m_adapters;
-}
-
-IAdapter* BackendImpl::getAdapter(uint32_t index)
-{
-    return index < m_adapters.size() ? &m_adapters[index] : nullptr;
-}
-
-Result BackendImpl::createDevice(const DeviceDesc& desc, IDevice** outDevice)
-{
-    RefPtr<DeviceImpl> result = new DeviceImpl();
-    SLANG_RETURN_ON_FAIL(result->initialize(desc, this));
-    returnComPtr(outDevice, result);
     return SLANG_OK;
 }
 
@@ -120,7 +117,6 @@ namespace rhi {
 Result createVKBackend(Backend** outBackend)
 {
     RefPtr<vk::BackendImpl> backend = new vk::BackendImpl();
-    SLANG_RETURN_ON_FAIL(backend->initialize());
     returnRefPtr(outBackend, backend);
     return SLANG_OK;
 }

--- a/src/vulkan/vk-backend.cpp
+++ b/src/vulkan/vk-backend.cpp
@@ -72,7 +72,7 @@ Result BackendImpl::enumerateAdapters()
         VkPhysicalDeviceIDProperties idProps = {VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_ID_PROPERTIES};
         VkPhysicalDeviceProperties2 props = {VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PROPERTIES_2};
         props.pNext = &idProps;
-        SLANG_RHI_ASSERT(api.vkGetPhysicalDeviceFeatures2);
+        SLANG_RHI_ASSERT(api.vkGetPhysicalDeviceProperties2);
         api.vkGetPhysicalDeviceProperties2(physicalDevice, &props);
 
         AdapterInfo info = {};

--- a/src/vulkan/vk-backend.h
+++ b/src/vulkan/vk-backend.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include "vk-base.h"
+#include "../backend.h"
+
+namespace rhi::vk {
+
+class BackendImpl : public Backend
+{
+public:
+    Result initialize();
+
+    std::vector<AdapterImpl>& getAdapters() { return m_adapters; }
+
+    // Backend implementation
+
+    IAdapter* getAdapter(uint32_t index) override;
+    Result createDevice(const DeviceDesc& desc, IDevice** outDevice) override;
+
+private:
+    std::vector<AdapterImpl> m_adapters;
+};
+
+} // namespace rhi::vk

--- a/src/vulkan/vk-backend.h
+++ b/src/vulkan/vk-backend.h
@@ -8,14 +8,15 @@ namespace rhi::vk {
 class BackendImpl : public Backend
 {
 public:
-    Result initialize();
-
-    std::span<const AdapterImpl> getAdapters() const;
+    std::span<const AdapterImpl> getAdapters();
 
     // Backend implementation
 
     IAdapter* getAdapter(uint32_t index) override;
     Result createDevice(const DeviceDesc& desc, IDevice** outDevice) override;
+
+protected:
+    Result enumerateAdapters() override;
 
 private:
     std::vector<AdapterImpl> m_adapters;

--- a/src/vulkan/vk-backend.h
+++ b/src/vulkan/vk-backend.h
@@ -10,7 +10,7 @@ class BackendImpl : public Backend
 public:
     Result initialize();
 
-    std::vector<AdapterImpl>& getAdapters() { return m_adapters; }
+    std::span<const AdapterImpl> getAdapters() const { return m_adapters; }
 
     // Backend implementation
 

--- a/src/vulkan/vk-backend.h
+++ b/src/vulkan/vk-backend.h
@@ -10,7 +10,7 @@ class BackendImpl : public Backend
 public:
     Result initialize();
 
-    std::span<const AdapterImpl> getAdapters() const { return m_adapters; }
+    std::span<const AdapterImpl> getAdapters() const;
 
     // Backend implementation
 

--- a/src/vulkan/vk-base.h
+++ b/src/vulkan/vk-base.h
@@ -11,6 +11,7 @@
 
 namespace rhi::vk {
 
+class BackendImpl;
 class AdapterImpl;
 class DeviceImpl;
 class InputLayoutImpl;

--- a/src/vulkan/vk-device.cpp
+++ b/src/vulkan/vk-device.cpp
@@ -1,4 +1,5 @@
 #include "vk-device.h"
+#include "vk-backend.h"
 #include "vk-command.h"
 #include "vk-buffer.h"
 #include "vk-texture.h"
@@ -28,96 +29,6 @@
 #include <vector>
 
 namespace rhi::vk {
-
-inline Result getAdaptersImpl(std::vector<AdapterImpl>& outAdapters)
-{
-    VulkanModule module;
-    SLANG_RETURN_ON_FAIL(module.init());
-    SLANG_RHI_DEFERRED({ module.destroy(); });
-
-    VulkanApi api;
-    SLANG_RETURN_ON_FAIL(api.initGlobalProcs(module));
-
-    VkInstanceCreateInfo instanceCreateInfo = {VK_STRUCTURE_TYPE_INSTANCE_CREATE_INFO};
-    const char* instanceExtensions[] = {
-        VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME,
-#if SLANG_APPLE_FAMILY
-        VK_KHR_PORTABILITY_ENUMERATION_EXTENSION_NAME,
-#endif
-    };
-    instanceCreateInfo.enabledExtensionCount = SLANG_COUNT_OF(instanceExtensions);
-    instanceCreateInfo.ppEnabledExtensionNames = &instanceExtensions[0];
-#if SLANG_APPLE_FAMILY
-    instanceCreateInfo.flags = VK_INSTANCE_CREATE_ENUMERATE_PORTABILITY_BIT_KHR;
-#endif
-    VkInstance instance;
-    SLANG_VK_RETURN_ON_FAIL(api.vkCreateInstance(&instanceCreateInfo, nullptr, &instance));
-    SLANG_RHI_DEFERRED({ api.vkDestroyInstance(instance, nullptr); });
-
-    // This will fail due to not loading any extensions.
-    api.initInstanceProcs(instance);
-
-    if (!(api.vkEnumeratePhysicalDevices && api.vkGetPhysicalDeviceProperties2 &&
-          api.vkEnumerateDeviceExtensionProperties))
-    {
-        return SLANG_FAIL;
-    }
-
-    uint32_t physicalDeviceCount = 0;
-    SLANG_VK_RETURN_ON_FAIL(api.vkEnumeratePhysicalDevices(instance, &physicalDeviceCount, nullptr));
-    std::vector<VkPhysicalDevice> physicalDevices(physicalDeviceCount);
-    SLANG_VK_RETURN_ON_FAIL(api.vkEnumeratePhysicalDevices(instance, &physicalDeviceCount, physicalDevices.data()));
-
-    for (const auto& physicalDevice : physicalDevices)
-    {
-        VkPhysicalDeviceIDProperties idProps = {VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_ID_PROPERTIES};
-        VkPhysicalDeviceProperties2 props = {VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PROPERTIES_2};
-        props.pNext = &idProps;
-        SLANG_RHI_ASSERT(api.vkGetPhysicalDeviceFeatures2);
-        api.vkGetPhysicalDeviceProperties2(physicalDevice, &props);
-
-        AdapterInfo info = {};
-        info.deviceType = DeviceType::Vulkan;
-        switch (props.properties.deviceType)
-        {
-        case VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU:
-            info.adapterType = AdapterType::Discrete;
-            break;
-        case VK_PHYSICAL_DEVICE_TYPE_INTEGRATED_GPU:
-            info.adapterType = AdapterType::Integrated;
-            break;
-        case VK_PHYSICAL_DEVICE_TYPE_CPU:
-            info.adapterType = AdapterType::Software;
-            break;
-        default:
-            info.adapterType = AdapterType::Unknown;
-            break;
-        }
-        string::copy_safe(info.name, sizeof(info.name), props.properties.deviceName);
-        info.vendorID = props.properties.vendorID;
-        info.deviceID = props.properties.deviceID;
-        info.luid = getAdapterLUID(idProps);
-
-        AdapterImpl adapter;
-        adapter.m_info = info;
-        memcpy(adapter.m_deviceUUID, idProps.deviceUUID, VK_UUID_SIZE);
-
-        outAdapters.push_back(adapter);
-    }
-
-    // Mark default adapter (prefer discrete if available).
-    markDefaultAdapter(outAdapters);
-
-    return SLANG_OK;
-}
-
-std::vector<AdapterImpl>& getAdapters()
-{
-    static std::vector<AdapterImpl> adapters;
-    static Result initResult = getAdaptersImpl(adapters);
-    SLANG_UNUSED(initResult);
-    return adapters;
-}
 
 DeviceImpl::DeviceImpl() {}
 
@@ -448,6 +359,7 @@ Result DeviceImpl::initVulkanInstance(const DeviceDesc& desc, const DebugLayerOp
 
 Result DeviceImpl::initVulkanDevice(
     const DeviceDesc& desc,
+    BackendImpl* backend,
     std::vector<Feature>& availableFeatures,
     std::vector<Capability>& availableCapabilities
 )
@@ -462,7 +374,7 @@ Result DeviceImpl::initVulkanDevice(
     if (!desc.existingDeviceHandles.handles[1])
     {
         AdapterImpl* adapter = nullptr;
-        SLANG_RETURN_ON_FAIL(selectAdapter(this, getAdapters(), desc, adapter));
+        SLANG_RETURN_ON_FAIL(selectAdapter(this, backend->getAdapters(), desc, adapter));
 
         uint32_t physicalDeviceCount = 0;
         SLANG_VK_RETURN_ON_FAIL(m_api.vkEnumeratePhysicalDevices(m_api.m_instance, &physicalDeviceCount, nullptr));
@@ -1299,7 +1211,7 @@ Result DeviceImpl::initVulkanDevice(
     return SLANG_OK;
 }
 
-Result DeviceImpl::initialize(const DeviceDesc& desc)
+Result DeviceImpl::initialize(const DeviceDesc& desc, BackendImpl* backend)
 {
     SLANG_RETURN_ON_FAIL(Device::initialize(desc));
 
@@ -1352,7 +1264,7 @@ Result DeviceImpl::initialize(const DeviceDesc& desc)
     // Initialize Vulkan device and query available features and capabilities.
     std::vector<Feature> availableFeatures;
     std::vector<Capability> availableCapabilities;
-    SLANG_RETURN_ON_FAIL(initVulkanDevice(desc, availableFeatures, availableCapabilities));
+    SLANG_RETURN_ON_FAIL(initVulkanDevice(desc, backend, availableFeatures, availableCapabilities));
 
     VkPhysicalDeviceIDProperties idProps = {VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_ID_PROPERTIES};
     VkPhysicalDeviceProperties2 props = {VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PROPERTIES_2};
@@ -2339,21 +2251,3 @@ Result DeviceImpl::waitForFences(
 }
 
 } // namespace rhi::vk
-
-namespace rhi {
-
-IAdapter* getVKAdapter(uint32_t index)
-{
-    std::vector<vk::AdapterImpl>& adapters = vk::getAdapters();
-    return index < adapters.size() ? &adapters[index] : nullptr;
-}
-
-Result createVKDevice(const DeviceDesc* desc, IDevice** outDevice)
-{
-    RefPtr<vk::DeviceImpl> result = new vk::DeviceImpl();
-    SLANG_RETURN_ON_FAIL(result->initialize(*desc));
-    returnComPtr(outDevice, result);
-    return SLANG_OK;
-}
-
-} // namespace rhi

--- a/src/vulkan/vk-device.cpp
+++ b/src/vulkan/vk-device.cpp
@@ -373,7 +373,7 @@ Result DeviceImpl::initVulkanDevice(
     VkPhysicalDevice physicalDevice = VK_NULL_HANDLE;
     if (!desc.existingDeviceHandles.handles[1])
     {
-        AdapterImpl* adapter = nullptr;
+        const AdapterImpl* adapter = nullptr;
         SLANG_RETURN_ON_FAIL(selectAdapter(this, backend->getAdapters(), desc, adapter));
 
         uint32_t physicalDeviceCount = 0;

--- a/src/vulkan/vk-device.h
+++ b/src/vulkan/vk-device.h
@@ -22,11 +22,12 @@ public:
     Result initVulkanInstance(const DeviceDesc& desc, const DebugLayerOptions& debugLayerOptions);
     Result initVulkanDevice(
         const DeviceDesc& desc,
+        BackendImpl* backend,
         std::vector<Feature>& availableFeatures,
         std::vector<Capability>& availableCapabilities
     );
 
-    virtual SLANG_NO_THROW Result SLANG_MCALL initialize(const DeviceDesc& desc) override;
+    Result initialize(const DeviceDesc& desc, BackendImpl* backend);
     virtual SLANG_NO_THROW Result SLANG_MCALL getQueue(QueueType type, ICommandQueue** outQueue) override;
     virtual SLANG_NO_THROW Result SLANG_MCALL createSurface(WindowHandle windowHandle, ISurface** outSurface) override;
     virtual SLANG_NO_THROW Result SLANG_MCALL createTexture(
@@ -257,10 +258,3 @@ public:
 };
 
 } // namespace rhi::vk
-
-namespace rhi {
-
-IAdapter* getVKAdapter(uint32_t index);
-Result createVKDevice(const DeviceDesc* desc, IDevice** outDevice);
-
-} // namespace rhi

--- a/src/vulkan/vk-surface.cpp
+++ b/src/vulkan/vk-surface.cpp
@@ -13,7 +13,7 @@
 
 namespace rhi::vk {
 
-static auto translateVkFormat = reverseMap<Format, VkFormat>(getVkFormat, Format::Undefined, Format::_Count);
+static auto translateVkFormat = reverseMap<Format, VkFormat, Format::Undefined, Format::_Count>(getVkFormat);
 
 SurfaceImpl::~SurfaceImpl()
 {

--- a/src/wgpu/wgpu-backend.cpp
+++ b/src/wgpu/wgpu-backend.cpp
@@ -8,7 +8,21 @@
 
 namespace rhi::wgpu {
 
-static Result getAdaptersImpl(std::vector<Adapter>& outAdapters)
+IAdapter* BackendImpl::getAdapter(uint32_t index)
+{
+    ensureAdapters();
+    return index < m_adapters.size() ? &m_adapters[index] : nullptr;
+}
+
+Result BackendImpl::createDevice(const DeviceDesc& desc, IDevice** outDevice)
+{
+    RefPtr<DeviceImpl> result = new DeviceImpl();
+    SLANG_RETURN_ON_FAIL(result->initialize(desc, this));
+    returnComPtr(outDevice, result);
+    return SLANG_OK;
+}
+
+Result BackendImpl::enumerateAdapters()
 {
     // If WGPU is not available, return no adapters.
     API api;
@@ -52,26 +66,8 @@ static Result getAdaptersImpl(std::vector<Adapter>& outAdapters)
     Adapter adapter;
     adapter.m_info = info;
     adapter.m_isDefault = true;
-    outAdapters.push_back(adapter);
+    m_adapters.push_back(adapter);
 
-    return SLANG_OK;
-}
-
-Result BackendImpl::initialize()
-{
-    return getAdaptersImpl(m_adapters);
-}
-
-IAdapter* BackendImpl::getAdapter(uint32_t index)
-{
-    return index < m_adapters.size() ? &m_adapters[index] : nullptr;
-}
-
-Result BackendImpl::createDevice(const DeviceDesc& desc, IDevice** outDevice)
-{
-    RefPtr<DeviceImpl> result = new DeviceImpl();
-    SLANG_RETURN_ON_FAIL(result->initialize(desc, this));
-    returnComPtr(outDevice, result);
     return SLANG_OK;
 }
 
@@ -82,7 +78,6 @@ namespace rhi {
 Result createWGPUBackend(Backend** outBackend)
 {
     RefPtr<wgpu::BackendImpl> backend = new wgpu::BackendImpl();
-    SLANG_RETURN_ON_FAIL(backend->initialize());
     returnRefPtr(outBackend, backend);
     return SLANG_OK;
 }

--- a/src/wgpu/wgpu-backend.cpp
+++ b/src/wgpu/wgpu-backend.cpp
@@ -8,6 +8,12 @@
 
 namespace rhi::wgpu {
 
+std::span<const Adapter> BackendImpl::getAdapters()
+{
+    ensureAdapters();
+    return m_adapters;
+}
+
 IAdapter* BackendImpl::getAdapter(uint32_t index)
 {
     ensureAdapters();

--- a/src/wgpu/wgpu-backend.cpp
+++ b/src/wgpu/wgpu-backend.cpp
@@ -45,29 +45,31 @@ Result BackendImpl::enumerateAdapters()
     SLANG_RETURN_ON_FAIL(createWGPUAdapter(api, wgpuInstance, &wgpuAdapter));
     SLANG_RHI_DEFERRED({ api.wgpuAdapterRelease(wgpuAdapter); });
 
-    WGPUAdapterInfo wgpuAdapterInfo = {};
-    api.wgpuAdapterGetInfo(wgpuAdapter, &wgpuAdapterInfo);
-
     AdapterInfo info = {};
     info.deviceType = DeviceType::WGPU;
-    switch (wgpuAdapterInfo.adapterType)
     {
-    case WGPUAdapterType_DiscreteGPU:
-        info.adapterType = AdapterType::Discrete;
-        break;
-    case WGPUAdapterType_IntegratedGPU:
-        info.adapterType = AdapterType::Integrated;
-        break;
-    case WGPUAdapterType_CPU:
-        info.adapterType = AdapterType::Software;
-        break;
-    default:
-        info.adapterType = AdapterType::Unknown;
-        break;
+        WGPUAdapterInfo wgpuAdapterInfo = {};
+        api.wgpuAdapterGetInfo(wgpuAdapter, &wgpuAdapterInfo);
+        switch (wgpuAdapterInfo.adapterType)
+        {
+        case WGPUAdapterType_DiscreteGPU:
+            info.adapterType = AdapterType::Discrete;
+            break;
+        case WGPUAdapterType_IntegratedGPU:
+            info.adapterType = AdapterType::Integrated;
+            break;
+        case WGPUAdapterType_CPU:
+            info.adapterType = AdapterType::Software;
+            break;
+        default:
+            info.adapterType = AdapterType::Unknown;
+            break;
+        }
+        string::copy_safe(info.name, sizeof(info.name), wgpuAdapterInfo.device.data, wgpuAdapterInfo.device.length);
+        info.vendorID = wgpuAdapterInfo.vendorID;
+        info.deviceID = wgpuAdapterInfo.deviceID;
+        api.wgpuAdapterInfoFreeMembers(wgpuAdapterInfo);
     }
-    string::copy_safe(info.name, sizeof(info.name), wgpuAdapterInfo.device.data, wgpuAdapterInfo.device.length);
-    info.vendorID = wgpuAdapterInfo.vendorID;
-    info.deviceID = wgpuAdapterInfo.deviceID;
 
     Adapter adapter;
     adapter.m_info = info;

--- a/src/wgpu/wgpu-backend.cpp
+++ b/src/wgpu/wgpu-backend.cpp
@@ -1,0 +1,90 @@
+#include "wgpu-backend.h"
+#include "wgpu-device.h"
+#include "wgpu-utils.h"
+#include "../reference.h"
+
+#include "core/deferred.h"
+#include "core/string.h"
+
+namespace rhi::wgpu {
+
+static Result getAdaptersImpl(std::vector<Adapter>& outAdapters)
+{
+    // If WGPU is not available, return no adapters.
+    API api;
+    if (SLANG_FAILED(api.init()))
+    {
+        return SLANG_OK;
+    }
+
+    WGPUInstance wgpuInstance = {};
+    SLANG_RETURN_ON_FAIL(createWGPUInstance(api, &wgpuInstance));
+    SLANG_RHI_DEFERRED({ api.wgpuInstanceRelease(wgpuInstance); });
+
+    WGPUAdapter wgpuAdapter = {};
+    SLANG_RETURN_ON_FAIL(createWGPUAdapter(api, wgpuInstance, &wgpuAdapter));
+    SLANG_RHI_DEFERRED({ api.wgpuAdapterRelease(wgpuAdapter); });
+
+    WGPUAdapterInfo wgpuAdapterInfo = {};
+    api.wgpuAdapterGetInfo(wgpuAdapter, &wgpuAdapterInfo);
+
+    AdapterInfo info = {};
+    info.deviceType = DeviceType::WGPU;
+    switch (wgpuAdapterInfo.adapterType)
+    {
+    case WGPUAdapterType_DiscreteGPU:
+        info.adapterType = AdapterType::Discrete;
+        break;
+    case WGPUAdapterType_IntegratedGPU:
+        info.adapterType = AdapterType::Integrated;
+        break;
+    case WGPUAdapterType_CPU:
+        info.adapterType = AdapterType::Software;
+        break;
+    default:
+        info.adapterType = AdapterType::Unknown;
+        break;
+    }
+    string::copy_safe(info.name, sizeof(info.name), wgpuAdapterInfo.device.data, wgpuAdapterInfo.device.length);
+    info.vendorID = wgpuAdapterInfo.vendorID;
+    info.deviceID = wgpuAdapterInfo.deviceID;
+
+    Adapter adapter;
+    adapter.m_info = info;
+    adapter.m_isDefault = true;
+    outAdapters.push_back(adapter);
+
+    return SLANG_OK;
+}
+
+Result BackendImpl::initialize()
+{
+    return getAdaptersImpl(m_adapters);
+}
+
+IAdapter* BackendImpl::getAdapter(uint32_t index)
+{
+    return index < m_adapters.size() ? &m_adapters[index] : nullptr;
+}
+
+Result BackendImpl::createDevice(const DeviceDesc& desc, IDevice** outDevice)
+{
+    RefPtr<DeviceImpl> result = new DeviceImpl();
+    SLANG_RETURN_ON_FAIL(result->initialize(desc, this));
+    returnComPtr(outDevice, result);
+    return SLANG_OK;
+}
+
+} // namespace rhi::wgpu
+
+namespace rhi {
+
+Result createWGPUBackend(Backend** outBackend)
+{
+    RefPtr<wgpu::BackendImpl> backend = new wgpu::BackendImpl();
+    SLANG_RETURN_ON_FAIL(backend->initialize());
+    returnRefPtr(outBackend, backend);
+    return SLANG_OK;
+}
+
+} // namespace rhi

--- a/src/wgpu/wgpu-backend.h
+++ b/src/wgpu/wgpu-backend.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include "wgpu-base.h"
+#include "../backend.h"
+
+namespace rhi::wgpu {
+
+class BackendImpl : public Backend
+{
+public:
+    Result initialize();
+
+    std::vector<Adapter>& getAdapters() { return m_adapters; }
+
+    // Backend implementation
+
+    IAdapter* getAdapter(uint32_t index) override;
+    Result createDevice(const DeviceDesc& desc, IDevice** outDevice) override;
+
+private:
+    std::vector<Adapter> m_adapters;
+};
+
+} // namespace rhi::wgpu

--- a/src/wgpu/wgpu-backend.h
+++ b/src/wgpu/wgpu-backend.h
@@ -8,14 +8,19 @@ namespace rhi::wgpu {
 class BackendImpl : public Backend
 {
 public:
-    Result initialize();
-
-    std::vector<Adapter>& getAdapters() { return m_adapters; }
+    std::vector<Adapter>& getAdapters()
+    {
+        ensureAdapters();
+        return m_adapters;
+    }
 
     // Backend implementation
 
     IAdapter* getAdapter(uint32_t index) override;
     Result createDevice(const DeviceDesc& desc, IDevice** outDevice) override;
+
+protected:
+    Result enumerateAdapters() override;
 
 private:
     std::vector<Adapter> m_adapters;

--- a/src/wgpu/wgpu-backend.h
+++ b/src/wgpu/wgpu-backend.h
@@ -8,11 +8,7 @@ namespace rhi::wgpu {
 class BackendImpl : public Backend
 {
 public:
-    std::vector<Adapter>& getAdapters()
-    {
-        ensureAdapters();
-        return m_adapters;
-    }
+    std::span<const Adapter> getAdapters();
 
     // Backend implementation
 

--- a/src/wgpu/wgpu-base.h
+++ b/src/wgpu/wgpu-base.h
@@ -8,6 +8,7 @@
 namespace rhi::wgpu {
 
 struct Context;
+class BackendImpl;
 class DeviceImpl;
 class InputLayoutImpl;
 class BufferImpl;

--- a/src/wgpu/wgpu-device.cpp
+++ b/src/wgpu/wgpu-device.cpp
@@ -14,87 +14,6 @@
 
 namespace rhi::wgpu {
 
-static inline WGPUDawnTogglesDescriptor getDawnTogglesDescriptor()
-{
-    // Currently no toggles are needed.
-    static const std::vector<const char*> enabledToggles = {};
-    static const std::vector<const char*> disabledToggles = {};
-    WGPUDawnTogglesDescriptor togglesDesc = {};
-    togglesDesc.chain.sType = WGPUSType_DawnTogglesDescriptor;
-    togglesDesc.enabledToggleCount = enabledToggles.size();
-    togglesDesc.enabledToggles = enabledToggles.data();
-    togglesDesc.disabledToggleCount = disabledToggles.size();
-    togglesDesc.disabledToggles = disabledToggles.data();
-    return togglesDesc;
-}
-
-static inline Result createWGPUInstance(API& api, WGPUInstance* outInstance)
-{
-    WGPUInstanceDescriptor instanceDesc = {};
-    instanceDesc.capabilities.timedWaitAnyEnable = WGPUBool(true);
-    WGPUDawnTogglesDescriptor togglesDesc = getDawnTogglesDescriptor();
-    instanceDesc.nextInChain = &togglesDesc.chain;
-    WGPUInstance instance = api.wgpuCreateInstance(&instanceDesc);
-    if (!instance)
-    {
-        return SLANG_FAIL;
-    }
-    *outInstance = instance;
-    return SLANG_OK;
-}
-
-#if 0
-
-
-#endif
-
-static inline Result createWGPUAdapter(API& api, WGPUInstance instance, WGPUAdapter* outAdapter)
-{
-    // Request adapter.
-    WGPURequestAdapterOptions options = {};
-    options.powerPreference = WGPUPowerPreference_HighPerformance;
-#if SLANG_WINDOWS_FAMILY
-    // TODO: D3D12 Validation errors prevents use of D3D12, use Vulkan for now.
-    options.backendType = WGPUBackendType_Vulkan;
-#elif SLANG_LINUX_FAMILY
-    options.backendType = WGPUBackendType_Vulkan;
-#endif
-    WGPUDawnTogglesDescriptor togglesDesc = getDawnTogglesDescriptor();
-    options.nextInChain = &togglesDesc.chain;
-
-    WGPUAdapter adapter = {};
-    {
-        WGPURequestAdapterStatus status = WGPURequestAdapterStatus(0);
-        WGPURequestAdapterCallbackInfo callbackInfo = {};
-        callbackInfo.mode = WGPUCallbackMode_WaitAnyOnly;
-        callbackInfo.callback = [](WGPURequestAdapterStatus status_,
-                                   WGPUAdapter adapter_,
-                                   WGPUStringView message,
-                                   void* userdata1,
-                                   void* userdata2)
-        {
-            *(WGPURequestAdapterStatus*)userdata1 = status_;
-            *(WGPUAdapter*)userdata2 = adapter_;
-        };
-        callbackInfo.userdata1 = &status;
-        callbackInfo.userdata2 = &adapter;
-        WGPUFuture future = api.wgpuInstanceRequestAdapter(instance, &options, callbackInfo);
-        WGPUFutureWaitInfo futures[1] = {{future}};
-        uint64_t timeoutNS = UINT64_MAX;
-        WGPUWaitStatus waitStatus = api.wgpuInstanceWaitAny(instance, SLANG_COUNT_OF(futures), futures, timeoutNS);
-        if (waitStatus != WGPUWaitStatus_Success || status != WGPURequestAdapterStatus_Success)
-        {
-            return SLANG_FAIL;
-        }
-    }
-    if (!adapter)
-    {
-        return SLANG_FAIL;
-    }
-    *outAdapter = adapter;
-    return SLANG_OK;
-}
-
 Context::~Context()
 {
     if (device)
@@ -153,7 +72,7 @@ WGPUErrorType DeviceImpl::getAndClearLastUncapturedError()
     return error;
 }
 
-Result DeviceImpl::initialize(const DeviceDesc& desc)
+Result DeviceImpl::initialize(const DeviceDesc& desc, BackendImpl* backend)
 {
     SLANG_RETURN_ON_FAIL(Device::initialize(desc));
 
@@ -629,79 +548,4 @@ Result DeviceImpl::createShaderTable(const ShaderTableDesc& desc, IShaderTable**
     return SLANG_E_NOT_IMPLEMENTED;
 }
 
-inline Result getAdaptersImpl(std::vector<Adapter>& outAdapters)
-{
-    // If WGPU is not available, return no adapters.
-    API api;
-    if (SLANG_FAILED(api.init()))
-    {
-        return SLANG_OK;
-    }
-
-    WGPUInstance wgpuInstance = {};
-    SLANG_RETURN_ON_FAIL(createWGPUInstance(api, &wgpuInstance));
-    SLANG_RHI_DEFERRED({ api.wgpuInstanceRelease(wgpuInstance); });
-
-    WGPUAdapter wgpuAdapter = {};
-    SLANG_RETURN_ON_FAIL(createWGPUAdapter(api, wgpuInstance, &wgpuAdapter));
-    SLANG_RHI_DEFERRED({ api.wgpuAdapterRelease(wgpuAdapter); });
-
-    WGPUAdapterInfo wgpuAdapterInfo = {};
-    api.wgpuAdapterGetInfo(wgpuAdapter, &wgpuAdapterInfo);
-
-    AdapterInfo info = {};
-    info.deviceType = DeviceType::WGPU;
-    switch (wgpuAdapterInfo.adapterType)
-    {
-    case WGPUAdapterType_DiscreteGPU:
-        info.adapterType = AdapterType::Discrete;
-        break;
-    case WGPUAdapterType_IntegratedGPU:
-        info.adapterType = AdapterType::Integrated;
-        break;
-    case WGPUAdapterType_CPU:
-        info.adapterType = AdapterType::Software;
-        break;
-    default:
-        info.adapterType = AdapterType::Unknown;
-        break;
-    }
-    string::copy_safe(info.name, sizeof(info.name), wgpuAdapterInfo.device.data, wgpuAdapterInfo.device.length);
-    info.vendorID = wgpuAdapterInfo.vendorID;
-    info.deviceID = wgpuAdapterInfo.deviceID;
-
-    Adapter adapter;
-    adapter.m_info = info;
-    adapter.m_isDefault = true;
-    outAdapters.push_back(adapter);
-
-    return SLANG_OK;
-}
-
-std::vector<Adapter>& getAdapters()
-{
-    static std::vector<Adapter> adapters;
-    static Result initResult = getAdaptersImpl(adapters);
-    SLANG_UNUSED(initResult);
-    return adapters;
-}
-
 } // namespace rhi::wgpu
-
-namespace rhi {
-
-IAdapter* getWGPUAdapter(uint32_t index)
-{
-    std::vector<Adapter>& adapters = wgpu::getAdapters();
-    return index < adapters.size() ? &adapters[index] : nullptr;
-}
-
-Result createWGPUDevice(const DeviceDesc* desc, IDevice** outDevice)
-{
-    RefPtr<wgpu::DeviceImpl> result = new wgpu::DeviceImpl();
-    SLANG_RETURN_ON_FAIL(result->initialize(*desc));
-    returnComPtr(outDevice, result);
-    return SLANG_OK;
-}
-
-} // namespace rhi

--- a/src/wgpu/wgpu-device.h
+++ b/src/wgpu/wgpu-device.h
@@ -30,7 +30,7 @@ public:
     RefPtr<CommandQueueImpl> m_queue;
 
     ~DeviceImpl();
-    virtual SLANG_NO_THROW Result SLANG_MCALL initialize(const DeviceDesc& desc) override;
+    Result initialize(const DeviceDesc& desc, BackendImpl* backend);
 
     void reportError(const char* func, WGPUStringView message);
     void reportDeviceLost(WGPUDeviceLostReason reason, WGPUStringView message);
@@ -141,10 +141,3 @@ private:
 };
 
 } // namespace rhi::wgpu
-
-namespace rhi {
-
-IAdapter* getWGPUAdapter(uint32_t index);
-Result createWGPUDevice(const DeviceDesc* desc, IDevice** outDevice);
-
-} // namespace rhi

--- a/src/wgpu/wgpu-surface.cpp
+++ b/src/wgpu/wgpu-surface.cpp
@@ -12,7 +12,7 @@
 namespace rhi::wgpu {
 
 static auto translateWGPUFormat =
-    reverseMap<Format, WGPUTextureFormat>(translateTextureFormat, Format::Undefined, Format::_Count);
+    reverseMap<Format, WGPUTextureFormat, Format::Undefined, Format::_Count>(translateTextureFormat);
 
 SurfaceImpl::~SurfaceImpl()
 {

--- a/src/wgpu/wgpu-utils.cpp
+++ b/src/wgpu/wgpu-utils.cpp
@@ -6,6 +6,82 @@
 
 namespace rhi::wgpu {
 
+WGPUDawnTogglesDescriptor getDawnTogglesDescriptor()
+{
+    // Currently no toggles are needed.
+    static const std::vector<const char*> enabledToggles = {};
+    static const std::vector<const char*> disabledToggles = {};
+    WGPUDawnTogglesDescriptor togglesDesc = {};
+    togglesDesc.chain.sType = WGPUSType_DawnTogglesDescriptor;
+    togglesDesc.enabledToggleCount = enabledToggles.size();
+    togglesDesc.enabledToggles = enabledToggles.data();
+    togglesDesc.disabledToggleCount = disabledToggles.size();
+    togglesDesc.disabledToggles = disabledToggles.data();
+    return togglesDesc;
+}
+
+Result createWGPUInstance(API& api, WGPUInstance* outInstance)
+{
+    WGPUInstanceDescriptor instanceDesc = {};
+    instanceDesc.capabilities.timedWaitAnyEnable = WGPUBool(true);
+    WGPUDawnTogglesDescriptor togglesDesc = getDawnTogglesDescriptor();
+    instanceDesc.nextInChain = &togglesDesc.chain;
+    WGPUInstance instance = api.wgpuCreateInstance(&instanceDesc);
+    if (!instance)
+    {
+        return SLANG_FAIL;
+    }
+    *outInstance = instance;
+    return SLANG_OK;
+}
+
+Result createWGPUAdapter(API& api, WGPUInstance instance, WGPUAdapter* outAdapter)
+{
+    // Request adapter.
+    WGPURequestAdapterOptions options = {};
+    options.powerPreference = WGPUPowerPreference_HighPerformance;
+#if SLANG_WINDOWS_FAMILY
+    // TODO: D3D12 Validation errors prevents use of D3D12, use Vulkan for now.
+    options.backendType = WGPUBackendType_Vulkan;
+#elif SLANG_LINUX_FAMILY
+    options.backendType = WGPUBackendType_Vulkan;
+#endif
+    WGPUDawnTogglesDescriptor togglesDesc = getDawnTogglesDescriptor();
+    options.nextInChain = &togglesDesc.chain;
+
+    WGPUAdapter adapter = {};
+    {
+        WGPURequestAdapterStatus status = WGPURequestAdapterStatus(0);
+        WGPURequestAdapterCallbackInfo callbackInfo = {};
+        callbackInfo.mode = WGPUCallbackMode_WaitAnyOnly;
+        callbackInfo.callback = [](WGPURequestAdapterStatus status_,
+                                   WGPUAdapter adapter_,
+                                   WGPUStringView message,
+                                   void* userdata1,
+                                   void* userdata2)
+        {
+            *(WGPURequestAdapterStatus*)userdata1 = status_;
+            *(WGPUAdapter*)userdata2 = adapter_;
+        };
+        callbackInfo.userdata1 = &status;
+        callbackInfo.userdata2 = &adapter;
+        WGPUFuture future = api.wgpuInstanceRequestAdapter(instance, &options, callbackInfo);
+        WGPUFutureWaitInfo futures[1] = {{future}};
+        uint64_t timeoutNS = UINT64_MAX;
+        WGPUWaitStatus waitStatus = api.wgpuInstanceWaitAny(instance, SLANG_COUNT_OF(futures), futures, timeoutNS);
+        if (waitStatus != WGPUWaitStatus_Success || status != WGPURequestAdapterStatus_Success)
+        {
+            return SLANG_FAIL;
+        }
+    }
+    if (!adapter)
+    {
+        return SLANG_FAIL;
+    }
+    *outAdapter = adapter;
+    return SLANG_OK;
+}
+
 WGPUStringView translateString(const char* str)
 {
     return str ? WGPUStringView{str, ::strlen(str)} : WGPUStringView{nullptr, 0};

--- a/src/wgpu/wgpu-utils.h
+++ b/src/wgpu/wgpu-utils.h
@@ -4,6 +4,8 @@
 
 #include "wgpu-api.h"
 
+#include <vector>
+
 namespace rhi::wgpu {
 
 WGPUStringView translateString(const char* str);
@@ -30,5 +32,81 @@ WGPUBlendOperation translateBlendOperation(BlendOp op);
 
 WGPULoadOp translateLoadOp(LoadOp op);
 WGPUStoreOp translateStoreOp(StoreOp op);
+
+inline WGPUDawnTogglesDescriptor getDawnTogglesDescriptor()
+{
+    // Currently no toggles are needed.
+    static const std::vector<const char*> enabledToggles = {};
+    static const std::vector<const char*> disabledToggles = {};
+    WGPUDawnTogglesDescriptor togglesDesc = {};
+    togglesDesc.chain.sType = WGPUSType_DawnTogglesDescriptor;
+    togglesDesc.enabledToggleCount = enabledToggles.size();
+    togglesDesc.enabledToggles = enabledToggles.data();
+    togglesDesc.disabledToggleCount = disabledToggles.size();
+    togglesDesc.disabledToggles = disabledToggles.data();
+    return togglesDesc;
+}
+
+inline Result createWGPUInstance(API& api, WGPUInstance* outInstance)
+{
+    WGPUInstanceDescriptor instanceDesc = {};
+    instanceDesc.capabilities.timedWaitAnyEnable = WGPUBool(true);
+    WGPUDawnTogglesDescriptor togglesDesc = getDawnTogglesDescriptor();
+    instanceDesc.nextInChain = &togglesDesc.chain;
+    WGPUInstance instance = api.wgpuCreateInstance(&instanceDesc);
+    if (!instance)
+    {
+        return SLANG_FAIL;
+    }
+    *outInstance = instance;
+    return SLANG_OK;
+}
+
+inline Result createWGPUAdapter(API& api, WGPUInstance instance, WGPUAdapter* outAdapter)
+{
+    // Request adapter.
+    WGPURequestAdapterOptions options = {};
+    options.powerPreference = WGPUPowerPreference_HighPerformance;
+#if SLANG_WINDOWS_FAMILY
+    // TODO: D3D12 Validation errors prevents use of D3D12, use Vulkan for now.
+    options.backendType = WGPUBackendType_Vulkan;
+#elif SLANG_LINUX_FAMILY
+    options.backendType = WGPUBackendType_Vulkan;
+#endif
+    WGPUDawnTogglesDescriptor togglesDesc = getDawnTogglesDescriptor();
+    options.nextInChain = &togglesDesc.chain;
+
+    WGPUAdapter adapter = {};
+    {
+        WGPURequestAdapterStatus status = WGPURequestAdapterStatus(0);
+        WGPURequestAdapterCallbackInfo callbackInfo = {};
+        callbackInfo.mode = WGPUCallbackMode_WaitAnyOnly;
+        callbackInfo.callback = [](WGPURequestAdapterStatus status_,
+                                   WGPUAdapter adapter_,
+                                   WGPUStringView message,
+                                   void* userdata1,
+                                   void* userdata2)
+        {
+            *(WGPURequestAdapterStatus*)userdata1 = status_;
+            *(WGPUAdapter*)userdata2 = adapter_;
+        };
+        callbackInfo.userdata1 = &status;
+        callbackInfo.userdata2 = &adapter;
+        WGPUFuture future = api.wgpuInstanceRequestAdapter(instance, &options, callbackInfo);
+        WGPUFutureWaitInfo futures[1] = {{future}};
+        uint64_t timeoutNS = UINT64_MAX;
+        WGPUWaitStatus waitStatus = api.wgpuInstanceWaitAny(instance, SLANG_COUNT_OF(futures), futures, timeoutNS);
+        if (waitStatus != WGPUWaitStatus_Success || status != WGPURequestAdapterStatus_Success)
+        {
+            return SLANG_FAIL;
+        }
+    }
+    if (!adapter)
+    {
+        return SLANG_FAIL;
+    }
+    *outAdapter = adapter;
+    return SLANG_OK;
+}
 
 } // namespace rhi::wgpu

--- a/src/wgpu/wgpu-utils.h
+++ b/src/wgpu/wgpu-utils.h
@@ -8,6 +8,10 @@
 
 namespace rhi::wgpu {
 
+WGPUDawnTogglesDescriptor getDawnTogglesDescriptor();
+Result createWGPUInstance(API& api, WGPUInstance* outInstance);
+Result createWGPUAdapter(API& api, WGPUInstance instance, WGPUAdapter* outAdapter);
+
 WGPUStringView translateString(const char* str);
 
 WGPUTextureFormat translateTextureFormat(Format format);
@@ -32,81 +36,5 @@ WGPUBlendOperation translateBlendOperation(BlendOp op);
 
 WGPULoadOp translateLoadOp(LoadOp op);
 WGPUStoreOp translateStoreOp(StoreOp op);
-
-inline WGPUDawnTogglesDescriptor getDawnTogglesDescriptor()
-{
-    // Currently no toggles are needed.
-    static const std::vector<const char*> enabledToggles = {};
-    static const std::vector<const char*> disabledToggles = {};
-    WGPUDawnTogglesDescriptor togglesDesc = {};
-    togglesDesc.chain.sType = WGPUSType_DawnTogglesDescriptor;
-    togglesDesc.enabledToggleCount = enabledToggles.size();
-    togglesDesc.enabledToggles = enabledToggles.data();
-    togglesDesc.disabledToggleCount = disabledToggles.size();
-    togglesDesc.disabledToggles = disabledToggles.data();
-    return togglesDesc;
-}
-
-inline Result createWGPUInstance(API& api, WGPUInstance* outInstance)
-{
-    WGPUInstanceDescriptor instanceDesc = {};
-    instanceDesc.capabilities.timedWaitAnyEnable = WGPUBool(true);
-    WGPUDawnTogglesDescriptor togglesDesc = getDawnTogglesDescriptor();
-    instanceDesc.nextInChain = &togglesDesc.chain;
-    WGPUInstance instance = api.wgpuCreateInstance(&instanceDesc);
-    if (!instance)
-    {
-        return SLANG_FAIL;
-    }
-    *outInstance = instance;
-    return SLANG_OK;
-}
-
-inline Result createWGPUAdapter(API& api, WGPUInstance instance, WGPUAdapter* outAdapter)
-{
-    // Request adapter.
-    WGPURequestAdapterOptions options = {};
-    options.powerPreference = WGPUPowerPreference_HighPerformance;
-#if SLANG_WINDOWS_FAMILY
-    // TODO: D3D12 Validation errors prevents use of D3D12, use Vulkan for now.
-    options.backendType = WGPUBackendType_Vulkan;
-#elif SLANG_LINUX_FAMILY
-    options.backendType = WGPUBackendType_Vulkan;
-#endif
-    WGPUDawnTogglesDescriptor togglesDesc = getDawnTogglesDescriptor();
-    options.nextInChain = &togglesDesc.chain;
-
-    WGPUAdapter adapter = {};
-    {
-        WGPURequestAdapterStatus status = WGPURequestAdapterStatus(0);
-        WGPURequestAdapterCallbackInfo callbackInfo = {};
-        callbackInfo.mode = WGPUCallbackMode_WaitAnyOnly;
-        callbackInfo.callback = [](WGPURequestAdapterStatus status_,
-                                   WGPUAdapter adapter_,
-                                   WGPUStringView message,
-                                   void* userdata1,
-                                   void* userdata2)
-        {
-            *(WGPURequestAdapterStatus*)userdata1 = status_;
-            *(WGPUAdapter*)userdata2 = adapter_;
-        };
-        callbackInfo.userdata1 = &status;
-        callbackInfo.userdata2 = &adapter;
-        WGPUFuture future = api.wgpuInstanceRequestAdapter(instance, &options, callbackInfo);
-        WGPUFutureWaitInfo futures[1] = {{future}};
-        uint64_t timeoutNS = UINT64_MAX;
-        WGPUWaitStatus waitStatus = api.wgpuInstanceWaitAny(instance, SLANG_COUNT_OF(futures), futures, timeoutNS);
-        if (waitStatus != WGPUWaitStatus_Success || status != WGPURequestAdapterStatus_Success)
-        {
-            return SLANG_FAIL;
-        }
-    }
-    if (!adapter)
-    {
-        return SLANG_FAIL;
-    }
-    *outAdapter = adapter;
-    return SLANG_OK;
-}
 
 } // namespace rhi::wgpu

--- a/tests/main.cpp
+++ b/tests/main.cpp
@@ -102,6 +102,8 @@ int main(int argc, const char** argv)
 
     rhi::testing::cleanupTestTempDirectories();
 
+    rhi::destroyRHI();
+
 #if SLANG_RHI_ENABLE_REF_OBJECT_TRACKING
     if (!rhi::RefObjectTracker::instance().objects.empty())
     {


### PR DESCRIPTION
## Clean up static/global state to fix leaked objects on shutdown

Static objects (global task pool, Aftermath crash dumper, backend instances, reverse-map lookup tables) were persisting past the test harness's leak detection, causing false positives.

### Changes

- **Add `rhiDestroyInstance()` / `rhi::destroyRHI()` API** to explicitly tear down the global RHI singleton, releasing backends, the global task pool, and the Aftermath crash dumper. The RHI singleton is now heap-allocated (`new`/`delete`) rather than a Meyer's singleton, so it can be fully destroyed and re-created.
- **Add `AftermathCrashDumper::clear()`** to release the static Aftermath instance during `RHI::destroy()`.
- **Replace `reverseMap` heap-allocated `std::unordered_map`** with a stack-allocated `std::array` using linear search, eliminating static map objects that leaked on shutdown.
- **Remove static `std::unordered_map` instances in device code** that were persisting after device destruction.
- **Call `rhi::destroyRHI()` in test teardown** (main.cpp) before leak detection runs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added RHI instance destruction API to explicitly tear down the global RHI and free resources.

* **New Features**
  * Added multiple new backend implementations (CPU, D3D11, D3D12, Vulkan, Metal, CUDA, WGPU) with runtime backend factories.

* **Refactor**
  * Unified backend interface and moved adapter enumeration/device creation into per-backend implementations; device initialization now routes through backends.

* **Tests**
  * Test harness now explicitly destroys RHI before leak checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->