### PR TITLE
Timestamp calibration

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -242,13 +242,14 @@
 
 ## `ICommandQueue` interface
 
-| API                     | CPU | CUDA | D3D11 | D3D12 | Vulkan | Metal | WGPU |
-|-------------------------|-----|------|-------|-------|--------|-------|------|
-| `getType`               | yes | yes  | yes   | yes   | yes    | yes   | yes  |
-| `createCommandEncoder`  | yes | yes  | yes   | yes   | yes    | yes   | yes  |
-| `submit`                | yes | yes  | yes   | yes   | yes    | yes   | yes  |
-| `getNativeHandle`       | :x: | yes  | :x:   | yes   | yes    | yes   | yes  |
-| `waitOnHost`            | yes | yes  | yes   | yes   | yes    | yes   | yes  |
+| API                       | CPU | CUDA | D3D11 | D3D12 | Vulkan | Metal | WGPU |
+|---------------------------|-----|------|-------|-------|--------|-------|------|
+| `getType`                 | yes | yes  | yes   | yes   | yes    | yes   | yes  |
+| `createCommandEncoder`    | yes | yes  | yes   | yes   | yes    | yes   | yes  |
+| `submit`                  | yes | yes  | yes   | yes   | yes    | yes   | yes  |
+| `getNativeHandle`         | :x: | yes  | :x:   | yes   | yes    | yes   | yes  |
+| `waitOnHost`              | yes | yes  | yes   | yes   | yes    | yes   | yes  |
+| `getTimestampCalibration` | yes | yes  | yes   | yes   | yes    | :x:   | :x:  |
 
 ## `ISurface` interface
 

--- a/include/slang-rhi.h
+++ b/include/slang-rhi.h
@@ -130,6 +130,7 @@ enum class DeviceType
     x(ClusterAccelerationStructure,             "cluster-acceleration-structure"                ) \
     /* Other features */                                                                          \
     x(TimestampQuery,                           "timestamp-query"                               ) \
+    x(TimestampCalibration,                     "timestamp-calibration"                         ) \
     x(RealtimeClock,                            "realtime-clock"                                ) \
     x(CooperativeVector,                        "cooperative-vector"                            ) \
     x(CooperativeMatrix,                        "cooperative-matrix"                            ) \
@@ -2785,6 +2786,22 @@ enum class CpuTimestampDomain
     MachAbsoluteTime,
 };
 
+struct TimestampCalibration
+{
+    /// The domain of the CPU timestamp.
+    CpuTimestampDomain cpuDomain = CpuTimestampDomain::Unknown;
+    /// The current CPU timestamp.
+    uint64_t cpuTimestamp = 0;
+    /// The frequency of the CPU timestamp in ticks per second.
+    uint64_t cpuFrequency = 0;
+    /// The current GPU timestamp.
+    uint64_t gpuTimestamp = 0;
+    /// The frequency of the GPU timestamp in ticks per second.
+    uint64_t gpuFrequency = 0;
+    /// The maximum deviation between the CPU and GPU timestamps in nanoseconds.
+    uint64_t maxDeviationNs = 0;
+};
+
 // The NULL CUDA stream is valid (it refers to the default stream), so we
 // use this constant to indicate the absence of one.
 void* const kInvalidCUDAStream = reinterpret_cast<void*>(~uintptr_t{0});
@@ -2856,6 +2873,8 @@ public:
     virtual SLANG_NO_THROW Result SLANG_MCALL waitOnHost() = 0;
 
     virtual SLANG_NO_THROW Result SLANG_MCALL getNativeHandle(NativeHandle* outHandle) = 0;
+
+    virtual SLANG_NO_THROW Result SLANG_MCALL getTimestampCalibration(TimestampCalibration* outCalibration) = 0;
 };
 
 struct SurfaceInfo
@@ -3137,6 +3156,10 @@ struct DeviceInfo
     AdapterLUID adapterLUID;
 
     /// The clock frequency used in timestamp queries.
+    /// This is a legacy/static convenience value for converting differences
+    /// between QueryType::Timestamp results. New code that needs to correlate
+    /// GPU timestamps with a CPU clock should use
+    /// ICommandQueue::getTimestampCalibration().
     uint64_t timestampFrequency = 0;
 
     /// The version of OptiX used by the device (0 if OptiX is not supported).

--- a/include/slang-rhi.h
+++ b/include/slang-rhi.h
@@ -2776,6 +2776,15 @@ enum class QueueType
     Graphics,
 };
 
+enum class CpuTimestampDomain
+{
+    Unknown,
+    QueryPerformanceCounter,
+    ClockMonotonic,
+    ClockMonotonicRaw,
+    MachAbsoluteTime,
+};
+
 // The NULL CUDA stream is valid (it refers to the default stream), so we
 // use this constant to indicate the absence of one.
 void* const kInvalidCUDAStream = reinterpret_cast<void*>(~uintptr_t{0});

--- a/src/command-buffer.h
+++ b/src/command-buffer.h
@@ -44,6 +44,11 @@ public:
 
     // ICommandQueue implementation
     virtual SLANG_NO_THROW QueueType SLANG_MCALL getType() override { return m_type; }
+    virtual SLANG_NO_THROW Result SLANG_MCALL getTimestampCalibration(TimestampCalibration* outCalibration) override
+    {
+        SLANG_UNUSED(outCalibration);
+        return SLANG_E_NOT_AVAILABLE;
+    }
 
 public:
     QueueType m_type;

--- a/src/core/platform.cpp
+++ b/src/core/platform.cpp
@@ -6,6 +6,12 @@
 #include <windows.h>
 #elif SLANG_LINUX_FAMILY || SLANG_APPLE_FAMILY
 #include <dlfcn.h>
+#if SLANG_LINUX_FAMILY
+#include <time.h>
+#endif
+#if SLANG_APPLE_FAMILY
+#include <mach/mach_time.h>
+#endif
 #elif SLANG_WASM
 // nothing to include for WASM
 #else
@@ -76,6 +82,121 @@ const char* findSharedLibraryPath(void* symbolAddress)
     SLANG_RHI_ASSERT_FAILURE("Not implemented");
     return nullptr;
 #endif
