### PR TITLE
Fix feature checks in raytracing tests

### DIFF
--- a/tests/test-ray-tracing-clusters.cpp
+++ b/tests/test-ray-tracing-clusters.cpp
@@ -781,6 +781,8 @@ static void testClusterTracing(
 // Build two clusters with device-written TriangleClusterArgs and render two horizontal bands.
 GPU_TEST_CASE("ray-tracing-cluster-tracing", D3D12 | Vulkan | CUDA)
 {
+    if (!device->hasFeature(Feature::RayTracing))
+        SKIP("ray tracing not supported");
     if (!device->hasFeature(Feature::ClusterAccelerationStructure))
         SKIP("cluster acceleration structure not supported");
 
@@ -789,8 +791,12 @@ GPU_TEST_CASE("ray-tracing-cluster-tracing", D3D12 | Vulkan | CUDA)
 
 GPU_TEST_CASE("ray-tracing-cluster-tracing-hit-object", D3D12 | Vulkan | CUDA)
 {
+    if (!device->hasFeature(Feature::RayTracing))
+        SKIP("ray tracing not supported");
     if (!device->hasFeature(Feature::ClusterAccelerationStructure))
         SKIP("cluster acceleration structure not supported");
+    if (!device->hasFeature(Feature::ShaderExecutionReordering))
+        SKIP("Shader execution reordering not supported");
 
     testClusterTracing(device, "rayGenClustersHitObject", nullptr);
 }

--- a/tests/test-ray-tracing-lss.cpp
+++ b/tests/test-ray-tracing-lss.cpp
@@ -242,6 +242,8 @@ GPU_TEST_CASE("ray-tracing-lss-intrinsics-hit-object", ALL)
         SKIP("ray tracing not supported");
     if (!device->hasFeature(Feature::AccelerationStructureLinearSweptSpheres))
         SKIP("acceleration structure linear swept spheres not supported");
+    if (!device->hasFeature(Feature::ShaderExecutionReordering))
+        SKIP("Shader execution reordering not supported");
 
     RayTracingLssIntrinsicsTest test;
     test.init(device);

--- a/tests/test-ray-tracing-sphere.cpp
+++ b/tests/test-ray-tracing-sphere.cpp
@@ -243,6 +243,8 @@ GPU_TEST_CASE("ray-tracing-sphere-intrinsics-hit-object", ALL & ~D3D12)
         SKIP("ray tracing not supported");
     if (!device->hasFeature(Feature::AccelerationStructureSpheres))
         SKIP("acceleration structure spheres not supported");
+    if (!device->hasFeature(Feature::ShaderExecutionReordering))
+        SKIP("Shader execution reordering not supported");
 
     RayTracingSphereIntrinsicsTest test;
     test.init(device);


### PR DESCRIPTION
Fixes running tests correctly on HW without SER.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced ray-tracing tests to conditionally skip execution when required device features are unavailable, improving test reliability and compatibility across varying hardware configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->