### PR TITLE
Metal: add useResource fallback for devices without MTLResidencySet

### DIFF
--- a/include/slang-rhi.h
+++ b/include/slang-rhi.h
@@ -167,6 +167,7 @@ enum class DeviceType
     x(ShaderResourceMinLod,                     "shader-resource-min-lod"                       ) \
     /* Metal specific features */                                                                 \
     x(ArgumentBufferTier2,                      "argument-buffer-tier-2"                        ) \
+    x(ResidencySet,                             "residency-set"                                 ) \
     /* CUDA specific features */                                                                  \
     x(AtomicBfloat16,                           "atomic-bfloat16"                               )
 // clang-format on

--- a/src/metal/metal-acceleration-structure.cpp
+++ b/src/metal/metal-acceleration-structure.cpp
@@ -13,6 +13,10 @@ AccelerationStructureImpl::AccelerationStructureImpl(Device* device, const Accel
 AccelerationStructureImpl::~AccelerationStructureImpl()
 {
     DeviceImpl* device = getDevice<DeviceImpl>();
+    if (m_accelerationStructure)
+    {
+        device->unregisterResource(m_accelerationStructure.get());
+    }
     device->m_accelerationStructures.freeList.push_back(m_globalIndex);
     device->m_accelerationStructures.list[m_globalIndex] = nullptr;
     device->m_accelerationStructures.dirty = true;
@@ -64,6 +68,8 @@ Result DeviceImpl::createAccelerationStructure(
     }
     m_accelerationStructures.dirty = true;
     result->m_globalIndex = globalIndex;
+
+    registerResource(result->m_accelerationStructure.get());
 
     returnComPtr(outAccelerationStructure, result);
     return SLANG_OK;

--- a/src/metal/metal-buffer-address-map.h
+++ b/src/metal/metal-buffer-address-map.h
@@ -1,0 +1,105 @@
+#pragma once
+
+#include <mutex>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+#include "slang-rhi.h"
+
+namespace rhi::metal {
+
+class BufferImpl;
+
+/// Thread-safe map from GPU virtual addresses to their owning BufferImpl.
+///
+/// Provides O(1) average lookup for exact base-address matches (the common case)
+/// and O(log N) fallback for pointers that land inside a buffer's address range.
+/// A lazy-sorted vector is only built when a range lookup is actually needed.
+///
+/// Used by the residency fallback path (!m_hasResidencySet) to resolve device
+/// pointers found in shader uniform data for useResources calls.
+class BufferAddressMap
+{
+public:
+    void insert(DeviceAddress baseAddr, DeviceAddress size, BufferImpl* buffer)
+    {
+        std::lock_guard<std::mutex> lock(m_mutex);
+        m_baseAddrMap[baseAddr] = {buffer, size};
+        m_sortedDirty = true;
+    }
+
+    void erase(DeviceAddress baseAddr)
+    {
+        std::lock_guard<std::mutex> lock(m_mutex);
+        m_baseAddrMap.erase(baseAddr);
+        m_sortedDirty = true;
+    }
+
+    /// Look up the buffer owning a given GPU address.
+    /// Returns nullptr if no buffer contains the address.
+    BufferImpl* find(DeviceAddress addr)
+    {
+        std::lock_guard<std::mutex> lock(m_mutex);
+
+        // Fast path: exact base-address match.
+        auto it = m_baseAddrMap.find(addr);
+        if (it != m_baseAddrMap.end())
+            return it->second.buffer;
+
+        // Slow path: address may point into the middle of a buffer.
+        return findByRange(addr);
+    }
+
+private:
+    struct Entry
+    {
+        BufferImpl* buffer;
+        DeviceAddress size;
+    };
+
+    BufferImpl* findByRange(DeviceAddress addr)
+    {
+        if (m_sortedDirty)
+            rebuildSorted();
+
+        if (m_sorted.empty())
+            return nullptr;
+
+        // upper_bound finds first entry with base > addr; step back one.
+        auto it = std::upper_bound(
+            m_sorted.begin(),
+            m_sorted.end(),
+            addr,
+            [](DeviceAddress a, const std::pair<DeviceAddress, Entry>& e) { return a < e.first; }
+        );
+
+        if (it == m_sorted.begin())
+            return nullptr;
+
+        --it;
+        if (addr < it->first + it->second.size)
+            return it->second.buffer;
+
+        return nullptr;
+    }
+
+    void rebuildSorted()
+    {
+        m_sorted.clear();
+        m_sorted.reserve(m_baseAddrMap.size());
+        for (auto& [addr, entry] : m_baseAddrMap)
+            m_sorted.push_back({addr, entry});
+        std::sort(m_sorted.begin(), m_sorted.end(), [](const auto& a, const auto& b) {
+            return a.first < b.first;
+        });
+        m_sortedDirty = false;
+    }
+
+    std::mutex m_mutex;
+    std::unordered_map<DeviceAddress, Entry> m_baseAddrMap;
+    std::vector<std::pair<DeviceAddress, Entry>> m_sorted;
+    bool m_sortedDirty = true;
+};
+
+} // namespace rhi::metal

--- a/src/metal/metal-buffer-address-map.h
+++ b/src/metal/metal-buffer-address-map.h
@@ -71,7 +71,10 @@ private:
             m_sorted.begin(),
             m_sorted.end(),
             addr,
-            [](DeviceAddress a, const std::pair<DeviceAddress, Entry>& e) { return a < e.first; }
+            [](DeviceAddress a, const std::pair<DeviceAddress, Entry>& e)
+            {
+                return a < e.first;
+            }
         );
 
         if (it == m_sorted.begin())
@@ -90,9 +93,14 @@ private:
         m_sorted.reserve(m_baseAddrMap.size());
         for (auto& [addr, entry] : m_baseAddrMap)
             m_sorted.push_back({addr, entry});
-        std::sort(m_sorted.begin(), m_sorted.end(), [](const auto& a, const auto& b) {
-            return a.first < b.first;
-        });
+        std::sort(
+            m_sorted.begin(),
+            m_sorted.end(),
+            [](const auto& a, const auto& b)
+            {
+                return a.first < b.first;
+            }
+        );
         m_sortedDirty = false;
     }
 

--- a/src/metal/metal-buffer.cpp
+++ b/src/metal/metal-buffer.cpp
@@ -18,6 +18,7 @@ BufferImpl::~BufferImpl()
         if (!device->m_hasResidencySet && m_deviceAddress != 0)
             device->m_addressToBuffer.erase(m_deviceAddress);
         device->unregisterResource(m_buffer.get());
+
     }
 }
 
