### PR TITLE
Add support for requiredFeatures in DeviceDesc

### DIFF
--- a/examples/base/utils.h
+++ b/examples/base/utils.h
@@ -107,17 +107,10 @@ inline Result createDevice(
     deviceDesc.slang.preprocessorMacros = preprocessorMacrosDescs.data();
     deviceDesc.slang.preprocessorMacroCount = preprocessorMacrosDescs.size();
 
-    SLANG_RETURN_ON_FAIL(getRHI()->createDevice(deviceDesc, outDevice));
+    deviceDesc.requiredFeatureCount = static_cast<uint32_t>(requiredFeatures.size());
+    deviceDesc.requiredFeatures = requiredFeatures.data();
 
-    for (const auto& feature : requiredFeatures)
-    {
-        if (!(*outDevice)->hasFeature(feature))
-        {
-            return SLANG_E_NOT_AVAILABLE;
-        }
-    }
-
-    return SLANG_OK;
+    return getRHI()->createDevice(deviceDesc, outDevice);
 }
 
 // ---------------------------------------------------------------------------------------

--- a/include/slang-rhi.h
+++ b/include/slang-rhi.h
@@ -3176,8 +3176,8 @@ struct DeviceDesc
     const AdapterLUID* adapterLUID = nullptr;
     // Number of required features.
     uint32_t requiredFeatureCount = 0;
-    // Array of required feature names, whose size is `requiredFeatureCount`.
-    const char* const* requiredFeatures = nullptr;
+    // Array of required features, whose size is `requiredFeatureCount`.
+    const Feature* requiredFeatures = nullptr;
     // Configurations for Slang compiler.
     SlangDesc slang = {};
 

--- a/include/slang-rhi.h
+++ b/include/slang-rhi.h
@@ -3956,10 +3956,10 @@ struct VulkanDeviceExtendedDesc
 
     bool enableDebugPrintf = false;
 
-    const char* const* instanceExtensions = nullptr;
     uint32_t instanceExtensionCount = 0;
-    const char* const* deviceExtensions = nullptr;
+    const char* const* instanceExtensions = nullptr;
     uint32_t deviceExtensionCount = 0;
+    const char* const* deviceExtensions = nullptr;
 };
 
 } // namespace rhi

--- a/src/cpu/cpu-device.cpp
+++ b/src/cpu/cpu-device.cpp
@@ -61,6 +61,8 @@ Result DeviceImpl::initialize(const DeviceDesc& desc, BackendImpl* backend)
     m_queue = new CommandQueueImpl(this, QueueType::Graphics);
     m_queue->setInternalReferenceCount(1);
 
+    SLANG_RETURN_ON_FAIL(checkRequiredFeatures(desc));
+
     return SLANG_OK;
 }
 

--- a/src/cuda/cuda-device.cpp
+++ b/src/cuda/cuda-device.cpp
@@ -321,6 +321,8 @@ Result DeviceImpl::initialize(const DeviceDesc& desc, BackendImpl* backend)
 
     SLANG_RETURN_ON_FAIL(m_clearEngine.initialize(this));
 
+    SLANG_RETURN_ON_FAIL(checkRequiredFeatures(desc));
+
     return SLANG_OK;
 }
 

--- a/src/d3d11/d3d11-device.cpp
+++ b/src/d3d11/d3d11-device.cpp
@@ -411,6 +411,8 @@ Result DeviceImpl::initialize(const DeviceDesc& desc, BackendImpl* backend)
     m_queue = new CommandQueueImpl(this, QueueType::Graphics);
     m_queue->setInternalReferenceCount(1);
 
+    SLANG_RETURN_ON_FAIL(checkRequiredFeatures(desc));
+
     return SLANG_OK;
 }
 

--- a/src/d3d12/d3d12-device.cpp
+++ b/src/d3d12/d3d12-device.cpp
@@ -1053,6 +1053,8 @@ Result DeviceImpl::initialize(const DeviceDesc& desc, BackendImpl* backend)
         SLANG_RETURN_ON_FAIL(m_bindlessDescriptorSet->initialize());
     }
 
+    SLANG_RETURN_ON_FAIL(checkRequiredFeatures(desc));
+
     return SLANG_OK;
 }
 

