### PR TITLE
Fix Vulkan adapter enumeration on macOS

### DIFF
--- a/src/vulkan/vk-api.cpp
+++ b/src/vulkan/vk-api.cpp
@@ -140,13 +140,13 @@ Result VulkanApi::initEnumerationProcs(VkInstance instance)
         (PFN_vkEnumeratePhysicalDevices)vkGetInstanceProcAddr(instance, "vkEnumeratePhysicalDevices");
     vkGetPhysicalDeviceProperties2 =
         (PFN_vkGetPhysicalDeviceProperties2)vkGetInstanceProcAddr(instance, "vkGetPhysicalDeviceProperties2");
-    vkEnumerateDeviceExtensionProperties =
-        (PFN_vkEnumerateDeviceExtensionProperties)vkGetInstanceProcAddr(
-            instance,
-            "vkEnumerateDeviceExtensionProperties"
-        );
+    if (!vkGetPhysicalDeviceProperties2)
+    {
+        vkGetPhysicalDeviceProperties2 =
+            (PFN_vkGetPhysicalDeviceProperties2)vkGetInstanceProcAddr(instance, "vkGetPhysicalDeviceProperties2KHR");
+    }
 
-    if (!(vkEnumeratePhysicalDevices && vkGetPhysicalDeviceProperties2 && vkEnumerateDeviceExtensionProperties))
+    if (!(vkEnumeratePhysicalDevices && vkGetPhysicalDeviceProperties2))
     {
         return SLANG_FAIL;
     }
@@ -165,6 +165,16 @@ Result VulkanApi::initInstanceProcs(VkInstance instance)
 
     // Get optional
     VK_API_INSTANCE_PROCS_OPT(VK_API_GET_INSTANCE_PROC)
+    if (!vkGetPhysicalDeviceFeatures2)
+    {
+        vkGetPhysicalDeviceFeatures2 =
+            (PFN_vkGetPhysicalDeviceFeatures2)vkGetInstanceProcAddr(instance, "vkGetPhysicalDeviceFeatures2KHR");
+    }
+    if (!vkGetPhysicalDeviceProperties2)
+    {
+        vkGetPhysicalDeviceProperties2 =
+            (PFN_vkGetPhysicalDeviceProperties2)vkGetInstanceProcAddr(instance, "vkGetPhysicalDeviceProperties2KHR");
+    }
 
     if (!areDefined(ProcType::Instance))
     {

--- a/src/vulkan/vk-api.cpp
+++ b/src/vulkan/vk-api.cpp
@@ -13,18 +13,6 @@
 
 namespace rhi::vk {
 
-#if SLANG_APPLE_FAMILY
-static void* _tryLoadVulkanModule(const char* const* candidates, size_t candidateCount)
-{
-    for (size_t i = 0; i < candidateCount; ++i)
-    {
-        if (void* module = dlopen(candidates[i], RTLD_NOW | RTLD_GLOBAL))
-            return module;
-    }
-    return nullptr;
-}
-#endif
-
 // !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! VulkanModule !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
 Result VulkanModule::init()
@@ -52,7 +40,10 @@ Result VulkanModule::init()
         "/usr/local/lib/libvulkan.1.dylib",
         "/usr/local/lib/libvulkan.dylib",
     };
-    m_module = _tryLoadVulkanModule(kVulkanModuleCandidates, SLANG_COUNT_OF(kVulkanModuleCandidates));
+    for (size_t i = 0; i < SLANG_COUNT_OF(kVulkanModuleCandidates) && !m_module; ++i)
+    {
+        m_module = dlopen(kVulkanModuleCandidates[i], RTLD_NOW | RTLD_GLOBAL);
+    }
 #else
 #error "Unsupported platform"
 #endif
@@ -129,29 +120,6 @@ Result VulkanApi::initGlobalProcs(const VulkanModule& module)
         return SLANG_FAIL;
     }
     m_module = &module;