@@ -82,7 +83,7 @@ Result DeviceImpl::createBuffer(const BufferDesc& desc_, const void* initData, I
     // Blit encoders handle residency for explicit operands automatically.
     buffer->m_deviceAddress = buffer->m_buffer->gpuAddress();
     if (!m_hasResidencySet && buffer->m_deviceAddress != 0)
-        m_addressToBuffer[buffer->m_deviceAddress] = buffer.get();
+        m_addressToBuffer.insert(buffer->m_deviceAddress, buffer->m_buffer->length(), buffer.get());
     registerResource(buffer->m_buffer.get());
 
     if (desc.label)

--- a/src/metal/metal-buffer.cpp
+++ b/src/metal/metal-buffer.cpp
@@ -14,7 +14,10 @@ BufferImpl::~BufferImpl()
 {
     if (m_buffer)
     {
-        getDevice<DeviceImpl>()->unregisterResource(m_buffer.get());
+        auto* device = getDevice<DeviceImpl>();
+        if (!device->m_hasResidencySet && m_deviceAddress != 0)
+            device->m_addressToBuffer.erase(m_deviceAddress);
+        device->unregisterResource(m_buffer.get());
     }
 }
 
@@ -78,6 +81,8 @@ Result DeviceImpl::createBuffer(const BufferDesc& desc_, const void* initData, I
     // render/compute command buffer using this address via argument buffers.
     // Blit encoders handle residency for explicit operands automatically.
     buffer->m_deviceAddress = buffer->m_buffer->gpuAddress();
+    if (!m_hasResidencySet && buffer->m_deviceAddress != 0)
+        m_addressToBuffer[buffer->m_deviceAddress] = buffer.get();
     registerResource(buffer->m_buffer.get());
 
     if (desc.label)

--- a/src/metal/metal-buffer.cpp
+++ b/src/metal/metal-buffer.cpp
@@ -14,7 +14,7 @@ BufferImpl::~BufferImpl()
 {
     if (m_buffer)
     {
-        getDevice<DeviceImpl>()->unregisterAllocation(m_buffer.get());
+        getDevice<DeviceImpl>()->unregisterResource(m_buffer.get());
     }
 }
 
@@ -78,7 +78,7 @@ Result DeviceImpl::createBuffer(const BufferDesc& desc_, const void* initData, I
     // render/compute command buffer using this address via argument buffers.
     // Blit encoders handle residency for explicit operands automatically.
     buffer->m_deviceAddress = buffer->m_buffer->gpuAddress();
-    registerAllocation(buffer->m_buffer.get());
+    registerResource(buffer->m_buffer.get());
 
     if (desc.label)
         buffer->m_buffer->addDebugMarker(createString(desc.label).get(), NS::Range(0, desc.size));

--- a/src/metal/metal-buffer.cpp
+++ b/src/metal/metal-buffer.cpp
@@ -18,7 +18,6 @@ BufferImpl::~BufferImpl()
         if (!device->m_hasResidencySet && m_deviceAddress != 0)
             device->m_addressToBuffer.erase(m_deviceAddress);
         device->unregisterResource(m_buffer.get());
-
     }
 }
 

--- a/src/metal/metal-command.cpp
+++ b/src/metal/metal-command.cpp
@@ -1029,6 +1029,18 @@ void CommandRecorder::endCommandEncoder()
 
     if (m_renderCommandEncoder)
     {
+        if (!m_device->m_hasResidencySet)
+        {
+            std::lock_guard<std::mutex> lock(m_device->m_allResourcesMutex);
+            if (!m_device->m_allResources.empty())
+            {
+                m_renderCommandEncoder->useResources(
+                    (const MTL::Resource* const*)m_device->m_allResources.data(),
+                    m_device->m_allResources.size(),
+                    MTL::ResourceUsageRead | MTL::ResourceUsageWrite
+                );
+            }
+        }
         m_renderCommandEncoder->updateFence(
             fence,
             MTL::RenderStages(MTL::RenderStageVertex | MTL::RenderStageFragment)
@@ -1042,6 +1054,18 @@ void CommandRecorder::endCommandEncoder()
     }
     if (m_computeCommandEncoder)
     {
+        if (!m_device->m_hasResidencySet)
+        {
+            std::lock_guard<std::mutex> lock(m_device->m_allResourcesMutex);
+            if (!m_device->m_allResources.empty())
+            {
+                m_computeCommandEncoder->useResources(
+                    (const MTL::Resource* const*)m_device->m_allResources.data(),
+                    m_device->m_allResources.size(),
+                    MTL::ResourceUsageRead | MTL::ResourceUsageWrite
+                );
+            }
+        }
         m_computeCommandEncoder->updateFence(fence);
         m_computeCommandEncoder->endEncoding();
         m_computeCommandEncoder.reset();
@@ -1052,12 +1076,26 @@ void CommandRecorder::endCommandEncoder()
     }
     if (m_accelerationStructureCommandEncoder)
     {
+        if (!m_device->m_hasResidencySet)
+        {
+            std::lock_guard<std::mutex> lock(m_device->m_allResourcesMutex);
+            if (!m_device->m_allResources.empty())
+            {
+                m_accelerationStructureCommandEncoder->useResources(
+                    (const MTL::Resource* const*)m_device->m_allResources.data(),
+                    m_device->m_allResources.size(),
+                    MTL::ResourceUsageRead | MTL::ResourceUsageWrite
+                );
+            }
+        }
         m_accelerationStructureCommandEncoder->updateFence(fence);
         m_accelerationStructureCommandEncoder->endEncoding();
         m_accelerationStructureCommandEncoder.reset();
     }
     if (m_blitCommandEncoder)
     {
+        // Blit encoders don't support useResources — residency for blit
+        // operands is handled automatically by Metal.
         m_blitCommandEncoder->updateFence(fence);
         m_blitCommandEncoder->endEncoding();
         m_blitCommandEncoder.reset();
@@ -1231,11 +1269,14 @@ Result CommandQueueImpl::submit(const SubmitDesc& desc)
     // Commit any pending residency set changes.
     {
         auto* device = getDevice<DeviceImpl>();
-        std::lock_guard<std::mutex> lock(device->m_residencySetMutex);
-        if (device->m_residencySetDirty)
+        if (device->m_hasResidencySet)
         {
-            device->m_residencySet->commit();
-            device->m_residencySetDirty = false;
+            std::lock_guard<std::mutex> lock(device->m_residencySetMutex);
+            if (device->m_residencySetDirty)
+            {
+                device->m_residencySet->commit();
+                device->m_residencySetDirty = false;
+            }
         }
     }
 

--- a/src/metal/metal-command.cpp
+++ b/src/metal/metal-command.cpp
@@ -598,6 +598,26 @@ void CommandRecorder::cmdSetRenderState(const commands::SetRenderState& cmd)
         encoder->setFragmentTextures(m_bindingData->textures, NS::Range(0, m_bindingData->textureCount));
         encoder->setVertexSamplerStates(m_bindingData->samplers, NS::Range(0, m_bindingData->samplerCount));
         encoder->setFragmentSamplerStates(m_bindingData->samplers, NS::Range(0, m_bindingData->samplerCount));
+
+        if (!m_device->m_hasResidencySet)
+        {
+            if (m_bindingData->usedResourceCount > 0)
+            {
+                encoder->useResources(
+                    (const MTL::Resource* const*)m_bindingData->usedResources,
+                    m_bindingData->usedResourceCount,
+                    MTL::ResourceUsageRead
+                );
+            }
+            if (m_bindingData->usedRWResourceCount > 0)
+            {
+                encoder->useResources(
+                    (const MTL::Resource* const*)m_bindingData->usedRWResources,
+                    m_bindingData->usedRWResourceCount,
+                    MTL::ResourceUsageRead | MTL::ResourceUsageWrite
+                );
+            }
+        }
     }
 
     if (updateVertexBuffers)
@@ -773,6 +793,26 @@ void CommandRecorder::cmdSetComputeState(const commands::SetComputeState& cmd)
         );
         encoder->setTextures(m_bindingData->textures, NS::Range(0, m_bindingData->textureCount));
         encoder->setSamplerStates(m_bindingData->samplers, NS::Range(0, m_bindingData->samplerCount));
+
+        if (!m_device->m_hasResidencySet)
+        {
+            if (m_bindingData->usedResourceCount > 0)
+            {
+                encoder->useResources(
+                    (const MTL::Resource* const*)m_bindingData->usedResources,
+                    m_bindingData->usedResourceCount,
+                    MTL::ResourceUsageRead
+                );
+            }
+            if (m_bindingData->usedRWResourceCount > 0)
+            {
+                encoder->useResources(
+                    (const MTL::Resource* const*)m_bindingData->usedRWResources,
+                    m_bindingData->usedRWResourceCount,
+                    MTL::ResourceUsageRead | MTL::ResourceUsageWrite
+                );
+            }
+        }
     }
 
     if (m_computeEncoderHasDispatched)
