### PR TITLE
Fix Vulkan barrier stage masks

### DIFF
--- a/src/vulkan/vk-api.cpp
+++ b/src/vulkan/vk-api.cpp
@@ -144,6 +144,29 @@ Result VulkanApi::initPhysicalDevice(VkPhysicalDevice physicalDevice)
     return SLANG_OK;
 }
 
+void VulkanApi::initDerivedDeviceProperties()
+{
+    m_supportedShaderStageFlags = VK_PIPELINE_STAGE_VERTEX_SHADER_BIT | VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT |
+                                  VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT;
+
+    if (m_deviceFeatures.tessellationShader)
+    {
+        m_supportedShaderStageFlags |=
+            VK_PIPELINE_STAGE_TESSELLATION_CONTROL_SHADER_BIT | VK_PIPELINE_STAGE_TESSELLATION_EVALUATION_SHADER_BIT;
+    }
+
+    if (m_deviceFeatures.geometryShader)
+        m_supportedShaderStageFlags |= VK_PIPELINE_STAGE_GEOMETRY_SHADER_BIT;
+
+    if (m_extendedFeatures.rayTracingPipelineFeatures.rayTracingPipeline)
+        m_supportedShaderStageFlags |= VK_PIPELINE_STAGE_RAY_TRACING_SHADER_BIT_KHR;
+
+    if (m_extendedFeatures.meshShaderFeatures.taskShader)
+        m_supportedShaderStageFlags |= VK_PIPELINE_STAGE_TASK_SHADER_BIT_EXT;
+    if (m_extendedFeatures.meshShaderFeatures.meshShader)
+        m_supportedShaderStageFlags |= VK_PIPELINE_STAGE_MESH_SHADER_BIT_EXT;
+}
+
 Result VulkanApi::initDeviceProcs(VkDevice device)
 {
     SLANG_RHI_ASSERT(m_instance && device && vkGetDeviceProcAddr != nullptr);

--- a/src/vulkan/vk-api.h
+++ b/src/vulkan/vk-api.h
@@ -564,6 +564,9 @@ struct VulkanApi
     /// Initialize the device functions
     Result initDeviceProcs(VkDevice device);
 
+    /// Initialize cached properties derived from the enabled device features.
+    void initDerivedDeviceProperties();
+
     /// Type bits control which indices are tested against bit 0 for testing at index 0
     /// properties - a memory type must have all the bits set as passed in
     /// Returns -1 if couldn't find an appropriate memory type index
@@ -583,6 +586,9 @@ struct VulkanApi
     VkPhysicalDeviceFeatures m_deviceFeatures;
     VkPhysicalDeviceMemoryProperties m_deviceMemoryProperties;
     VulkanExtendedFeatures m_extendedFeatures;
+    VkPipelineStageFlags m_supportedShaderStageFlags = VK_PIPELINE_STAGE_VERTEX_SHADER_BIT |
+                                                       VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT |
+                                                       VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT;
 };
 
 } // namespace rhi::vk