+}
+
+namespace {
+
+struct TimeSource
+{
+    CpuTimestampDomain domain = CpuTimestampDomain::Unknown;
+    uint64_t frequency = 0;
+
+#if SLANG_LINUX_FAMILY
+    clockid_t clockId = 0;
+#endif
+
+    TimeSource()
+    {
+#if SLANG_WINDOWS_FAMILY
+        LARGE_INTEGER qpcFrequency = {};
+        if (QueryPerformanceFrequency(&qpcFrequency))
+        {
+            domain = CpuTimestampDomain::QueryPerformanceCounter;
+            frequency = uint64_t(qpcFrequency.QuadPart);
+        }
+#elif SLANG_LINUX_FAMILY
+        timespec ts = {};
+#if defined(CLOCK_MONOTONIC_RAW)
+        if (clock_gettime(CLOCK_MONOTONIC_RAW, &ts) == 0)
+        {
+            domain = CpuTimestampDomain::ClockMonotonicRaw;
+            frequency = kNanosecondsPerSecond;
+            clockId = CLOCK_MONOTONIC_RAW;
+            return;
+        }
+#endif
+        if (clock_gettime(CLOCK_MONOTONIC, &ts) == 0)
+        {
+            domain = CpuTimestampDomain::ClockMonotonic;
+            frequency = kNanosecondsPerSecond;
+            clockId = CLOCK_MONOTONIC;
+            return;
+        }
+#elif SLANG_APPLE_FAMILY
+        mach_timebase_info_data_t timebaseInfo = {};
+        if (mach_timebase_info(&timebaseInfo) == KERN_SUCCESS && timebaseInfo.numer != 0)
+        {
+            domain = CpuTimestampDomain::MachAbsoluteTime;
+            frequency = uint64_t(
+                (double(timebaseInfo.denom) * double(kNanosecondsPerSecond) / double(timebaseInfo.numer)) + 0.5
+            );
+        }
+#endif
+    }
+
+    uint64_t timestamp() const
+    {
+        if (domain == CpuTimestampDomain::Unknown)
+        {
+            return 0;
+        }
+
+#if SLANG_WINDOWS_FAMILY
+        LARGE_INTEGER counter = {};
+        return QueryPerformanceCounter(&counter) ? uint64_t(counter.QuadPart) : 0;
+#elif SLANG_LINUX_FAMILY
+        timespec ts = {};
+        return clock_gettime(clockId, &ts) == 0 ? uint64_t(ts.tv_sec) * kNanosecondsPerSecond + uint64_t(ts.tv_nsec)
+                                                : 0;
+#elif SLANG_APPLE_FAMILY
+        return mach_absolute_time();
+#else
+        return 0;
+#endif
+    }
+};
+
+static const TimeSource& getTimeSource()
+{
+    static TimeSource timeSource;
+    return timeSource;
+}
+
+} // namespace
+
+CpuTimestampDomain getCpuTimestampDomain()
+{
+    return getTimeSource().domain;
+}
+
+uint64_t getCpuTimestampFrequency()
+{
+    return getTimeSource().frequency;
+}
+
+uint64_t getCpuTimestamp()
+{
+    return getTimeSource().timestamp();
+}
+
+uint64_t ticksToNanoseconds(uint64_t ticks, uint64_t frequency)
+{
+    if (frequency == 0)
+    {
+        return 0;
+    }
+    if (frequency == kNanosecondsPerSecond)
+    {
+        return ticks;
+    }
+
+    // This assumes practical timer frequencies where remainder * 1e9 fits in uint64_t.
+    // The CPU/GPU timestamp frequencies used by RHI are far below that limit.
+    const uint64_t seconds = ticks / frequency;
+    const uint64_t remainder = ticks % frequency;
+    const uint64_t wholeNanoseconds = seconds * kNanosecondsPerSecond;
+    const uint64_t fractionalNanoseconds = (remainder * kNanosecondsPerSecond + frequency / 2) / frequency;
+    return wholeNanoseconds + fractionalNanoseconds;
 }
 
 } // namespace rhi

--- a/src/core/platform.h
+++ b/src/core/platform.h
@@ -16,4 +16,21 @@ void* findSymbolAddressByName(SharedLibraryHandle handle, const char* name);
 /// Given a symbol from a loaded shared library, return the library's path.
 const char* findSharedLibraryPath(void* symbolAddress);
 
+static constexpr uint64_t kNanosecondsPerSecond = 1000000000ull;
+
+/// Return a timestamp value from the CPU's high-resolution timer, if available.
+/// The frequency of the timer can be obtained via `getCpuTimestampFrequency()`.
+/// If a high-resolution timer is not available, this function will return 0.
+uint64_t getCpuTimestamp();
+
+/// Return the frequency of the CPU's high-resolution timer, if available.
+/// If a high-resolution timer is not available, this function will return 0.
+uint64_t getCpuTimestampFrequency();
+
+/// Return the domain of the CPU timestamp, if available.
+/// If a high-resolution timer is not available, this function will return `CpuTimestampDomain::Unknown`.
+CpuTimestampDomain getCpuTimestampDomain();
+
+uint64_t ticksToNanoseconds(uint64_t ticks, uint64_t frequency);
+
 } // namespace rhi

--- a/src/cpu/cpu-command.cpp
+++ b/src/cpu/cpu-command.cpp
@@ -5,7 +5,7 @@
 #include "../command-list.h"
 #include "../strings.h"
 