@@ -1029,18 +1069,6 @@ void CommandRecorder::endCommandEncoder()
 
     if (m_renderCommandEncoder)
     {
-        if (!m_device->m_hasResidencySet)
-        {
-            std::lock_guard<std::mutex> lock(m_device->m_allResourcesMutex);
-            if (!m_device->m_allResources.empty())
-            {
-                m_renderCommandEncoder->useResources(
-                    (const MTL::Resource* const*)m_device->m_allResources.data(),
-                    m_device->m_allResources.size(),
-                    MTL::ResourceUsageRead | MTL::ResourceUsageWrite
-                );
-            }
-        }
         m_renderCommandEncoder->updateFence(
             fence,
             MTL::RenderStages(MTL::RenderStageVertex | MTL::RenderStageFragment)
@@ -1054,18 +1082,6 @@ void CommandRecorder::endCommandEncoder()
     }
     if (m_computeCommandEncoder)
     {
-        if (!m_device->m_hasResidencySet)
-        {
-            std::lock_guard<std::mutex> lock(m_device->m_allResourcesMutex);
-            if (!m_device->m_allResources.empty())
-            {
-                m_computeCommandEncoder->useResources(
-                    (const MTL::Resource* const*)m_device->m_allResources.data(),
-                    m_device->m_allResources.size(),
-                    MTL::ResourceUsageRead | MTL::ResourceUsageWrite
-                );
-            }
-        }
         m_computeCommandEncoder->updateFence(fence);
         m_computeCommandEncoder->endEncoding();
         m_computeCommandEncoder.reset();
@@ -1076,18 +1092,6 @@ void CommandRecorder::endCommandEncoder()
     }
     if (m_accelerationStructureCommandEncoder)
     {
-        if (!m_device->m_hasResidencySet)
-        {
-            std::lock_guard<std::mutex> lock(m_device->m_allResourcesMutex);
-            if (!m_device->m_allResources.empty())
-            {
-                m_accelerationStructureCommandEncoder->useResources(
-                    (const MTL::Resource* const*)m_device->m_allResources.data(),
-                    m_device->m_allResources.size(),
-                    MTL::ResourceUsageRead | MTL::ResourceUsageWrite
-                );
-            }
-        }
         m_accelerationStructureCommandEncoder->updateFence(fence);
         m_accelerationStructureCommandEncoder->endEncoding();
         m_accelerationStructureCommandEncoder.reset();

--- a/src/metal/metal-command.cpp
+++ b/src/metal/metal-command.cpp
@@ -1094,7 +1094,7 @@ void CommandRecorder::endCommandEncoder()
     }
     if (m_blitCommandEncoder)
     {
-        // Blit encoders don't support useResources — residency for blit
+        // Blit encoders don't support useResources - residency for blit
         // operands is handled automatically by Metal.
         m_blitCommandEncoder->updateFence(fence);
         m_blitCommandEncoder->endEncoding();

--- a/src/metal/metal-device.cpp
+++ b/src/metal/metal-device.cpp
@@ -123,7 +123,15 @@ Result DeviceImpl::initialize(const DeviceDesc& desc, BackendImpl* backend)
     // Environment variable to force fallback path for testing.
     {
         bool forceUseResourceFallback = std::getenv("SLANG_RHI_METAL_NO_RESIDENCY_SET") != nullptr;
-        if (!forceUseResourceFallback && m_device->supportsFamily(MTL::GPUFamilyApple6))
+        if (forceUseResourceFallback)
+        {
+            handleMessage(
+                DebugMessageType::Info,
+                DebugMessageSource::Driver,
+                "SLANG_RHI_METAL_NO_RESIDENCY_SET set; using per-encoder useResource fallback"
+            );
+        }
+        else if (m_device->supportsFamily(MTL::GPUFamilyApple6))
         {
             NS::Error* error = nullptr;
             auto rsDesc = NS::TransferPtr(MTL::ResidencySetDescriptor::alloc()->init());

--- a/src/metal/metal-device.cpp
+++ b/src/metal/metal-device.cpp
@@ -250,6 +250,10 @@ Result DeviceImpl::initialize(const DeviceDesc& desc, BackendImpl* backend)
         addFeature(Feature::ArgumentBufferTier2);
         addFeature(Feature::ParameterBlock);
     }
+    if (m_hasResidencySet)
+    {
+        addFeature(Feature::ResidencySet);
+    }
 
     addCapability(Capability::metal);
 

--- a/src/metal/metal-device.cpp
+++ b/src/metal/metal-device.cpp
@@ -554,11 +554,6 @@ void DeviceImpl::registerResource(MTL::Resource* resource)
         m_residencySet->addAllocation(resource);
         m_residencySetDirty = true;
     }
-    else
-    {
-        std::lock_guard<std::mutex> lock(m_allResourcesMutex);
-        m_allResources.push_back(resource);
-    }
 }
 
 void DeviceImpl::unregisterResource(MTL::Resource* resource)
@@ -569,16 +564,6 @@ void DeviceImpl::unregisterResource(MTL::Resource* resource)
         std::lock_guard<std::mutex> lock(m_residencySetMutex);
         m_residencySet->removeAllocation(resource);
         m_residencySetDirty = true;
-    }
-    else
-    {
-        std::lock_guard<std::mutex> lock(m_allResourcesMutex);
-        auto it = std::find(m_allResources.begin(), m_allResources.end(), resource);
-        if (it != m_allResources.end())
-        {
-            *it = m_allResources.back();
-            m_allResources.pop_back();
-        }
     }
 }
 

--- a/src/metal/metal-device.cpp
+++ b/src/metal/metal-device.cpp
@@ -16,6 +16,8 @@
 
 #include "core/common.h"
 
+#include <cstdio>
+#include <cstdlib>
 #include <vector>
 
 namespace rhi::metal {
@@ -82,32 +84,72 @@ Result DeviceImpl::initialize(const DeviceDesc& desc, BackendImpl* backend)
         return SLANG_FAIL;
     }
 
-    // R5: Require Apple Silicon (GPU Family 6+) for untracked mode + MTLResidencySet.
-    if (!m_device->supportsFamily(MTL::GPUFamilyApple6))
+    // Log device identity for diagnostics.
+    {
+        char buf[256];
+        std::snprintf(
+            buf,
+            sizeof(buf),
+            "Metal device: %s (UMA=%s, ArgBufTier=%d)",
+            m_device->name()->utf8String(),
+            m_device->hasUnifiedMemory() ? "yes" : "no",
+            (int)m_device->argumentBuffersSupport()
+        );
+        handleMessage(DebugMessageType::Info, DebugMessageSource::Driver, buf);
+    }
+
+    // Gate on Argument Buffers Tier 2 — the actual functional requirement
+    // for gpuAddress() and bindless argument buffer access.
+    if (m_device->argumentBuffersSupport() < MTL::ArgumentBuffersTier2)
     {
         handleMessage(
             DebugMessageType::Error,
             DebugMessageSource::Driver,
-            "Metal backend requires Apple GPU Family 6+ (Apple Silicon)"
+            "Metal backend requires Argument Buffers Tier 2"
         );
         return SLANG_FAIL;
     }
 
-    // R2: Create residency set (mandatory - all allocations are registered here).
+    if (!m_device->hasUnifiedMemory())
     {
-        NS::Error* error = nullptr;
-        auto rsDesc = NS::TransferPtr(MTL::ResidencySetDescriptor::alloc()->init());
-        m_residencySet = NS::TransferPtr(m_device->newResidencySet(rsDesc.get(), &error));
-        if (!m_residencySet)
+        handleMessage(
+            DebugMessageType::Warning,
+            DebugMessageSource::Driver,
+            "Non-UMA device detected; shared texture support may be limited"
+        );
+    }
+
+    // Try residency set (requires GPUFamilyApple6 + runtime support).
+    // Environment variable to force fallback path for testing.
+    {
+        bool forceUseResourceFallback = std::getenv("SLANG_RHI_METAL_NO_RESIDENCY_SET") != nullptr;
+        if (!forceUseResourceFallback && m_device->supportsFamily(MTL::GPUFamilyApple6))
         {
-            if (error)
+            NS::Error* error = nullptr;
+            auto rsDesc = NS::TransferPtr(MTL::ResidencySetDescriptor::alloc()->init());
+            m_residencySet = NS::TransferPtr(m_device->newResidencySet(rsDesc.get(), &error));
+            if (m_residencySet)
             {
-                if (NS::String* errStr = error->localizedDescription())
-                    handleMessage(DebugMessageType::Error, DebugMessageSource::Driver, errStr->utf8String());
+                m_commandQueue->addResidencySet(m_residencySet.get());
+                m_hasResidencySet = true;
             }
-            return SLANG_FAIL;
+            else
+            {
+                handleMessage(
+                    DebugMessageType::Warning,
+                    DebugMessageSource::Driver,
+                    "MTLResidencySet creation failed; using per-encoder useResource fallback"
+                );
+            }
         }
-        m_commandQueue->addResidencySet(m_residencySet.get());
+        else
+        {
+            handleMessage(
+                DebugMessageType::Info,
+                DebugMessageSource::Driver,
+                "GPUFamilyApple6 not supported; using per-encoder useResource fallback"
+            );
+        }
     }
 
     m_queue = new CommandQueueImpl(this, QueueType::Graphics);
@@ -491,20 +533,41 @@ Result DeviceImpl::createQueryPool(const QueryPoolDesc& desc, IQueryPool** outPo
     return SLANG_OK;
 }
 
-void DeviceImpl::registerAllocation(MTL::Allocation* allocation)
+void DeviceImpl::registerResource(MTL::Resource* resource)
 {
-    SLANG_RHI_ASSERT(allocation);
-    std::lock_guard<std::mutex> lock(m_residencySetMutex);
-    m_residencySet->addAllocation(allocation);
-    m_residencySetDirty = true;
+    SLANG_RHI_ASSERT(resource);
+    if (m_hasResidencySet)
+    {
+        std::lock_guard<std::mutex> lock(m_residencySetMutex);
+        m_residencySet->addAllocation(resource);
+        m_residencySetDirty = true;
+    }
+    else
+    {
+        std::lock_guard<std::mutex> lock(m_allResourcesMutex);
+        m_allResources.push_back(resource);
+    }
 }
 
