### PR TITLE
Add full 'execute callback' mechanism

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -911,6 +911,7 @@ if(SLANG_RHI_BUILD_TESTS AND NOT SLANG_RHI_BUILD_SHARED AND NOT EMSCRIPTEN)
         tests/test-aftermath.cpp
         tests/test-arena-allocator.cpp
         tests/test-device-features.cpp
+        tests/test-execute-callback.cpp
         tests/test-block-allocator.cpp
         tests/test-benchmark-command.cpp
         tests/test-bindless.cpp

--- a/include/slang-rhi.h
+++ b/include/slang-rhi.h
@@ -2508,6 +2508,37 @@ struct CommandEncoderDesc
     const char* label = nullptr;
 };
 
+struct ExecuteCallbackContext
+{
+    /// Native handle for the active backend command context.
+    /// D3D12 supplies D3D12GraphicsCommandList, Vulkan supplies VkCommandBuffer,
+    /// and CUDA supplies CUstream. Backends without an active native command
+    /// context pass Undefined.
+    NativeHandle nativeHandle;
+};
+
+typedef void(SLANG_MCALL* ExecuteCallbackFunc)(
+    const ExecuteCallbackContext* context,
+    void* userObject,
+    const void* userData
+);
+typedef void(SLANG_MCALL* ExecuteCallbackObjectFunc)(void* userObject);
+
+struct ExecuteCallbackDesc
+{
+    /// Function to call when the callback command is recorded/executed.
+    ExecuteCallbackFunc callback = nullptr;
+
+    /// Optional object retained until the command buffer is reset or destroyed.
+    void* userObject = nullptr;
+    ExecuteCallbackObjectFunc retainUserObject = nullptr;
+    ExecuteCallbackObjectFunc releaseUserObject = nullptr;
+
+    /// Optional small user-data block copied into the command buffer.
+    const void* userData = nullptr;
+    Size userDataSize = 0;
+};
+
 class ICommandEncoder : public ISlangUnknown
 {
     SLANG_COM_INTERFACE(0x8ee39d55, 0x2b07, 0x4e61, {0x8f, 0x13, 0x1d, 0x6c, 0x01, 0xa9, 0x15, 0x43});
@@ -2684,6 +2715,8 @@ public:
     virtual SLANG_NO_THROW void SLANG_MCALL insertDebugMarker(const char* name, const MarkerColor& color) = 0;
 
     virtual SLANG_NO_THROW void SLANG_MCALL writeTimestamp(IQueryPool* queryPool, uint32_t queryIndex) = 0;
+
+    virtual SLANG_NO_THROW void SLANG_MCALL executeCallback(const ExecuteCallbackDesc& desc) = 0;
 
     virtual SLANG_NO_THROW Result SLANG_MCALL finish(
         const CommandBufferDesc& desc,

--- a/include/slang-rhi.h
+++ b/include/slang-rhi.h
@@ -549,6 +549,8 @@ enum class NativeHandleType
     Win32 = 0x00000001,
     FileDescriptor = 0x00000002,
 
+    D3D11DeviceContext = 0x00010001,
+
     D3D12Device = 0x00020001,
     D3D12CommandQueue = 0x00020002,
     D3D12GraphicsCommandList = 0x00020003,
@@ -2511,14 +2513,19 @@ struct CommandEncoderDesc
 struct ExecuteCallbackContext
 {
     /// Native handle for the active backend command context.
-    /// D3D12 supplies D3D12GraphicsCommandList, Vulkan supplies VkCommandBuffer,
-    /// and CUDA supplies CUstream. Backends without an active native command
-    /// context pass Undefined.
+    /// D3D11 supplies D3D11DeviceContext, D3D12 supplies D3D12GraphicsCommandList,
+    /// Vulkan supplies VkCommandBuffer, Metal supplies MTLCommandBuffer, CUDA
+    /// supplies CUstream, and WGPU supplies WGPUCommandEncoder. Backends without
+    /// an active native command context pass Undefined.
     NativeHandle nativeHandle;
 };
 
-typedef void(SLANG_MCALL*
-                 ExecuteCallbackFunc)(const ExecuteCallbackContext* context, void* userObject, const void* userData);
+typedef void(SLANG_MCALL* ExecuteCallbackFunc)(
+    const ExecuteCallbackContext* context,
+    void* userObject,
+    const void* userData,
+    Size userDataSize
+);
 typedef void(SLANG_MCALL* ExecuteCallbackObjectFunc)(void* userObject);
 
 struct ExecuteCallbackDesc

--- a/include/slang-rhi.h
+++ b/include/slang-rhi.h
@@ -2517,11 +2517,8 @@ struct ExecuteCallbackContext
     NativeHandle nativeHandle;
 };
 
-typedef void(SLANG_MCALL* ExecuteCallbackFunc)(
-    const ExecuteCallbackContext* context,
-    void* userObject,
-    const void* userData
-);
+typedef void(SLANG_MCALL*
+                 ExecuteCallbackFunc)(const ExecuteCallbackContext* context, void* userObject, const void* userData);
 typedef void(SLANG_MCALL* ExecuteCallbackObjectFunc)(void* userObject);
 
 struct ExecuteCallbackDesc

--- a/src/command-buffer.cpp
+++ b/src/command-buffer.cpp
@@ -1004,4 +1004,30 @@ ICommandBuffer* CommandBuffer::getInterface(const Guid& guid)
     return nullptr;
 }
 