-#include <chrono>
+#include "core/platform.h"
 
 namespace rhi::cpu {
 
@@ -319,7 +319,7 @@ void CommandExecutor::cmdInsertDebugMarker(const commands::InsertDebugMarker& cm
 void CommandExecutor::cmdWriteTimestamp(const commands::WriteTimestamp& cmd)
 {
     auto queryPool = checked_cast<QueryPoolImpl*>(cmd.queryPool);
-    queryPool->m_queries[cmd.queryIndex] = std::chrono::high_resolution_clock::now().time_since_epoch().count();
+    queryPool->m_queries[cmd.queryIndex] = getCpuTimestamp();
     queryPool->markQueryRangeSubmitted(cmd.queryIndex, 1, m_submissionID);
     queryPool->markQueryRangeReady(cmd.queryIndex, 1, m_submissionID);
 }
@@ -385,6 +385,26 @@ Result CommandQueueImpl::getNativeHandle(NativeHandle* outHandle)
 {
     *outHandle = {};
     return SLANG_E_NOT_AVAILABLE;
+}
+
+Result CommandQueueImpl::getTimestampCalibration(TimestampCalibration* outCalibration)
+{
+    if (!outCalibration)
+    {
+        return SLANG_E_INVALID_ARG;
+    }
+
+    const uint64_t cpuFrequency = getCpuTimestampFrequency();
+    const uint64_t cpuTimestamp = getCpuTimestamp();
+
+    outCalibration->cpuDomain = getCpuTimestampDomain();
+    outCalibration->cpuTimestamp = cpuTimestamp;
+    outCalibration->cpuFrequency = cpuFrequency;
+    outCalibration->gpuTimestamp = cpuTimestamp;
+    outCalibration->gpuFrequency = cpuFrequency;
+    outCalibration->maxDeviationNs = 0;
+
+    return SLANG_OK;
 }
 
 // CommandEncoderImpl

--- a/src/cpu/cpu-command.h
+++ b/src/cpu/cpu-command.h
@@ -21,6 +21,7 @@ public:
     virtual SLANG_NO_THROW Result SLANG_MCALL submit(const SubmitDesc& desc) override;
     virtual SLANG_NO_THROW Result SLANG_MCALL waitOnHost() override;
     virtual SLANG_NO_THROW Result SLANG_MCALL getNativeHandle(NativeHandle* outHandle) override;
+    virtual SLANG_NO_THROW Result SLANG_MCALL getTimestampCalibration(TimestampCalibration* outCalibration) override;
 };
 
 class CommandEncoderImpl : public CommandEncoder

--- a/src/cpu/cpu-device.cpp
+++ b/src/cpu/cpu-device.cpp
@@ -5,6 +5,8 @@
 #include "cpu-shader-program.h"
 #include "cpu-texture.h"
 
+#include "core/platform.h"
+
 namespace rhi::cpu {
 
 DeviceImpl::~DeviceImpl() {}
@@ -19,13 +21,14 @@ Result DeviceImpl::initialize(const DeviceDesc& desc, BackendImpl* backend)
         m_info.apiName = "CPU";
         m_info.adapterName = "CPU";
         m_info.adapterLUID = {};
-        m_info.timestampFrequency = 1000000000;
+        m_info.timestampFrequency = getCpuTimestampFrequency();
     }
 
     // Initialize features & capabilities
     addFeature(Feature::SoftwareDevice);
     addFeature(Feature::ParameterBlock);
     addFeature(Feature::TimestampQuery);
+    addFeature(Feature::TimestampCalibration);
     addFeature(Feature::Pointer);
 
     addCapability(Capability::cpp);

--- a/src/cuda/cuda-command.cpp
+++ b/src/cuda/cuda-command.cpp
@@ -13,6 +13,7 @@
 #include "../strings.h"
 
 #include "core/deferred.h"
+#include "core/platform.h"
 
 #include <chrono>
 
@@ -185,6 +186,31 @@ static Result resolveTimestampAnchor(CommandQueueImpl* queue, uint64_t generatio
 
     anchor->offsetUs = previous->offsetUs + cudaEventMillisecondsToMicroseconds(elapsedMs);
     anchor->resolved = true;
+    return SLANG_OK;
+}
+
+static Result resolveTimestampEvent(
+    CommandQueueImpl* queue,
+    CUevent event,
+    uint64_t anchorGeneration,
+    uint64_t* outTimestampUs
+)
+{
+    if (anchorGeneration == kInvalidTimestampAnchorGeneration)
+    {
+        return SLANG_FAIL;
+    }
+
+    SLANG_RETURN_ON_FAIL(resolveTimestampAnchor(queue, anchorGeneration));
+    TimestampAnchor* anchor = findTimestampAnchor(queue, anchorGeneration);
+    if (!anchor)
+    {
+        return SLANG_FAIL;
+    }
+
+    float elapsedMs = 0.0f;
+    SLANG_CUDA_RETURN_ON_FAIL_REPORT(cuEventElapsedTime(&elapsedMs, anchor->event, event), queue);
+    *outTimestampUs = anchor->offsetUs + cudaEventMillisecondsToMicroseconds(elapsedMs);
     return SLANG_OK;
 }
 
@@ -1067,17 +1093,7 @@ Result CommandQueueImpl::resolveTimestampQueries(CommandBufferImpl* commandBuffe
             }
 
             QueryPoolImpl::Query& query = pool->m_queries[queryIndex];
-            SLANG_RETURN_ON_FAIL(resolveTimestampAnchor(this, query.anchorGeneration));
-
-            TimestampAnchor* anchor = findTimestampAnchor(this, query.anchorGeneration);
-            if (!anchor)
-            {
-                return SLANG_FAIL;
-            }
-
-            float elapsedMs = 0.0f;
-            SLANG_CUDA_RETURN_ON_FAIL_REPORT(cuEventElapsedTime(&elapsedMs, anchor->event, query.event), this);
-            query.resultData = anchor->offsetUs + cudaEventMillisecondsToMicroseconds(elapsedMs);
+            SLANG_RETURN_ON_FAIL(resolveTimestampEvent(this, query.event, query.anchorGeneration, &query.resultData));
         }
 
         pool->markQueryRangeReady(queryWrite.index, queryWrite.count, commandBuffer->m_submissionID);