-void DeviceImpl::unregisterAllocation(MTL::Allocation* allocation)
+void DeviceImpl::unregisterResource(MTL::Resource* resource)
 {
-    SLANG_RHI_ASSERT(allocation);
-    std::lock_guard<std::mutex> lock(m_residencySetMutex);
-    m_residencySet->removeAllocation(allocation);
-    m_residencySetDirty = true;
+    SLANG_RHI_ASSERT(resource);
+    if (m_hasResidencySet)
+    {
+        std::lock_guard<std::mutex> lock(m_residencySetMutex);
+        m_residencySet->removeAllocation(resource);
+        m_residencySetDirty = true;
+    }
+    else
+    {
+        std::lock_guard<std::mutex> lock(m_allResourcesMutex);
+        auto it = std::find(m_allResources.begin(), m_allResources.end(), resource);
+        if (it != m_allResources.end())
+        {
+            *it = m_allResources.back();
+            m_allResources.pop_back();
+        }
+    }
 }
 
 } // namespace rhi::metal

--- a/src/metal/metal-device.cpp
+++ b/src/metal/metal-device.cpp
@@ -83,16 +83,6 @@ Result DeviceImpl::initialize(const DeviceDesc& desc, BackendImpl* backend)
         return SLANG_FAIL;
     }
 
-    // Log device identity for diagnostics.
-    printMessage(
-        DebugMessageType::Info,
-        DebugMessageSource::Driver,
-        "Metal device: %s (UMA=%s, ArgBufTier=%d)",
-        m_device->name()->utf8String(),
-        m_device->hasUnifiedMemory() ? "yes" : "no",
-        (int)m_device->argumentBuffersSupport()
-    );
-
     // Gate on Argument Buffers Tier 2 - the actual functional requirement
     // for gpuAddress() and bindless argument buffer access.
     if (m_device->argumentBuffersSupport() < MTL::ArgumentBuffersTier2)

--- a/src/metal/metal-device.cpp
+++ b/src/metal/metal-device.cpp
@@ -16,7 +16,6 @@
 
 #include "core/common.h"
 
-#include <cstdio>
 #include <cstdlib>
 #include <vector>
 
@@ -85,18 +84,14 @@ Result DeviceImpl::initialize(const DeviceDesc& desc, BackendImpl* backend)
     }
 
     // Log device identity for diagnostics.
-    {
-        char buf[256];
-        std::snprintf(
-            buf,
-            sizeof(buf),
-            "Metal device: %s (UMA=%s, ArgBufTier=%d)",
-            m_device->name()->utf8String(),
-            m_device->hasUnifiedMemory() ? "yes" : "no",
-            (int)m_device->argumentBuffersSupport()
-        );
-        handleMessage(DebugMessageType::Info, DebugMessageSource::Driver, buf);
-    }
+    printMessage(
+        DebugMessageType::Info,
+        DebugMessageSource::Driver,
+        "Metal device: %s (UMA=%s, ArgBufTier=%d)",
+        m_device->name()->utf8String(),
+        m_device->hasUnifiedMemory() ? "yes" : "no",
+        (int)m_device->argumentBuffersSupport()
+    );
 
     // Gate on Argument Buffers Tier 2 - the actual functional requirement
     // for gpuAddress() and bindless argument buffer access.

--- a/src/metal/metal-device.cpp
+++ b/src/metal/metal-device.cpp
@@ -98,7 +98,7 @@ Result DeviceImpl::initialize(const DeviceDesc& desc, BackendImpl* backend)
         handleMessage(DebugMessageType::Info, DebugMessageSource::Driver, buf);
     }
 
-    // Gate on Argument Buffers Tier 2 — the actual functional requirement
+    // Gate on Argument Buffers Tier 2 - the actual functional requirement
     // for gpuAddress() and bindless argument buffer access.
     if (m_device->argumentBuffersSupport() < MTL::ArgumentBuffersTier2)
     {

--- a/src/metal/metal-device.h
+++ b/src/metal/metal-device.h
@@ -5,6 +5,7 @@
 
 #include <algorithm>
 #include <string>
+#include <unordered_map>
 #include <vector>
 
 namespace rhi::metal {
@@ -177,9 +178,11 @@ public:
     bool m_residencySetDirty = false;
     std::mutex m_residencySetMutex;
 
-    // Fallback residency: all live resources tracked for per-encoder useResources.
-    std::vector<MTL::Resource*> m_allResources;
-    std::mutex m_allResourcesMutex;
+    // Fallback residency: maps GPU virtual addresses to their owning BufferImpl.
+    // Populated at buffer creation, erased at destruction. Used by the shader
+    // object binding code to resolve device pointers for useResources calls.
+    // Only active when !m_hasResidencySet.
+    std::unordered_map<DeviceAddress, class BufferImpl*> m_addressToBuffer;
 
     void registerResource(MTL::Resource* resource);
     void unregisterResource(MTL::Resource* resource);

--- a/src/metal/metal-device.h
+++ b/src/metal/metal-device.h
@@ -3,7 +3,9 @@
 #include "metal-base.h"
 #include "metal-clear-engine.h"
 
+#include <algorithm>
 #include <string>
+#include <vector>
 
 namespace rhi::metal {
 
@@ -171,11 +173,16 @@ public:
     bool m_hasArgumentBufferTier2 = false;
 
     NS::SharedPtr<MTL::ResidencySet> m_residencySet;
+    bool m_hasResidencySet = false;
     bool m_residencySetDirty = false;
     std::mutex m_residencySetMutex;
 
-    void registerAllocation(MTL::Allocation* allocation);
-    void unregisterAllocation(MTL::Allocation* allocation);
+    // Fallback residency: all live resources tracked for per-encoder useResources.
+    std::vector<MTL::Resource*> m_allResources;
+    std::mutex m_allResourcesMutex;
+
+    void registerResource(MTL::Resource* resource);
+    void unregisterResource(MTL::Resource* resource);
 };
 
 } // namespace rhi::metal

--- a/src/metal/metal-device.h
+++ b/src/metal/metal-device.h
@@ -3,7 +3,6 @@
 #include "metal-base.h"
 #include "metal-clear-engine.h"
 
-#include <algorithm>
 #include <string>
 #include <unordered_map>
 #include <vector>

--- a/src/metal/metal-device.h
+++ b/src/metal/metal-device.h
@@ -3,9 +3,9 @@
 #include "metal-base.h"
 #include "metal-clear-engine.h"
 
+#include "metal-buffer-address-map.h"
+
 #include <string>
-#include <unordered_map>
-#include <vector>
 
 namespace rhi::metal {
 
@@ -178,10 +178,8 @@ public:
     std::mutex m_residencySetMutex;
 
     // Fallback residency: maps GPU virtual addresses to their owning BufferImpl.
-    // Populated at buffer creation, erased at destruction. Used by the shader
-    // object binding code to resolve device pointers for useResources calls.
     // Only active when !m_hasResidencySet.
-    std::unordered_map<DeviceAddress, class BufferImpl*> m_addressToBuffer;
+    BufferAddressMap m_addressToBuffer;
 
     void registerResource(MTL::Resource* resource);
     void unregisterResource(MTL::Resource* resource);

--- a/src/metal/metal-shader-object-layout.cpp
+++ b/src/metal/metal-shader-object-layout.cpp
@@ -1,6 +1,38 @@
 #include "metal-shader-object-layout.h"
+#include "metal-device.h"
 
 namespace rhi::metal {
+
+static void collectPointerFields(
+    slang::TypeLayoutReflection* typeLayout,
+    uint32_t baseOffset,
+    std::vector<ShaderObjectLayoutImpl::PointerFieldInfo>& outFields
+)
+{
+    auto kind = typeLayout->getKind();
+    if (kind == slang::TypeReflection::Kind::Pointer)
+    {
+        outFields.push_back({baseOffset});
+        return;
+    }
+    if (kind == slang::TypeReflection::Kind::Array)
+    {
+        auto elemLayout = typeLayout->getElementTypeLayout();
+        auto stride = typeLayout->getElementStride(SLANG_PARAMETER_CATEGORY_MIXED);
+        auto count = typeLayout->getElementCount();
+        if (count == 0)
+            return;
+        for (size_t i = 0; i < count; i++)
+            collectPointerFields(elemLayout, baseOffset + (uint32_t)(i * stride), outFields);
+        return;
+    }
+    for (unsigned i = 0; i < typeLayout->getFieldCount(); i++)
+    {
+        auto field = typeLayout->getFieldByIndex(i);
+        uint32_t fieldOffset = baseOffset + (uint32_t)field->getOffset();
+        collectPointerFields(field->getTypeLayout(), fieldOffset, outFields);
+    }
+}
 
 static slang::TypeLayoutReflection* _getParameterBlockTypeLayout(
     slang::ISession* slangSession,
@@ -246,6 +278,8 @@ Result ShaderObjectLayoutImpl::_init(const Builder* builder)
     auto device = builder->m_device;
 
     initBase(device, builder->m_session, builder->m_elementTypeLayout);
+    if (!static_cast<DeviceImpl*>(device)->m_hasResidencySet)
+        collectPointerFields(m_elementTypeLayout, 0, m_pointerFields);
     m_parameterBlockTypeLayout = builder->m_parameterBlockTypeLayout;
     m_slotCount = builder->m_slotCount;
     m_subObjectCount = builder->m_subObjectCount;

--- a/src/metal/metal-shader-object-layout.h
+++ b/src/metal/metal-shader-object-layout.h
@@ -115,8 +115,17 @@ public:
     BindingOffset m_resourceCount;
     BindingOffset m_totalResourceCount;
 
+    struct PointerFieldInfo
+    {
+        uint32_t uniformOffset;
+    };
+
+    const std::vector<PointerFieldInfo>& getPointerFields() const { return m_pointerFields; }
+    bool hasPointerFields() const { return !m_pointerFields.empty(); }
+
     std::vector<BindingRangeInfo> m_bindingRanges;
     std::vector<SubObjectRangeInfo> m_subObjectRanges;
+    std::vector<PointerFieldInfo> m_pointerFields;
 
     // The type layout to use when the shader object is bind as a parameter block.
     slang::TypeLayoutReflection* m_parameterBlockTypeLayout = nullptr;

--- a/src/metal/metal-shader-object.cpp
+++ b/src/metal/metal-shader-object.cpp
@@ -414,6 +414,15 @@ Result BindingDataBuilder::bindOrdinaryDataBufferIfNeeded(
                         SLANG_RETURN_ON_FAIL(addUsedRWResource(m_bindingData, it->second->m_buffer.get()));
                         m_bindingCache->buffers.push_back(it->second);
                     }
+                    else
+                    {
+                        m_device->printWarning(
+                            "Pointer field at uniform offset %u references GPU address 0x%llx "
+                            "which does not match any known buffer; resource may not be resident",
+                            pf.uniformOffset,
+                            (unsigned long long)addr
+                        );
+                    }
                 }
             }
         }
@@ -635,6 +644,15 @@ Result BindingDataBuilder::writeArgumentBuffer(
                     {
                         SLANG_RETURN_ON_FAIL(addUsedRWResource(m_bindingData, it->second->m_buffer.get()));
                         m_bindingCache->buffers.push_back(it->second);
+                    }
+                    else
+                    {
+                        m_device->printWarning(
+                            "Pointer field at uniform offset %u references GPU address 0x%llx "
+                            "which does not match any known buffer; resource may not be resident",
+                            pf.uniformOffset,
+                            (unsigned long long)addr
+                        );
                     }
                 }
             }