+CommandBuffer::~CommandBuffer()
+{
+    resetCallbackObjects();
+}
+
+Result CommandBuffer::reset()
+{
+    m_commandList.reset();
+    resetCallbackObjects();
+    m_allocator.reset();
+    m_trackedObjects.clear();
+    return SLANG_OK;
+}
+
+void CommandBuffer::resetCallbackObjects()
+{
+    for (const ExecuteCallbackObjectRetainer& object : m_trackedExecuteCallbackObjects)
+    {
+        if (object.userObject && object.releaseUserObject)
+        {
+            object.releaseUserObject(object.userObject);
+        }
+    }
+    m_trackedExecuteCallbackObjects.clear();
+}
+
 } // namespace rhi

--- a/src/command-buffer.cpp
+++ b/src/command-buffer.cpp
@@ -918,6 +918,13 @@ void CommandEncoder::writeTimestamp(IQueryPool* queryPool, uint32_t queryIndex)
     m_commandList->write(std::move(cmd));
 }
 
+void CommandEncoder::executeCallback(const ExecuteCallbackDesc& desc)
+{
+    commands::ExecuteCallback cmd;
+    cmd.desc = desc;
+    m_commandList->write(std::move(cmd));
+}
+
 Result CommandEncoder::finish(const CommandBufferDesc& desc, ICommandBuffer** outCommandBuffer)
 {
     // iterate over commands and specialize pipelines

--- a/src/command-buffer.h
+++ b/src/command-buffer.h
@@ -383,6 +383,8 @@ public:
 
     virtual SLANG_NO_THROW void SLANG_MCALL writeTimestamp(IQueryPool* queryPool, uint32_t queryIndex) override;
 
+    virtual SLANG_NO_THROW void SLANG_MCALL executeCallback(const ExecuteCallbackDesc& desc) override;
+
     virtual SLANG_NO_THROW Result SLANG_MCALL finish(
         const CommandBufferDesc& desc,
         ICommandBuffer** outCommandBuffer
@@ -398,7 +400,7 @@ public:
 public:
     CommandBuffer(Device* device)
         : DeviceChild(device)
-        , m_commandList(m_allocator, m_trackedObjects)
+        , m_commandList(m_allocator, m_trackedObjects, m_trackedExecuteCallbackObjects)
     {
     }
     virtual ~CommandBuffer() = default;
@@ -411,6 +413,7 @@ public:
         m_commandList.reset();
         m_allocator.reset();
         m_trackedObjects.clear();
+        m_trackedExecuteCallbackObjects.clear();
         return SLANG_OK;
     }
 
@@ -428,8 +431,9 @@ public:
     CommandBufferDesc m_desc;
     StructHolder m_descHolder;
     ArenaAllocator m_allocator;
-    CommandList m_commandList;
     std::set<RefPtr<RefObject>> m_trackedObjects;
+    std::vector<ExecuteCallbackObjectRetainer> m_trackedExecuteCallbackObjects;
+    CommandList m_commandList;
 };
 
 } // namespace rhi

--- a/src/command-buffer.h
+++ b/src/command-buffer.h
@@ -403,19 +403,12 @@ public:
         , m_commandList(m_allocator, m_trackedObjects, m_trackedExecuteCallbackObjects)
     {
     }
-    virtual ~CommandBuffer() = default;
+    virtual ~CommandBuffer();
 
     virtual void makeExternal() override { establishStrongReferenceToDevice(); }
     virtual void makeInternal() override { breakStrongReferenceToDevice(); }
 
-    virtual Result reset()
-    {
-        m_commandList.reset();
-        m_allocator.reset();
-        m_trackedObjects.clear();
-        m_trackedExecuteCallbackObjects.clear();
-        return SLANG_OK;
-    }
+    virtual Result reset();
 
     void setDesc(const CommandBufferDesc& desc)
     {
@@ -434,6 +427,9 @@ public:
     std::set<RefPtr<RefObject>> m_trackedObjects;
     std::vector<ExecuteCallbackObjectRetainer> m_trackedExecuteCallbackObjects;
     CommandList m_commandList;
+
+private:
+    void resetCallbackObjects();
 };
 
 } // namespace rhi

--- a/src/command-list.cpp
+++ b/src/command-list.cpp
@@ -382,7 +382,7 @@ void CommandList::write(commands::ExecuteCallback&& cmd)
     if (cmd.desc.userObject && cmd.desc.retainUserObject && cmd.desc.releaseUserObject)
     {
         cmd.desc.retainUserObject(cmd.desc.userObject);
-        m_trackedExecuteCallbackObjects.emplace_back(cmd.desc.userObject, cmd.desc.releaseUserObject);
+        m_trackedExecuteCallbackObjects.push_back({cmd.desc.userObject, cmd.desc.releaseUserObject});
     }
 
     writeCommand(std::move(cmd));