@@ -1108,6 +1124,43 @@ Result CommandQueueImpl::createCommandEncoder(const CommandEncoderDesc& desc, IC
     RefPtr<CommandEncoderImpl> encoder = new CommandEncoderImpl(m_device, this, desc);
     SLANG_RETURN_ON_FAIL(encoder->init());
     returnComPtr(outEncoder, encoder);
+    return SLANG_OK;
+}
+
+Result CommandQueueImpl::getTimestampCalibration(TimestampCalibration* outCalibration)
+{
+    if (!outCalibration)
+    {
+        return SLANG_E_INVALID_ARG;
+    }
+
+    uint64_t anchorGeneration = kInvalidTimestampAnchorGeneration;
+    SLANG_RETURN_ON_FAIL(getTimestampAnchorGeneration(this, &anchorGeneration));
+
+    CUevent event = nullptr;
+    SLANG_CUDA_RETURN_ON_FAIL_REPORT(cuEventCreate(&event, 0), this);
+    SLANG_RHI_DEFERRED({ SLANG_CUDA_ASSERT_ON_FAIL(cuEventDestroy(event)); });
+
+    uint64_t before = 0;
+    uint64_t after = 0;
+    uint64_t gpuTimestampUs = 0;
+
+    before = getCpuTimestamp();
+    SLANG_CUDA_RETURN_ON_FAIL_REPORT(cuEventRecord(event, m_stream), this);
+    SLANG_CUDA_RETURN_ON_FAIL_REPORT(cuEventSynchronize(event), this);
+    after = getCpuTimestamp();
+    SLANG_RETURN_ON_FAIL(resolveTimestampEvent(this, event, anchorGeneration, &gpuTimestampUs));
+
+    const uint64_t cpuFrequency = getCpuTimestampFrequency();
+    const uint64_t cpuDelta = after - before;
+
+    outCalibration->cpuDomain = getCpuTimestampDomain();
+    outCalibration->cpuTimestamp = before + cpuDelta / 2;
+    outCalibration->cpuFrequency = cpuFrequency;
+    outCalibration->gpuTimestamp = gpuTimestampUs;
+    outCalibration->gpuFrequency = getDevice<DeviceImpl>()->getInfo().timestampFrequency;
+    outCalibration->maxDeviationNs = ticksToNanoseconds(cpuDelta, cpuFrequency) / 2 + 1;
+
     return SLANG_OK;
 }
 

--- a/src/cuda/cuda-command.h
+++ b/src/cuda/cuda-command.h
@@ -86,6 +86,7 @@ public:
     virtual SLANG_NO_THROW Result SLANG_MCALL submit(const SubmitDesc& desc) override;
     virtual SLANG_NO_THROW Result SLANG_MCALL waitOnHost() override;
     virtual SLANG_NO_THROW Result SLANG_MCALL getNativeHandle(NativeHandle* outHandle) override;
+    virtual SLANG_NO_THROW Result SLANG_MCALL getTimestampCalibration(TimestampCalibration* outCalibration) override;
 };
 
 class CommandEncoderImpl : public CommandEncoder

--- a/src/cuda/cuda-device.cpp
+++ b/src/cuda/cuda-device.cpp
@@ -14,6 +14,8 @@
 #include "cuda-utils.h"
 #include "cuda-heap.h"
 
+#include "core/platform.h"
+
 namespace rhi::cuda {
 
 struct ComputeCapabilityInfo
@@ -210,6 +212,7 @@ Result DeviceImpl::initialize(const DeviceDesc& desc, BackendImpl* backend)
     addFeature(Feature::CustomBorderColor);
     addFeature(Feature::CombinedTextureSampler);
     addFeature(Feature::TimestampQuery);
+    addFeature(Feature::TimestampCalibration);
     addFeature(Feature::Pointer);
 
     int computeCapabilityMajor = 0;

--- a/src/d3d11/d3d11-command.cpp
+++ b/src/d3d11/d3d11-command.cpp
@@ -12,6 +12,8 @@
 #include "../strings.h"
 #include "../format-conversion.h"
 
+#include "core/platform.h"
+
 #include <chrono>
 #include <thread>
 
@@ -974,6 +976,72 @@ Result CommandQueueImpl::getNativeHandle(NativeHandle* outHandle)
 {
     *outHandle = {};
     return SLANG_E_NOT_AVAILABLE;
+}
+
+Result CommandQueueImpl::getTimestampCalibration(TimestampCalibration* outCalibration)
+{
+    if (!outCalibration)
+    {
+        return SLANG_E_INVALID_ARG;
+    }
+
+    DeviceImpl* device = getDevice<DeviceImpl>();
+
+    D3D11_QUERY_DESC timestampQueryDesc = {};
+    timestampQueryDesc.Query = D3D11_QUERY_TIMESTAMP;
+    ComPtr<ID3D11Query> timestampQuery;
+    SLANG_RETURN_ON_FAIL(device->m_device->CreateQuery(&timestampQueryDesc, timestampQuery.writeRef()));
+
+    D3D11_QUERY_DESC disjointQueryDesc = {};
+    disjointQueryDesc.Query = D3D11_QUERY_TIMESTAMP_DISJOINT;
+    ComPtr<ID3D11Query> disjointQuery;
+    SLANG_RETURN_ON_FAIL(device->m_device->CreateQuery(&disjointQueryDesc, disjointQuery.writeRef()));
+
+    device->m_immediateContext->Begin(disjointQuery);
+    const uint64_t before = getCpuTimestamp();
+    device->m_immediateContext->End(timestampQuery);
+    device->m_immediateContext->End(disjointQuery);
+    device->m_immediateContext->Flush();
+
+    D3D11_QUERY_DATA_TIMESTAMP_DISJOINT disjointData = {};
+    HRESULT hr = S_FALSE;
+    while ((hr = device->m_immediateContext->GetData(disjointQuery, &disjointData, sizeof(disjointData), 0)) == S_FALSE)
+    {
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    }
+    SLANG_RETURN_ON_FAIL(hr);
+    const uint64_t after = getCpuTimestamp();
+
+    if (disjointData.Disjoint || disjointData.Frequency == 0)
+    {
+        return SLANG_FAIL;
+    }
+
+    uint64_t gpuTimestamp = 0;
+    hr = S_FALSE;
+    while ((hr = device->m_immediateContext->GetData(timestampQuery, &gpuTimestamp, sizeof(gpuTimestamp), 0)) ==
+           S_FALSE)
+    {
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    }
+    SLANG_RETURN_ON_FAIL(hr);
+
+    if (after < before)
+    {
+        return SLANG_FAIL;
+    }
+
+    const uint64_t cpuFrequency = getCpuTimestampFrequency();
+    const uint64_t cpuDelta = after - before;
+
+    outCalibration->cpuDomain = getCpuTimestampDomain();
+    outCalibration->cpuTimestamp = before + cpuDelta / 2;
+    outCalibration->cpuFrequency = cpuFrequency;
+    outCalibration->gpuTimestamp = gpuTimestamp;
+    outCalibration->gpuFrequency = disjointData.Frequency;
+    outCalibration->maxDeviationNs = ticksToNanoseconds(cpuDelta, cpuFrequency) / 2 + 1;
+
+    return SLANG_OK;
 }
 
 // CommandEncoderImpl

--- a/src/d3d11/d3d11-command.h
+++ b/src/d3d11/d3d11-command.h
@@ -22,6 +22,7 @@ public:
     virtual SLANG_NO_THROW Result SLANG_MCALL submit(const SubmitDesc& desc) override;
     virtual SLANG_NO_THROW Result SLANG_MCALL waitOnHost() override;
     virtual SLANG_NO_THROW Result SLANG_MCALL getNativeHandle(NativeHandle* outHandle) override;
+    virtual SLANG_NO_THROW Result SLANG_MCALL getTimestampCalibration(TimestampCalibration* outCalibration) override;
 };
 
 class CommandEncoderImpl : public CommandEncoder