--- a/src/vulkan/vk-command.cpp
+++ b/src/vulkan/vk-command.cpp
@@ -1751,8 +1751,10 @@ void CommandRecorder::commitBarriers()
     {
         BufferImpl* buffer = checked_cast<BufferImpl*>(bufferBarrier.buffer);
 
-        VkPipelineStageFlags beforeStageFlags = calcPipelineStageFlags(m_api, bufferBarrier.stateBefore, true);
-        VkPipelineStageFlags afterStageFlags = calcPipelineStageFlags(m_api, bufferBarrier.stateAfter, false);
+        VkPipelineStageFlags beforeStageFlags =
+            calcPipelineStageFlags(m_api.m_supportedShaderStageFlags, bufferBarrier.stateBefore, true);
+        VkPipelineStageFlags afterStageFlags =
+            calcPipelineStageFlags(m_api.m_supportedShaderStageFlags, bufferBarrier.stateAfter, false);
 
         if ((beforeStageFlags != activeBeforeStageFlags || afterStageFlags != activeAfterStageFlags) &&
             !bufferBarriers.empty())
@@ -1786,8 +1788,10 @@ void CommandRecorder::commitBarriers()
     {
         TextureImpl* texture = checked_cast<TextureImpl*>(textureBarrier.texture);
 
-        VkPipelineStageFlags beforeStageFlags = calcPipelineStageFlags(m_api, textureBarrier.stateBefore, true);
-        VkPipelineStageFlags afterStageFlags = calcPipelineStageFlags(m_api, textureBarrier.stateAfter, false);
+        VkPipelineStageFlags beforeStageFlags =
+            calcPipelineStageFlags(m_api.m_supportedShaderStageFlags, textureBarrier.stateBefore, true);
+        VkPipelineStageFlags afterStageFlags =
+            calcPipelineStageFlags(m_api.m_supportedShaderStageFlags, textureBarrier.stateAfter, false);
 
         if ((beforeStageFlags != activeBeforeStageFlags || afterStageFlags != activeAfterStageFlags) &&
             !imageBarriers.empty())

--- a/src/vulkan/vk-command.cpp
+++ b/src/vulkan/vk-command.cpp
@@ -1751,8 +1751,8 @@ void CommandRecorder::commitBarriers()
     {
         BufferImpl* buffer = checked_cast<BufferImpl*>(bufferBarrier.buffer);
 
-        VkPipelineStageFlags beforeStageFlags = calcPipelineStageFlags(bufferBarrier.stateBefore, true);
-        VkPipelineStageFlags afterStageFlags = calcPipelineStageFlags(bufferBarrier.stateAfter, false);
+        VkPipelineStageFlags beforeStageFlags = calcPipelineStageFlags(m_api, bufferBarrier.stateBefore, true);
+        VkPipelineStageFlags afterStageFlags = calcPipelineStageFlags(m_api, bufferBarrier.stateAfter, false);
 
         if ((beforeStageFlags != activeBeforeStageFlags || afterStageFlags != activeAfterStageFlags) &&
             !bufferBarriers.empty())
@@ -1786,8 +1786,8 @@ void CommandRecorder::commitBarriers()
     {
         TextureImpl* texture = checked_cast<TextureImpl*>(textureBarrier.texture);
 
-        VkPipelineStageFlags beforeStageFlags = calcPipelineStageFlags(textureBarrier.stateBefore, true);
-        VkPipelineStageFlags afterStageFlags = calcPipelineStageFlags(textureBarrier.stateAfter, false);
+        VkPipelineStageFlags beforeStageFlags = calcPipelineStageFlags(m_api, textureBarrier.stateBefore, true);
+        VkPipelineStageFlags afterStageFlags = calcPipelineStageFlags(m_api, textureBarrier.stateAfter, false);
 
         if ((beforeStageFlags != activeBeforeStageFlags || afterStageFlags != activeAfterStageFlags) &&
             !imageBarriers.empty())

--- a/src/vulkan/vk-device.cpp
+++ b/src/vulkan/vk-device.cpp
@@ -1241,6 +1241,7 @@ Result DeviceImpl::initVulkanDevice(
     {
         return SLANG_FAIL;
     }
+    m_api.initDerivedDeviceProperties();
     SLANG_RETURN_ON_FAIL(m_api.initDeviceProcs(m_device));
 
     return SLANG_OK;
@@ -1611,8 +1612,10 @@ Result DeviceImpl::readBuffer(IBuffer* buffer, Offset offset, Size size, void* o
     barrier.offset = 0;
     barrier.size = bufferImpl->m_desc.size;
 
-    VkPipelineStageFlags srcStageFlags = calcPipelineStageFlags(m_api, bufferImpl->m_desc.defaultState, true);
-    VkPipelineStageFlags dstStageFlags = calcPipelineStageFlags(m_api, ResourceState::CopySource, false);
+    VkPipelineStageFlags srcStageFlags =
+        calcPipelineStageFlags(m_api.m_supportedShaderStageFlags, bufferImpl->m_desc.defaultState, true);
+    VkPipelineStageFlags dstStageFlags =
+        calcPipelineStageFlags(m_api.m_supportedShaderStageFlags, ResourceState::CopySource, false);
 
     m_api.vkCmdPipelineBarrier(
         commandBuffer,

--- a/src/vulkan/vk-device.cpp
+++ b/src/vulkan/vk-device.cpp
@@ -1606,7 +1606,7 @@ Result DeviceImpl::readBuffer(IBuffer* buffer, Offset offset, Size size, void* o
     VkBufferMemoryBarrier barrier = {};
     barrier.sType = VK_STRUCTURE_TYPE_BUFFER_MEMORY_BARRIER;
     barrier.srcAccessMask = calcAccessFlags(bufferImpl->m_desc.defaultState);
-    barrier.dstAccessMask = calcAccessFlags(ResourceState::CopyDestination);
+    barrier.dstAccessMask = calcAccessFlags(ResourceState::CopySource);
     barrier.buffer = bufferImpl->m_buffer.m_buffer;
     barrier.offset = 0;
     barrier.size = bufferImpl->m_desc.size;

--- a/src/vulkan/vk-device.cpp
+++ b/src/vulkan/vk-device.cpp
@@ -1611,8 +1611,8 @@ Result DeviceImpl::readBuffer(IBuffer* buffer, Offset offset, Size size, void* o
     barrier.offset = 0;
     barrier.size = bufferImpl->m_desc.size;
 
-    VkPipelineStageFlags srcStageFlags = calcPipelineStageFlags(bufferImpl->m_desc.defaultState, true);
-    VkPipelineStageFlags dstStageFlags = calcPipelineStageFlags(ResourceState::CopySource, false);
+    VkPipelineStageFlags srcStageFlags = calcPipelineStageFlags(m_api, bufferImpl->m_desc.defaultState, true);
+    VkPipelineStageFlags dstStageFlags = calcPipelineStageFlags(m_api, ResourceState::CopySource, false);
 
     m_api.vkCmdPipelineBarrier(
         commandBuffer,

--- a/src/vulkan/vk-utils.cpp
+++ b/src/vulkan/vk-utils.cpp
@@ -328,7 +328,28 @@ VkAccessFlagBits calcAccessFlags(ResourceState state)
     }
 }
 
-VkPipelineStageFlagBits calcPipelineStageFlags(ResourceState state, bool src)
+static VkPipelineStageFlags getSupportedShaderStageFlags(const VulkanApi& api)
+{
+    VkPipelineStageFlags result = VK_PIPELINE_STAGE_VERTEX_SHADER_BIT |
+                                  VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT |
+                                  VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT;
+
+    if (api.m_deviceFeatures.tessellationShader)
+    {
+        result |= VK_PIPELINE_STAGE_TESSELLATION_CONTROL_SHADER_BIT |
+                  VK_PIPELINE_STAGE_TESSELLATION_EVALUATION_SHADER_BIT;
+    }
+
+    if (api.m_deviceFeatures.geometryShader)
+        result |= VK_PIPELINE_STAGE_GEOMETRY_SHADER_BIT;
+
+    if (api.m_extendedFeatures.rayTracingPipelineFeatures.rayTracingPipeline)
+        result |= VK_PIPELINE_STAGE_RAY_TRACING_SHADER_BIT_KHR;
+
+    return result;
+}
+
+VkPipelineStageFlags calcPipelineStageFlags(const VulkanApi& api, ResourceState state, bool src)
 {
     switch (state)
     {
@@ -340,14 +361,9 @@ VkPipelineStageFlagBits calcPipelineStageFlags(ResourceState state, bool src)
         return VK_PIPELINE_STAGE_VERTEX_INPUT_BIT;
     case ResourceState::ConstantBuffer:
     case ResourceState::UnorderedAccess:
-        return VkPipelineStageFlagBits(
-            VK_PIPELINE_STAGE_VERTEX_SHADER_BIT | VK_PIPELINE_STAGE_TESSELLATION_CONTROL_SHADER_BIT |
-            VK_PIPELINE_STAGE_TESSELLATION_EVALUATION_SHADER_BIT | VK_PIPELINE_STAGE_GEOMETRY_SHADER_BIT |
-            VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT | VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT |
-            VK_PIPELINE_STAGE_RAY_TRACING_SHADER_BIT_KHR
-        );
+        return getSupportedShaderStageFlags(api);
     case ResourceState::ShaderResource:
-        return VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT;
+        return getSupportedShaderStageFlags(api);
     case ResourceState::RenderTarget:
         return VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT;
     case ResourceState::DepthRead:
@@ -368,9 +384,12 @@ VkPipelineStageFlagBits calcPipelineStageFlags(ResourceState state, bool src)
     case ResourceState::General:
         return VkPipelineStageFlagBits(VK_PIPELINE_STAGE_ALL_COMMANDS_BIT);
     case ResourceState::AccelerationStructureRead:
-        return VkPipelineStageFlagBits(
-            VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT | VK_PIPELINE_STAGE_RAY_TRACING_SHADER_BIT_KHR
-        );
+    {
+        VkPipelineStageFlags result = VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT;
+        if (api.m_extendedFeatures.rayTracingPipelineFeatures.rayTracingPipeline)
+            result |= VK_PIPELINE_STAGE_RAY_TRACING_SHADER_BIT_KHR;
+        return result;
+    }
     case ResourceState::AccelerationStructureWrite:
         return VK_PIPELINE_STAGE_ACCELERATION_STRUCTURE_BUILD_BIT_KHR;
     case ResourceState::AccelerationStructureBuildInput:

--- a/src/vulkan/vk-utils.cpp
+++ b/src/vulkan/vk-utils.cpp
@@ -330,14 +330,13 @@ VkAccessFlagBits calcAccessFlags(ResourceState state)
 
 static VkPipelineStageFlags getSupportedShaderStageFlags(const VulkanApi& api)
 {
-    VkPipelineStageFlags result = VK_PIPELINE_STAGE_VERTEX_SHADER_BIT |
-                                  VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT |
+    VkPipelineStageFlags result = VK_PIPELINE_STAGE_VERTEX_SHADER_BIT | VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT |
                                   VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT;
 
     if (api.m_deviceFeatures.tessellationShader)
     {
-        result |= VK_PIPELINE_STAGE_TESSELLATION_CONTROL_SHADER_BIT |
-                  VK_PIPELINE_STAGE_TESSELLATION_EVALUATION_SHADER_BIT;
+        result |=
+            VK_PIPELINE_STAGE_TESSELLATION_CONTROL_SHADER_BIT | VK_PIPELINE_STAGE_TESSELLATION_EVALUATION_SHADER_BIT;
     }
 
     if (api.m_deviceFeatures.geometryShader)
@@ -345,6 +344,11 @@ static VkPipelineStageFlags getSupportedShaderStageFlags(const VulkanApi& api)
 
     if (api.m_extendedFeatures.rayTracingPipelineFeatures.rayTracingPipeline)
         result |= VK_PIPELINE_STAGE_RAY_TRACING_SHADER_BIT_KHR;
+
+    if (api.m_extendedFeatures.meshShaderFeatures.taskShader)
+        result |= VK_PIPELINE_STAGE_TASK_SHADER_BIT_EXT;
+    if (api.m_extendedFeatures.meshShaderFeatures.meshShader)
+        result |= VK_PIPELINE_STAGE_MESH_SHADER_BIT_EXT;
 
     return result;
 }
@@ -384,12 +388,7 @@ VkPipelineStageFlags calcPipelineStageFlags(const VulkanApi& api, ResourceState 
     case ResourceState::General:
         return VkPipelineStageFlagBits(VK_PIPELINE_STAGE_ALL_COMMANDS_BIT);
     case ResourceState::AccelerationStructureRead:
-    {
-        VkPipelineStageFlags result = VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT;
-        if (api.m_extendedFeatures.rayTracingPipelineFeatures.rayTracingPipeline)
-            result |= VK_PIPELINE_STAGE_RAY_TRACING_SHADER_BIT_KHR;
-        return result;
-    }
+        return getSupportedShaderStageFlags(api) | VK_PIPELINE_STAGE_ACCELERATION_STRUCTURE_BUILD_BIT_KHR;
     case ResourceState::AccelerationStructureWrite:
         return VK_PIPELINE_STAGE_ACCELERATION_STRUCTURE_BUILD_BIT_KHR;
     case ResourceState::AccelerationStructureBuildInput:

--- a/src/vulkan/vk-utils.cpp
+++ b/src/vulkan/vk-utils.cpp
@@ -328,32 +328,11 @@ VkAccessFlagBits calcAccessFlags(ResourceState state)
     }
 }
 
-static VkPipelineStageFlags getSupportedShaderStageFlags(const VulkanApi& api)
-{
-    VkPipelineStageFlags result = VK_PIPELINE_STAGE_VERTEX_SHADER_BIT | VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT |
-                                  VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT;
-
-    if (api.m_deviceFeatures.tessellationShader)
-    {
-        result |=
-            VK_PIPELINE_STAGE_TESSELLATION_CONTROL_SHADER_BIT | VK_PIPELINE_STAGE_TESSELLATION_EVALUATION_SHADER_BIT;
-    }
-
-    if (api.m_deviceFeatures.geometryShader)
-        result |= VK_PIPELINE_STAGE_GEOMETRY_SHADER_BIT;
-
-    if (api.m_extendedFeatures.rayTracingPipelineFeatures.rayTracingPipeline)
-        result |= VK_PIPELINE_STAGE_RAY_TRACING_SHADER_BIT_KHR;
-
-    if (api.m_extendedFeatures.meshShaderFeatures.taskShader)
-        result |= VK_PIPELINE_STAGE_TASK_SHADER_BIT_EXT;
-    if (api.m_extendedFeatures.meshShaderFeatures.meshShader)
-        result |= VK_PIPELINE_STAGE_MESH_SHADER_BIT_EXT;
-
-    return result;
-}
-
-VkPipelineStageFlags calcPipelineStageFlags(const VulkanApi& api, ResourceState state, bool src)
+VkPipelineStageFlags calcPipelineStageFlags(
+    VkPipelineStageFlags supportedShaderStageFlags,
+    ResourceState state,
+    bool src
+)
 {
     switch (state)
     {
@@ -365,9 +344,9 @@ VkPipelineStageFlags calcPipelineStageFlags(const VulkanApi& api, ResourceState 
         return VK_PIPELINE_STAGE_VERTEX_INPUT_BIT;
     case ResourceState::ConstantBuffer:
     case ResourceState::UnorderedAccess:
-        return getSupportedShaderStageFlags(api);
+        return supportedShaderStageFlags;
     case ResourceState::ShaderResource:
-        return getSupportedShaderStageFlags(api);
+        return supportedShaderStageFlags;
     case ResourceState::RenderTarget:
         return VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT;
     case ResourceState::DepthRead:
@@ -388,7 +367,7 @@ VkPipelineStageFlags calcPipelineStageFlags(const VulkanApi& api, ResourceState 
     case ResourceState::General:
         return VkPipelineStageFlagBits(VK_PIPELINE_STAGE_ALL_COMMANDS_BIT);
     case ResourceState::AccelerationStructureRead:
-        return getSupportedShaderStageFlags(api) | VK_PIPELINE_STAGE_ACCELERATION_STRUCTURE_BUILD_BIT_KHR;
+        return supportedShaderStageFlags | VK_PIPELINE_STAGE_ACCELERATION_STRUCTURE_BUILD_BIT_KHR;
     case ResourceState::AccelerationStructureWrite:
         return VK_PIPELINE_STAGE_ACCELERATION_STRUCTURE_BUILD_BIT_KHR;
     case ResourceState::AccelerationStructureBuildInput:

--- a/src/vulkan/vk-utils.h
+++ b/src/vulkan/vk-utils.h
@@ -48,7 +48,11 @@ VkPipelineCreateFlags2 translateRayTracingPipelineFlags2(RayTracingPipelineFlags
 VkImageLayout translateImageLayout(ResourceState state);
 
 VkAccessFlagBits calcAccessFlags(ResourceState state);
-VkPipelineStageFlags calcPipelineStageFlags(const VulkanApi& api, ResourceState state, bool src);
+VkPipelineStageFlags calcPipelineStageFlags(
+    VkPipelineStageFlags supportedShaderStageFlags,
+    ResourceState state,
+    bool src
+);
 VkAccessFlags translateAccelerationStructureAccessFlag(AccessFlag access);
 
 VkBufferUsageFlagBits _calcBufferUsageFlags(BufferUsage usage);

--- a/src/vulkan/vk-utils.h
+++ b/src/vulkan/vk-utils.h
@@ -48,7 +48,7 @@ VkPipelineCreateFlags2 translateRayTracingPipelineFlags2(RayTracingPipelineFlags
 VkImageLayout translateImageLayout(ResourceState state);
 
 VkAccessFlagBits calcAccessFlags(ResourceState state);
-VkPipelineStageFlagBits calcPipelineStageFlags(ResourceState state, bool src);
+VkPipelineStageFlags calcPipelineStageFlags(const VulkanApi& api, ResourceState state, bool src);
 VkAccessFlags translateAccelerationStructureAccessFlag(AccessFlag access);
 
 VkBufferUsageFlagBits _calcBufferUsageFlags(BufferUsage usage);


### PR DESCRIPTION
## Summary
- make Vulkan barrier stage masks depend on enabled device features instead of always including optional shader stages
- include mesh/task shader stages when supported
- include acceleration-structure build stage for acceleration-structure read/query/copy paths
- fix readBuffer transition dst access to CopySource

## Notes
Split out from shader-slang/slang-rhi#739 to keep the synthetic-resource binding PR focused.
