### PR TITLE
Cleanup static initialization (part 2)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -589,6 +589,19 @@ target_compile_options(slang-rhi-warnings-as-errors INTERFACE
 )
 target_link_libraries(slang-rhi PRIVATE slang-rhi-warnings slang-rhi-warnings-as-errors)
 
+# Make using non-trivial static variables in slang-rhi a compile error.
+# This avoids issues with DSOs and static initialization order.
+target_compile_options(slang-rhi PRIVATE
+    $<$<CXX_COMPILER_ID:Clang>:
+        -Wglobal-constructors
+        -Wexit-time-destructors
+    >
+    $<$<CXX_COMPILER_ID:AppleClang>:
+        -Wglobal-constructors
+        -Wexit-time-destructors
+    >
+)
+
 target_sources(slang-rhi PRIVATE
     src/aftermath.cpp
     src/command-buffer.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -504,7 +504,12 @@ list(SORT SLANG_RHI_OPTIX_VERSIONS_SORTED COMPARE NATURAL)
 list(REVERSE SLANG_RHI_OPTIX_VERSIONS_SORTED)
 set(SLANG_RHI_OPTIX_VERSIONS_X "")
 foreach(ver IN LISTS SLANG_RHI_OPTIX_VERSIONS_SORTED)
-    string(APPEND SLANG_RHI_OPTIX_VERSIONS_X " x(v${ver})")
+    # Compute OptiX version integer (major * 10000 + minor * 100)
+    string(REPLACE "_" ";" ver_parts "${ver}")
+    list(GET ver_parts 0 ver_major)
+    list(GET ver_parts 1 ver_minor)
+    math(EXPR ver_int "${ver_major} * 10000 + ${ver_minor} * 100")
+    string(APPEND SLANG_RHI_OPTIX_VERSIONS_X " x(v${ver}, ${ver_int})")
 endforeach()
 
 # Generate config header

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -596,10 +596,6 @@ target_compile_options(slang-rhi PRIVATE
         -Wglobal-constructors
         -Wexit-time-destructors
     >
-    $<$<CXX_COMPILER_ID:AppleClang>:
-        -Wglobal-constructors
-        -Wexit-time-destructors
-    >
 )
 
 target_sources(slang-rhi PRIVATE

--- a/src/aftermath.cpp
+++ b/src/aftermath.cpp
@@ -266,7 +266,9 @@ const std::string* AftermathCrashDumper::findMarker(uint64_t hash)
     return nullptr;
 }
 
+SLANG_RHI_STATIC_MUTEX_BEGIN
 static std::mutex s_aftermathCrashDumperMutex;
+SLANG_RHI_STATIC_MUTEX_END
 static RefPtr<AftermathCrashDumper> s_aftermathCrashDumper;
 
 AftermathCrashDumper* AftermathCrashDumper::getOrCreate()

--- a/src/core/block-allocator.h
+++ b/src/core/block-allocator.h
@@ -196,7 +196,9 @@ private:                                                                        
 /// The allocator is constexpr-constructed, requiring no static constructor.
 /// releasePages() must be called at shutdown to free memory.
 #define SLANG_RHI_IMPLEMENT_BLOCK_ALLOCATED(ClassName)                                                                 \
+    SLANG_RHI_STATIC_MUTEX_BEGIN                                                                                       \
     ClassName::BlockAllocatorType ClassName::s_allocator;                                                              \
+    SLANG_RHI_STATIC_MUTEX_END                                                                                         \
                                                                                                                        \
     ClassName::BlockAllocatorType& ClassName::getAllocator()                                                           \
     {                                                                                                                  \

--- a/src/core/block-allocator.h
+++ b/src/core/block-allocator.h
@@ -9,22 +9,29 @@ namespace rhi {
 /// Allocates fixed-size blocks of sizeof(T) out of larger pages.
 /// Thread-safe for concurrent allocations and deallocations using a mutex.
 ///
-/// This allocator never frees pages, which means it can only
-/// grow in size and never shrink.
-template<typename T>
+/// Designed to be safe for use as a static/global variable without relying
+/// on static constructors or destructors (avoiding DSO/shared library
+/// initialization order hazards). The constructor is constexpr, so static
+/// instances are constant-initialized by the compiler. The destructor is
+/// intentionally trivial and does NOT free pages. Call releasePages()
+/// manually before the allocator goes out of scope to avoid memory leaks.
+template<typename T, size_t BlocksPerPage = 256>
 class BlockAllocator
 {
 public:
-    /// Constructor
-    /// @param blocksPerPage Number of blocks to allocate per page (default: 256).
-    BlockAllocator(size_t blocksPerPage = 256)
-        : m_blocksPerPage(blocksPerPage)
-    {
-        SLANG_RHI_ASSERT(blocksPerPage > 0);
-    }
+    constexpr BlockAllocator() = default;
+    ~BlockAllocator() = default;
 
-    /// Destructor - frees all pages (NOT thread safe).
-    ~BlockAllocator()
+    // Non-copyable, non-movable
+    BlockAllocator(const BlockAllocator&) = delete;
+    BlockAllocator& operator=(const BlockAllocator&) = delete;
+    BlockAllocator(BlockAllocator&&) = delete;
+    BlockAllocator& operator=(BlockAllocator&&) = delete;
+
+    /// Release all pages and reset the allocator (NOT thread safe).
+    /// Must be called manually to free memory, as the destructor is trivial.
+    /// After calling this, the allocator is empty and can be reused.
+    void releasePages()
     {
         Page* page = m_pageListHead;
         while (page)
@@ -33,16 +40,13 @@ public:
             std::free(page);
             page = next;
         }
+        m_pageListHead = nullptr;
+        m_freeList = nullptr;
+        m_numPages = 0;
     }
 
-    // Non-copyable, non-movable
-    BlockAllocator(const BlockAllocator&) = delete;
-    BlockAllocator& operator=(const BlockAllocator&) = delete;
-    BlockAllocator(BlockAllocator&&) = delete;
-    BlockAllocator& operator=(BlockAllocator&&) = delete;
-
     /// Allocate a block (thread safe).
-    /// @return Pointer to allocated block, or nullptr if allocation fails
+    /// @return Pointer to an uninitialized block, or nullptr if allocation fails.
     T* allocate()
     {
         std::lock_guard<std::mutex> lock(m_mutex);
@@ -55,8 +59,9 @@ public:
         return allocateFromNewPageLocked();
     }
 
-    /// Free a block (thread safe).
-    /// @param ptr Pointer to block to free
+    /// Return a block to the free list (thread safe).
+    /// The caller is responsible for destroying the object before calling this.
+    /// @param ptr Pointer to block to free. No-op if nullptr.
     void free(T* ptr)
     {
         if (!ptr)
@@ -80,7 +85,7 @@ public:
         while (page)
         {
             uintptr_t pageStart = reinterpret_cast<uintptr_t>(page->blocks);
-            uintptr_t pageEnd = pageStart + m_blocksPerPage * sizeof(Block);
+            uintptr_t pageEnd = pageStart + BlocksPerPage * sizeof(Block);
             if (addr >= pageStart && addr < pageEnd)
             {
                 return true;
@@ -90,14 +95,15 @@ public:
         return false;
     }
 
-    /// Reset the allocator, rebuilding the free list from all pages (NOT thread safe).
+    /// Reset the free list to contain all blocks from all pages (NOT thread safe).
+    /// Does not free any pages. Useful for bulk-recycling all blocks without releasing memory.
     void reset()
     {
         FreeBlock* head = nullptr;
         Page* page = m_pageListHead;
         while (page)
         {
-            for (size_t i = 0; i < m_blocksPerPage; ++i)
+            for (size_t i = 0; i < BlocksPerPage; ++i)
             {
                 FreeBlock* block = reinterpret_cast<FreeBlock*>(&page->blocks[i]);
                 block->next = head;
@@ -121,18 +127,18 @@ private:
         FreeBlock* next;
     };
 
-    /// A block must be large enough to hold either T or a FreeBlock.
+    /// A block is a union large enough to hold either T or a FreeBlock pointer.
     union Block
     {
         alignas(T) uint8_t data[sizeof(T)];
-        FreeBlock freeBlock; // Used when block is free
+        FreeBlock freeBlock;
     };
 
     static_assert(sizeof(Block) >= sizeof(FreeBlock*), "Block must be large enough to hold a pointer");
     static_assert(alignof(Block) >= alignof(T), "Block alignment must be sufficient for T");
 
-    /// A page contains multiple blocks and a link to the next page.
-    /// Note: blocks[1] is a flexible array member pattern - actual size is m_blocksPerPage.
+    /// A page holds BlocksPerPage blocks and links to the next page.
+    /// blocks[1] is a C-style flexible array; actual allocation is BlocksPerPage blocks.
     struct Page
     {
         Page* next;
@@ -144,7 +150,7 @@ private:
     T* allocateFromNewPageLocked()
     {
         // Allocate a new page
-        size_t pageSize = sizeof(Page) + (m_blocksPerPage - 1) * sizeof(Block);
+        size_t pageSize = sizeof(Page) + (BlocksPerPage - 1) * sizeof(Block);
         Page* page = reinterpret_cast<Page*>(std::malloc(pageSize));
         if (!page)
         {
@@ -157,7 +163,7 @@ private:
         m_numPages++;
 
         // Generate free list from all except first block.
-        for (size_t i = 1; i < m_blocksPerPage; ++i)
+        for (size_t i = 1; i < BlocksPerPage; ++i)
         {
             FreeBlock* block = reinterpret_cast<FreeBlock*>(&page->blocks[i]);
             block->next = m_freeList;
@@ -168,7 +174,6 @@ private:
         return reinterpret_cast<T*>(&page->blocks[0]);
     }
 
-    size_t m_blocksPerPage;
     FreeBlock* m_freeList{nullptr};
     mutable std::mutex m_mutex; // Protects all operations
     Page* m_pageListHead{nullptr};
@@ -176,20 +181,27 @@ private:
 };
 
 /// Macro to declare block allocator support for a class.
-/// The block size is automatically determined from sizeof(ClassName).
-#define SLANG_RHI_DECLARE_BLOCK_ALLOCATED(ClassName)                                                                   \
+/// Overrides operator new/delete to use a static BlockAllocator instance.
+#define SLANG_RHI_DECLARE_BLOCK_ALLOCATED(ClassName, BlocksPerPage)                                                    \
 public:                                                                                                                \
+    using BlockAllocatorType = ::rhi::BlockAllocator<ClassName, BlocksPerPage>;                                        \
     void* operator new(size_t count);                                                                                  \
     void operator delete(void* ptr);                                                                                   \
+    static BlockAllocatorType& getAllocator();                                                                         \
                                                                                                                        \
 private:                                                                                                               \
-    static ::rhi::BlockAllocator<ClassName> s_allocator;
+    static BlockAllocatorType s_allocator;
 
-/// Macro to implement block allocator operators in .cpp file.
-/// @param ClassName The class name to implement block allocation for.
-/// @param BlocksPerPage Number of blocks to allocate per page.
-#define SLANG_RHI_IMPLEMENT_BLOCK_ALLOCATED(ClassName, BlocksPerPage)                                                  \
-    ::rhi::BlockAllocator<ClassName> ClassName::s_allocator(BlocksPerPage);                                            \
+/// Macro to implement block allocator operators in a .cpp file.
+/// The allocator is constexpr-constructed, requiring no static constructor.
+/// releasePages() must be called at shutdown to free memory.
+#define SLANG_RHI_IMPLEMENT_BLOCK_ALLOCATED(ClassName)                                                                 \
+    ClassName::BlockAllocatorType ClassName::s_allocator;                                                              \
+                                                                                                                       \
+    ClassName::BlockAllocatorType& ClassName::getAllocator()                                                           \
+    {                                                                                                                  \
+        return s_allocator;                                                                                            \
+    }                                                                                                                  \
                                                                                                                        \
     void* ClassName::operator new(size_t count)                                                                        \
     {                                                                                                                  \

--- a/src/core/common.h
+++ b/src/core/common.h
@@ -22,7 +22,7 @@
 // Clang < 16 warns about global constructors/exit-time destructors for std::mutex,
 // even though it has a trivial destructor. Clang 16+ recognizes its constexpr constructor
 // and no longer emits these warnings.
-#if defined(__clang__) && (defined(__apple_build_version__) || __clang_major__ < 16)
+#if defined(__clang__) && (__clang_major__ < 16)
 // clang-format off
 #define SLANG_RHI_STATIC_MUTEX_BEGIN                                                                                   \
     _Pragma("clang diagnostic push")                                                                                   \

--- a/src/core/common.h
+++ b/src/core/common.h
@@ -22,7 +22,7 @@
 // Clang < 16 warns about global constructors/exit-time destructors for std::mutex,
 // even though it has a trivial destructor. Clang 16+ recognizes its constexpr constructor
 // and no longer emits these warnings.
-#if defined(__clang__) && __clang_major__ < 16
+#if defined(__clang__) && (defined(__apple_build_version__) || __clang_major__ < 16)
 // clang-format off
 #define SLANG_RHI_STATIC_MUTEX_BEGIN                                                                                   \
     _Pragma("clang diagnostic push")                                                                                   \

--- a/src/core/common.h
+++ b/src/core/common.h
@@ -18,6 +18,24 @@
 #include "string.h"
 #include "struct-holder.h"
 
+// Suppress clang warnings for static std::mutex declarations.
+// Clang < 16 warns about global constructors/exit-time destructors for std::mutex,
+// even though it has a trivial destructor. Clang 16+ recognizes its constexpr constructor
+// and no longer emits these warnings.
+#if defined(__clang__) && __clang_major__ < 16
+// clang-format off
+#define SLANG_RHI_STATIC_MUTEX_BEGIN                                                                                   \
+    _Pragma("clang diagnostic push")                                                                                   \
+    _Pragma("clang diagnostic ignored \"-Wglobal-constructors\"")                                                      \
+    _Pragma("clang diagnostic ignored \"-Wexit-time-destructors\"")
+#define SLANG_RHI_STATIC_MUTEX_END                                                                                     \
+    _Pragma("clang diagnostic pop")
+// clang-format on
+#else
+#define SLANG_RHI_STATIC_MUTEX_BEGIN
+#define SLANG_RHI_STATIC_MUTEX_END
+#endif
+
 namespace rhi {
 
 // A type cast that is safer than static_cast in debug builds, and is a simple static_cast in release builds.

--- a/src/core/reverse-map.h
+++ b/src/core/reverse-map.h
@@ -1,32 +1,19 @@
 #pragma once
 
-#include <array>
-
 namespace rhi {
 
-/// Given a mapping function, create a reverse map from To to From.
-/// The mapping function func must be bijective.
-/// The reverse map will return defaultValue if the value is not found.
+/// Given a forward mapping function, perform a reverse lookup from To to From.
+/// Iterates over all values in [min, max) and returns the first From whose forward mapping equals value.
+/// Returns defaultValue if no match is found.
 template<typename From, typename To, From min, From max, typename Func>
-auto reverseMap(Func func, From defaultValue = From(0))
+From reverseMapLookup(Func func, To value, From defaultValue = From(0))
 {
-    constexpr size_t size = size_t(max) - size_t(min) + 1;
-    static std::array<std::pair<To, From>, size> data = [&]()
+    for (int i = int(min); i < int(max); i++)
     {
-        std::array<std::pair<To, From>, size> arr{};
-        for (size_t i = 0; i < size; i++)
-        {
-            arr[i] = {func(From(int(min) + int(i))), From(int(min) + int(i))};
-        }
-        return arr;
-    }();
-    return [defaultValue](To value) -> From
-    {
-        for (const auto& [k, v] : data)
-            if (k == value)
-                return v;
-        return defaultValue;
-    };
+        if (func(From(i)) == value)
+            return From(i);
+    }
+    return defaultValue;
 }
 
 } // namespace rhi

--- a/src/core/reverse-map.h
+++ b/src/core/reverse-map.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <type_traits>
+
 namespace rhi {
 
 /// Given a forward mapping function, perform a reverse lookup from To to From.
@@ -8,10 +10,11 @@ namespace rhi {
 template<typename From, typename To, From min, From max, typename Func>
 From reverseMapLookup(Func func, To value, From defaultValue = From(0))
 {
-    for (int i = int(min); i < int(max); i++)
+    using U = std::underlying_type_t<From>;
+    for (U i = static_cast<U>(min); i < static_cast<U>(max); i++)
     {
-        if (func(From(i)) == value)
-            return From(i);
+        if (func(static_cast<From>(i)) == value)
+            return static_cast<From>(i);
     }
     return defaultValue;
 }

--- a/src/core/task-pool.cpp
+++ b/src/core/task-pool.cpp
@@ -611,8 +611,7 @@ void ThreadedTaskPool::releaseTaskGroup(TaskGroupHandle group)
 // ----------------------------------------------------------------------------
 
 static std::mutex s_globalTaskPoolMutex;
-static ComPtr<ITaskPool> s_globalTaskPool;
-static std::atomic<ITaskPool*> s_cachedGlobalTaskPool{nullptr};
+static ITaskPool* s_globalTaskPool;
 
 // WARNING: setGlobalTaskPool must only be called when no devices are alive
 // and no other threads are using the global task pool. Calling it concurrently
@@ -620,8 +619,11 @@ static std::atomic<ITaskPool*> s_cachedGlobalTaskPool{nullptr};
 Result setGlobalTaskPool(ITaskPool* taskPool)
 {
     std::lock_guard<std::mutex> lock(s_globalTaskPoolMutex);
+    if (s_globalTaskPool)
+        s_globalTaskPool->release();
     s_globalTaskPool = taskPool;
-    s_cachedGlobalTaskPool.store(taskPool, std::memory_order_release);
+    if (s_globalTaskPool)
+        s_globalTaskPool->addRef();
     return SLANG_OK;
 }
 
@@ -641,18 +643,13 @@ Result initGlobalTaskPool(int workerCount)
 
 ITaskPool* globalTaskPool()
 {
-    ITaskPool* cached = s_cachedGlobalTaskPool.load(std::memory_order_acquire);
-    if (cached)
-    {
-        return cached;
-    }
     std::lock_guard<std::mutex> lock(s_globalTaskPoolMutex);
     if (!s_globalTaskPool)
     {
         s_globalTaskPool = new ThreadedTaskPool(-1);
+        s_globalTaskPool->addRef();
     }
-    s_cachedGlobalTaskPool.store(s_globalTaskPool.get(), std::memory_order_release);
-    return s_globalTaskPool.get();
+    return s_globalTaskPool;
 }
 
 } // namespace rhi

--- a/src/core/task-pool.cpp
+++ b/src/core/task-pool.cpp
@@ -610,7 +610,9 @@ void ThreadedTaskPool::releaseTaskGroup(TaskGroupHandle group)
 // Global task pool
 // ----------------------------------------------------------------------------
 
+SLANG_RHI_STATIC_MUTEX_BEGIN
 static std::mutex s_globalTaskPoolMutex;
+SLANG_RHI_STATIC_MUTEX_END
 static ITaskPool* s_globalTaskPool;
 
 // WARNING: setGlobalTaskPool must only be called when no devices are alive

--- a/src/cpu/cpu-texture.cpp
+++ b/src/cpu/cpu-texture.cpp
@@ -112,6 +112,8 @@ static constexpr auto g_formatInfoMap = makeFormatInfoMap();
 
 const CPUTextureFormatInfo* _getFormatInfo(Format format)
 {
+    if (size_t(format) >= size_t(Format::_Count))
+        return nullptr;
     const CPUTextureFormatInfo& info = g_formatInfoMap[size_t(format)];
     return info.unpackFunc ? &info : nullptr;
 }

--- a/src/cpu/cpu-texture.cpp
+++ b/src/cpu/cpu-texture.cpp
@@ -1,6 +1,8 @@
 #include "cpu-texture.h"
 #include "cpu-device.h"
 
+#include <array>
+
 namespace rhi::cpu {
 
 inline const CPUTextureBaseShapeInfo* _getBaseShapeInfo(TextureType baseShape)
@@ -79,6 +81,39 @@ void _unpackUInt32Texel(const void* texelData, void* outData, size_t outSize)
         temp[i] = input[i];
 
     memcpy(outData, temp, outSize);
+}
+
+static constexpr auto makeFormatInfoMap()
+{
+    std::array<CPUTextureFormatInfo, size_t(Format::_Count)> infos{};
+
+    infos[size_t(Format::RGBA32Uint)] = {&_unpackUInt32Texel<4>};
+
+    infos[size_t(Format::RGBA32Float)] = {&_unpackFloatTexel<4>};
+    infos[size_t(Format::RGB32Float)] = {&_unpackFloatTexel<3>};
+
+    infos[size_t(Format::RG32Float)] = {&_unpackFloatTexel<2>};
+    infos[size_t(Format::R32Float)] = {&_unpackFloatTexel<1>};
+
+    infos[size_t(Format::RGBA16Float)] = {&_unpackFloat16Texel<4>};
+    infos[size_t(Format::RG16Float)] = {&_unpackFloat16Texel<2>};
+    infos[size_t(Format::R16Float)] = {&_unpackFloat16Texel<1>};
+
+    infos[size_t(Format::RGBA8Unorm)] = {&_unpackUnorm8Texel<4>};
+    infos[size_t(Format::BGRA8Unorm)] = {&_unpackUnormBGRA8Texel};
+    infos[size_t(Format::R16Uint)] = {&_unpackUInt16Texel<1>};
+    infos[size_t(Format::R32Uint)] = {&_unpackUInt32Texel<1>};
+    infos[size_t(Format::D32Float)] = {&_unpackFloatTexel<1>};
+
+    return infos;
+}
+
+static constexpr auto g_formatInfoMap = makeFormatInfoMap();
+
+const CPUTextureFormatInfo* _getFormatInfo(Format format)
+{
+    const CPUTextureFormatInfo& info = g_formatInfoMap[size_t(format)];
+    return info.unpackFunc ? &info : nullptr;
 }
 
 TextureImpl::TextureImpl(Device* device, const TextureDesc& desc)

--- a/src/cpu/cpu-texture.h
+++ b/src/cpu/cpu-texture.h
@@ -52,49 +52,7 @@ void _unpackUInt16Texel(const void* texelData, void* outData, size_t outSize);
 template<int N>
 void _unpackUInt32Texel(const void* texelData, void* outData, size_t outSize);
 
-struct CPUFormatInfoMap
-{
-    CPUFormatInfoMap()
-    {
-        memset(m_infos, 0, sizeof(m_infos));
-
-        set(Format::RGBA32Uint, &_unpackUInt32Texel<4>);
-
-        set(Format::RGBA32Float, &_unpackFloatTexel<4>);
-        set(Format::RGB32Float, &_unpackFloatTexel<3>);
-
-        set(Format::RG32Float, &_unpackFloatTexel<2>);
-        set(Format::R32Float, &_unpackFloatTexel<1>);
-
-        set(Format::RGBA16Float, &_unpackFloat16Texel<4>);
-        set(Format::RG16Float, &_unpackFloat16Texel<2>);
-        set(Format::R16Float, &_unpackFloat16Texel<1>);
-
-        set(Format::RGBA8Unorm, &_unpackUnorm8Texel<4>);
-        set(Format::BGRA8Unorm, &_unpackUnormBGRA8Texel);
-        set(Format::R16Uint, &_unpackUInt16Texel<1>);
-        set(Format::R32Uint, &_unpackUInt32Texel<1>);
-        set(Format::D32Float, &_unpackFloatTexel<1>);
-    }
-
-    void set(Format format, CPUTextureUnpackFunc func)
-    {
-        auto& info = m_infos[size_t(format)];
-        info.unpackFunc = func;
-    }
-
-    SLANG_FORCE_INLINE const CPUTextureFormatInfo& get(Format format) const { return m_infos[size_t(format)]; }
-
-    CPUTextureFormatInfo m_infos[size_t(Format::_Count)];
-};
-
-static const CPUFormatInfoMap g_formatInfoMap;
-
-inline const CPUTextureFormatInfo* _getFormatInfo(Format format)
-{
-    const CPUTextureFormatInfo& info = g_formatInfoMap.get(format);
-    return info.unpackFunc ? &info : nullptr;
-}
+const CPUTextureFormatInfo* _getFormatInfo(Format format);
 
 class TextureImpl : public Texture
 {

--- a/src/cuda-driver-api.cpp
+++ b/src/cuda-driver-api.cpp
@@ -4,6 +4,7 @@
 
 #if SLANG_RHI_USE_DYNAMIC_CUDA
 
+#include "core/common.h"
 #include "core/platform.h"
 
 #include <cstdio>
@@ -11,7 +12,9 @@
 
 #include <mutex>
 
+SLANG_RHI_STATIC_MUTEX_BEGIN
 static std::mutex sCudaModuleMutex;
+SLANG_RHI_STATIC_MUTEX_END
 static int sCudaModuleRefCount;
 static rhi::SharedLibraryHandle sCudaModule;
 

--- a/src/cuda-driver-api.cpp
+++ b/src/cuda-driver-api.cpp
@@ -11,13 +11,15 @@
 
 #include <mutex>
 
-static std::recursive_mutex sCudaModuleMutex;
-static int sCudaModuleRefCount = 0;
+static std::mutex sCudaModuleMutex;
+static int sCudaModuleRefCount;
 static rhi::SharedLibraryHandle sCudaModule;
+
+static void shutdownImpl();
 
 extern "C" bool rhiCudaDriverApiInit()
 {
-    std::lock_guard<std::recursive_mutex> lock(sCudaModuleMutex);
+    std::lock_guard<std::mutex> lock(sCudaModuleMutex);
 
     if (sCudaModule)
     {
@@ -161,7 +163,7 @@ extern "C" bool rhiCudaDriverApiInit()
 
     if (symbol)
     {
-        rhiCudaDriverApiShutdown();
+        shutdownImpl();
         printf("rhiCudaDriverApiInit(): could not find symbol \"%s\"\n", symbol);
         return false;
     }
@@ -170,10 +172,8 @@ extern "C" bool rhiCudaDriverApiInit()
     return true;
 }
 
-extern "C" void rhiCudaDriverApiShutdown()
+static void shutdownImpl()
 {
-    std::lock_guard<std::recursive_mutex> lock(sCudaModuleMutex);
-
     if (!sCudaModule)
         return;
     sCudaModuleRefCount--;
@@ -279,6 +279,12 @@ extern "C" void rhiCudaDriverApiShutdown()
 
     rhi::unloadSharedLibrary(sCudaModule);
     sCudaModule = nullptr;
+}
+
+extern "C" void rhiCudaDriverApiShutdown()
+{
+    std::lock_guard<std::mutex> lock(sCudaModuleMutex);
+    shutdownImpl();
 }
 
 #else // SLANG_RHI_USE_DYNAMIC_CUDA

--- a/src/cuda/cuda-surface.cpp
+++ b/src/cuda/cuda-surface.cpp
@@ -109,7 +109,10 @@ public:
     virtual SLANG_NO_THROW Result SLANG_MCALL present() override;
 };
 
-static auto translateVkFormat = reverseMap<Format, VkFormat, Format::Undefined, Format::_Count>(vk::getVkFormat);
+static Format translateVkFormat(VkFormat format)
+{
+    return reverseMapLookup<Format, VkFormat, Format::Undefined, Format::_Count>(vk::getVkFormat, format);
+}
 
 SurfaceImpl::~SurfaceImpl()
 {

--- a/src/cuda/optix-api-impl.cpp
+++ b/src/cuda/optix-api-impl.cpp
@@ -1645,8 +1645,6 @@ Result createContext(const ContextDesc& desc, Context** outContext)
     return SLANG_OK;
 }
 
-uint32_t optixVersion = OPTIX_VERSION;
-
 bool initialize(IDebugCallback* debugCallback)
 {
     OptixResult result = optixInit();

--- a/src/cuda/optix-api.cpp
+++ b/src/cuda/optix-api.cpp
@@ -1,12 +1,12 @@
 #include "optix-api.h"
 
 #include "cuda-device.h"
+#include "core/common.h"
 
 #if SLANG_RHI_ENABLE_OPTIX
 
-#define IMPORT_OPTIX_API(tag)                                                                                          \
+#define IMPORT_OPTIX_API(tag, version)                                                                                 \
     namespace rhi::cuda::optix::tag {                                                                                  \
-    extern uint32_t optixVersion;                                                                                      \
     bool initialize(IDebugCallback* debugCallback);                                                                    \
     Result createContext(const ContextDesc& desc, Context** outContext);                                               \
     }                                                                                                                  \
@@ -29,15 +29,15 @@ struct OptixAPI
     rhi::Result (*createOptixDenoiserAPI)(rhi::optix_denoiser::IOptixDenoiserAPI** /*outAPI*/);
 };
 
-#define DEFINE_OPTIX_API(tag)                                                                                          \
+#define DEFINE_OPTIX_API(tag, version)                                                                                 \
     {                                                                                                                  \
-        rhi::cuda::optix::tag::optixVersion,                                                                           \
+        version,                                                                                                       \
         rhi::cuda::optix::tag::initialize,                                                                             \
         rhi::cuda::optix::tag::createContext,                                                                          \
         rhi::optix_denoiser::tag::createOptixDenoiserAPI,                                                              \
     },
 
-static OptixAPI s_optixAPIs[] = {SLANG_RHI_OPTIX_VERSIONS_X(DEFINE_OPTIX_API)};
+static constexpr OptixAPI s_optixAPIs[] = {SLANG_RHI_OPTIX_VERSIONS_X(DEFINE_OPTIX_API)};
 
 #endif // SLANG_RHI_ENABLE_OPTIX
 

--- a/src/cuda/optix-api.cpp
+++ b/src/cuda/optix-api.cpp
@@ -1,7 +1,6 @@
 #include "optix-api.h"
 
 #include "cuda-device.h"
-#include "core/common.h"
 
 #if SLANG_RHI_ENABLE_OPTIX
 

--- a/src/d3d/d3d-utils.cpp
+++ b/src/d3d/d3d-utils.cpp
@@ -333,6 +333,9 @@ Result createDXGIFactory(bool debug, ComPtr<IDXGIFactory>& outFactory)
     }
 }
 
+SLANG_RHI_STATIC_MUTEX_BEGIN
+static std::mutex s_dxgiFactoryMutex;
+SLANG_RHI_STATIC_MUTEX_END
 static IDXGIFactory* s_dxgiFactory;
 static DebugLayerOptions s_previousDebugLayerOptions;
 
@@ -340,6 +343,8 @@ static DebugLayerOptions s_previousDebugLayerOptions;
 // Warnings will be emitted via the `device` (if not present), else, stderr.
 ComPtr<IDXGIFactory> getDXGIFactory(DebugLayerOptions debugLayerOptions, Device* device)
 {
+    std::lock_guard<std::mutex> lock(s_dxgiFactoryMutex);
+
     // Try to remake our current `s_dxgiFactory` if:
     // 1. s_dxgiFactory is null
     // 2. The current `getDXGIFactory` settings do not match the previous settings.
@@ -354,26 +359,29 @@ ComPtr<IDXGIFactory> getDXGIFactory(DebugLayerOptions debugLayerOptions, Device*
         s_dxgiFactory = nullptr;
     }
 
-    ComPtr<IDXGIFactory> dxgiFactory = [&debugLayerOptions, &device]()
+    ComPtr<IDXGIFactory> dxgiFactory;
+    if (SLANG_FAILED(createDXGIFactory(debugLayerOptions.isDebugLayersEnabled(), dxgiFactory)))
     {
-        ComPtr<IDXGIFactory> f;
-        if (SLANG_FAILED(createDXGIFactory(debugLayerOptions.isDebugLayersEnabled(), f)))
+        // If debug was enabled && debug is *not* required, try again without debug
+        if (debugLayerOptions.isDebugLayersEnabled() && !debugLayerOptions.required)
         {
-            // If debug was enabled && debug is *not* required, try again without debug
-            if (debugLayerOptions.isDebugLayersEnabled() && !debugLayerOptions.required)
+            if (device)
+                device->printWarning("Failed to create a debug DXGIFactory.");
+            else
+                fprintf(stderr, "WARNING: Failed to create a debug DXGIFactory.");
+            debugLayerOptions = DebugLayerOptions();
+            if (SLANG_FAILED(createDXGIFactory(debugLayerOptions.isDebugLayersEnabled(), dxgiFactory)))
             {
-                if (device)
-                    device->printWarning("Failed to create a debug DXGIFactory.");
-                else
-                    fprintf(stderr, "WARNING: Failed to create a debug DXGIFactory.");
-                DebugLayerOptions newDebugLayerOptions = DebugLayerOptions();
-                return getDXGIFactory(newDebugLayerOptions, device);
+                return ComPtr<IDXGIFactory>();
             }
+        }
+        else
+        {
             return ComPtr<IDXGIFactory>();
         }
-        s_previousDebugLayerOptions = debugLayerOptions;
-        return f;
-    }();
+    }
+
+    s_previousDebugLayerOptions = debugLayerOptions;
 
     if (dxgiFactory)
     {
@@ -386,6 +394,8 @@ ComPtr<IDXGIFactory> getDXGIFactory(DebugLayerOptions debugLayerOptions, Device*
 
 void clearDXGIFactory()
 {
+    std::lock_guard<std::mutex> lock(s_dxgiFactoryMutex);
+
     if (s_dxgiFactory)
     {
         s_dxgiFactory->Release();

--- a/src/d3d/d3d-utils.cpp
+++ b/src/d3d/d3d-utils.cpp
@@ -259,6 +259,8 @@ Result compileHLSLShader(
 #endif // SLANG_ENABLE_DXBC_SUPPORT
 }
 
+static SharedLibraryHandle s_dxgiModule;
+
 SharedLibraryHandle getDXGIModule()
 {
 #if SLANG_WINDOWS_FAMILY
@@ -267,17 +269,24 @@ SharedLibraryHandle getDXGIModule()
     const char* const libName = "libdxvk_dxgi.so";
 #endif
 
-    static SharedLibraryHandle s_dxgiModule = [&]()
+    if (!s_dxgiModule)
     {
-        SharedLibraryHandle h = nullptr;
-        loadSharedLibrary(libName, h);
-        if (!h)
+        loadSharedLibrary(libName, s_dxgiModule);
+        if (!s_dxgiModule)
         {
             fprintf(stderr, "error: failed to load dll '%s'\n", libName);
         }
-        return h;
-    }();
+    }
     return s_dxgiModule;
+}
+
+void clearDXGIModule()
+{
+    if (s_dxgiModule)
+    {
+        unloadSharedLibrary(s_dxgiModule);
+        s_dxgiModule = nullptr;
+    }
 }
 
 Result createDXGIFactory(bool debug, ComPtr<IDXGIFactory>& outFactory)
@@ -324,25 +333,28 @@ Result createDXGIFactory(bool debug, ComPtr<IDXGIFactory>& outFactory)
     }
 }
 
+static IDXGIFactory* s_dxgiFactory;
+static DebugLayerOptions s_previousDebugLayerOptions;
+
 // Get `DXGIFactory`.
 // Warnings will be emitted via the `device` (if not present), else, stderr.
 ComPtr<IDXGIFactory> getDXGIFactory(DebugLayerOptions debugLayerOptions, Device* device)
 {
-    static ComPtr<IDXGIFactory> factory;
-    /// Tracks if the current DXGIFactory created is debug.
-    static DebugLayerOptions previousDebugLayerOptions;
-
-    // Try to remake our current `factory` if:
-    // 1. factory is null
+    // Try to remake our current `s_dxgiFactory` if:
+    // 1. s_dxgiFactory is null
     // 2. The current `getDXGIFactory` settings do not match the previous settings.
-    if (factory == ComPtr<IDXGIFactory>() || previousDebugLayerOptions != debugLayerOptions)
+    if (s_dxgiFactory && s_previousDebugLayerOptions == debugLayerOptions)
     {
-        factory.setNull();
+        return ComPtr<IDXGIFactory>(s_dxgiFactory);
     }
-    else
-        return factory;
 
-    factory = [&debugLayerOptions, &device]()
+    if (s_dxgiFactory)
+    {
+        s_dxgiFactory->Release();
+        s_dxgiFactory = nullptr;
+    }
+
+    ComPtr<IDXGIFactory> dxgiFactory = [&debugLayerOptions, &device]()
     {
         ComPtr<IDXGIFactory> f;
         if (SLANG_FAILED(createDXGIFactory(debugLayerOptions.isDebugLayersEnabled(), f)))
@@ -359,10 +371,27 @@ ComPtr<IDXGIFactory> getDXGIFactory(DebugLayerOptions debugLayerOptions, Device*
             }
             return ComPtr<IDXGIFactory>();
         }
-        previousDebugLayerOptions = debugLayerOptions;
+        s_previousDebugLayerOptions = debugLayerOptions;
         return f;
     }();
-    return factory;
+
+    if (dxgiFactory)
+    {
+        s_dxgiFactory = dxgiFactory;
+        s_dxgiFactory->AddRef();
+    }
+
+    return dxgiFactory;
+}
+
+void clearDXGIFactory()
+{
+    if (s_dxgiFactory)
+    {
+        s_dxgiFactory->Release();
+        s_dxgiFactory = nullptr;
+    }
+    s_previousDebugLayerOptions = {};
 }
 
 Result enumAdapters(IDXGIFactory* dxgiFactory, std::vector<ComPtr<IDXGIAdapter>>& outAdapters)

--- a/src/d3d/d3d-utils.h
+++ b/src/d3d/d3d-utils.h
@@ -43,8 +43,11 @@ Result compileHLSLShader(
 );
 
 SharedLibraryHandle getDXGIModule();
+void clearDXGIModule();
+
 Result createDXGIFactory(bool debug, ComPtr<IDXGIFactory>& outFactory);
 ComPtr<IDXGIFactory> getDXGIFactory(DebugLayerOptions debugLayerOptions, Device* device);
+void clearDXGIFactory();
 
 Result enumAdapters(IDXGIFactory* dxgiFactory, std::vector<ComPtr<IDXGIAdapter>>& outAdapters);
 Result enumAdapters(std::vector<ComPtr<IDXGIAdapter>>& outAdapters);

--- a/src/rhi.cpp
+++ b/src/rhi.cpp
@@ -157,6 +157,11 @@ Result RHI::destroy()
 #if SLANG_RHI_ENABLE_AFTERMATH
     AftermathCrashDumper::clear();
 #endif
+
+    // Release block allocator pages.
+    ShaderObject::getAllocator().releasePages();
+    RootShaderObject::getAllocator().releasePages();
+
     // Release DXGI factory and module.
 #if SLANG_RHI_ENABLE_D3D11 || SLANG_RHI_ENABLE_D3D12
     clearDXGIFactory();

--- a/src/rhi.cpp
+++ b/src/rhi.cpp
@@ -14,6 +14,10 @@
 #include "d3d/d3d-utils.h"
 #endif
 
+#if SLANG_RHI_ENABLE_CUDA
+#include <slang-rhi/cuda-driver-api.h>
+#endif
+
 #include <cstring>
 #include <vector>
 
@@ -159,6 +163,10 @@ Result RHI::destroy()
     clearDXGIModule();
 #endif
 
+    // Release CUDA driver API.
+#if SLANG_RHI_ENABLE_CUDA
+    rhiCudaDriverApiShutdown();
+#endif
 
     return SLANG_OK;
 }

--- a/src/rhi.cpp
+++ b/src/rhi.cpp
@@ -5,9 +5,14 @@
 #include "backend.h"
 #include "debug-layer/debug-device.h"
 #include "rhi-shared.h"
+#include "shader-object.h"
 
 #include "core/common.h"
 #include "core/task-pool.h"
+
+#if SLANG_RHI_ENABLE_D3D11 || SLANG_RHI_ENABLE_D3D12
+#include "d3d/d3d-utils.h"
+#endif
 
 #include <cstring>
 #include <vector>
@@ -148,6 +153,12 @@ Result RHI::destroy()
 #if SLANG_RHI_ENABLE_AFTERMATH
     AftermathCrashDumper::clear();
 #endif
+    // Release DXGI factory and module.
+#if SLANG_RHI_ENABLE_D3D11 || SLANG_RHI_ENABLE_D3D12
+    clearDXGIFactory();
+    clearDXGIModule();
+#endif
+
 
     return SLANG_OK;
 }

--- a/src/rhi.cpp
+++ b/src/rhi.cpp
@@ -461,7 +461,9 @@ Backend* RHI::getBackend(DeviceType type)
     return backend;
 }
 
+SLANG_RHI_STATIC_MUTEX_BEGIN
 static std::mutex s_instanceMutex;
+SLANG_RHI_STATIC_MUTEX_END
 static RHI* s_instance = nullptr;
 
 static RHI* getInstance()

--- a/src/shader-object.cpp
+++ b/src/shader-object.cpp
@@ -5,11 +5,11 @@
 namespace rhi {
 
 // ----------------------------------------------------------------------------
-// Allocators (~1MB page size for each type)
+// Block allocators
 // ----------------------------------------------------------------------------
 
-SLANG_RHI_IMPLEMENT_BLOCK_ALLOCATED(ShaderObject, 4 * 1024)
-SLANG_RHI_IMPLEMENT_BLOCK_ALLOCATED(RootShaderObject, 4 * 1024)
+SLANG_RHI_IMPLEMENT_BLOCK_ALLOCATED(ShaderObject)
+SLANG_RHI_IMPLEMENT_BLOCK_ALLOCATED(RootShaderObject)
 
 // ----------------------------------------------------------------------------
 // ShaderObjectLayout

--- a/src/shader-object.h
+++ b/src/shader-object.h
@@ -207,7 +207,7 @@ using ShaderObjectSetBindingHook = void (*)(
 
 class ShaderObject : public IShaderObject, public ComObject
 {
-    SLANG_RHI_DECLARE_BLOCK_ALLOCATED(ShaderObject)
+    SLANG_RHI_DECLARE_BLOCK_ALLOCATED(ShaderObject, 4 * 1024)
 
 public:
     SLANG_COM_OBJECT_IUNKNOWN_ALL
@@ -330,7 +330,7 @@ protected:
 
 class RootShaderObject : public ShaderObject
 {
-    SLANG_RHI_DECLARE_BLOCK_ALLOCATED(RootShaderObject)
+    SLANG_RHI_DECLARE_BLOCK_ALLOCATED(RootShaderObject, 4 * 1024)
 
 public:
     RefPtr<ShaderProgram> m_shaderProgram;

--- a/src/staging-heap.cpp
+++ b/src/staging-heap.cpp
@@ -5,8 +5,6 @@
 
 namespace rhi {
 
-static const std::thread::id NO_THREAD_ID;
-
 void StagingHeap::initialize(Device* device, Size pageSize, MemoryType memoryType)
 {
     std::lock_guard<std::mutex> lock(m_mutex);
@@ -74,7 +72,7 @@ Result StagingHeap::allocInternal(size_t size, MetaData metadata, StagingHeap::A
 
     // If pages are kept mapped, then can't have multiple threads allocating from the same page,
     // so record the thread id to lock pages to.
-    auto thread_id = m_keepPagesMapped ? NO_THREAD_ID : std::this_thread::get_id();
+    auto thread_id = m_keepPagesMapped ? std::thread::id() : std::this_thread::get_id();
 
     // Attempt to allocate from page if size is less than page size.
     if (alignedSize < m_pageSize)
@@ -82,7 +80,7 @@ Result StagingHeap::allocInternal(size_t size, MetaData metadata, StagingHeap::A
         for (auto& page_pair : m_pages)
         {
             Page* page = page_pair.second;
-            if (page->getLockedToThread() == NO_THREAD_ID || page->getLockedToThread() == thread_id)
+            if (page->getLockedToThread() == std::thread::id() || page->getLockedToThread() == thread_id)
             {
                 std::list<Node>::iterator node;
                 if (page->allocNode(alignedSize, metadata, thread_id, node))
@@ -265,7 +263,7 @@ bool StagingHeap::Page::allocNode(
 )
 {
     // Check if page is locked to a thread, and if so, that it is the same thread.
-    SLANG_RHI_ASSERT(m_locked_to_thread == lock_to_thread || m_locked_to_thread == NO_THREAD_ID);
+    SLANG_RHI_ASSERT(m_locked_to_thread == lock_to_thread || m_locked_to_thread == std::thread::id());
 
     // Scan nodes for a free slot greater than or equal to size requested
     for (auto node = m_nodes.begin(); node != m_nodes.end(); ++node)
@@ -336,7 +334,7 @@ void StagingHeap::Page::freeNode(std::list<StagingHeap::Node>::iterator node)
 
     // Unlock thread if back to 0 allocs
     if (m_totalUsed == 0)
-        m_locked_to_thread = NO_THREAD_ID;
+        m_locked_to_thread = std::thread::id();
 }
 
 void StagingHeap::Page::checkConsistency()

--- a/src/staging-heap.cpp
+++ b/src/staging-heap.cpp
@@ -5,7 +5,7 @@
 
 namespace rhi {
 
-static constexpr std::thread::id NO_THREAD_ID;
+static const std::thread::id NO_THREAD_ID;
 
 void StagingHeap::initialize(Device* device, Size pageSize, MemoryType memoryType)
 {

--- a/src/staging-heap.cpp
+++ b/src/staging-heap.cpp
@@ -5,7 +5,7 @@
 
 namespace rhi {
 
-const std::thread::id NO_THREAD_ID;
+static constexpr std::thread::id NO_THREAD_ID;
 
 void StagingHeap::initialize(Device* device, Size pageSize, MemoryType memoryType)
 {

--- a/src/vulkan/vk-surface.cpp
+++ b/src/vulkan/vk-surface.cpp
@@ -13,7 +13,10 @@
 
 namespace rhi::vk {
 
-static auto translateVkFormat = reverseMap<Format, VkFormat, Format::Undefined, Format::_Count>(getVkFormat);
+static Format translateVkFormat(VkFormat format)
+{
+    return reverseMapLookup<Format, VkFormat, Format::Undefined, Format::_Count>(getVkFormat, format);
+}
 
 SurfaceImpl::~SurfaceImpl()
 {

--- a/src/wgpu/wgpu-surface.cpp
+++ b/src/wgpu/wgpu-surface.cpp
@@ -11,8 +11,13 @@
 
 namespace rhi::wgpu {
 
-static auto translateWGPUFormat =
-    reverseMap<Format, WGPUTextureFormat, Format::Undefined, Format::_Count>(translateTextureFormat);
+static Format translateWGPUFormat(WGPUTextureFormat format)
+{
+    return reverseMapLookup<Format, WGPUTextureFormat, Format::Undefined, Format::_Count>(
+        translateTextureFormat,
+        format
+    );
+}
 
 SurfaceImpl::~SurfaceImpl()
 {

--- a/src/wgpu/wgpu-utils.cpp
+++ b/src/wgpu/wgpu-utils.cpp
@@ -2,21 +2,24 @@
 
 #include "core/assert.h"
 
+#include <array>
 #include <cstring>
 
 namespace rhi::wgpu {
 
 WGPUDawnTogglesDescriptor getDawnTogglesDescriptor()
 {
-    // Currently no toggles are needed.
-    static const std::vector<const char*> enabledToggles = {};
-    static const std::vector<const char*> disabledToggles = {};
     WGPUDawnTogglesDescriptor togglesDesc = {};
     togglesDesc.chain.sType = WGPUSType_DawnTogglesDescriptor;
-    togglesDesc.enabledToggleCount = enabledToggles.size();
-    togglesDesc.enabledToggles = enabledToggles.data();
-    togglesDesc.disabledToggleCount = disabledToggles.size();
-    togglesDesc.disabledToggles = disabledToggles.data();
+    // Currently no toggles are needed.
+#if 0
+    static constexpr const char* enabledToggles[] = {"foo"};
+    togglesDesc.enabledToggleCount = std::size(enabledToggles);
+    togglesDesc.enabledToggles = enabledToggles;
+    static constexpr const char* disabledToggles[] = {"foo"};
+    togglesDesc.disabledToggleCount = std::size(disabledToggles);
+    togglesDesc.disabledToggles = disabledToggles;
+#endif
     return togglesDesc;
 }
 

--- a/tests/test-block-allocator.cpp
+++ b/tests/test-block-allocator.cpp
@@ -34,7 +34,7 @@ struct TestObject
 
 TEST_CASE("block-allocator-single-threaded")
 {
-    BlockAllocator<TestObject> allocator(4); // Small page size for testing
+    BlockAllocator<TestObject, 4> allocator; // Small page size for testing
 
     SUBCASE("basic-allocation")
     {
@@ -124,11 +124,13 @@ TEST_CASE("block-allocator-single-threaded")
             allocator.free(obj);
         }
     }
+
+    allocator.releasePages();
 }
 
 TEST_CASE("block-allocator-ownership")
 {
-    BlockAllocator<TestObject> allocator(16);
+    BlockAllocator<TestObject, 16> allocator;
 
     SUBCASE("owns-allocated-blocks")
     {
@@ -185,11 +187,13 @@ TEST_CASE("block-allocator-ownership")
             allocator.free(obj);
         }
     }
+
+    allocator.releasePages();
 }
 
 TEST_CASE("block-allocator-reset")
 {
-    BlockAllocator<TestObject> allocator(4);
+    BlockAllocator<TestObject, 4> allocator;
 
     // Allocate some objects
     std::vector<TestObject*> objects;
@@ -233,11 +237,13 @@ TEST_CASE("block-allocator-reset")
     {
         allocator.free(obj);
     }
+
+    allocator.releasePages();
 }
 
 TEST_CASE("block-allocator-multi-threaded")
 {
-    BlockAllocator<TestObject> allocator(64);
+    BlockAllocator<TestObject, 64> allocator;
 
     constexpr int numThreads = 8;
     constexpr int allocationsPerThread = 10000;
@@ -293,12 +299,14 @@ TEST_CASE("block-allocator-multi-threaded")
     // Verify all allocations and deallocations completed
     CHECK(totalAllocations.load() == numThreads * allocationsPerThread);
     CHECK(totalDeallocations.load() == numThreads * allocationsPerThread);
+
+    allocator.releasePages();
 }
 
 TEST_CASE("block-allocator-stress-test")
 {
     constexpr int blocksPerPage = 1000;
-    BlockAllocator<TestObject> allocator(blocksPerPage);
+    BlockAllocator<TestObject, 1000> allocator;
 
     // Quick test for CI
     constexpr int numThreads = 16;
@@ -385,6 +393,8 @@ TEST_CASE("block-allocator-stress-test")
     {
         thread.join();
     }
+
+    allocator.releasePages();
 }
 
 #if 0
@@ -396,7 +406,7 @@ TEST_CASE("block-allocator-performance")
 
     SUBCASE("block-allocator-performance")
     {
-        BlockAllocator<TestObject> allocator(1000000);
+        BlockAllocator<TestObject, 1000000> allocator;
 
         std::vector<TestObject*> objects;
         objects.reserve(numAllocations);
@@ -447,7 +457,7 @@ TEST_CASE("block-allocator-performance")
 // Test the macro system
 class TestMacroClass
 {
-    SLANG_RHI_DECLARE_BLOCK_ALLOCATED(TestMacroClass)
+    SLANG_RHI_DECLARE_BLOCK_ALLOCATED(TestMacroClass, 32)
 
 public:
     int value = 0;
@@ -456,12 +466,9 @@ public:
         : value(v)
     {
     }
-
-    // For testing - expose allocator
-    static BlockAllocator<TestMacroClass>& getAllocator() { return s_allocator; }
 };
 
-SLANG_RHI_IMPLEMENT_BLOCK_ALLOCATED(TestMacroClass, 32)
+SLANG_RHI_IMPLEMENT_BLOCK_ALLOCATED(TestMacroClass)
 
 TEST_CASE("block-allocator-macro-system")
 {
@@ -503,4 +510,6 @@ TEST_CASE("block-allocator-macro-system")
             delete obj;
         }
     }
+
+    TestMacroClass::getAllocator().releasePages();
 }


### PR DESCRIPTION
**Remove static constructors/destructors from slang-rhi**

Eliminates reliance on static constructors and destructors throughout the codebase, replacing them with explicit initialization and shutdown patterns. Static initialization order issues and hidden startup costs are avoided.

**Changes:**
- Add `SLANG_RHI_STATIC_MUTEX_BEGIN`/`END` macros to safely declare static mutexes (with suppression for pre-Clang 16 warnings and Apple Clang)
- Add CMake flag to make non-trivial static variables a compile error (`-Werror=global-constructors` / `-Werror=exit-time-destructors`)
- Refactor `BlockAllocator` to not depend on static constructor/destructor
- Replace static `g_formatInfoMap` with a constexpr-friendly approach
- Convert `reverseMap` to avoid static constructors
- Make global task pool use explicit init/shutdown instead of static constructor
- Make DXGI module/factory use explicit lifecycle management with `clearDXGIModule()`/`clearDXGIFactory()`
- Make OptiX API table `constexpr`
- Remove `recursive_mutex` from CUDA driver API; add explicit `shutdownCudaDriverApi()`
- Fix static in `getDawnTogglesDescriptor()`
- Centralize shutdown logic in `rhi.cpp`

Fixes #651 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved OptiX version handling and compiler diagnostics.
  * Optimized block allocators for better memory behavior and explicit page release.
  * Improved resource lifecycle with new explicit cleanup for DXGI and CUDA.
  * Reworked internal caching and task-pool management.

* **Bug Fixes**
  * Safer texture format handling with explicit validation to catch unsupported formats early.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->