--- a/src/d3d11/d3d11-device.cpp
+++ b/src/d3d11/d3d11-device.cpp
@@ -296,6 +296,7 @@ Result DeviceImpl::initialize(const DeviceDesc& desc, BackendImpl* backend)
     if (m_info.timestampFrequency > 0)
     {
         addFeature(Feature::TimestampQuery);
+        addFeature(Feature::TimestampCalibration);
     }
 
     addCapability(Capability::hlsl);

--- a/src/d3d12/d3d12-command.cpp
+++ b/src/d3d12/d3d12-command.cpp
@@ -17,6 +17,7 @@
 
 #include "core/short_vector.h"
 #include "core/common.h"
+#include "core/platform.h"
 
 namespace rhi::d3d12 {
 
@@ -2067,6 +2068,41 @@ Result CommandQueueImpl::getNativeHandle(NativeHandle* outHandle)
 {
     outHandle->type = NativeHandleType::D3D12CommandQueue;
     outHandle->value = (uint64_t)m_d3dQueue.get();
+    return SLANG_OK;
+}
+
+Result CommandQueueImpl::getTimestampCalibration(TimestampCalibration* outCalibration)
+{
+    if (!outCalibration)
+    {
+        return SLANG_E_INVALID_ARG;
+    }
+
+    if (getCpuTimestampDomain() != CpuTimestampDomain::QueryPerformanceCounter)
+    {
+        return SLANG_FAIL;
+    }
+
+    const uint64_t before = getCpuTimestamp();
+
+    UINT64 gpuTimestamp = 0;
+    UINT64 cpuTimestamp = 0;
+    SLANG_RETURN_ON_FAIL(m_d3dQueue->GetClockCalibration(&gpuTimestamp, &cpuTimestamp));
+
+    const uint64_t after = getCpuTimestamp();
+
+    UINT64 gpuFrequency = 0;
+    SLANG_RETURN_ON_FAIL(m_d3dQueue->GetTimestampFrequency(&gpuFrequency));
+
+    const uint64_t cpuFrequency = getCpuTimestampFrequency();
+
+    outCalibration->cpuDomain = CpuTimestampDomain::QueryPerformanceCounter;
+    outCalibration->cpuTimestamp = cpuTimestamp;
+    outCalibration->cpuFrequency = cpuFrequency;
+    outCalibration->gpuTimestamp = gpuTimestamp;
+    outCalibration->gpuFrequency = gpuFrequency;
+    outCalibration->maxDeviationNs = ticksToNanoseconds(after - before, cpuFrequency);
+
     return SLANG_OK;
 }
 

--- a/src/d3d12/d3d12-command.h
+++ b/src/d3d12/d3d12-command.h
@@ -66,6 +66,7 @@ public:
     virtual SLANG_NO_THROW Result SLANG_MCALL submit(const SubmitDesc& desc) override;
     virtual SLANG_NO_THROW Result SLANG_MCALL waitOnHost() override;
     virtual SLANG_NO_THROW Result SLANG_MCALL getNativeHandle(NativeHandle* outHandle) override;
+    virtual SLANG_NO_THROW Result SLANG_MCALL getTimestampCalibration(TimestampCalibration* outCalibration) override;
 };
 
 class CommandEncoderImpl : public CommandEncoder

--- a/src/d3d12/d3d12-device.cpp
+++ b/src/d3d12/d3d12-device.cpp
@@ -663,6 +663,7 @@ Result DeviceImpl::initialize(const DeviceDesc& desc, BackendImpl* backend)
     addFeature(Feature::Rasterization);
     addFeature(Feature::CustomBorderColor);
     addFeature(Feature::TimestampQuery);
+    addFeature(Feature::TimestampCalibration);
 
     addCapability(Capability::hlsl);
 

--- a/src/debug-layer/debug-command-queue.cpp
+++ b/src/debug-layer/debug-command-queue.cpp
@@ -122,4 +122,17 @@ Result DebugCommandQueue::getNativeHandle(NativeHandle* outHandle)
     return baseObject->getNativeHandle(outHandle);
 }
 
+Result DebugCommandQueue::getTimestampCalibration(TimestampCalibration* outCalibration)
+{
+    SLANG_RHI_DEBUG_API(ICommandQueue, getTimestampCalibration);
+
+    if (!outCalibration)
+    {
+        RHI_VALIDATION_ERROR("'outCalibration' must not be null.");
+        return SLANG_E_INVALID_ARG;
+    }
+
+    return baseObject->getTimestampCalibration(outCalibration);
+}
+
 } // namespace rhi::debug

--- a/src/debug-layer/debug-command-queue.h
+++ b/src/debug-layer/debug-command-queue.h
@@ -22,6 +22,7 @@ public:
     virtual SLANG_NO_THROW Result SLANG_MCALL submit(const SubmitDesc& desc) override;
     virtual SLANG_NO_THROW Result SLANG_MCALL waitOnHost() override;
     virtual SLANG_NO_THROW Result SLANG_MCALL getNativeHandle(NativeHandle* outHandle) override;
+    virtual SLANG_NO_THROW Result SLANG_MCALL getTimestampCalibration(TimestampCalibration* outCalibration) override;
 };
 
 } // namespace rhi::debug