-    return SLANG_OK;
-}
-
-Result VulkanApi::initEnumerationProcs(VkInstance instance)
-{
-    SLANG_RHI_ASSERT(instance && vkGetInstanceProcAddr != nullptr);
-
-    vkEnumeratePhysicalDevices =
-        (PFN_vkEnumeratePhysicalDevices)vkGetInstanceProcAddr(instance, "vkEnumeratePhysicalDevices");
-    vkGetPhysicalDeviceProperties2 =
-        (PFN_vkGetPhysicalDeviceProperties2)vkGetInstanceProcAddr(instance, "vkGetPhysicalDeviceProperties2");
-    if (!vkGetPhysicalDeviceProperties2)
-    {
-        vkGetPhysicalDeviceProperties2 =
-            (PFN_vkGetPhysicalDeviceProperties2)vkGetInstanceProcAddr(instance, "vkGetPhysicalDeviceProperties2KHR");
-    }
-
-    if (!(vkEnumeratePhysicalDevices && vkGetPhysicalDeviceProperties2))
-    {
-        return SLANG_FAIL;
-    }
-
-    m_instance = instance;
     return SLANG_OK;
 }
 

--- a/src/vulkan/vk-api.cpp
+++ b/src/vulkan/vk-api.cpp
@@ -13,6 +13,18 @@
 
 namespace rhi::vk {
 
+#if SLANG_APPLE_FAMILY
+static void* _tryLoadVulkanModule(const char* const* candidates, size_t candidateCount)
+{
+    for (size_t i = 0; i < candidateCount; ++i)
+    {
+        if (void* module = dlopen(candidates[i], RTLD_NOW | RTLD_GLOBAL))
+            return module;
+    }
+    return nullptr;
+}
+#endif
+
 // !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! VulkanModule !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
 Result VulkanModule::init()
@@ -32,7 +44,15 @@ Result VulkanModule::init()
     m_module = dlopen("libvulkan.so.1", RTLD_NOW);
 #endif
 #elif SLANG_APPLE_FAMILY
-    m_module = dlopen("libvulkan.1.dylib", RTLD_NOW | RTLD_GLOBAL);
+    static const char* const kVulkanModuleCandidates[] = {
+        "libvulkan.1.dylib",
+        "libvulkan.dylib",
+        "/opt/homebrew/lib/libvulkan.1.dylib",
+        "/opt/homebrew/lib/libvulkan.dylib",
+        "/usr/local/lib/libvulkan.1.dylib",
+        "/usr/local/lib/libvulkan.dylib",
+    };
+    m_module = _tryLoadVulkanModule(kVulkanModuleCandidates, SLANG_COUNT_OF(kVulkanModuleCandidates));
 #else
 #error "Unsupported platform"
 #endif
@@ -109,6 +129,29 @@ Result VulkanApi::initGlobalProcs(const VulkanModule& module)
         return SLANG_FAIL;
     }
     m_module = &module;
+    return SLANG_OK;
+}
+
+Result VulkanApi::initEnumerationProcs(VkInstance instance)
+{
+    SLANG_RHI_ASSERT(instance && vkGetInstanceProcAddr != nullptr);
+
+    vkEnumeratePhysicalDevices =
+        (PFN_vkEnumeratePhysicalDevices)vkGetInstanceProcAddr(instance, "vkEnumeratePhysicalDevices");
+    vkGetPhysicalDeviceProperties2 =
+        (PFN_vkGetPhysicalDeviceProperties2)vkGetInstanceProcAddr(instance, "vkGetPhysicalDeviceProperties2");
+    vkEnumerateDeviceExtensionProperties =
+        (PFN_vkEnumerateDeviceExtensionProperties)vkGetInstanceProcAddr(
+            instance,
+            "vkEnumerateDeviceExtensionProperties"
+        );
+
+    if (!(vkEnumeratePhysicalDevices && vkGetPhysicalDeviceProperties2 && vkEnumerateDeviceExtensionProperties))
+    {
+        return SLANG_FAIL;
+    }
+
+    m_instance = instance;
     return SLANG_OK;
 }
 