--- a/src/metal/metal-shader-object.cpp
+++ b/src/metal/metal-shader-object.cpp
@@ -67,9 +67,6 @@ Result BindingDataBuilder::bindAsRoot(
     // then we could switch to asserts instead of error checks when writing binding data
     m_bindingData->bufferCapacity = 256;
     m_bindingData->textureCapacity = 256;
-    m_bindingData->usedResourceCapacity = 256;
-    m_bindingData->usedRWResourceCapacity = 256;
-
     m_bindingData->bufferCount = 0;
     m_bindingData->buffers = m_allocator->allocate<MTL::Buffer*>(m_bindingData->bufferCapacity);
     ::memset(m_bindingData->buffers, 0, sizeof(MTL::Buffer*) * m_bindingData->bufferCapacity);
@@ -85,10 +82,24 @@ Result BindingDataBuilder::bindAsRoot(
     m_bindingData->samplers = m_allocator->allocate<MTL::SamplerState*>(samplerCount);
     ::memset(m_bindingData->samplers, 0, sizeof(MTL::SamplerState*) * samplerCount);
 
-    m_bindingData->usedResourceCount = 0;
-    m_bindingData->usedResources = m_allocator->allocate<MTL::Resource*>(m_bindingData->usedResourceCapacity);
-    m_bindingData->usedRWResourceCount = 0;
-    m_bindingData->usedRWResources = m_allocator->allocate<MTL::Resource*>(m_bindingData->usedRWResourceCapacity);
+    if (!m_device->m_hasResidencySet)
+    {
+        m_bindingData->usedResourceCapacity = 256;
+        m_bindingData->usedRWResourceCapacity = 256;
+        m_bindingData->usedResourceCount = 0;
+        m_bindingData->usedResources = m_allocator->allocate<MTL::Resource*>(m_bindingData->usedResourceCapacity);
+        m_bindingData->usedRWResourceCount = 0;
+        m_bindingData->usedRWResources = m_allocator->allocate<MTL::Resource*>(m_bindingData->usedRWResourceCapacity);
+    }
+    else
+    {
+        m_bindingData->usedResourceCapacity = 0;
+        m_bindingData->usedRWResourceCapacity = 0;
+        m_bindingData->usedResourceCount = 0;
+        m_bindingData->usedResources = nullptr;
+        m_bindingData->usedRWResourceCount = 0;
+        m_bindingData->usedRWResources = nullptr;
+    }
 
     // Initialize binding offset for shader parameters.
     //
@@ -385,6 +396,29 @@ Result BindingDataBuilder::bindOrdinaryDataBufferIfNeeded(
     // Pass ownership of the buffer to the binding cache.
     m_bindingCache->buffers.push_back(bufferImpl);
 
+    // Resolve pointer-referenced buffers for residency (fallback path only).
+    if (!m_device->m_hasResidencySet)
+    {
+        auto& pointerFields = specializedLayout->getPointerFields();
+        for (auto& pf : pointerFields)
+        {
+            if (pf.uniformOffset + sizeof(DeviceAddress) <= shaderObject->m_data.size())
+            {
+                DeviceAddress addr;
+                memcpy(&addr, shaderObject->m_data.data() + pf.uniformOffset, sizeof(addr));
+                if (addr != 0)
+                {
+                    auto it = m_device->m_addressToBuffer.find(addr);
+                    if (it != m_device->m_addressToBuffer.end())
+                    {
+                        SLANG_RETURN_ON_FAIL(addUsedRWResource(m_bindingData, it->second->m_buffer.get()));
+                        m_bindingCache->buffers.push_back(it->second);
+                    }
+                }
+            }
+        }
+    }
+
     return SLANG_OK;
 }
 
@@ -460,13 +494,16 @@ Result BindingDataBuilder::writeArgumentBuffer(
                 {
                     auto resourceId = textureView->m_textureView->gpuResourceID();
                     memcpy(argumentPtr + i * sizeof(uint64_t), &resourceId, sizeof(resourceId));
-                    if (bindingRangeInfo.bindingType == slang::BindingType::MutableTexture)
+                    if (!m_device->m_hasResidencySet)
                     {
-                        SLANG_RETURN_ON_FAIL(addUsedRWResource(m_bindingData, textureView->m_textureView.get()));
-                    }
-                    else
-                    {
-                        SLANG_RETURN_ON_FAIL(addUsedResource(m_bindingData, textureView->m_textureView.get()));
+                        if (bindingRangeInfo.bindingType == slang::BindingType::MutableTexture)
+                        {
+                            SLANG_RETURN_ON_FAIL(addUsedRWResource(m_bindingData, textureView->m_textureView.get()));
+                        }
+                        else
+                        {
+                            SLANG_RETURN_ON_FAIL(addUsedResource(m_bindingData, textureView->m_textureView.get()));
+                        }
                     }
                 }
             }
@@ -496,14 +533,17 @@ Result BindingDataBuilder::writeArgumentBuffer(
                 {
                     DeviceAddress bufferPtr = buffer->getDeviceAddress() + slot.bufferRange.offset;
                     memcpy(argumentPtr + i * sizeof(uint64_t), &bufferPtr, sizeof(bufferPtr));
-                    if (bindingRangeInfo.bindingType == slang::BindingType::MutableRawBuffer ||
-                        bindingRangeInfo.bindingType == slang::BindingType::MutableTypedBuffer)
+                    if (!m_device->m_hasResidencySet)
                     {
-                        SLANG_RETURN_ON_FAIL(addUsedRWResource(m_bindingData, buffer->m_buffer.get()));
-                    }
-                    else
-                    {
-                        SLANG_RETURN_ON_FAIL(addUsedResource(m_bindingData, buffer->m_buffer.get()));
+                        if (bindingRangeInfo.bindingType == slang::BindingType::MutableRawBuffer ||
+                            bindingRangeInfo.bindingType == slang::BindingType::MutableTypedBuffer)
+                        {
+                            SLANG_RETURN_ON_FAIL(addUsedRWResource(m_bindingData, buffer->m_buffer.get()));
+                        }
+                        else
+                        {
+                            SLANG_RETURN_ON_FAIL(addUsedResource(m_bindingData, buffer->m_buffer.get()));
+                        }
                     }
                 }
             }
@@ -519,9 +559,12 @@ Result BindingDataBuilder::writeArgumentBuffer(
                 {
                     auto resourceId = accelerationStructure->m_accelerationStructure->gpuResourceID();
                     memcpy(argumentPtr + i * sizeof(uint64_t), &resourceId, sizeof(resourceId));
-                    SLANG_RETURN_ON_FAIL(
-                        addUsedResource(m_bindingData, accelerationStructure->m_accelerationStructure.get())
-                    );
+                    if (!m_device->m_hasResidencySet)
+                    {
+                        SLANG_RETURN_ON_FAIL(
+                            addUsedResource(m_bindingData, accelerationStructure->m_accelerationStructure.get())
+                        );
+                    }
                 }
             }
             break;
@@ -563,12 +606,38 @@ Result BindingDataBuilder::writeArgumentBuffer(
                 SLANG_RETURN_ON_FAIL(writeArgumentBuffer(subObject, subObjectLayout, subArgumentBuffer));
                 DeviceAddress bufferPtr = subArgumentBuffer->m_buffer->gpuAddress();
                 memcpy(argumentPtr + i * sizeof(uint64_t), &bufferPtr, sizeof(bufferPtr));
-                SLANG_RETURN_ON_FAIL(addUsedResource(m_bindingData, subArgumentBuffer->m_buffer.get()));
+                if (!m_device->m_hasResidencySet)
+                {
+                    SLANG_RETURN_ON_FAIL(addUsedResource(m_bindingData, subArgumentBuffer->m_buffer.get()));
+                }
             }
             break;
         }
         default:
             break;
+        }
+    }
+
+    // Resolve pointer-referenced buffers for residency (fallback path only).
+    if (!m_device->m_hasResidencySet)
+    {
+        auto& pointerFields = specializedLayout->getPointerFields();
+        for (auto& pf : pointerFields)
+        {
+            if (pf.uniformOffset + sizeof(DeviceAddress) <= shaderObject->m_data.size())
+            {
+                DeviceAddress addr;
+                memcpy(&addr, shaderObject->m_data.data() + pf.uniformOffset, sizeof(addr));
+                if (addr != 0)
+                {
+                    auto it = m_device->m_addressToBuffer.find(addr);
+                    if (it != m_device->m_addressToBuffer.end())
+                    {
+                        SLANG_RETURN_ON_FAIL(addUsedRWResource(m_bindingData, it->second->m_buffer.get()));
+                        m_bindingCache->buffers.push_back(it->second);
+                    }
+                }
+            }
         }
     }
 