--- a/src/vulkan/vk-api.cpp
+++ b/src/vulkan/vk-api.cpp
@@ -143,6 +143,10 @@ Result VulkanApi::initInstanceProcs(VkInstance instance)
         vkGetPhysicalDeviceProperties2 =
             (PFN_vkGetPhysicalDeviceProperties2)vkGetInstanceProcAddr(instance, "vkGetPhysicalDeviceProperties2KHR");
     }
+    if (!vkGetPhysicalDeviceCalibrateableTimeDomainsKHR && vkGetPhysicalDeviceCalibrateableTimeDomainsEXT)
+        vkGetPhysicalDeviceCalibrateableTimeDomainsKHR = vkGetPhysicalDeviceCalibrateableTimeDomainsEXT;
+    if (!vkGetPhysicalDeviceCalibrateableTimeDomainsEXT && vkGetPhysicalDeviceCalibrateableTimeDomainsKHR)
+        vkGetPhysicalDeviceCalibrateableTimeDomainsEXT = vkGetPhysicalDeviceCalibrateableTimeDomainsKHR;
 
     if (!areDefined(ProcType::Instance))
     {
@@ -209,6 +213,10 @@ Result VulkanApi::initDeviceProcs(VkDevice device)
         vkGetSemaphoreCounterValue = vkGetSemaphoreCounterValueKHR;
     if (!vkSignalSemaphore && vkSignalSemaphoreKHR)
         vkSignalSemaphore = vkSignalSemaphoreKHR;
+    if (!vkGetCalibratedTimestampsKHR && vkGetCalibratedTimestampsEXT)
+        vkGetCalibratedTimestampsKHR = vkGetCalibratedTimestampsEXT;
+    if (!vkGetCalibratedTimestampsEXT && vkGetCalibratedTimestampsKHR)
+        vkGetCalibratedTimestampsEXT = vkGetCalibratedTimestampsKHR;
     m_device = device;
     return SLANG_OK;
 }

--- a/src/vulkan/vk-api.h
+++ b/src/vulkan/vk-api.h
@@ -68,6 +68,8 @@ protected:
     x(vkGetPhysicalDeviceCooperativeMatrixFlexibleDimensionsPropertiesNV) \
     x(vkGetPhysicalDeviceCooperativeMatrixPropertiesKHR) \
     x(vkGetPhysicalDeviceCooperativeVectorPropertiesNV) \
+    x(vkGetPhysicalDeviceCalibrateableTimeDomainsKHR) \
+    x(vkGetPhysicalDeviceCalibrateableTimeDomainsEXT) \
     /* */
 
 #define VK_API_INSTANCE_PROCS(x) \
@@ -288,6 +290,8 @@ protected:
     x(vkGetPipelineKeyKHR) \
     x(vkReleaseCapturedPipelineDataKHR) \
     x(vkCmdSetCheckpointNV) \
+    x(vkGetCalibratedTimestampsKHR) \
+    x(vkGetCalibratedTimestampsEXT) \
     /* */
 
 #define VK_API_ALL_GLOBAL_PROCS(x) \

--- a/src/vulkan/vk-command.cpp
+++ b/src/vulkan/vk-command.cpp
@@ -2097,6 +2097,42 @@ Result CommandQueueImpl::getNativeHandle(NativeHandle* outHandle)
     return SLANG_OK;
 }
 
+Result CommandQueueImpl::getTimestampCalibration(TimestampCalibration* outCalibration)
+{
+    if (!outCalibration)
+    {
+        return SLANG_E_INVALID_ARG;
+    }
+
+    DeviceImpl* device = getDevice<DeviceImpl>();
+    const CalibratedTimestampSupport& timestampSupport = device->m_calibratedTimestampSupport;
+    if (!timestampSupport.available || !m_api.vkGetCalibratedTimestampsKHR)
+    {
+        return SLANG_E_NOT_AVAILABLE;
+    }
+
+    VkCalibratedTimestampInfoKHR timestampInfos[2] = {};
+    timestampInfos[0].sType = VK_STRUCTURE_TYPE_CALIBRATED_TIMESTAMP_INFO_KHR;
+    timestampInfos[0].timeDomain = VK_TIME_DOMAIN_DEVICE_KHR;
+    timestampInfos[1].sType = VK_STRUCTURE_TYPE_CALIBRATED_TIMESTAMP_INFO_KHR;
+    timestampInfos[1].timeDomain = timestampSupport.hostTimeDomain;
+
+    uint64_t timestamps[2] = {};
+    uint64_t maxDeviation = 0;
+    SLANG_VK_RETURN_ON_FAIL(
+        m_api.vkGetCalibratedTimestampsKHR(m_api.m_device, 2, timestampInfos, timestamps, &maxDeviation)
+    );
+
+    outCalibration->cpuDomain = timestampSupport.cpuTimestampDomain;
+    outCalibration->cpuTimestamp = timestamps[1];
+    outCalibration->cpuFrequency = timestampSupport.cpuTimestampFrequency;
+    outCalibration->gpuTimestamp = timestamps[0];
+    outCalibration->gpuFrequency = device->getInfo().timestampFrequency;
+    outCalibration->maxDeviationNs = maxDeviation;
+
+    return SLANG_OK;
+}
+
 // CommandEncoderImpl
 
 CommandEncoderImpl::CommandEncoderImpl(Device* device, CommandQueueImpl* queue, const CommandEncoderDesc& desc)

--- a/src/vulkan/vk-command.h
+++ b/src/vulkan/vk-command.h
@@ -68,6 +68,7 @@ public:
     virtual SLANG_NO_THROW Result SLANG_MCALL submit(const SubmitDesc& desc) override;
     virtual SLANG_NO_THROW Result SLANG_MCALL waitOnHost() override;
     virtual SLANG_NO_THROW Result SLANG_MCALL getNativeHandle(NativeHandle* outHandle) override;
+    virtual SLANG_NO_THROW Result SLANG_MCALL getTimestampCalibration(TimestampCalibration* outCalibration) override;
 };
 
 class CommandEncoderImpl : public CommandEncoder

