### PR TITLE
Fixed two issues with clang 22.1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,29 @@ endif()
 
 project(slang-rhi)
 
+function(slang_rhi_print_clang_details language compiler_path)
+    execute_process(
+        COMMAND ${compiler_path} --version
+        OUTPUT_VARIABLE SLANG_RHI_CLANG_VERSION_OUTPUT
+        ERROR_VARIABLE SLANG_RHI_CLANG_VERSION_ERROR
+        OUTPUT_STRIP_TRAILING_WHITESPACE
+        ERROR_STRIP_TRAILING_WHITESPACE
+    )
+    if(SLANG_RHI_CLANG_VERSION_ERROR)
+        string(APPEND SLANG_RHI_CLANG_VERSION_OUTPUT "\n" "${SLANG_RHI_CLANG_VERSION_ERROR}")
+    endif()
+    message(STATUS "Using ${language} clang compiler: ${compiler_path}")
+    message(STATUS "${language} clang --version:\n${SLANG_RHI_CLANG_VERSION_OUTPUT}")
+endfunction()
+
+if(CMAKE_C_COMPILER_ID MATCHES "Clang")
+    slang_rhi_print_clang_details("C" "${CMAKE_C_COMPILER}")
+endif()
+
+if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+    slang_rhi_print_clang_details("C++" "${CMAKE_CXX_COMPILER}")
+endif()
+
 # Avoid warning about DOWNLOAD_EXTRACT_TIMESTAMP in CMake 3.24:
 if(CMAKE_VERSION VERSION_GREATER_EQUAL "3.24.0")
     cmake_policy(SET CMP0135 NEW)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -598,6 +598,7 @@ target_compile_options(slang-rhi-warnings INTERFACE
         -Wno-nested-anon-types
         -Wno-cast-function-type-mismatch
         -Wno-c++20-extensions
+        -Wno-c2y-extensions
         # Windows specific warnings
         -Wno-microsoft-exception-spec
         -Wno-microsoft-enum-value
@@ -615,6 +616,7 @@ target_compile_options(slang-rhi-warnings INTERFACE
         -Wno-gnu-anonymous-struct
         -Wno-gnu-zero-variadic-macro-arguments
         -Wno-nested-anon-types
+        -Wno-c2y-extensions
     >
     $<$<BOOL:${EMSCRIPTEN}>:-Wno-c2y-extensions>
 )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,29 +5,6 @@ endif()
 
 project(slang-rhi)
 
-function(slang_rhi_print_clang_details language compiler_path)
-    execute_process(
-        COMMAND ${compiler_path} --version
-        OUTPUT_VARIABLE SLANG_RHI_CLANG_VERSION_OUTPUT
-        ERROR_VARIABLE SLANG_RHI_CLANG_VERSION_ERROR
-        OUTPUT_STRIP_TRAILING_WHITESPACE
-        ERROR_STRIP_TRAILING_WHITESPACE
-    )
-    if(SLANG_RHI_CLANG_VERSION_ERROR)
-        string(APPEND SLANG_RHI_CLANG_VERSION_OUTPUT "\n" "${SLANG_RHI_CLANG_VERSION_ERROR}")
-    endif()
-    message(STATUS "Using ${language} clang compiler: ${compiler_path}")
-    message(STATUS "${language} clang --version:\n${SLANG_RHI_CLANG_VERSION_OUTPUT}")
-endfunction()
-
-if(CMAKE_C_COMPILER_ID MATCHES "Clang")
-    slang_rhi_print_clang_details("C" "${CMAKE_C_COMPILER}")
-endif()
-
-if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-    slang_rhi_print_clang_details("C++" "${CMAKE_CXX_COMPILER}")
-endif()
-
 # Avoid warning about DOWNLOAD_EXTRACT_TIMESTAMP in CMake 3.24:
 if(CMAKE_VERSION VERSION_GREATER_EQUAL "3.24.0")
     cmake_policy(SET CMP0135 NEW)

--- a/src/core/common.h
+++ b/src/core/common.h
@@ -19,10 +19,11 @@
 #include "struct-holder.h"
 
 // Suppress clang warnings for static std::mutex declarations.
-// Clang < 16 warns about global constructors/exit-time destructors for std::mutex,
-// even though it has a trivial destructor. Clang 16+ recognizes its constexpr constructor
-// and no longer emits these warnings.
-#if defined(__clang__) && (__clang_major__ < 16)
+// Clang reports -Wglobal-constructors and -Wexit-time-destructors for file-scope std::mutex
+// declarations because they participate in global initialization and teardown. For this
+// usage the warning is noise: std::mutex is the intended primitive here, and the warning does
+// not indicate unsafe custom initialization logic or destructor side effects in our code.
+#if defined(__clang__)
 // clang-format off
 #define SLANG_RHI_STATIC_MUTEX_BEGIN                                                                                   \
     _Pragma("clang diagnostic push")                                                                                   \


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated compiler warning suppression flags to improve build compatibility with Clang and AppleClang toolchains.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->