### PR TITLE
Expose CUDA fp8 feature on SM 8.9

### DIFF
--- a/include/slang-rhi/capabilities.h
+++ b/include/slang-rhi/capabilities.h
@@ -69,6 +69,7 @@
     x(_cuda_sm_6_0) \
     x(_cuda_sm_7_0) \
     x(_cuda_sm_8_0) \
+    x(_cuda_sm_8_9) \
     x(_cuda_sm_9_0) \
     x(optix_coopvec) \
     x(vertex) \

--- a/src/cuda/cuda-device.cpp
+++ b/src/cuda/cuda-device.cpp
@@ -36,6 +36,7 @@ static ComputeCapabilityInfo kKnownComputeCapabilities[] = {
     COMPUTE_CAPABILITY(6, 0),
     COMPUTE_CAPABILITY(7, 0),
     COMPUTE_CAPABILITY(8, 0),
+    COMPUTE_CAPABILITY(8, 9),
     COMPUTE_CAPABILITY(9, 0),
 #undef COMPUTE_CAPABILITY
 };
@@ -245,6 +246,10 @@ Result DeviceImpl::initialize(const DeviceDesc& desc, BackendImpl* backend)
     if (hasComputeCapability(8, 0))
     {
         addFeature(Feature::Bfloat16);
+    }
+    if (hasComputeCapability(8, 9))
+    {
+        addFeature(Feature::Float8);
     }
     if (hasComputeCapability(9, 0))
     {


### PR DESCRIPTION
## Summary
- add the cuda_sm_8_9 capability atom
- advertise the Float8 render feature for CUDA devices with compute capability 8.9+

Close shader-slang/slang#11161