--- a/src/metal/metal-shader-object.cpp
+++ b/src/metal/metal-shader-object.cpp
@@ -396,37 +396,7 @@ Result BindingDataBuilder::bindOrdinaryDataBufferIfNeeded(
     // Pass ownership of the buffer to the binding cache.
     m_bindingCache->buffers.push_back(bufferImpl);
 
-    // Resolve pointer-referenced buffers for residency (fallback path only).
-    if (!m_device->m_hasResidencySet)
-    {
-        auto& pointerFields = specializedLayout->getPointerFields();
-        for (auto& pf : pointerFields)
-        {
-            if (pf.uniformOffset + sizeof(DeviceAddress) <= shaderObject->m_data.size())
-            {
-                DeviceAddress addr;
-                memcpy(&addr, shaderObject->m_data.data() + pf.uniformOffset, sizeof(addr));
-                if (addr != 0)
-                {
-                    auto it = m_device->m_addressToBuffer.find(addr);
-                    if (it != m_device->m_addressToBuffer.end())
-                    {
-                        SLANG_RETURN_ON_FAIL(addUsedRWResource(m_bindingData, it->second->m_buffer.get()));
-                        m_bindingCache->buffers.push_back(it->second);
-                    }
-                    else
-                    {
-                        m_device->printWarning(
-                            "Pointer field at uniform offset %u references GPU address 0x%llx "
-                            "which does not match any known buffer; resource may not be resident",
-                            pf.uniformOffset,
-                            (unsigned long long)addr
-                        );
-                    }
-                }
-            }
-        }
-    }
+    SLANG_RETURN_ON_FAIL(resolvePointerFieldResidency(shaderObject, specializedLayout));
 
     return SLANG_OK;
 }
@@ -627,37 +597,7 @@ Result BindingDataBuilder::writeArgumentBuffer(
         }
     }
 
-    // Resolve pointer-referenced buffers for residency (fallback path only).
-    if (!m_device->m_hasResidencySet)
-    {
-        auto& pointerFields = specializedLayout->getPointerFields();
-        for (auto& pf : pointerFields)
-        {
-            if (pf.uniformOffset + sizeof(DeviceAddress) <= shaderObject->m_data.size())
-            {
-                DeviceAddress addr;
-                memcpy(&addr, shaderObject->m_data.data() + pf.uniformOffset, sizeof(addr));
-                if (addr != 0)
-                {
-                    auto it = m_device->m_addressToBuffer.find(addr);
-                    if (it != m_device->m_addressToBuffer.end())
-                    {
-                        SLANG_RETURN_ON_FAIL(addUsedRWResource(m_bindingData, it->second->m_buffer.get()));
-                        m_bindingCache->buffers.push_back(it->second);
-                    }
-                    else
-                    {
-                        m_device->printWarning(
-                            "Pointer field at uniform offset %u references GPU address 0x%llx "
-                            "which does not match any known buffer; resource may not be resident",
-                            pf.uniformOffset,
-                            (unsigned long long)addr
-                        );
-                    }
-                }
-            }
-        }
-    }
+    SLANG_RETURN_ON_FAIL(resolvePointerFieldResidency(shaderObject, specializedLayout));
 
     // Pass ownership of the buffer to the binding cache.
     m_bindingCache->buffers.push_back(argumentBufferImpl);
@@ -720,6 +660,44 @@ Result BindingDataBuilder::writeOrdinaryDataIntoArgumentBuffer(
             argumentBuffer + argumentBufferField->getOffset(),
             srcData + defaultLayoutField->getOffset()
         ));
+    }
+    return SLANG_OK;
+}
+
+Result BindingDataBuilder::resolvePointerFieldResidency(
+    ShaderObject* shaderObject,
+    ShaderObjectLayoutImpl* specializedLayout
+)
+{
+    if (m_device->m_hasResidencySet)
+        return SLANG_OK;
+
+    auto& pointerFields = specializedLayout->getPointerFields();
+    for (auto& pf : pointerFields)
+    {
+        if (pf.uniformOffset + sizeof(DeviceAddress) > shaderObject->m_data.size())
+            continue;
+
+        DeviceAddress addr;
+        memcpy(&addr, shaderObject->m_data.data() + pf.uniformOffset, sizeof(addr));
+        if (addr == 0)
+            continue;
+
+        auto it = m_device->m_addressToBuffer.find(addr);
+        if (it != m_device->m_addressToBuffer.end())
+        {
+            SLANG_RETURN_ON_FAIL(addUsedRWResource(m_bindingData, it->second->m_buffer.get()));
+            m_bindingCache->buffers.push_back(it->second);
+        }
+        else
+        {
+            m_device->printWarning(
+                "Pointer field at uniform offset %u references GPU address 0x%llx "
+                "which does not match any known buffer; resource may not be resident",
+                pf.uniformOffset,
+                (unsigned long long)addr
+            );
+        }
     }
     return SLANG_OK;
 }

--- a/src/metal/metal-shader-object.cpp
+++ b/src/metal/metal-shader-object.cpp
@@ -683,11 +683,11 @@ Result BindingDataBuilder::resolvePointerFieldResidency(
         if (addr == 0)
             continue;
 
-        auto it = m_device->m_addressToBuffer.find(addr);
-        if (it != m_device->m_addressToBuffer.end())
+        BufferImpl* resolved = m_device->m_addressToBuffer.find(addr);
+        if (resolved)
         {
-            SLANG_RETURN_ON_FAIL(addUsedRWResource(m_bindingData, it->second->m_buffer.get()));
-            m_bindingCache->buffers.push_back(it->second);
+            SLANG_RETURN_ON_FAIL(addUsedRWResource(m_bindingData, resolved->m_buffer.get()));
+            m_bindingCache->buffers.push_back(resolved);
         }
         else
         {

--- a/src/metal/metal-shader-object.h
+++ b/src/metal/metal-shader-object.h
@@ -71,6 +71,8 @@ struct BindingDataBuilder
         uint8_t* argumentBuffer,
         uint8_t* srcData
     );
+
+    Result resolvePointerFieldResidency(ShaderObject* shaderObject, ShaderObjectLayoutImpl* specializedLayout);
 };
 
 struct BindingDataImpl : BindingData