--- a/src/vulkan/vk-device.cpp
+++ b/src/vulkan/vk-device.cpp
@@ -22,6 +22,7 @@
 #include "core/short_vector.h"
 #include "core/static_vector.h"
 #include "core/deferred.h"
+#include "core/platform.h"
 
 #include <algorithm>
 #include <set>
@@ -34,6 +35,112 @@ static constexpr VkSubgroupFeatureFlags kWaveOpsSubgroupFeatureMask =
     VK_SUBGROUP_FEATURE_BASIC_BIT | VK_SUBGROUP_FEATURE_VOTE_BIT | VK_SUBGROUP_FEATURE_ARITHMETIC_BIT |
     VK_SUBGROUP_FEATURE_BALLOT_BIT | VK_SUBGROUP_FEATURE_SHUFFLE_BIT | VK_SUBGROUP_FEATURE_SHUFFLE_RELATIVE_BIT |
     VK_SUBGROUP_FEATURE_CLUSTERED_BIT | VK_SUBGROUP_FEATURE_QUAD_BIT | VK_SUBGROUP_FEATURE_PARTITIONED_BIT_NV;
+
+static Result queryCalibratedTimestampSupport(
+    VulkanApi& api,
+    const std::set<std::string>& extensionNames,
+    CalibratedTimestampSupport& outSupport
+)
+{
+    outSupport = {};
+
+    const char* calibratedTimestampExtension = nullptr;
+    if (extensionNames.count(VK_KHR_CALIBRATED_TIMESTAMPS_EXTENSION_NAME))
+    {
+        calibratedTimestampExtension = VK_KHR_CALIBRATED_TIMESTAMPS_EXTENSION_NAME;
+    }
+    else if (extensionNames.count(VK_EXT_CALIBRATED_TIMESTAMPS_EXTENSION_NAME))
+    {
+        calibratedTimestampExtension = VK_EXT_CALIBRATED_TIMESTAMPS_EXTENSION_NAME;
+    }
+
+    if (!calibratedTimestampExtension || !api.vkGetPhysicalDeviceCalibrateableTimeDomainsKHR)
+    {
+        return SLANG_OK;
+    }
+
+    uint32_t timeDomainCount = 0;
+    SLANG_VK_RETURN_ON_FAIL(
+        api.vkGetPhysicalDeviceCalibrateableTimeDomainsKHR(api.m_physicalDevice, &timeDomainCount, nullptr)
+    );
+    if (timeDomainCount == 0)
+    {
+        return SLANG_OK;
+    }
+
+    std::vector<VkTimeDomainKHR> timeDomains(timeDomainCount);
+    SLANG_VK_RETURN_ON_FAIL(
+        api.vkGetPhysicalDeviceCalibrateableTimeDomainsKHR(api.m_physicalDevice, &timeDomainCount, timeDomains.data())
+    );
+
+    const auto hasTimeDomain = [&](VkTimeDomainKHR domain)
+    {
+        return std::find(timeDomains.begin(), timeDomains.end(), domain) != timeDomains.end();
+    };
+    if (!hasTimeDomain(VK_TIME_DOMAIN_DEVICE_KHR))
+    {
+        return SLANG_OK;
+    }
+
+    struct Candidate
+    {
+        VkTimeDomainKHR vkDomain;
+        CpuTimestampDomain cpuTimestampDomain;
+        uint64_t cpuTimestampFrequency;
+    };
+
+    const CpuTimestampDomain cpuTimestampDomain = getCpuTimestampDomain();
+    const uint64_t cpuTimestampFrequency = getCpuTimestampFrequency();
+    if (cpuTimestampDomain == CpuTimestampDomain::Unknown || cpuTimestampFrequency == 0)
+    {
+        return SLANG_OK;
+    }
+
+    short_vector<Candidate, 3> candidates;
+#if SLANG_WINDOWS_FAMILY
+    if (cpuTimestampDomain == CpuTimestampDomain::QueryPerformanceCounter)
+    {
+        candidates.push_back({
+            VK_TIME_DOMAIN_QUERY_PERFORMANCE_COUNTER_KHR,
+            CpuTimestampDomain::QueryPerformanceCounter,
+            cpuTimestampFrequency,
+        });
+    }
+#endif
+#if SLANG_LINUX_FAMILY
+    if (cpuTimestampDomain == CpuTimestampDomain::ClockMonotonicRaw)
+    {
+        candidates.push_back({
+            VK_TIME_DOMAIN_CLOCK_MONOTONIC_RAW_KHR,
+            CpuTimestampDomain::ClockMonotonicRaw,
+            cpuTimestampFrequency,
+        });
+    }
+    else if (cpuTimestampDomain == CpuTimestampDomain::ClockMonotonic)
+    {
+        candidates.push_back({
+            VK_TIME_DOMAIN_CLOCK_MONOTONIC_KHR,
+            CpuTimestampDomain::ClockMonotonic,
+            cpuTimestampFrequency,
+        });
+    }
+#endif
+
+    for (const Candidate& candidate : candidates)
+    {
+        if (candidate.cpuTimestampFrequency != 0 && hasTimeDomain(candidate.vkDomain))
+        {
+            outSupport.available = true;
+            outSupport.deviceExtensionName = calibratedTimestampExtension;
+            outSupport.hostTimeDomain = candidate.vkDomain;
+            outSupport.cpuTimestampDomain = candidate.cpuTimestampDomain;
+            outSupport.cpuTimestampFrequency = candidate.cpuTimestampFrequency;
+            break;
+        }
+    }
+
+    return SLANG_OK;
+}
 
 DeviceImpl::DeviceImpl() {}
 
@@ -1016,6 +1123,12 @@ Result DeviceImpl::initVulkanDevice(
 
 #undef SIMPLE_EXTENSION_FEATURE
 
+        SLANG_RETURN_ON_FAIL(queryCalibratedTimestampSupport(m_api, extensionNames, m_calibratedTimestampSupport));
+        if (m_calibratedTimestampSupport.available && !desc.existingDeviceHandles.handles[2])
+        {
+            deviceExtensions.push_back(m_calibratedTimestampSupport.deviceExtensionName);
+        }
+
         if (extendedFeatures.vulkan12Features.shaderBufferInt64Atomics)
             availableFeatures.push_back(Feature::AtomicInt64);
 
@@ -1248,6 +1361,15 @@ Result DeviceImpl::initVulkanDevice(
     }
     m_api.initDerivedDeviceProperties();
     SLANG_RETURN_ON_FAIL(m_api.initDeviceProcs(m_device));
+
+    if (m_calibratedTimestampSupport.available && m_api.vkGetCalibratedTimestampsKHR)
+    {
+        availableFeatures.push_back(Feature::TimestampCalibration);
+    }
+    else
+    {
+        m_calibratedTimestampSupport = {};
+    }
 
     return SLANG_OK;
 }

