### PR TITLE
Use emscripten 5.0.6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,7 +87,7 @@ jobs:
         if: matrix.compiler == 'emscripten'
         uses: emscripten-core/setup-emsdk@v16
         with:
-          version: 'latest'
+          version: '5.0.6'
 
       - name: Configure
         run: cmake --preset ${{matrix.preset}} ${{ contains(matrix.flags, 'coverage') && '-DSLANG_RHI_ENABLE_COVERAGE=ON' || '' }}


### PR DESCRIPTION
Unfortunately the emscripten build depends on a specific range of versions to work (due to webgpu dependency). We manually set the version to `5.0.6` instead of `latest` until this can be fixed in a different way.