--- a/src/metal/metal-texture.cpp
+++ b/src/metal/metal-texture.cpp
@@ -16,7 +16,7 @@ TextureImpl::~TextureImpl()
     m_defaultView.setNull();
     if (m_texture && !m_isSwapchainTexture)
     {
-        getDevice<DeviceImpl>()->unregisterAllocation(m_texture.get());
+        getDevice<DeviceImpl>()->unregisterResource(m_texture.get());
     }
 }
 
@@ -159,7 +159,7 @@ Result DeviceImpl::createTexture(const TextureDesc& desc_, const SubresourceData
     textureImpl->m_textureType = textureDesc->textureType();
     textureImpl->m_pixelFormat = textureDesc->pixelFormat();
 
-    registerAllocation(textureImpl->m_texture.get());
+    registerResource(textureImpl->m_texture.get());
 
     if (desc.label)
     {

--- a/tests/main.cpp
+++ b/tests/main.cpp
@@ -97,7 +97,7 @@ int main(int argc, const char** argv)
 
         result = context.run();
 
-        bool noSilentSkips = rhi::testing::checkNoSilentSkips();
+        bool noSilentSkips = rhi::testing::checkNoSilentGpuSkips();
         if (result == 0 && !noSilentSkips)
             result = 1;
 

--- a/tests/main.cpp
+++ b/tests/main.cpp
@@ -97,6 +97,10 @@ int main(int argc, const char** argv)
 
         result = context.run();
 
+        bool noSilentSkips = rhi::testing::checkNoSilentSkips();
+        if (result == 0 && !noSilentSkips)
+            result = 1;
+
         rhi::testing::releaseCachedDevices();
     }
 

--- a/tests/test-benchmark-command.cpp
+++ b/tests/test-benchmark-command.cpp
@@ -18,8 +18,6 @@ GPU_TEST_CASE("benchmark-command", ALL)
 {
     if (!device->hasFeature(Feature::ParameterBlock))
         SKIP("no support for parameter blocks");
-    if (ctx->deviceType == DeviceType::Metal && !device->hasFeature(Feature::ResidencySet))
-        SKIP("no residency set support (useResources fallback has per-encoder overhead limits)");
 
     Shader shader;
     REQUIRE_CALL(

--- a/tests/test-benchmark-command.cpp
+++ b/tests/test-benchmark-command.cpp
@@ -18,6 +18,8 @@ GPU_TEST_CASE("benchmark-command", ALL)
 {
     if (!device->hasFeature(Feature::ParameterBlock))
         SKIP("no support for parameter blocks");
+    if (ctx->deviceType == DeviceType::Metal && !device->hasFeature(Feature::ResidencySet))
+        SKIP("no residency set support (useResources fallback has per-encoder overhead limits)");
 
     Shader shader;
     REQUIRE_CALL(

--- a/tests/test-bind-pointers.cpp
+++ b/tests/test-bind-pointers.cpp
@@ -446,9 +446,6 @@ GPU_TEST_CASE("bind-pointers-offset-address", CUDA | Metal)
         queue->waitOnHost();
     }
 
-    std::span<uint8_t> expected(
-        fullData.data() + offsetElements * sizeof(uint32_t),
-        numberCount * sizeof(uint32_t)
-    );
+    std::span<uint8_t> expected(fullData.data() + offsetElements * sizeof(uint32_t), numberCount * sizeof(uint32_t));
     compareComputeResult(device, dst, expected);
 }

--- a/tests/test-bind-pointers.cpp
+++ b/tests/test-bind-pointers.cpp
@@ -386,3 +386,69 @@ GPU_TEST_CASE("bind-pointers-intra-pass-rebind", CUDA | Metal)
 
     compareComputeResult(device, dst, std::span<uint8_t>(data));
 }
+
+// Binds a pointer into the middle of a buffer (base + offset) rather than the
+// base address. On Metal without MTLResidencySet, the runtime must resolve
+// this non-base GPU address back to the owning buffer for residency.
+GPU_TEST_CASE("bind-pointers-offset-address", CUDA | Metal)
+{
+    ComPtr<IShaderProgram> shaderProgram;
+    REQUIRE_CALL(loadProgram(device, "test-pointer-copy", "computeMain", shaderProgram.writeRef()));
+
+    ComputePipelineDesc pipelineDesc = {};
+    pipelineDesc.program = shaderProgram.get();
+    ComPtr<IComputePipeline> pipeline;
+    REQUIRE_CALL(device->createComputePipeline(pipelineDesc, pipeline.writeRef()));
+
+    const int numberCount = 4096;
+    const int offsetElements = 1024;
+    const int totalElements = offsetElements + numberCount;
+
+    std::vector<uint8_t> fullData(totalElements * sizeof(uint32_t));
+    std::mt19937 rng(334455);
+    std::uniform_int_distribution<int> dist(0, 255);
+    for (auto& byte : fullData)
+        byte = (uint8_t)dist(rng);
+
+    BufferDesc srcBufDesc = {};
+    srcBufDesc.size = totalElements * sizeof(uint32_t);
+    srcBufDesc.format = Format::Undefined;
+    srcBufDesc.elementSize = sizeof(uint32_t);
+    srcBufDesc.usage = BufferUsage::ShaderResource | BufferUsage::UnorderedAccess | BufferUsage::CopyDestination |
+                       BufferUsage::CopySource;
+    srcBufDesc.defaultState = ResourceState::UnorderedAccess;
+    srcBufDesc.memoryType = MemoryType::DeviceLocal;
+
+    ComPtr<IBuffer> src;
+    REQUIRE_CALL(device->createBuffer(srcBufDesc, (void*)fullData.data(), src.writeRef()));
+
+    BufferDesc dstBufDesc = srcBufDesc;
+    dstBufDesc.size = numberCount * sizeof(uint32_t);
+
+    ComPtr<IBuffer> dst;
+    REQUIRE_CALL(device->createBuffer(dstBufDesc, nullptr, dst.writeRef()));
+
+    {
+        auto queue = device->getQueue(QueueType::Graphics);
+        auto commandEncoder = queue->createCommandEncoder();
+
+        auto passEncoder = commandEncoder->beginComputePass();
+        auto rootObject = passEncoder->bindPipeline(pipeline);
+        ShaderCursor shaderCursor(rootObject);
+        DeviceAddress srcOffset = src->getDeviceAddress() + offsetElements * sizeof(uint32_t);
+        shaderCursor["src"].setData(srcOffset);
+        shaderCursor["dst"].setData(dst->getDeviceAddress());
+
+        passEncoder->dispatchCompute(numberCount / 32, 1, 1);
+        passEncoder->end();
+
+        queue->submit(commandEncoder->finish());
+        queue->waitOnHost();
+    }
+
+    std::span<uint8_t> expected(
+        fullData.data() + offsetElements * sizeof(uint32_t),
+        numberCount * sizeof(uint32_t)
+    );
+    compareComputeResult(device, dst, expected);
+}

--- a/tests/testing.cpp
+++ b/tests/testing.cpp
@@ -948,6 +948,9 @@ slang::IGlobalSession* getSlangGlobalSession()
     return slangGlobalSession;
 }
 
+static std::map<DeviceType, int> sTestsEncountered;
+static std::map<DeviceType, int> sTestsExecuted;
+
 // Trampoline test function registered in doctest for each GPU test instance.
 // Uses GpuTestInfo for additional information about the specific test instance.
 static void gpuTestTrampoline()
@@ -959,6 +962,8 @@ static void gpuTestTrampoline()
     DeviceType deviceType = info->deviceType;
     bool createDevice = (info->flags & GpuTestFlags::DontCreateDevice) == 0;
     bool cacheDevice = (info->flags & GpuTestFlags::DontCacheDevice) == 0;
+
+    sTestsEncountered[deviceType]++;
 
     if (!isDeviceTypeSelected(deviceType))
     {
@@ -1008,6 +1013,7 @@ static void gpuTestTrampoline()
             device->setCudaContextCurrent();
         }
         info->func(&ctx, device);
+        reportTestExecuted(deviceType);
         if (device)
         {
             device->getQueue(QueueType::Graphics)->waitOnHost();
@@ -1118,6 +1124,40 @@ const char* getSkipMessage(const doctest::TestCaseData* tc)
 {
     auto it = sSkipMessages.find(tc);
     return it != sSkipMessages.end() ? it->second : nullptr;
+}
+
+void reportTestExecuted(DeviceType deviceType)
+{
+    sTestsExecuted[deviceType]++;
+}
+
+bool checkNoSilentSkips()
+{
+    bool ok = true;
+    for (DeviceType deviceType : kPlatformDeviceTypes)
+    {
+        if (!isDeviceTypeSelected(deviceType))
+            continue;
+        if (sTestsEncountered.find(deviceType) == sTestsEncountered.end())
+            continue;
+        auto availIt = sDeviceTypeAvailable.find(deviceType);
+        if (availIt == sDeviceTypeAvailable.end() || !availIt->second)
+            continue;
+        auto execIt = sTestsExecuted.find(deviceType);
+        int count = (execIt != sTestsExecuted.end()) ? execIt->second : 0;
+        if (count == 0)
+        {
+            std::fprintf(
+                stderr,
+                "ERROR: Device type '%s' was available but zero tests executed "
+                "(all silently skipped). This likely indicates a device "
+                "initialization regression.\n",
+                deviceTypeToString(deviceType)
+            );
+            ok = false;
+        }
+    }
+    return ok;
 }
 
 } // namespace rhi::testing

--- a/tests/testing.cpp
+++ b/tests/testing.cpp
@@ -948,8 +948,8 @@ slang::IGlobalSession* getSlangGlobalSession()
     return slangGlobalSession;
 }
 