--- a/src/vulkan/vk-device.h
+++ b/src/vulkan/vk-device.h
@@ -14,6 +14,15 @@ public:
     uint8_t m_deviceUUID[VK_UUID_SIZE];
 };
 
+struct CalibratedTimestampSupport
+{
+    bool available = false;
+    const char* deviceExtensionName = nullptr;
+    VkTimeDomainKHR hostTimeDomain = VK_TIME_DOMAIN_CLOCK_MONOTONIC_KHR;
+    CpuTimestampDomain cpuTimestampDomain = CpuTimestampDomain::Unknown;
+    uint64_t cpuTimestampFrequency = 0;
+};
+
 class DeviceImpl : public Device
 {
 public:
@@ -232,6 +241,7 @@ public:
 
     VkDevice m_device = VK_NULL_HANDLE;
     bool m_hasSubgroupSizeControl = false;
+    CalibratedTimestampSupport m_calibratedTimestampSupport;
 
     VulkanModule m_module;
     VulkanApi m_api;

--- a/tests/test-cmd-query.cpp
+++ b/tests/test-cmd-query.cpp
@@ -2,6 +2,7 @@
 
 #include <chrono>
 #include <initializer_list>
+#include <cmath>
 
 using namespace rhi;
 using namespace rhi::testing;

--- a/tests/test-cmd-query.cpp
+++ b/tests/test-cmd-query.cpp
@@ -535,3 +535,71 @@ GPU_TEST_CASE("cmd-query-resolve-device", ALL & ~(D3D11 | CPU | CUDA))
     CHECK(durationGPU < durationCPU);
     // printf("Duration CPU: %.3f ms, GPU: %.3f\n", durationCPU * 1000.0, durationGPU * 1000.0);
 }
+
+static uint64_t getGpuToleranceTicks(const TimestampCalibration& calibration)
+{
+    return uint64_t(
+               std::ceil(
+                   (long double)calibration.maxDeviationNs * (long double)calibration.gpuFrequency /
+                   (long double)1000000000.0
+               )
+           ) +
+           1;
+}
+
+GPU_TEST_CASE("cmd-query-timestamp-calibration", ALL)
+{
+    if (!device->hasFeature(Feature::TimestampCalibration))
+    {
+        SKIP("Timestamp calibration not supported");
+    }
+
+    REQUIRE(device->hasFeature(Feature::TimestampQuery));
+
+    auto queue = device->getQueue(QueueType::Graphics);
+    REQUIRE(queue);
+
+    TimestampCalibration calibration0 = {};
+    TimestampCalibration calibration1 = {};
+    REQUIRE_CALL(queue->getTimestampCalibration(&calibration0));
+    REQUIRE_CALL(queue->getTimestampCalibration(&calibration1));
+
+    CHECK(calibration0.cpuDomain != CpuTimestampDomain::Unknown);
+    CHECK(calibration0.cpuFrequency > 0);
+    CHECK(calibration0.gpuFrequency > 0);
+    CHECK(calibration1.cpuDomain == calibration0.cpuDomain);
+    CHECK(calibration1.cpuFrequency == calibration0.cpuFrequency);
+    CHECK(calibration1.gpuFrequency == calibration0.gpuFrequency);
+    CHECK(calibration1.cpuTimestamp >= calibration0.cpuTimestamp);
+    CHECK(calibration1.gpuTimestamp >= calibration0.gpuTimestamp);
+
+    QueryPoolDesc queryPoolDesc = {};
+    queryPoolDesc.type = QueryType::Timestamp;
+    queryPoolDesc.count = 1;
+    ComPtr<IQueryPool> queryPool;
+    REQUIRE_CALL(device->createQueryPool(queryPoolDesc, queryPool.writeRef()));
+
+    TimestampCalibration before = {};
+    TimestampCalibration after = {};
+    REQUIRE_CALL(queue->getTimestampCalibration(&before));
+
+    auto commandEncoder = queue->createCommandEncoder();
+    commandEncoder->writeTimestamp(queryPool, 0);
+    REQUIRE_CALL(queue->submit(commandEncoder->finish()));
+    REQUIRE_CALL(queue->waitOnHost());
+
+    REQUIRE_CALL(queue->getTimestampCalibration(&after));
+
+    uint64_t timestamp = 0;
+    REQUIRE_CALL(queryPool->getResult(0, 1, &timestamp));
+
+    const uint64_t lowerTolerance = getGpuToleranceTicks(before);
+    const uint64_t upperTolerance = getGpuToleranceTicks(after);
+    const uint64_t lowerBound = before.gpuTimestamp > lowerTolerance ? before.gpuTimestamp - lowerTolerance : 0;
+    const uint64_t upperBound = after.gpuTimestamp > std::numeric_limits<uint64_t>::max() - upperTolerance
+                                    ? std::numeric_limits<uint64_t>::max()
+                                    : after.gpuTimestamp + upperTolerance;
+
+    CHECK(timestamp >= lowerBound);
+    CHECK(timestamp <= upperBound);
+}


### PR DESCRIPTION
Adds timestamp calibration support for correlating GPU timestamp queries with a CPU clock.

- Adds `Feature::TimestampCalibration`, `CpuTimestampDomain`, `TimestampCalibration`, and `ICommandQueue::getTimestampCalibration()`.
- Implements calibration for CPU, CUDA, D3D11, D3D12, and Vulkan; Metal/WGPU report unsupported.
- Adds cross-platform CPU timestamp helpers and updates timestamp query frequency docs.
- Adds timestamp calibration coverage in `test-cmd-query`, including CUDA timestamp anchor handling.