--- a/src/device.cpp
+++ b/src/device.cpp
@@ -565,6 +565,27 @@ bool Device::hasFeature(const char* feature)
     return false;
 }
 
+Result Device::checkRequiredFeatures(const DeviceDesc& desc)
+{
+#define SLANG_RHI_FEATURES_X(id, name) name,
+    static constexpr const char* kFeatureNames[] = {SLANG_RHI_FEATURES(SLANG_RHI_FEATURES_X)};
+#undef SLANG_RHI_FEATURES_X
+
+    Result result = SLANG_OK;
+    for (uint32_t i = 0; i < desc.requiredFeatureCount; i++)
+    {
+        Feature feature = desc.requiredFeatures[i];
+        if (!hasFeature(feature))
+        {
+            const char* featureName =
+                size_t(feature) < size_t(Feature::_Count) ? kFeatureNames[size_t(feature)] : "unknown";
+            printError("Required feature '%s' is not available\n", featureName);
+            result = SLANG_E_NOT_AVAILABLE;
+        }
+    }
+    return result;
+}
+
 Result Device::getCapabilities(uint32_t* outCapabilityCount, Capability* outCapabilities)
 {
     if (!outCapabilityCount)

--- a/src/device.h
+++ b/src/device.h
@@ -447,6 +447,8 @@ protected:
     void addCapability(Capability capability);
     std::vector<Capability> getCapabilities();
 
+    Result checkRequiredFeatures(const DeviceDesc& desc);
+
 protected:
     std::array<bool, size_t(Feature::_Count)> m_featureSet;
     std::array<bool, size_t(Capability::_Count)> m_capabilitySet;

--- a/src/metal/metal-device.cpp
+++ b/src/metal/metal-device.cpp
@@ -294,6 +294,8 @@ Result DeviceImpl::initialize(const DeviceDesc& desc, BackendImpl* backend)
 
     SLANG_RETURN_ON_FAIL(m_clearEngine.initialize(m_device.get()));
 
+    SLANG_RETURN_ON_FAIL(checkRequiredFeatures(desc));
+
     return SLANG_OK;
 }
 

--- a/src/vulkan/vk-device.cpp
+++ b/src/vulkan/vk-device.cpp
@@ -1562,6 +1562,8 @@ Result DeviceImpl::initialize(const DeviceDesc& desc, BackendImpl* backend)
     m_queue->init(m_deviceQueue.getQueue(), m_queueFamilyIndex);
     m_queue->setInternalReferenceCount(1);
 
+    SLANG_RETURN_ON_FAIL(checkRequiredFeatures(desc));
+
     return SLANG_OK;
 }
 

--- a/src/wgpu/wgpu-device.cpp
+++ b/src/wgpu/wgpu-device.cpp
@@ -266,6 +266,8 @@ Result DeviceImpl::initialize(const DeviceDesc& desc, BackendImpl* backend)
     m_queue = new CommandQueueImpl(this, QueueType::Graphics);
     m_queue->setInternalReferenceCount(1);
 
+    SLANG_RETURN_ON_FAIL(checkRequiredFeatures(desc));
+
     return SLANG_OK;
 }
 


### PR DESCRIPTION
Changes `DeviceDesc::requiredFeatures` from `const char* const*` to `const Feature*` and adds validation during device initialization that returns `SLANG_E_NOT_AVAILABLE` if any required feature is unavailable.

- Changed `requiredFeatures` field type from `const char* const*` to `const Feature*`
- Added `Device::checkRequiredFeatures()` helper that checks all required features and prints an error naming any missing feature
- All backends (CPU, CUDA, D3D11, D3D12, Vulkan, Metal, WGPU) call the validation at the end of `initialize()`, after features have been populated
- Updated example `createDevice()` helper to pass features through `DeviceDesc` instead of checking post-creation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Device initialization now validates required features across all backend implementations (CPU, CUDA, Direct3D, Metal, Vulkan, WebGPU), ensuring creation fails gracefully with clear error messages when required features are unavailable.

* **API Changes**
  * Updated required features specification to use Feature enum values instead of string identifiers; reordered Vulkan extension fields for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->