-static std::map<DeviceType, int> sTestsEncountered;
-static std::map<DeviceType, int> sTestsExecuted;
+static std::map<DeviceType, int> sGpuTestsEncountered;
+static std::map<DeviceType, int> sGpuTestsExecuted;
 
 // Trampoline test function registered in doctest for each GPU test instance.
 // Uses GpuTestInfo for additional information about the specific test instance.
@@ -963,7 +963,7 @@ static void gpuTestTrampoline()
     bool createDevice = (info->flags & GpuTestFlags::DontCreateDevice) == 0;
     bool cacheDevice = (info->flags & GpuTestFlags::DontCacheDevice) == 0;
 
-    sTestsEncountered[deviceType]++;
+    sGpuTestsEncountered[deviceType]++;
 
     if (!isDeviceTypeSelected(deviceType))
     {
@@ -1013,7 +1013,7 @@ static void gpuTestTrampoline()
             device->setCudaContextCurrent();
         }
         info->func(&ctx, device);
-        reportTestExecuted(deviceType);
+        reportGpuTestExecuted(deviceType);
         if (device)
         {
             device->getQueue(QueueType::Graphics)->waitOnHost();
@@ -1126,25 +1126,25 @@ const char* getSkipMessage(const doctest::TestCaseData* tc)
     return it != sSkipMessages.end() ? it->second : nullptr;
 }
 
-void reportTestExecuted(DeviceType deviceType)
+void reportGpuTestExecuted(DeviceType deviceType)
 {
-    sTestsExecuted[deviceType]++;
+    sGpuTestsExecuted[deviceType]++;
 }
 
-bool checkNoSilentSkips()
+bool checkNoSilentGpuSkips()
 {
     bool ok = true;
     for (DeviceType deviceType : kPlatformDeviceTypes)
     {
         if (!isDeviceTypeSelected(deviceType))
             continue;
-        if (sTestsEncountered.find(deviceType) == sTestsEncountered.end())
+        if (sGpuTestsEncountered.find(deviceType) == sGpuTestsEncountered.end())
             continue;
         auto availIt = sDeviceTypeAvailable.find(deviceType);
         if (availIt == sDeviceTypeAvailable.end() || !availIt->second)
             continue;
-        auto execIt = sTestsExecuted.find(deviceType);
-        int count = (execIt != sTestsExecuted.end()) ? execIt->second : 0;
+        auto execIt = sGpuTestsExecuted.find(deviceType);
+        int count = (execIt != sGpuTestsExecuted.end()) ? execIt->second : 0;
         if (count == 0)
         {
             std::fprintf(

--- a/tests/testing.h
+++ b/tests/testing.h
@@ -482,6 +482,9 @@ int registerGpuTest(
 void reportSkip(const doctest::detail::TestCase* tc, const char* reason);
 const char* getSkipMessage(const doctest::TestCaseData* tc);
 
+void reportTestExecuted(DeviceType deviceType);
+bool checkNoSilentSkips();
+
 } // namespace rhi::testing
 
 #define GPU_TEST_CASE_IMPL(name, func, flags, debugLayerOptions)                                                       \

--- a/tests/testing.h
+++ b/tests/testing.h
@@ -482,8 +482,8 @@ int registerGpuTest(
 void reportSkip(const doctest::detail::TestCase* tc, const char* reason);
 const char* getSkipMessage(const doctest::TestCaseData* tc);
 
-void reportTestExecuted(DeviceType deviceType);
-bool checkNoSilentSkips();
+void reportGpuTestExecuted(DeviceType deviceType);
+bool checkNoSilentGpuSkips();
 
 } // namespace rhi::testing
 


### PR DESCRIPTION
Fixes #725
Part of shader-slang/slang#10841

## Summary

- **useResource fallback**: Devices that lack `MTLResidencySet` support (e.g. Apple Paravirtual on GitHub Actions macOS VMs) now fall back to per-encoder `useResources` calls instead of failing device initialization.
- **Capability detection**: Replaced the hard `GPUFamilyApple6` gate with `argumentBuffersSupport >= Tier2`, allowing Metal to initialize on paravirtualized devices. `MTLResidencySet` is attempted conditionally and falls back gracefully.
- **Silent all-skip detection**: The test harness now tracks per-device-type GPU test execution counts. If a device probes as available but zero GPU tests actually execute (all silently skipped), the test run fails with a clear diagnostic instead of reporting false success.

## Details

### Residency fallback (`metal-device.cpp`, `metal-command.cpp`, `metal-shader-object.cpp`)
- `m_hasResidencySet` flag controls which path is used at runtime
- **ResidencySet path** (default on capable hardware): Resources are added to `MTLResidencySet` via `registerResource`/`unregisterResource`. No per-binding resource tracking overhead — `usedResources`/`usedRWResources` arrays are not allocated, `collectPointerFields` is skipped.
- **Fallback path** (`!m_hasResidencySet`): Per-binding `useResources` calls in `cmdSetComputeState`/`cmdSetRenderState` declare resources for residency before dispatches/draws. Resources are tracked via `BindingDataImpl::usedResources`/`usedRWResources`, populated during `writeArgumentBuffer()` for textures, buffers, acceleration structures, and sub-argument buffers.
- **Pointer resolution**: `BufferAddressMap` (`metal-buffer-address-map.h`) maps GPU addresses to their owning `BufferImpl*` on the fallback path. It provides O(1) exact base-address lookups via `unordered_map` and O(log N) range lookups via a lazily-sorted vector for pointers that land in the middle of a buffer. All operations are mutex-protected for thread safety. Pointer fields in uniform data are resolved via `resolvePointerFieldResidency()` during `bindOrdinaryDataBufferIfNeeded()` and `writeArgumentBuffer()` to automatically declare pointer-accessed buffers for residency.
- `SLANG_RHI_METAL_NO_RESIDENCY_SET` env var forces the fallback path for testing
- Acceleration structure residency tracking added (fixes pre-existing omission)
- Only actionable diagnostics are emitted (forced fallback, unsupported GPU family, residency set creation failure)

### Test harness (`testing.cpp`, `testing.h`, `main.cpp`)
- `sGpuTestsEncountered` / `sGpuTestsExecuted` maps track per-device-type counts
- `checkNoSilentGpuSkips()` runs after the test suite and checks: device selected AND tests encountered AND device probed available AND zero executed → error
- Does not fire for devices excluded by `-select-devices`, filtered out by `-tc`, or that legitimately fail the availability probe

## Test plan
- [x] All Metal RHI tests pass on Apple Silicon (normal ResidencySet path) — 933/933
- [x] All Metal RHI tests pass with `SLANG_RHI_METAL_NO_RESIDENCY_SET=1` (fallback path) — 933/933
- [x] `benchmark-command` passes on both paths with comparable performance (~109ms vs ~110ms for 10k dispatches)
- [x] `bind-pointers-offset-address` passes on both paths — exercises range-based address lookup by binding a pointer into the middle of a buffer
- [x] slangpy pointer tests pass on fallback path — 20/20
- [x] Silent-skip detection verified: fires when device is available but all tests skip, does not fire for legitimately unavailable devices or filtered test runs


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added residency set support for optimized GPU memory management on Metal devices; includes fallback per-encoder tracking when unavailable.
  * Enhanced test infrastructure to detect and prevent silent GPU skips during test execution.

* **Bug Fixes**
  * Improved GPU pointer field resolution to correctly track shader-visible memory pointers.

* **Tests**
  * Added test coverage for pointer binding at offset addresses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->