--- a/src/command-list.cpp
+++ b/src/command-list.cpp
@@ -3,9 +3,14 @@
 
 namespace rhi {
 
-CommandList::CommandList(ArenaAllocator& allocator, std::set<RefPtr<RefObject>>& trackedObjects)
+CommandList::CommandList(
+    ArenaAllocator& allocator,
+    std::set<RefPtr<RefObject>>& trackedObjects,
+    std::vector<ExecuteCallbackObjectRetainer>& trackedExecuteCallbackObjects
+)
     : m_allocator(allocator)
     , m_trackedObjects(trackedObjects)
+    , m_trackedExecuteCallbackObjects(trackedExecuteCallbackObjects)
 {
 }
 
@@ -371,8 +376,15 @@ void CommandList::write(commands::WriteTimestamp&& cmd)
 
 void CommandList::write(commands::ExecuteCallback&& cmd)
 {
-    if (cmd.userData && cmd.userDataSize > 0)
-        cmd.userData = writeData(cmd.userData, cmd.userDataSize);
+    if (cmd.desc.userData && cmd.desc.userDataSize > 0)
+        cmd.desc.userData = writeData(cmd.desc.userData, cmd.desc.userDataSize);
+
+    if (cmd.desc.userObject && cmd.desc.retainUserObject && cmd.desc.releaseUserObject)
+    {
+        cmd.desc.retainUserObject(cmd.desc.userObject);
+        m_trackedExecuteCallbackObjects.emplace_back(cmd.desc.userObject, cmd.desc.releaseUserObject);
+    }
+
     writeCommand(std::move(cmd));
 }
 

--- a/src/command-list.h
+++ b/src/command-list.h
@@ -376,59 +376,13 @@ inline void invokeExecuteCallback(const commands::ExecuteCallback& cmd, NativeHa
 
     ExecuteCallbackContext context;
     context.nativeHandle = nativeHandle;
-    cmd.desc.callback(&context, cmd.desc.userObject, cmd.desc.userData);
+    cmd.desc.callback(&context, cmd.desc.userObject, cmd.desc.userData, cmd.desc.userDataSize);
 }
 
-class ExecuteCallbackObjectRetainer
+struct ExecuteCallbackObjectRetainer
 {
-public:
-    ExecuteCallbackObjectRetainer() = default;
-
-    ExecuteCallbackObjectRetainer(void* userObject, ExecuteCallbackObjectFunc releaseUserObject)
-        : m_userObject(userObject)
-        , m_releaseUserObject(releaseUserObject)
-    {
-    }
-
-    ExecuteCallbackObjectRetainer(const ExecuteCallbackObjectRetainer&) = delete;
-    ExecuteCallbackObjectRetainer& operator=(const ExecuteCallbackObjectRetainer&) = delete;
-
-    ExecuteCallbackObjectRetainer(ExecuteCallbackObjectRetainer&& other) noexcept
-        : m_userObject(other.m_userObject)
-        , m_releaseUserObject(other.m_releaseUserObject)
-    {
-        other.m_userObject = nullptr;
-        other.m_releaseUserObject = nullptr;
-    }
-
-    ExecuteCallbackObjectRetainer& operator=(ExecuteCallbackObjectRetainer&& other) noexcept
-    {
-        if (this != &other)
-        {
-            reset();
-            m_userObject = other.m_userObject;
-            m_releaseUserObject = other.m_releaseUserObject;
-            other.m_userObject = nullptr;
-            other.m_releaseUserObject = nullptr;
-        }
-        return *this;
-    }
-
-    ~ExecuteCallbackObjectRetainer() { reset(); }
-
-    void reset()
-    {
-        if (m_userObject && m_releaseUserObject)
-        {
-            m_releaseUserObject(m_userObject);
-        }
-        m_userObject = nullptr;
-        m_releaseUserObject = nullptr;
-    }
-
-private:
-    void* m_userObject = nullptr;
-    ExecuteCallbackObjectFunc m_releaseUserObject = nullptr;
+    void* userObject = nullptr;
+    ExecuteCallbackObjectFunc releaseUserObject = nullptr;
 };
 
 

--- a/src/command-list.h
+++ b/src/command-list.h
@@ -7,6 +7,7 @@
 #include <utility>
 #include <set>
 #include <cstring>
+#include <vector>
 
 // clang-format off
 #define SLANG_RHI_COMMANDS(x) \
@@ -340,10 +341,7 @@ struct WriteTimestamp
 
 struct ExecuteCallback
 {
-    using Callback = void (*)(const void* userData);
-    Callback callback;
-    const void* userData;
-    Size userDataSize;
+    ExecuteCallbackDesc desc;
 };
 
 #define SLANG_RHI_COMMAND_CHECK_X(x)                                                                                   \
@@ -371,6 +369,68 @@ SLANG_RHI_COMMANDS(SLANG_RHI_COMMAND_TRAITS_X)
 
 } // namespace commands
 