--- a/src/vulkan/vk-api.h
+++ b/src/vulkan/vk-api.h
@@ -61,6 +61,7 @@ protected:
 #define VK_API_INSTANCE_PROCS_OPT(x) \
     x(vkGetPhysicalDeviceFeatures2) \
     x(vkGetPhysicalDeviceProperties2) \
+    VK_API_INSTANCE_KHR_PROCS(x) \
     x(vkCreateDebugUtilsMessengerEXT) \
     x(vkDestroyDebugUtilsMessengerEXT) \
     x(vkGetPhysicalDeviceCooperativeMatrixPropertiesNV) \
@@ -294,7 +295,7 @@ protected:
 
 #define VK_API_ALL_INSTANCE_PROCS(x) \
     VK_API_INSTANCE_PROCS(x) \
-    VK_API_INSTANCE_KHR_PROCS(x)
+    /* */
 
 #define VK_API_ALL_DEVICE_PROCS(x) \
     VK_API_DEVICE_PROCS(x) \
@@ -555,8 +556,6 @@ struct VulkanApi
 
     /// Sets up global parameters
     Result initGlobalProcs(const VulkanModule& module);
-    /// Initialize only the instance functions needed for adapter enumeration.
-    Result initEnumerationProcs(VkInstance instance);
     /// Initialize the instance functions
     Result initInstanceProcs(VkInstance instance);
 

--- a/src/vulkan/vk-api.h
+++ b/src/vulkan/vk-api.h
@@ -555,6 +555,8 @@ struct VulkanApi
 
     /// Sets up global parameters
     Result initGlobalProcs(const VulkanModule& module);
+    /// Initialize only the instance functions needed for adapter enumeration.
+    Result initEnumerationProcs(VkInstance instance);
     /// Initialize the instance functions
     Result initInstanceProcs(VkInstance instance);
 

