### PR TITLE
Use clamped coordinate in TextureViewImpl::_getTexelPtr

### DIFF
--- a/src/cpu/cpu-texture.cpp
+++ b/src/cpu/cpu-texture.cpp
@@ -423,7 +423,7 @@ void* TextureViewImpl::_getTexelPtr(const int32_t* texelCoords)
         if (coord < 0)
             coord = 0;
 
-        texelOffset += texelCoords[axis] * mipLevelInfo.pitches[axis];
+        texelOffset += coord * mipLevelInfo.pitches[axis];
     }
 
     return (uint8_t*)texture->m_data + texelOffset;


### PR DESCRIPTION
## Summary
- `_getTexelPtr` computes a clamped `coord` value but then uses the original unclamped `texelCoords[axis]` for the offset calculation, making the clamping ineffective
- Out-of-range texel coordinates passed through `Load()` or `refAt()` result in out-of-bounds memory access instead of clamping to the texture edge
- Fix by using `coord` instead of `texelCoords[axis]`, matching the pattern already used in `SampleLevel()`

## Test plan
- [ ] Verify CPU backend texture load/store tests pass
- [ ] Test with out-of-bounds texel coordinates on CPU backend