+inline void invokeExecuteCallback(const commands::ExecuteCallback& cmd, NativeHandle nativeHandle)
+{
+    if (!cmd.desc.callback)
+        return;
+
+    ExecuteCallbackContext context;
+    context.nativeHandle = nativeHandle;
+    cmd.desc.callback(&context, cmd.desc.userObject, cmd.desc.userData);
+}
+
+class ExecuteCallbackObjectRetainer
+{
+public:
+    ExecuteCallbackObjectRetainer() = default;
+
+    ExecuteCallbackObjectRetainer(void* userObject, ExecuteCallbackObjectFunc releaseUserObject)
+        : m_userObject(userObject)
+        , m_releaseUserObject(releaseUserObject)
+    {
+    }
+
+    ExecuteCallbackObjectRetainer(const ExecuteCallbackObjectRetainer&) = delete;
+    ExecuteCallbackObjectRetainer& operator=(const ExecuteCallbackObjectRetainer&) = delete;
+
+    ExecuteCallbackObjectRetainer(ExecuteCallbackObjectRetainer&& other) noexcept
+        : m_userObject(other.m_userObject)
+        , m_releaseUserObject(other.m_releaseUserObject)
+    {
+        other.m_userObject = nullptr;
+        other.m_releaseUserObject = nullptr;
+    }
+
+    ExecuteCallbackObjectRetainer& operator=(ExecuteCallbackObjectRetainer&& other) noexcept
+    {
+        if (this != &other)
+        {
+            reset();
+            m_userObject = other.m_userObject;
+            m_releaseUserObject = other.m_releaseUserObject;
+            other.m_userObject = nullptr;
+            other.m_releaseUserObject = nullptr;
+        }
+        return *this;
+    }
+
+    ~ExecuteCallbackObjectRetainer() { reset(); }
+
+    void reset()
+    {
+        if (m_userObject && m_releaseUserObject)
+        {
+            m_releaseUserObject(m_userObject);
+        }
+        m_userObject = nullptr;
+        m_releaseUserObject = nullptr;
+    }
+
+private:
+    void* m_userObject = nullptr;
+    ExecuteCallbackObjectFunc m_releaseUserObject = nullptr;
+};
+
 
 /// A list of commands recorded by the command encoder.
 ///
@@ -397,7 +457,11 @@ public:
         void* data;
     };
 
-    CommandList(ArenaAllocator& allocator, std::set<RefPtr<RefObject>>& trackedObjects);
+    CommandList(
+        ArenaAllocator& allocator,
+        std::set<RefPtr<RefObject>>& trackedObjects,
+        std::vector<ExecuteCallbackObjectRetainer>& trackedExecuteCallbackObjects
+    );
 
     void reset();
 
@@ -487,6 +551,7 @@ public:
 private:
     ArenaAllocator& m_allocator;
     std::set<RefPtr<RefObject>>& m_trackedObjects;
+    std::vector<ExecuteCallbackObjectRetainer>& m_trackedExecuteCallbackObjects;
     CommandSlot* m_commandSlots = nullptr;
     CommandSlot* m_lastCommandSlot = nullptr;
 

--- a/src/cpu/cpu-command.cpp
+++ b/src/cpu/cpu-command.cpp
@@ -336,7 +336,7 @@ void CommandExecutor::cmdWriteTimestamp(const commands::WriteTimestamp& cmd)
 
 void CommandExecutor::cmdExecuteCallback(const commands::ExecuteCallback& cmd)
 {
-    cmd.callback(cmd.userData);
+    invokeExecuteCallback(cmd, {});
 }
 
 // CommandQueueImpl

--- a/src/cuda/cuda-command.cpp
+++ b/src/cuda/cuda-command.cpp
@@ -671,7 +671,15 @@ void CommandExecutor::cmdWriteTimestamp(const commands::WriteTimestamp& cmd)
 
 void CommandExecutor::cmdExecuteCallback(const commands::ExecuteCallback& cmd)
 {
-    cmd.callback(cmd.userData);
+    NativeHandle nativeHandle{
+        NativeHandleType::CUstream,
+        reinterpret_cast<uint64_t>(m_stream),
+    };
+    invokeExecuteCallback(cmd, nativeHandle);
+
+    m_computeStateValid = false;
+    m_rayTracingStateValid = false;
+    m_bindingData = nullptr;
 }
 
 // CommandQueueImpl

--- a/src/d3d11/d3d11-command.cpp
+++ b/src/d3d11/d3d11-command.cpp
@@ -896,7 +896,8 @@ void CommandExecutor::cmdWriteTimestamp(const commands::WriteTimestamp& cmd)
 
 void CommandExecutor::cmdExecuteCallback(const commands::ExecuteCallback& cmd)
 {
-    cmd.callback(cmd.userData);
+    invokeExecuteCallback(cmd, {});
+    clearState();
 }
 
 void CommandExecutor::clearState()

--- a/src/d3d11/d3d11-command.cpp
+++ b/src/d3d11/d3d11-command.cpp
@@ -93,6 +93,7 @@ public:
     void cmdWriteTimestamp(const commands::WriteTimestamp& cmd);
     void cmdExecuteCallback(const commands::ExecuteCallback& cmd);
 
+    void invalidateState();
     void clearState();
 };
 
@@ -896,19 +897,36 @@ void CommandExecutor::cmdWriteTimestamp(const commands::WriteTimestamp& cmd)
 
 void CommandExecutor::cmdExecuteCallback(const commands::ExecuteCallback& cmd)
 {
-    invokeExecuteCallback(cmd, {});
-    clearState();
+    NativeHandle nativeHandle{
+        NativeHandleType::D3D11DeviceContext,
+        reinterpret_cast<uint64_t>(m_immediateContext),
+    };
+    invokeExecuteCallback(cmd, nativeHandle);
+
+    if (m_renderPassActive)
+    {
+        invalidateState();
+    }
+    else
+    {
+        clearState();
+    }
 }
 