--- a/src/vulkan/vk-backend.cpp
+++ b/src/vulkan/vk-backend.cpp
@@ -31,11 +31,17 @@ Result BackendImpl::createDevice(const DeviceDesc& desc, IDevice** outDevice)
 Result BackendImpl::enumerateAdapters()
 {
     VulkanModule module;
-    SLANG_RETURN_ON_FAIL(module.init());
+    if (SLANG_FAILED(module.init()))
+    {
+        return SLANG_FAIL;
+    }
     SLANG_RHI_DEFERRED({ module.destroy(); });
 
     VulkanApi api;
-    SLANG_RETURN_ON_FAIL(api.initGlobalProcs(module));
+    if (SLANG_FAILED(api.initGlobalProcs(module)))
+    {
+        return SLANG_FAIL;
+    }
 
     VkInstanceCreateInfo instanceCreateInfo = {VK_STRUCTURE_TYPE_INSTANCE_CREATE_INFO};
     const char* instanceExtensions[] = {
@@ -50,14 +56,13 @@ Result BackendImpl::enumerateAdapters()
     instanceCreateInfo.flags = VK_INSTANCE_CREATE_ENUMERATE_PORTABILITY_BIT_KHR;
 #endif
     VkInstance instance;
-    SLANG_VK_RETURN_ON_FAIL(api.vkCreateInstance(&instanceCreateInfo, nullptr, &instance));
+    if (api.vkCreateInstance(&instanceCreateInfo, nullptr, &instance) != VK_SUCCESS)
+    {
+        return SLANG_FAIL;
+    }
     SLANG_RHI_DEFERRED({ api.vkDestroyInstance(instance, nullptr); });
 
-    // This will fail due to not loading any extensions.
-    api.initInstanceProcs(instance);
-
-    if (!(api.vkEnumeratePhysicalDevices && api.vkGetPhysicalDeviceProperties2 &&
-          api.vkEnumerateDeviceExtensionProperties))
+    if (SLANG_FAILED(api.initEnumerationProcs(instance)))
     {
         return SLANG_FAIL;
     }

--- a/src/vulkan/vk-backend.cpp
+++ b/src/vulkan/vk-backend.cpp
@@ -35,7 +35,6 @@ Result BackendImpl::enumerateAdapters()
     {
         return SLANG_FAIL;
     }
-    SLANG_RHI_DEFERRED({ module.destroy(); });
 
     VulkanApi api;
     if (SLANG_FAILED(api.initGlobalProcs(module)))
@@ -46,6 +45,7 @@ Result BackendImpl::enumerateAdapters()
     VkInstanceCreateInfo instanceCreateInfo = {VK_STRUCTURE_TYPE_INSTANCE_CREATE_INFO};
     const char* instanceExtensions[] = {
         VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME,
+        VK_KHR_EXTERNAL_MEMORY_CAPABILITIES_EXTENSION_NAME,
 #if SLANG_APPLE_FAMILY
         VK_KHR_PORTABILITY_ENUMERATION_EXTENSION_NAME,
 #endif

--- a/src/vulkan/vk-backend.cpp
+++ b/src/vulkan/vk-backend.cpp
@@ -31,21 +31,15 @@ Result BackendImpl::createDevice(const DeviceDesc& desc, IDevice** outDevice)
 Result BackendImpl::enumerateAdapters()
 {
     VulkanModule module;
-    if (SLANG_FAILED(module.init()))
-    {
-        return SLANG_FAIL;
-    }
+    SLANG_RETURN_ON_FAIL(module.init());
+    SLANG_RHI_DEFERRED({ module.destroy(); });
 
     VulkanApi api;
-    if (SLANG_FAILED(api.initGlobalProcs(module)))
-    {
-        return SLANG_FAIL;
-    }
+    SLANG_RETURN_ON_FAIL(api.initGlobalProcs(module));
 
     VkInstanceCreateInfo instanceCreateInfo = {VK_STRUCTURE_TYPE_INSTANCE_CREATE_INFO};
     const char* instanceExtensions[] = {
         VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME,
-        VK_KHR_EXTERNAL_MEMORY_CAPABILITIES_EXTENSION_NAME,
 #if SLANG_APPLE_FAMILY
         VK_KHR_PORTABILITY_ENUMERATION_EXTENSION_NAME,
 #endif
@@ -56,13 +50,11 @@ Result BackendImpl::enumerateAdapters()
     instanceCreateInfo.flags = VK_INSTANCE_CREATE_ENUMERATE_PORTABILITY_BIT_KHR;
 #endif
     VkInstance instance;
-    if (api.vkCreateInstance(&instanceCreateInfo, nullptr, &instance) != VK_SUCCESS)
-    {
-        return SLANG_FAIL;
-    }
+    SLANG_VK_RETURN_ON_FAIL(api.vkCreateInstance(&instanceCreateInfo, nullptr, &instance));
     SLANG_RHI_DEFERRED({ api.vkDestroyInstance(instance, nullptr); });
 
-    if (SLANG_FAILED(api.initEnumerationProcs(instance)))
+    SLANG_RETURN_ON_FAIL(api.initInstanceProcs(instance));
+    if (!(api.vkEnumeratePhysicalDevices && api.vkGetPhysicalDeviceProperties2))
     {
         return SLANG_FAIL;
     }


### PR DESCRIPTION
## Summary
- load Vulkan from common MoltenVK/Homebrew library locations on Apple platforms
- initialize the smaller Vulkan instance-proc set needed for adapter enumeration instead of requiring full device-instance proc loading
- use KHR fallbacks for physical-device feature/property queries
- enable the external-memory-capabilities instance extension needed for physical-device ID properties on Vulkan 1.0

## Notes
Split out from shader-slang/slang-rhi#739 to keep the synthetic-resource binding PR focused.
This PR depends on shader-slang/slang-rhi#748.