-void CommandExecutor::clearState()
+void CommandExecutor::invalidateState()
 {
-    m_immediateContext->ClearState();
     m_renderStateValid = false;
     m_renderState = {};
     m_renderPipeline = nullptr;
     m_computeStateValid = false;
     m_computePipeline = nullptr;
     m_bindingData = nullptr;
+}
+
+void CommandExecutor::clearState()
+{
+    m_immediateContext->ClearState();
+    invalidateState();
 }
 
 // CommandQueueImpl

--- a/src/d3d11/d3d11-command.cpp
+++ b/src/d3d11/d3d11-command.cpp
@@ -902,15 +902,7 @@ void CommandExecutor::cmdExecuteCallback(const commands::ExecuteCallback& cmd)
         reinterpret_cast<uint64_t>(m_immediateContext),
     };
     invokeExecuteCallback(cmd, nativeHandle);
-
-    if (m_renderPassActive)
-    {
-        invalidateState();
-    }
-    else
-    {
-        clearState();
-    }
+    clearState();
 }
 
 void CommandExecutor::invalidateState()

--- a/src/d3d12/d3d12-command.cpp
+++ b/src/d3d12/d3d12-command.cpp
@@ -1659,7 +1659,18 @@ void CommandRecorder::cmdWriteTimestamp(const commands::WriteTimestamp& cmd)
 
 void CommandRecorder::cmdExecuteCallback(const commands::ExecuteCallback& cmd)
 {
-    cmd.callback(cmd.userData);
+    commitBarriers();
+
+    NativeHandle nativeHandle{
+        NativeHandleType::D3D12GraphicsCommandList,
+        reinterpret_cast<uint64_t>(m_cmdList.get()),
+    };
+    invokeExecuteCallback(cmd, nativeHandle);
+
+    m_renderStateValid = false;
+    m_computeStateValid = false;
+    m_rayTracingStateValid = false;
+    m_bindingData = nullptr;
 }
 
 void CommandRecorder::setBindings(BindingDataImpl* bindingData, BindMode bindMode)

--- a/src/debug-layer/debug-command-encoder.cpp
+++ b/src/debug-layer/debug-command-encoder.cpp
@@ -1887,6 +1887,32 @@ void DebugCommandEncoder::writeTimestamp(IQueryPool* pool, uint32_t index)
     baseObject->writeTimestamp(getInnerObj(pool), index);
 }
 
+void DebugCommandEncoder::executeCallback(const ExecuteCallbackDesc& desc)
+{
+    SLANG_RHI_DEBUG_API(ICommandEncoder, executeCallback);
+
+    requireOpen();
+    requireNoPass();
+
+    if (!desc.callback)
+    {
+        RHI_VALIDATION_ERROR("'callback' must not be null.");
+        return;
+    }
+    if (desc.userDataSize > 0 && !desc.userData)
+    {
+        RHI_VALIDATION_ERROR("'userData' must not be null when 'userDataSize' is non-zero.");
+        return;
+    }
+    if (desc.userObject && (desc.retainUserObject == nullptr || desc.releaseUserObject == nullptr))
+    {
+        RHI_VALIDATION_ERROR("'retainUserObject' and 'releaseUserObject' are required when 'userObject' is set.");
+        return;
+    }
+
+    baseObject->executeCallback(desc);
+}
+
 Result DebugCommandEncoder::finish(const CommandBufferDesc& desc, ICommandBuffer** outCommandBuffer)
 {
     SLANG_RHI_DEBUG_API(ICommandEncoder, finish);

--- a/src/debug-layer/debug-command-encoder.cpp
+++ b/src/debug-layer/debug-command-encoder.cpp
@@ -1904,6 +1904,11 @@ void DebugCommandEncoder::executeCallback(const ExecuteCallbackDesc& desc)
         RHI_VALIDATION_ERROR("'userData' must not be null when 'userDataSize' is non-zero.");
         return;
     }
+    if (desc.userData && desc.userDataSize == 0)
+    {
+        RHI_VALIDATION_ERROR("'userDataSize' must be non-zero when 'userData' is set.");
+        return;
+    }
     if (desc.userObject && (desc.retainUserObject == nullptr || desc.releaseUserObject == nullptr))
     {
         RHI_VALIDATION_ERROR("'retainUserObject' and 'releaseUserObject' are required when 'userObject' is set.");

--- a/src/debug-layer/debug-command-encoder.h
+++ b/src/debug-layer/debug-command-encoder.h
@@ -302,6 +302,8 @@ public:
 
     virtual SLANG_NO_THROW void SLANG_MCALL writeTimestamp(IQueryPool* queryPool, uint32_t queryIndex) override;
 
+    virtual SLANG_NO_THROW void SLANG_MCALL executeCallback(const ExecuteCallbackDesc& desc) override;
+
     virtual SLANG_NO_THROW Result SLANG_MCALL finish(
         const CommandBufferDesc& desc,
         ICommandBuffer** outCommandBuffer

--- a/src/metal/metal-command.cpp
+++ b/src/metal/metal-command.cpp
@@ -1013,7 +1013,7 @@ void CommandRecorder::cmdWriteTimestamp(const commands::WriteTimestamp& cmd)
 
 void CommandRecorder::cmdExecuteCallback(const commands::ExecuteCallback& cmd)
 {
-    cmd.callback(cmd.userData);
+    invokeExecuteCallback(cmd, {});
 }
 
 MTL::RenderCommandEncoder* CommandRecorder::getRenderCommandEncoder(MTL::RenderPassDescriptor* renderPassDesc)

--- a/src/metal/metal-command.cpp
+++ b/src/metal/metal-command.cpp
@@ -1013,7 +1013,11 @@ void CommandRecorder::cmdWriteTimestamp(const commands::WriteTimestamp& cmd)
 
 void CommandRecorder::cmdExecuteCallback(const commands::ExecuteCallback& cmd)
 {
-    invokeExecuteCallback(cmd, {});
+    NativeHandle nativeHandle{
+        NativeHandleType::MTLCommandBuffer,
+        reinterpret_cast<uint64_t>(m_commandBuffer.get()),
+    };
+    invokeExecuteCallback(cmd, nativeHandle);
 }
 
 MTL::RenderCommandEncoder* CommandRecorder::getRenderCommandEncoder(MTL::RenderPassDescriptor* renderPassDesc)

--- a/src/vulkan/vk-command.cpp
+++ b/src/vulkan/vk-command.cpp
@@ -1628,7 +1628,19 @@ void CommandRecorder::cmdWriteTimestamp(const commands::WriteTimestamp& cmd)
 
 void CommandRecorder::cmdExecuteCallback(const commands::ExecuteCallback& cmd)
 {
-    cmd.callback(cmd.userData);
+    commitBarriers();
+
+    NativeHandle nativeHandle{
+        NativeHandleType::VkCommandBuffer,
+        reinterpret_cast<uint64_t>(m_cmdBuffer),
+    };
+    invokeExecuteCallback(cmd, nativeHandle);
+
+    m_renderStateValid = false;
+    m_preparedRenderStateValid = false;
+    m_computeStateValid = false;
+    m_rayTracingStateValid = false;
+    m_bindingData = nullptr;
 }
 
 void CommandRecorder::setBindings(BindingDataImpl* bindingData, VkPipelineBindPoint bindPoint)

--- a/src/wgpu/wgpu-command.cpp
+++ b/src/wgpu/wgpu-command.cpp
@@ -863,7 +863,11 @@ void CommandRecorder::cmdWriteTimestamp(const commands::WriteTimestamp& cmd)
 
 void CommandRecorder::cmdExecuteCallback(const commands::ExecuteCallback& cmd)
 {
-    invokeExecuteCallback(cmd, {});
+    NativeHandle nativeHandle{
+        NativeHandleType::WGPUCommandEncoder,
+        reinterpret_cast<uint64_t>(m_commandEncoder),
+    };
+    invokeExecuteCallback(cmd, nativeHandle);
 }
 
 void CommandRecorder::endPassEncoder()

--- a/src/wgpu/wgpu-command.cpp
+++ b/src/wgpu/wgpu-command.cpp
@@ -863,7 +863,7 @@ void CommandRecorder::cmdWriteTimestamp(const commands::WriteTimestamp& cmd)
 
 void CommandRecorder::cmdExecuteCallback(const commands::ExecuteCallback& cmd)
 {
-    cmd.callback(cmd.userData);
+    invokeExecuteCallback(cmd, {});
 }
 
 void CommandRecorder::endPassEncoder()

--- a/tests/test-execute-callback.cpp
+++ b/tests/test-execute-callback.cpp
@@ -1,0 +1,159 @@
+#include "testing.h"
+
+using namespace rhi;
+using namespace rhi::testing;
+
+namespace {
+
+struct CallbackPayload
+{
+    uint32_t value;
+};
+
+struct CallbackRecord
+{
+    uint32_t callCount = 0;
+    std::array<NativeHandle, 4> handles = {};
+    std::array<uint32_t, 4> payloadValues = {};
+    std::array<bool, 4> retainedDuringCallback = {};
+    uint32_t retainCount = 0;
+    uint32_t releaseCount = 0;
+};
+
+NativeHandleType getExpectedNativeHandleType(DeviceType deviceType)
+{
+    switch (deviceType)
+    {
+    case DeviceType::D3D12:
+        return NativeHandleType::D3D12GraphicsCommandList;
+    case DeviceType::Vulkan:
+        return NativeHandleType::VkCommandBuffer;
+    case DeviceType::CUDA:
+        return NativeHandleType::CUstream;
+    default:
+        return NativeHandleType::Undefined;
+    }
+}
+
+void SLANG_MCALL executeCallback(const ExecuteCallbackContext* context, void* userObject, const void* userData)
+{
+    CallbackRecord* record = static_cast<CallbackRecord*>(userObject);
+    const CallbackPayload* payload = static_cast<const CallbackPayload*>(userData);
+    uint32_t index = record->callCount++;
+
+    if (index < record->handles.size())
+    {
+        record->handles[index] = context ? context->nativeHandle : NativeHandle{};
+        record->payloadValues[index] = payload ? payload->value : 0;
+        record->retainedDuringCallback[index] = record->retainCount > record->releaseCount;
+    }
+}
+
+void SLANG_MCALL retainCallbackObject(void* userObject)
+{
+    CallbackRecord* record = static_cast<CallbackRecord*>(userObject);
+    record->retainCount++;
+}
+
+void SLANG_MCALL releaseCallbackObject(void* userObject)
+{
+    CallbackRecord* record = static_cast<CallbackRecord*>(userObject);
+    record->releaseCount++;
+}
+
+void addExecuteCallback(ICommandEncoder* encoder, CallbackRecord* record, const CallbackPayload& payload)
+{
+    ExecuteCallbackDesc desc = {};
+    desc.callback = executeCallback;
+    desc.userObject = record;
+    desc.retainUserObject = retainCallbackObject;
+    desc.releaseUserObject = releaseCallbackObject;
+    desc.userData = &payload;
+    desc.userDataSize = sizeof(payload);
+    encoder->executeCallback(desc);
+}
+
+} // namespace
+
+GPU_TEST_CASE("execute-callback-native-handle-and-user-data", D3D12 | Vulkan | CUDA)
+{
+    auto queue = device->getQueue(QueueType::Graphics);
+    REQUIRE(queue);
+
+    auto encoder = queue->createCommandEncoder();
+    REQUIRE(encoder);
+
+    CallbackRecord record;
+    CallbackPayload firstPayload = {0x12345678u};
+    CallbackPayload secondPayload = {0x87654321u};
+    addExecuteCallback(encoder, &record, firstPayload);
+    addExecuteCallback(encoder, &record, secondPayload);
+
+    firstPayload.value = 0;
+    secondPayload.value = 0;
+
+    auto commandBuffer = encoder->finish();
+    REQUIRE(commandBuffer);
+
+    REQUIRE_CALL(queue->submit(commandBuffer));
+    REQUIRE_CALL(queue->waitOnHost());
+
+    CHECK(record.callCount == 2);
+    CHECK(record.payloadValues[0] == 0x12345678u);
+    CHECK(record.payloadValues[1] == 0x87654321u);
+
+    NativeHandleType expectedType = getExpectedNativeHandleType(ctx->deviceType);
+    CHECK(record.handles[0].type == expectedType);
+    CHECK(record.handles[1].type == expectedType);
+
+    if (ctx->deviceType == DeviceType::CUDA)
+    {
+        NativeHandle queueHandle = {};
+        REQUIRE_CALL(queue->getNativeHandle(&queueHandle));
+        CHECK(record.handles[0].value == queueHandle.value);
+        CHECK(record.handles[1].value == queueHandle.value);
+    }
+    else
+    {
+        NativeHandle commandBufferHandle = {};
+        REQUIRE_CALL(commandBuffer->getNativeHandle(&commandBufferHandle));
+        CHECK(record.handles[0].value == commandBufferHandle.value);
+        CHECK(record.handles[1].value == commandBufferHandle.value);
+        CHECK(record.handles[0].value != 0);
+        CHECK(record.handles[1].value != 0);
+    }
+
+    CHECK(record.releaseCount == 2);
+}
+
+GPU_TEST_CASE("execute-callback-object-lifetime", D3D12 | Vulkan | CUDA)
+{
+    auto queue = device->getQueue(QueueType::Graphics);
+    REQUIRE(queue);
+
+    auto encoder = queue->createCommandEncoder();
+    REQUIRE(encoder);
+
+    CallbackRecord record;
+    CallbackPayload payload = {0xf00dcafeu};
+    addExecuteCallback(encoder, &record, payload);
+
+    CHECK(record.retainCount == 1);
+    CHECK(record.releaseCount == 0);
+
+    auto commandBuffer = encoder->finish();
+    REQUIRE(commandBuffer);
+    CHECK(record.releaseCount == 0);
+
+    REQUIRE_CALL(queue->submit(commandBuffer));
+    REQUIRE_CALL(queue->waitOnHost());
+
+    CHECK(record.callCount == 1);
+    CHECK(record.payloadValues[0] == 0xf00dcafeu);
+    CHECK(record.retainedDuringCallback[0]);
+    CHECK(record.retainCount == 1);
+    CHECK(record.releaseCount == 1);
+
+    commandBuffer.setNull();
+    CHECK(record.releaseCount == 1);
+}

--- a/tests/test-execute-callback.cpp
+++ b/tests/test-execute-callback.cpp
@@ -15,6 +15,7 @@ struct CallbackRecord
     uint32_t callCount = 0;
     std::array<NativeHandle, 4> handles = {};
     std::array<uint32_t, 4> payloadValues = {};
+    std::array<Size, 4> payloadSizes = {};
     std::array<bool, 4> retainedDuringCallback = {};
     uint32_t retainCount = 0;
     uint32_t releaseCount = 0;
@@ -24,18 +25,43 @@ NativeHandleType getExpectedNativeHandleType(DeviceType deviceType)
 {
     switch (deviceType)
     {
+    case DeviceType::D3D11:
+        return NativeHandleType::D3D11DeviceContext;
     case DeviceType::D3D12:
         return NativeHandleType::D3D12GraphicsCommandList;
     case DeviceType::Vulkan:
         return NativeHandleType::VkCommandBuffer;
+    case DeviceType::Metal:
+        return NativeHandleType::MTLCommandBuffer;
     case DeviceType::CUDA:
         return NativeHandleType::CUstream;
+    case DeviceType::WGPU:
+        return NativeHandleType::WGPUCommandEncoder;
     default:
         return NativeHandleType::Undefined;
     }
 }
 
-void SLANG_MCALL executeCallback(const ExecuteCallbackContext* context, void* userObject, const void* userData)
+bool releasesCallbackObjectsOnQueueWait(DeviceType deviceType)
+{
+    switch (deviceType)
+    {
+    case DeviceType::D3D12:
+    case DeviceType::Vulkan:
+    case DeviceType::Metal:
+    case DeviceType::CUDA:
+        return true;
+    default:
+        return false;
+    }
+}
+
+void SLANG_MCALL executeCallback(
+    const ExecuteCallbackContext* context,
+    void* userObject,
+    const void* userData,
+    Size userDataSize
+)
 {
     CallbackRecord* record = static_cast<CallbackRecord*>(userObject);
     const CallbackPayload* payload = static_cast<const CallbackPayload*>(userData);
@@ -45,6 +71,7 @@ void SLANG_MCALL executeCallback(const ExecuteCallbackContext* context, void* us
     {
         record->handles[index] = context ? context->nativeHandle : NativeHandle{};
         record->payloadValues[index] = payload ? payload->value : 0;
+        record->payloadSizes[index] = userDataSize;
         record->retainedDuringCallback[index] = record->retainCount > record->releaseCount;
     }
 }
@@ -75,7 +102,7 @@ void addExecuteCallback(ICommandEncoder* encoder, CallbackRecord* record, const 
 
 } // namespace
 
-GPU_TEST_CASE("execute-callback-native-handle-and-user-data", D3D12 | Vulkan | CUDA)
+GPU_TEST_CASE("execute-callback-native-handle-and-user-data", ALL)
 {
     auto queue = device->getQueue(QueueType::Graphics);
     REQUIRE(queue);
@@ -101,6 +128,8 @@ GPU_TEST_CASE("execute-callback-native-handle-and-user-data", D3D12 | Vulkan | C
     CHECK(record.callCount == 2);
     CHECK(record.payloadValues[0] == 0x12345678u);
     CHECK(record.payloadValues[1] == 0x87654321u);
+    CHECK(record.payloadSizes[0] == sizeof(CallbackPayload));
+    CHECK(record.payloadSizes[1] == sizeof(CallbackPayload));
 
     NativeHandleType expectedType = getExpectedNativeHandleType(ctx->deviceType);
     CHECK(record.handles[0].type == expectedType);
@@ -113,7 +142,8 @@ GPU_TEST_CASE("execute-callback-native-handle-and-user-data", D3D12 | Vulkan | C
         CHECK(record.handles[0].value == queueHandle.value);
         CHECK(record.handles[1].value == queueHandle.value);
     }
-    else
+    else if (ctx->deviceType == DeviceType::D3D12 || ctx->deviceType == DeviceType::Vulkan ||
+             ctx->deviceType == DeviceType::Metal)
     {
         NativeHandle commandBufferHandle = {};
         REQUIRE_CALL(commandBuffer->getNativeHandle(&commandBufferHandle));
@@ -122,11 +152,30 @@ GPU_TEST_CASE("execute-callback-native-handle-and-user-data", D3D12 | Vulkan | C
         CHECK(record.handles[0].value != 0);
         CHECK(record.handles[1].value != 0);
     }
+    else if (expectedType == NativeHandleType::Undefined)
+    {
+        CHECK(record.handles[0].value == 0);
+        CHECK(record.handles[1].value == 0);
+    }
+    else
+    {
+        CHECK(record.handles[0].value != 0);
+        CHECK(record.handles[1].value != 0);
+    }
 
-    CHECK(record.releaseCount == 2);
+    if (releasesCallbackObjectsOnQueueWait(ctx->deviceType))
+    {
+        CHECK(record.releaseCount == 2);
+    }
+    else
+    {
+        CHECK(record.releaseCount == 0);
+        commandBuffer.setNull();
+        CHECK(record.releaseCount == 2);
+    }
 }
 
-GPU_TEST_CASE("execute-callback-object-lifetime", D3D12 | Vulkan | CUDA)
+GPU_TEST_CASE("execute-callback-object-lifetime", ALL)
 {
     auto queue = device->getQueue(QueueType::Graphics);
     REQUIRE(queue);
@@ -150,9 +199,17 @@ GPU_TEST_CASE("execute-callback-object-lifetime", D3D12 | Vulkan | CUDA)
 
     CHECK(record.callCount == 1);
     CHECK(record.payloadValues[0] == 0xf00dcafeu);
+    CHECK(record.payloadSizes[0] == sizeof(CallbackPayload));
     CHECK(record.retainedDuringCallback[0]);
     CHECK(record.retainCount == 1);
-    CHECK(record.releaseCount == 1);
+    if (releasesCallbackObjectsOnQueueWait(ctx->deviceType))
+    {
+        CHECK(record.releaseCount == 1);
+    }
+    else
+    {
+        CHECK(record.releaseCount == 0);
+    }
 
     commandBuffer.setNull();
     CHECK(record.releaseCount == 1);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Execute-callback support in the command encoder: supply a callback, optional user-data, and optional retain/release hooks; callbacks receive native backend handles for context.
* **Bug Fixes / Reliability**
  * Command buffers track and release retained callback objects and invalidate/clear GPU state after callbacks to ensure correct subsequent encoding.
* **Tests**
  * New GPU tests validate callback invocation, payloads, native-handle reporting, and object retain/release timing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->