### PR TITLE
Refactor queries

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -182,8 +182,6 @@
 | `buildAccelerationStructure`           | :x: | yes  | :x:   | yes   | yes    | yes   | :x:  |
 | `copyAccelerationStructure`            | :x: | yes  | :x:   | yes   | yes    | yes   | :x:  |
 | `queryAccelerationStructureProperties` | :x: | :x:  | :x:   | yes   | yes    | :x:   | :x:  |
-| `serializeAccelerationStructure`       | :x: | :x:  | :x:   | yes   | yes    | :x:   | :x:  |
-| `deserializeAccelerationStructure`     | :x: | :x:  | :x:   | yes   | yes    | :x:   | :x:  |
 | `executeClusterOperation`              | :x: | yes  | :x:   | yes   | yes    | :x:   | :x:  |
 | `convertCooperativeVectorMatrix`       | :x: | yes  | :x:   | yes   | yes    | :x:   | :x:  |
 | `setBufferState`                       | :x: | :x:  | :x:   | yes   | yes    | :x:   | :x:  |

--- a/docs/api.md
+++ b/docs/api.md
@@ -153,11 +153,13 @@
 
 ## `IQueryPool` interface
 
-| API         | CPU | CUDA | D3D11 | D3D12 | Vulkan | Metal | WGPU |
-|-------------|-----|------|-------|-------|--------|-------|------|
-| `getDesc`   | yes | yes  | yes   | yes   | yes    | yes   | yes  |
-| `getResult` | yes | yes  | yes   | yes   | yes    | yes   | :x:  |
-| `reset`     | yes | yes  | yes   | yes   | yes    | yes   | yes  |
+| API                         | CPU | CUDA | D3D11 | D3D12 | Vulkan | Metal | WGPU |
+|-----------------------------|-----|------|-------|-------|--------|-------|------|
+| `getDesc`                   | yes | yes  | yes   | yes   | yes    | yes   | yes  |
+| `isResultReady`             | yes | yes  | yes   | yes   | yes    | :x:   | :x:  |
+| `getResult`                 | yes | yes  | yes   | yes   | yes    | :x:   | :x:  |
+| `reset`                     | yes | yes  | yes   | yes   | yes    | :x:   | :x:  |
+| `reset(queryIndex, count)`  | yes | yes  | yes   | yes   | yes    | :x:   | :x:  |
 
 ## `ICommandEncoder` interface
 

--- a/include/slang-rhi.h
+++ b/include/slang-rhi.h
@@ -2679,16 +2679,6 @@ public:
         const AccelerationStructureQueryDesc* queryDescs
     ) = 0;
 
-    virtual SLANG_NO_THROW void SLANG_MCALL serializeAccelerationStructure(
-        BufferOffsetPair dst,
-        IAccelerationStructure* src
-    ) = 0;
-
-    virtual SLANG_NO_THROW void SLANG_MCALL deserializeAccelerationStructure(
-        IAccelerationStructure* dst,
-        BufferOffsetPair src
-    ) = 0;
-
     virtual SLANG_NO_THROW void SLANG_MCALL executeClusterOperation(const ClusterOperationDesc& desc) = 0;
 
     virtual SLANG_NO_THROW void SLANG_MCALL convertCooperativeVectorMatrix(

--- a/include/slang-rhi.h
+++ b/include/slang-rhi.h
@@ -2234,7 +2234,6 @@ enum class QueryType
 {
     Timestamp,
     AccelerationStructureCompactedSize,
-    AccelerationStructureSerializedSize,
     AccelerationStructureCurrentSize,
 };
 
@@ -2255,8 +2254,33 @@ class IQueryPool : public ISlangUnknown
 
 public:
     virtual SLANG_NO_THROW const QueryPoolDesc& SLANG_MCALL getDesc() = 0;
+
+    /// Non-blocking host-readiness check for query results.
+    ///
+    /// Sets outReady to true when every requested query result is ready to read on the host,
+    /// and false when submitted query work is still pending. Returns SLANG_FAIL when the
+    /// requested range has no valid submitted result, and SLANG_E_INVALID_ARG for invalid
+    /// ranges or a null outReady pointer. A valid zero-count readiness check succeeds and
+    /// returns true. This call does not wait for GPU work and does not make reset or
+    /// never-submitted queries valid.
+    virtual SLANG_NO_THROW Result SLANG_MCALL isResultReady(uint32_t queryIndex, uint32_t count, bool* outReady) = 0;
+
+    /// Read query results on the host.
+    ///
+    /// Blocks until the latest submitted work required by the requested range is complete.
+    /// Returns SLANG_FAIL if any query in the range has no valid submitted result, and
+    /// SLANG_E_INVALID_ARG for invalid ranges or a null outData pointer.
+    /// Reusing a query slot without reset is allowed; host reads return the most recent
+    /// submitted result tracked for that slot.
     virtual SLANG_NO_THROW Result SLANG_MCALL getResult(uint32_t queryIndex, uint32_t count, uint64_t* outData) = 0;
+
+    /// Reset all queries, invalidating any host-readable results.
     virtual SLANG_NO_THROW Result SLANG_MCALL reset() = 0;
+
+    /// Reset a range of queries, invalidating any host-readable results for that range.
+    ///
+    /// A valid zero-count reset succeeds and has no effect.
+    virtual SLANG_NO_THROW Result SLANG_MCALL reset(uint32_t queryIndex, uint32_t count) = 0;
 };
 
 struct DrawArguments

--- a/src/command-buffer.cpp
+++ b/src/command-buffer.cpp
@@ -174,7 +174,7 @@ void RenderPassEncoder::writeTimestamp(IQueryPool* queryPool, uint32_t queryInde
     if (m_commandList)
     {
         commands::WriteTimestamp cmd;
-        cmd.queryPool = checked_cast<QueryPool*>(queryPool);
+        cmd.queryPool = queryPool;
         cmd.queryIndex = queryIndex;
         m_commandList->write(std::move(cmd));
     }
@@ -302,7 +302,7 @@ void ComputePassEncoder::writeTimestamp(IQueryPool* queryPool, uint32_t queryInd
     if (m_commandList)
     {
         commands::WriteTimestamp cmd;
-        cmd.queryPool = checked_cast<QueryPool*>(queryPool);
+        cmd.queryPool = queryPool;
         cmd.queryIndex = queryIndex;
         m_commandList->write(std::move(cmd));
     }
@@ -428,7 +428,7 @@ void RayTracingPassEncoder::writeTimestamp(IQueryPool* queryPool, uint32_t query
     if (m_commandList)
     {
         commands::WriteTimestamp cmd;
-        cmd.queryPool = checked_cast<QueryPool*>(queryPool);
+        cmd.queryPool = queryPool;
         cmd.queryIndex = queryIndex;
         m_commandList->write(std::move(cmd));
     }
@@ -897,7 +897,7 @@ void CommandEncoder::insertDebugMarker(const char* name, const MarkerColor& colo
 void CommandEncoder::writeTimestamp(IQueryPool* queryPool, uint32_t queryIndex)
 {
     commands::WriteTimestamp cmd;
-    cmd.queryPool = checked_cast<QueryPool*>(queryPool);
+    cmd.queryPool = queryPool;
     cmd.queryIndex = queryIndex;
     m_commandList->write(std::move(cmd));
 }

--- a/src/command-buffer.cpp
+++ b/src/command-buffer.cpp
@@ -824,22 +824,6 @@ void CommandEncoder::queryAccelerationStructureProperties(
     SLANG_RHI_UNIMPLEMENTED("queryAccelerationStructureProperties");
 }
 
-void CommandEncoder::serializeAccelerationStructure(BufferOffsetPair dst, IAccelerationStructure* src)
-{
-    commands::SerializeAccelerationStructure cmd;
-    cmd.dst = dst;
-    cmd.src = checked_cast<AccelerationStructure*>(src);
-    m_commandList->write(std::move(cmd));
-}
-
-void CommandEncoder::deserializeAccelerationStructure(IAccelerationStructure* dst, BufferOffsetPair src)
-{
-    commands::DeserializeAccelerationStructure cmd;
-    cmd.dst = checked_cast<AccelerationStructure*>(dst);
-    cmd.src = src;
-    m_commandList->write(std::move(cmd));
-}
-
 void CommandEncoder::executeClusterOperation(const ClusterOperationDesc& desc)
 {
     commands::ExecuteClusterOperation cmd;

--- a/src/command-buffer.h
+++ b/src/command-buffer.h
@@ -347,16 +347,6 @@ public:
         const AccelerationStructureQueryDesc* queryDescs
     ) override;
 
-    virtual SLANG_NO_THROW void SLANG_MCALL serializeAccelerationStructure(
-        BufferOffsetPair dst,
-        IAccelerationStructure* src
-    ) override;
-
-    virtual SLANG_NO_THROW void SLANG_MCALL deserializeAccelerationStructure(
-        IAccelerationStructure* dst,
-        BufferOffsetPair src
-    ) override;
-
     virtual SLANG_NO_THROW void SLANG_MCALL executeClusterOperation(const ClusterOperationDesc& desc) override;
 
     virtual SLANG_NO_THROW void SLANG_MCALL convertCooperativeVectorMatrix(

--- a/src/command-list.cpp
+++ b/src/command-list.cpp
@@ -290,20 +290,6 @@ void CommandList::write(commands::QueryAccelerationStructureProperties&& cmd)
     writeCommand(std::move(cmd));
 }
 
-void CommandList::write(commands::SerializeAccelerationStructure&& cmd)
-{
-    retainResource<Buffer>(cmd.dst.buffer);
-    retainResource<AccelerationStructure>(cmd.src);
-    writeCommand(std::move(cmd));
-}
-
-void CommandList::write(commands::DeserializeAccelerationStructure&& cmd)
-{
-    retainResource<AccelerationStructure>(cmd.dst);
-    retainResource<Buffer>(cmd.src.buffer);
-    writeCommand(std::move(cmd));
-}
-
 void CommandList::write(commands::ExecuteClusterOperation&& cmd)
 {
     retainResource<Buffer>(cmd.desc.argCountBuffer.buffer);

--- a/src/command-list.cpp
+++ b/src/command-list.cpp
@@ -18,6 +18,8 @@ void CommandList::reset()
 {
     m_commandSlots = nullptr;
     m_lastCommandSlot = nullptr;
+    m_queryWrites.clear();
+    m_writesTimestamp = false;
 }
 
 void CommandList::write(commands::CopyBuffer&& cmd)
@@ -259,7 +261,10 @@ void CommandList::write(commands::BuildAccelerationStructure&& cmd)
         cmd.queryDescs = (AccelerationStructureQueryDesc*)
             writeData(cmd.queryDescs, cmd.propertyQueryCount * sizeof(AccelerationStructureQueryDesc));
         for (uint32_t i = 0; i < cmd.propertyQueryCount; ++i)
+        {
             retainResource<QueryPool>(cmd.queryDescs[i].queryPool);
+            trackQueryWrite(cmd.queryDescs[i].queryPool, uint32_t(cmd.queryDescs[i].firstQueryIndex), 1);
+        }
     }
     writeCommand(std::move(cmd));
 }
@@ -285,7 +290,14 @@ void CommandList::write(commands::QueryAccelerationStructureProperties&& cmd)
         cmd.queryDescs = (AccelerationStructureQueryDesc*)
             writeData(cmd.queryDescs, cmd.queryCount * sizeof(AccelerationStructureQueryDesc));
         for (uint32_t i = 0; i < cmd.queryCount; ++i)
+        {
             retainResource<QueryPool>(cmd.queryDescs[i].queryPool);
+            trackQueryWrite(
+                cmd.queryDescs[i].queryPool,
+                uint32_t(cmd.queryDescs[i].firstQueryIndex),
+                cmd.accelerationStructureCount
+            );
+        }
     }
     writeCommand(std::move(cmd));
 }
@@ -358,6 +370,8 @@ void CommandList::write(commands::WriteTimestamp&& cmd)
 {
     retainResource<QueryPool>(cmd.queryPool);
     writeCommand(std::move(cmd));
+    trackQueryWrite(cmd.queryPool, cmd.queryIndex, 1);
+    m_writesTimestamp = true;
 }
 
 void CommandList::write(commands::ExecuteCallback&& cmd)
@@ -372,6 +386,26 @@ void CommandList::write(commands::ExecuteCallback&& cmd)
     }
 
     writeCommand(std::move(cmd));
+}
+
+void CommandList::trackQueryWrite(IQueryPool* queryPool, uint32_t index, uint32_t count)
+{
+    if (!queryPool || count == 0)
+    {
+        return;
+    }
+
+    if (!m_queryWrites.empty())
+    {
+        QueryWriteRange& last = m_queryWrites.back();
+        if (last.queryPool == queryPool && last.index + last.count == index)
+        {
+            last.count += count;
+            return;
+        }
+    }
+
+    m_queryWrites.push_back({queryPool, index, count});
 }
 
 } // namespace rhi

--- a/src/command-list.h
+++ b/src/command-list.h
@@ -40,8 +40,6 @@
     x(BuildAccelerationStructure) \
     x(CopyAccelerationStructure) \
     x(QueryAccelerationStructureProperties) \
-    x(SerializeAccelerationStructure) \
-    x(DeserializeAccelerationStructure) \
     x(ExecuteClusterOperation) \
     x(ConvertCooperativeVectorMatrix) \
     x(SetBufferState) \
@@ -276,18 +274,6 @@ struct QueryAccelerationStructureProperties
     const AccelerationStructureQueryDesc* queryDescs;
 };
 
-struct SerializeAccelerationStructure
-{
-    BufferOffsetPair dst;
-    IAccelerationStructure* src;
-};
-
-struct DeserializeAccelerationStructure
-{
-    IAccelerationStructure* dst;
-    BufferOffsetPair src;
-};
-
 struct ExecuteClusterOperation
 {
     ClusterOperationDesc desc;
@@ -448,8 +434,6 @@ public:
     void write(commands::BuildAccelerationStructure&& cmd);
     void write(commands::CopyAccelerationStructure&& cmd);
     void write(commands::QueryAccelerationStructureProperties&& cmd);
-    void write(commands::SerializeAccelerationStructure&& cmd);
-    void write(commands::DeserializeAccelerationStructure&& cmd);
     void write(commands::ExecuteClusterOperation&& cmd);
     void write(commands::ConvertCooperativeVectorMatrix&& cmd);
     void write(commands::SetBufferState&& cmd);

--- a/src/command-list.h
+++ b/src/command-list.h
@@ -3,6 +3,7 @@
 #include <slang-rhi.h>
 #include "core/common.h"
 #include "core/arena-allocator.h"
+#include "core/short_vector.h"
 
 #include <utility>
 #include <set>
@@ -397,6 +398,14 @@ public:
         void* data;
     };
 
+    struct QueryWriteRange
+    {
+        IQueryPool* queryPool;
+        uint32_t index;
+        uint32_t count;
+    };
+    using QueryWriteRangeList = short_vector<QueryWriteRange, 16>;
+
     CommandList(
         ArenaAllocator& allocator,
         std::set<RefPtr<RefObject>>& trackedObjects,
@@ -446,6 +455,8 @@ public:
     void write(commands::ExecuteCallback&& cmd);
 
     const CommandSlot* getCommands() const { return m_commandSlots; }
+    const QueryWriteRangeList& getQueryWrites() const { return m_queryWrites; }
+    bool writesTimestamp() const { return m_writesTimestamp; }
 
     template<typename T>
     T& getCommand(const CommandSlot* command)
@@ -492,6 +503,10 @@ private:
     std::vector<ExecuteCallbackObjectRetainer>& m_trackedExecuteCallbackObjects;
     CommandSlot* m_commandSlots = nullptr;
     CommandSlot* m_lastCommandSlot = nullptr;
+    QueryWriteRangeList m_queryWrites;
+    bool m_writesTimestamp = false;
+
+    void trackQueryWrite(IQueryPool* queryPool, uint32_t index, uint32_t count);
 
     template<typename T>
     void writeCommand(T&& cmd)

--- a/src/cpu/cpu-command.cpp
+++ b/src/cpu/cpu-command.cpp
@@ -318,6 +318,8 @@ void CommandExecutor::cmdWriteTimestamp(const commands::WriteTimestamp& cmd)
 {
     auto queryPool = checked_cast<QueryPoolImpl*>(cmd.queryPool);
     queryPool->m_queries[cmd.queryIndex] = std::chrono::high_resolution_clock::now().time_since_epoch().count();
+    queryPool->markQueryRangeSubmitted(cmd.queryIndex, 1, 0);
+    queryPool->markQueryRangeReady(cmd.queryIndex, 1, 0);
 }
 
 void CommandExecutor::cmdExecuteCallback(const commands::ExecuteCallback& cmd)

--- a/src/cpu/cpu-command.cpp
+++ b/src/cpu/cpu-command.cpp
@@ -53,8 +53,6 @@ public:
     void cmdBuildAccelerationStructure(const commands::BuildAccelerationStructure& cmd);
     void cmdCopyAccelerationStructure(const commands::CopyAccelerationStructure& cmd);
     void cmdQueryAccelerationStructureProperties(const commands::QueryAccelerationStructureProperties& cmd);
-    void cmdSerializeAccelerationStructure(const commands::SerializeAccelerationStructure& cmd);
-    void cmdDeserializeAccelerationStructure(const commands::DeserializeAccelerationStructure& cmd);
     void cmdExecuteClusterOperation(const commands::ExecuteClusterOperation& cmd);
     void cmdConvertCooperativeVectorMatrix(const commands::ConvertCooperativeVectorMatrix& cmd);
     void cmdSetBufferState(const commands::SetBufferState& cmd);
@@ -272,18 +270,6 @@ void CommandExecutor::cmdQueryAccelerationStructureProperties(const commands::Qu
 {
     SLANG_UNUSED(cmd);
     NOT_SUPPORTED(ICommandEncoder, queryAccelerationStructureProperties);
-}
-
-void CommandExecutor::cmdSerializeAccelerationStructure(const commands::SerializeAccelerationStructure& cmd)
-{
-    SLANG_UNUSED(cmd);
-    NOT_SUPPORTED(ICommandEncoder, serializeAccelerationStructure);
-}
-
-void CommandExecutor::cmdDeserializeAccelerationStructure(const commands::DeserializeAccelerationStructure& cmd)
-{
-    SLANG_UNUSED(cmd);
-    NOT_SUPPORTED(ICommandEncoder, deserializeAccelerationStructure);
 }
 
 void CommandExecutor::cmdExecuteClusterOperation(const commands::ExecuteClusterOperation& cmd)

--- a/src/cpu/cpu-command.cpp
+++ b/src/cpu/cpu-command.cpp
@@ -13,12 +13,14 @@ class CommandExecutor
 {
 public:
     DeviceImpl* m_device;
+    uint64_t m_submissionID;
     RefPtr<ComputePipelineImpl> m_computePipeline;
     BindingDataImpl* m_bindingData = nullptr;
     bool m_computeStateValid = false;
 
-    CommandExecutor(DeviceImpl* device)
+    CommandExecutor(DeviceImpl* device, uint64_t submissionID)
         : m_device(device)
+        , m_submissionID(submissionID)
     {
     }
 
@@ -318,8 +320,8 @@ void CommandExecutor::cmdWriteTimestamp(const commands::WriteTimestamp& cmd)
 {
     auto queryPool = checked_cast<QueryPoolImpl*>(cmd.queryPool);
     queryPool->m_queries[cmd.queryIndex] = std::chrono::high_resolution_clock::now().time_since_epoch().count();
-    queryPool->markQueryRangeSubmitted(cmd.queryIndex, 1, 0);
-    queryPool->markQueryRangeReady(cmd.queryIndex, 1, 0);
+    queryPool->markQueryRangeSubmitted(cmd.queryIndex, 1, m_submissionID);
+    queryPool->markQueryRangeReady(cmd.queryIndex, 1, m_submissionID);
 }
 
 void CommandExecutor::cmdExecuteCallback(const commands::ExecuteCallback& cmd)
@@ -356,10 +358,12 @@ Result CommandQueueImpl::submit(const SubmitDesc& desc)
         }
     }
 
+    ++m_lastSubmittedID;
+
     // Execute command buffers.
     for (uint32_t i = 0; i < desc.commandBufferCount; i++)
     {
-        CommandExecutor executor(getDevice<DeviceImpl>());
+        CommandExecutor executor(getDevice<DeviceImpl>(), m_lastSubmittedID);
         SLANG_RETURN_ON_FAIL(executor.execute(checked_cast<CommandBufferImpl*>(desc.commandBuffers[i])));
     }
 

--- a/src/cpu/cpu-command.h
+++ b/src/cpu/cpu-command.h
@@ -9,6 +9,8 @@ namespace rhi::cpu {
 class CommandQueueImpl : public CommandQueue
 {
 public:
+    uint64_t m_lastSubmittedID = 0;
+
     CommandQueueImpl(Device* device, QueueType type);
 
     // ICommandQueue implementation

--- a/src/cpu/cpu-query.cpp
+++ b/src/cpu/cpu-query.cpp
@@ -8,8 +8,38 @@ QueryPoolImpl::QueryPoolImpl(Device* device, const QueryPoolDesc& desc)
 {
 }
 
+Result QueryPoolImpl::isResultReady(uint32_t queryIndex, uint32_t count, bool* outReady)
+{
+    if (!outReady || !isValidQueryRange(queryIndex, count))
+    {
+        return SLANG_E_INVALID_ARG;
+    }
+
+    *outReady = false;
+    QueryRangeInfo queryInfo = getQueryRangeInfo(queryIndex, count);
+    if (queryInfo.state == QueryRangeState::Reset)
+    {
+        return SLANG_FAIL;
+    }
+    if (queryInfo.state == QueryRangeState::Resolved)
+    {
+        *outReady = true;
+    }
+    return SLANG_OK;
+}
+
 Result QueryPoolImpl::getResult(uint32_t queryIndex, uint32_t count, uint64_t* outData)
 {
+    if (!outData || !isValidQueryRange(queryIndex, count))
+    {
+        return SLANG_E_INVALID_ARG;
+    }
+
+    if (getQueryRangeInfo(queryIndex, count).state != QueryRangeState::Resolved)
+    {
+        return SLANG_FAIL;
+    }
+
     for (uint32_t i = 0; i < count; i++)
     {
         outData[i] = m_queries[queryIndex + i];

--- a/src/cpu/cpu-query.h
+++ b/src/cpu/cpu-query.h
@@ -11,6 +11,11 @@ public:
 
     QueryPoolImpl(Device* device, const QueryPoolDesc& desc);
 
+    virtual SLANG_NO_THROW Result SLANG_MCALL isResultReady(
+        uint32_t queryIndex,
+        uint32_t count,
+        bool* outReady
+    ) override;
     virtual SLANG_NO_THROW Result SLANG_MCALL getResult(
         uint32_t queryIndex,
         uint32_t count,

--- a/src/cuda/cuda-base.h
+++ b/src/cuda/cuda-base.h
@@ -14,6 +14,8 @@
 
 namespace rhi::cuda {
 
+static constexpr uint64_t kInvalidTimestampAnchorGeneration = uint64_t(-1);
+
 class BackendImpl;
 class AdapterImpl;
 class BufferImpl;

--- a/src/cuda/cuda-command.cpp
+++ b/src/cuda/cuda-command.cpp
@@ -69,8 +69,6 @@ public:
     void cmdBuildAccelerationStructure(const commands::BuildAccelerationStructure& cmd);
     void cmdCopyAccelerationStructure(const commands::CopyAccelerationStructure& cmd);
     void cmdQueryAccelerationStructureProperties(const commands::QueryAccelerationStructureProperties& cmd);
-    void cmdSerializeAccelerationStructure(const commands::SerializeAccelerationStructure& cmd);
-    void cmdDeserializeAccelerationStructure(const commands::DeserializeAccelerationStructure& cmd);
     void cmdExecuteClusterOperation(const commands::ExecuteClusterOperation& cmd);
     void cmdConvertCooperativeVectorMatrix(const commands::ConvertCooperativeVectorMatrix& cmd);
     void cmdSetBufferState(const commands::SetBufferState& cmd);
@@ -596,18 +594,6 @@ void CommandExecutor::cmdQueryAccelerationStructureProperties(const commands::Qu
 {
     SLANG_UNUSED(cmd);
     NOT_SUPPORTED(ICommandEncoder, queryAccelerationStructureProperties);
-}
-
-void CommandExecutor::cmdSerializeAccelerationStructure(const commands::SerializeAccelerationStructure& cmd)
-{
-    SLANG_UNUSED(cmd);
-    NOT_SUPPORTED(ICommandEncoder, serializeAccelerationStructure);
-}
-
-void CommandExecutor::cmdDeserializeAccelerationStructure(const commands::DeserializeAccelerationStructure& cmd)
-{
-    SLANG_UNUSED(cmd);
-    NOT_SUPPORTED(ICommandEncoder, deserializeAccelerationStructure);
 }
 
 void CommandExecutor::cmdExecuteClusterOperation(const commands::ExecuteClusterOperation& cmd)

--- a/src/cuda/cuda-command.cpp
+++ b/src/cuda/cuda-command.cpp
@@ -12,13 +12,189 @@
 #include "../command-list.h"
 #include "../strings.h"
 
+#include "core/deferred.h"
+
+#include <chrono>
+
 namespace rhi::cuda {
+
+// CUDA only exposes elapsed time between events, reported as float milliseconds. To present stable
+// query timestamps, the queue records periodic timestamp anchors on its default stream. Each timestamp
+// query stores the anchor generation that was current when the command buffer was submitted, and queue
+// retirement computes:
+//
+//     query timestamp = resolved anchor offset + elapsed(anchor event, query event)
+//
+// Anchors live in a generation-tagged ring. Query results are cached when their command buffer retires,
+// so old host reads do not need old anchor events. CUDA host callbacks are intentionally not used here
+// because timestamp resolution calls CUDA APIs.
+
+/// The maximum age of a timestamp anchor before it gets rolled.
+static constexpr uint64_t kCudaTimestampAnchorMaxAgeNs = 4ull * 1000ull * 1000ull * 1000ull;
+
+static uint64_t getTimestampAnchorTimeNs()
+{
+    return uint64_t(
+        std::chrono::duration_cast<std::chrono::nanoseconds>(std::chrono::steady_clock::now().time_since_epoch())
+            .count()
+    );
+}
+
+static void destroyTimestampAnchor(TimestampAnchor& anchor)
+{
+    if (anchor.event)
+    {
+        SLANG_CUDA_ASSERT_ON_FAIL(cuEventSynchronize(anchor.event));
+        SLANG_CUDA_ASSERT_ON_FAIL(cuEventDestroy(anchor.event));
+    }
+    anchor = {};
+}
+
+static size_t getTimestampAnchorSlot(uint64_t generation)
+{
+    return size_t(generation % CommandQueueImpl::kTimestampAnchorRingSize);
+}
+
+static TimestampAnchor* findTimestampAnchor(CommandQueueImpl* queue, uint64_t generation)
+{
+    if (generation == kInvalidTimestampAnchorGeneration)
+    {
+        return nullptr;
+    }
+
+    TimestampAnchor& anchor = queue->m_timestampAnchors[getTimestampAnchorSlot(generation)];
+    return anchor.generation == generation ? &anchor : nullptr;
+}
+
+static Result resolveTimestampAnchor(CommandQueueImpl* queue, uint64_t generation);
+
+static bool isTimestampAnchorInUse(CommandQueueImpl* queue, uint64_t generation)
+{
+    for (const RefPtr<CommandBufferImpl>& commandBuffer : queue->m_commandBuffersInFlight)
+    {
+        if (commandBuffer->m_timestampAnchorGeneration == generation)
+        {
+            return true;
+        }
+    }
+    return false;
+}
+
+static Result prepareTimestampAnchorSlotForReuse(CommandQueueImpl* queue, TimestampAnchor& anchor)
+{
+    if (!anchor.event)
+    {
+        return SLANG_OK;
+    }
+
+    // Resolve the current cumulative offset while the old ring slot is still available.
+    if (anchor.generation != kInvalidTimestampAnchorGeneration)
+    {
+        SLANG_RETURN_ON_FAIL(resolveTimestampAnchor(queue, queue->m_currentAnchorGeneration));
+    }
+
+    SLANG_RETURN_ON_FAIL(queue->retireCommandBuffers());
+    if (anchor.generation != kInvalidTimestampAnchorGeneration && isTimestampAnchorInUse(queue, anchor.generation))
+    {
+        SLANG_RETURN_ON_FAIL(queue->waitOnHost());
+    }
+    if (anchor.generation != kInvalidTimestampAnchorGeneration && isTimestampAnchorInUse(queue, anchor.generation))
+    {
+        return SLANG_FAIL;
+    }
+
+    destroyTimestampAnchor(anchor);
+    return SLANG_OK;
+}
+
+static Result recordTimestampAnchor(CommandQueueImpl* queue, uint64_t generation)
+{
+    TimestampAnchor anchor = {};
+    anchor.generation = generation;
+    const uint64_t anchorTimeNs = getTimestampAnchorTimeNs();
+
+    TimestampAnchor& slot = queue->m_timestampAnchors[getTimestampAnchorSlot(generation)];
+    SLANG_RETURN_ON_FAIL(prepareTimestampAnchorSlotForReuse(queue, slot));
+
+    SLANG_CUDA_RETURN_ON_FAIL_REPORT(cuEventCreate(&anchor.event, 0), queue);
+    SLANG_RHI_DEFERRED({ destroyTimestampAnchor(anchor); });
+
+    SLANG_CUDA_RETURN_ON_FAIL_REPORT(cuEventRecord(anchor.event, queue->m_stream), queue);
+
+    slot = anchor;
+    anchor.event = nullptr;
+    queue->m_currentAnchorGeneration = generation;
+    queue->m_timestampAnchorTimeNs = anchorTimeNs;
+    return SLANG_OK;
+}
+
+static Result maybeRollTimestampAnchor(CommandQueueImpl* queue)
+{
+    const uint64_t now = getTimestampAnchorTimeNs();
+    const uint64_t ageNs = now - queue->m_timestampAnchorTimeNs;
+    if (ageNs < kCudaTimestampAnchorMaxAgeNs)
+    {
+        return SLANG_OK;
+    }
+
+    return recordTimestampAnchor(queue, queue->m_currentAnchorGeneration + 1);
+}
+
+static Result getTimestampAnchorGeneration(CommandQueueImpl* queue, uint64_t* outGeneration)
+{
+    SLANG_RETURN_ON_FAIL(maybeRollTimestampAnchor(queue));
+    if (!findTimestampAnchor(queue, queue->m_currentAnchorGeneration))
+    {
+        return SLANG_FAIL;
+    }
+    *outGeneration = queue->m_currentAnchorGeneration;
+    return SLANG_OK;
+}
+
+static Result resolveTimestampAnchor(CommandQueueImpl* queue, uint64_t generation)
+{
+    TimestampAnchor* anchor = findTimestampAnchor(queue, generation);
+    if (!anchor)
+    {
+        return SLANG_FAIL;
+    }
+
+    if (anchor->resolved)
+    {
+        return SLANG_OK;
+    }
+    if (generation == 0)
+    {
+        anchor->offsetUs = 0;
+        anchor->resolved = true;
+        return SLANG_OK;
+    }
+
+    SLANG_RETURN_ON_FAIL(resolveTimestampAnchor(queue, generation - 1));
+
+    TimestampAnchor* previous = findTimestampAnchor(queue, generation - 1);
+    if (!previous)
+    {
+        return SLANG_FAIL;
+    }
+    SLANG_CUDA_RETURN_ON_FAIL_REPORT(cuEventSynchronize(previous->event), queue);
+    SLANG_CUDA_RETURN_ON_FAIL_REPORT(cuEventSynchronize(anchor->event), queue);
+
+    float elapsedMs = 0.0f;
+    SLANG_CUDA_RETURN_ON_FAIL_REPORT(cuEventElapsedTime(&elapsedMs, previous->event, anchor->event), queue);
+
+    anchor->offsetUs = previous->offsetUs + cudaEventMillisecondsToMicroseconds(elapsedMs);
+    anchor->resolved = true;
+    return SLANG_OK;
+}
+
 
 class CommandExecutor
 {
 public:
     DeviceImpl* m_device;
     CUstream m_stream;
+    uint64_t m_timestampAnchorGeneration;
 
     bool m_computePassActive = false;
     bool m_computeStateValid = false;
@@ -32,9 +208,10 @@ public:
 
     BindingDataImpl* m_bindingData = nullptr;
 
-    CommandExecutor(DeviceImpl* device, CUstream stream)
+    CommandExecutor(DeviceImpl* device, CUstream stream, uint64_t timestampAnchorGeneration)
         : m_device(device)
         , m_stream(stream)
+        , m_timestampAnchorGeneration(timestampAnchorGeneration)
     {
     }
 
@@ -651,8 +828,12 @@ void CommandExecutor::cmdInsertDebugMarker(const commands::InsertDebugMarker& cm
 
 void CommandExecutor::cmdWriteTimestamp(const commands::WriteTimestamp& cmd)
 {
+    SLANG_RHI_ASSERT(m_timestampAnchorGeneration != kInvalidTimestampAnchorGeneration);
     auto queryPool = checked_cast<QueryPoolImpl*>(cmd.queryPool);
-    SLANG_CUDA_ASSERT_ON_FAIL(cuEventRecord(queryPool->m_events[cmd.queryIndex], m_stream));
+    QueryPoolImpl::Query& query = queryPool->m_queries[cmd.queryIndex];
+    query.anchorGeneration = m_timestampAnchorGeneration;
+    query.resultData = 0;
+    SLANG_CUDA_ASSERT_ON_FAIL(cuEventRecord(query.event, m_stream));
 }
 
 void CommandExecutor::cmdExecuteCallback(const commands::ExecuteCallback& cmd)
@@ -691,6 +872,15 @@ Result CommandQueueImpl::init()
         SLANG_RETURN_ON_FAIL(cuStreamCreate(&m_stream, 0));
     }
 
+    SLANG_RETURN_ON_FAIL(recordTimestampAnchor(this, 0));
+    TimestampAnchor* initialAnchor = findTimestampAnchor(this, 0);
+    if (!initialAnchor)
+    {
+        return SLANG_FAIL;
+    }
+    initialAnchor->offsetUs = 0;
+    initialAnchor->resolved = true;
+
     return SLANG_OK;
 }
 
@@ -716,8 +906,13 @@ void CommandQueueImpl::shutdown()
     m_lastFinishedID = m_lastSubmittedID;
 
     // Retire finished command buffers, which should be all of them now
-    retireCommandBuffers();
+    SLANG_RHI_ASSERT(retireCommandBuffers() == SLANG_OK);
     SLANG_RHI_ASSERT(m_commandBuffersInFlight.empty());
+
+    for (TimestampAnchor& anchor : m_timestampAnchors)
+    {
+        destroyTimestampAnchor(anchor);
+    }
 
     // Release all command buffers in order to release all resources they may hold.
     m_commandBuffersPool.clear();
@@ -747,7 +942,7 @@ Result CommandQueueImpl::getOrCreateCommandBuffer(CommandBufferImpl** outCommand
     {
         // Pool exhausted - try lazy retirement to reclaim completed buffers
         // Use locked version since we already hold m_mutex
-        retireCommandBuffersLocked();
+        SLANG_RETURN_ON_FAIL(retireCommandBuffersLocked());
 
         // If retirement freed up buffers, use them instead of allocating new
         if (!m_commandBuffersPool.empty())
@@ -834,6 +1029,7 @@ Result CommandQueueImpl::retireCommandBuffersLocked()
         if (commandBuffer->m_submissionID > m_lastFinishedID)
             break;
 
+        SLANG_RETURN_ON_FAIL(resolveTimestampQueries(commandBuffer));
         retireCommandBufferLocked(commandBuffer);
         cbIt = m_commandBuffersInFlight.erase(cbIt);
     }
@@ -846,6 +1042,46 @@ Result CommandQueueImpl::retireCommandBuffersLocked()
     // and never enter the pending list. This flush now only processes the rare
     // cross-stream allocations that were deferred. Much cheaper than before!
     SLANG_RETURN_ON_FAIL(getDevice<DeviceImpl>()->flushHeaps());
+
+    return SLANG_OK;
+}
+
+Result CommandQueueImpl::resolveTimestampQueries(CommandBufferImpl* commandBuffer)
+{
+    for (const auto& queryWrite : commandBuffer->m_commandList.getQueryWrites())
+    {
+        if (!queryWrite.queryPool || queryWrite.queryPool->getDesc().type != QueryType::Timestamp)
+        {
+            continue;
+        }
+
+        auto pool = checked_cast<QueryPoolImpl*>(queryWrite.queryPool);
+        for (uint32_t i = 0; i < queryWrite.count; ++i)
+        {
+            uint32_t queryIndex = queryWrite.index + i;
+            QueryPool::QueryRangeInfo queryInfo = pool->getQueryRangeInfo(queryIndex, 1);
+            if (queryInfo.state != QueryPool::QueryRangeState::Pending ||
+                queryInfo.submissionID != commandBuffer->m_submissionID)
+            {
+                continue;
+            }
+
+            QueryPoolImpl::Query& query = pool->m_queries[queryIndex];
+            SLANG_RETURN_ON_FAIL(resolveTimestampAnchor(this, query.anchorGeneration));
+
+            TimestampAnchor* anchor = findTimestampAnchor(this, query.anchorGeneration);
+            if (!anchor)
+            {
+                return SLANG_FAIL;
+            }
+
+            float elapsedMs = 0.0f;
+            SLANG_CUDA_RETURN_ON_FAIL_REPORT(cuEventElapsedTime(&elapsedMs, anchor->event, query.event), this);
+            query.resultData = anchor->offsetUs + cudaEventMillisecondsToMicroseconds(elapsedMs);
+        }
+
+        pool->markQueryRangeReady(queryWrite.index, queryWrite.count, commandBuffer->m_submissionID);
+    }
 
     return SLANG_OK;
 }
@@ -940,6 +1176,21 @@ Result CommandQueueImpl::submit(const SubmitDesc& desc)
     // of this submission.
     CUstream requestedStream = desc.cudaStream == kInvalidCUDAStream ? m_stream : (CUstream)desc.cudaStream;
 
+    if (requestedStream != m_stream)
+    {
+        for (uint32_t i = 0; i < desc.commandBufferCount; i++)
+        {
+            CommandBufferImpl* commandBuffer = checked_cast<CommandBufferImpl*>(desc.commandBuffers[i]);
+            if (commandBuffer->m_commandList.writesTimestamp())
+            {
+                getDevice<DeviceImpl>()->printError(
+                    "CUDA timestamp queries are only supported on the queue's default stream."
+                );
+                return SLANG_E_NOT_AVAILABLE;
+            }
+        }
+    }
+
     // Wait for fences.
     for (uint32_t i = 0; i < desc.waitFenceCount; ++i)
     {
@@ -957,12 +1208,21 @@ Result CommandQueueImpl::submit(const SubmitDesc& desc)
     {
         // Get/execute the buffer.
         CommandBufferImpl* commandBuffer = checked_cast<CommandBufferImpl*>(desc.commandBuffers[i]);
-        CommandExecutor executor(getDevice<DeviceImpl>(), requestedStream);
+        uint64_t timestampAnchorGeneration = kInvalidTimestampAnchorGeneration;
+        bool writesTimestamp = commandBuffer->m_commandList.writesTimestamp();
+        if (writesTimestamp)
+        {
+            SLANG_RETURN_ON_FAIL(getTimestampAnchorGeneration(this, &timestampAnchorGeneration));
+        }
+        commandBuffer->m_timestampAnchorGeneration = timestampAnchorGeneration;
+
+        CommandExecutor executor(getDevice<DeviceImpl>(), requestedStream, timestampAnchorGeneration);
         SLANG_RETURN_ON_FAIL(executor.execute(commandBuffer));
 
-        // Lazy events: only create events for multi-stream workloads.
-        // Single-stream uses cuStreamQuery() instead - zero event overhead.
-        bool needsEvent = (requestedStream != m_stream) || m_submitsSinceEvent > kMaxSubmitsWithoutEvent;
+        // Lazy events: timestamp writes need per-submission completion so isResultReady can make
+        // progress without waiting for unrelated later work to drain the whole stream.
+        bool needsEvent =
+            writesTimestamp || (requestedStream != m_stream) || m_submitsSinceEvent > kMaxSubmitsWithoutEvent;
 
         if (needsEvent)
         {
@@ -977,6 +1237,12 @@ Result CommandQueueImpl::submit(const SubmitDesc& desc)
             m_lastSubmittedID++;
             m_submitsSinceEvent++;
             commandBuffer->m_submissionID = m_lastSubmittedID;
+        }
+
+        for (const auto& queryWrite : commandBuffer->m_commandList.getQueryWrites())
+        {
+            checked_cast<QueryPool*>(queryWrite.queryPool)
+                ->markQueryRangeSubmitted(queryWrite.index, queryWrite.count, commandBuffer->m_submissionID);
         }
 
         m_commandBuffersInFlight.push_back(commandBuffer);
@@ -998,7 +1264,7 @@ Result CommandQueueImpl::waitOnHost()
     m_lastFinishedID = m_lastSubmittedID;
 
     // Retire command buffers that have completed.
-    retireCommandBuffers();
+    SLANG_RETURN_ON_FAIL(retireCommandBuffers());
 
     // If there's any left, it represents a bug in slang-rhi
     SLANG_RHI_ASSERT(m_commandBuffersInFlight.empty());
@@ -1137,6 +1403,8 @@ Result CommandBufferImpl::reset()
 {
     m_bindingCache.reset();
     m_constantBufferPool.reset();
+    m_submissionID = 0;
+    m_timestampAnchorGeneration = kInvalidTimestampAnchorGeneration;
     return CommandBuffer::reset();
 }
 

--- a/src/cuda/cuda-command.h
+++ b/src/cuda/cuda-command.h
@@ -6,6 +6,8 @@
 
 #include "core/ring-queue.h"
 
+#include <array>
+
 namespace rhi::cuda {
 
 struct SubmitEvent
@@ -14,12 +16,24 @@ struct SubmitEvent
     uint64_t submitID = 0;
 };
 
+struct TimestampAnchor
+{
+    CUevent event = nullptr;
+    uint64_t generation = kInvalidTimestampAnchorGeneration;
+    uint64_t offsetUs = 0;
+    bool resolved = false;
+};
+
 class CommandQueueImpl : public CommandQueue
 {
 public:
     static constexpr size_t kMaxSubmitsWithoutEvent = 128;
+    static constexpr size_t kTimestampAnchorRingSize = 16;
 
     CUstream m_stream;
+    std::array<TimestampAnchor, kTimestampAnchorRingSize> m_timestampAnchors;
+    uint64_t m_currentAnchorGeneration = 0;
+    uint64_t m_timestampAnchorTimeNs = 0;
 
     uint64_t m_lastSubmittedID = 0;
     uint64_t m_lastFinishedID = 0;
@@ -53,6 +67,7 @@ public:
     Result retireCommandBuffers();
     Result retireCommandBuffersLocked();
 
+    Result resolveTimestampQueries(CommandBufferImpl* commandBuffer);
     Result signalFence(CUstream stream, uint64_t* outId);
     Result updateFence();
 
@@ -100,6 +115,7 @@ public:
     BindingCache m_bindingCache;
     ConstantBufferPool m_constantBufferPool;
     uint64_t m_submissionID = 0;
+    uint64_t m_timestampAnchorGeneration = kInvalidTimestampAnchorGeneration;
 
     CommandBufferImpl(Device* device);
     virtual ~CommandBufferImpl() = default;

--- a/src/cuda/cuda-query.cpp
+++ b/src/cuda/cuda-query.cpp
@@ -1,4 +1,5 @@
 #include "cuda-query.h"
+#include "cuda-command.h"
 #include "cuda-device.h"
 #include "cuda-utils.h"
 
@@ -13,38 +14,112 @@ QueryPoolImpl::~QueryPoolImpl()
 {
     SLANG_CUDA_CTX_SCOPE(getDevice<DeviceImpl>());
 
-    for (auto& e : m_events)
+    for (Query& query : m_queries)
     {
-        SLANG_CUDA_ASSERT_ON_FAIL(cuEventDestroy(e));
+        if (query.event)
+        {
+            SLANG_CUDA_ASSERT_ON_FAIL(cuEventDestroy(query.event));
+        }
     }
-    SLANG_CUDA_ASSERT_ON_FAIL(cuEventDestroy(m_startEvent));
 }
 
 Result QueryPoolImpl::init()
 {
-    SLANG_CUDA_RETURN_ON_FAIL_REPORT(cuEventCreate(&m_startEvent, 0), this);
-    SLANG_CUDA_RETURN_ON_FAIL_REPORT(cuEventRecord(m_startEvent, 0), this);
-    m_events.resize(m_desc.count);
-    for (size_t i = 0; i < m_events.size(); i++)
+    m_queries.resize(m_desc.count);
+    for (Query& query : m_queries)
     {
-        SLANG_CUDA_RETURN_ON_FAIL_REPORT(cuEventCreate(&m_events[i], 0), this);
+        SLANG_CUDA_RETURN_ON_FAIL_REPORT(cuEventCreate(&query.event, 0), this);
     }
     return SLANG_OK;
 }
 
+Result QueryPoolImpl::reset()
+{
+    return reset(0, m_desc.count);
+}
+
+Result QueryPoolImpl::reset(uint32_t queryIndex, uint32_t count)
+{
+    SLANG_RETURN_ON_FAIL(QueryPool::reset(queryIndex, count));
+    for (uint32_t i = 0; i < count; ++i)
+    {
+        Query& query = m_queries[queryIndex + i];
+        query.anchorGeneration = kInvalidTimestampAnchorGeneration;
+        query.resultData = 0;
+    }
+    return SLANG_OK;
+}
+
+Result QueryPoolImpl::isResultReady(uint32_t queryIndex, uint32_t count, bool* outReady)
+{
+    if (!outReady || !isValidQueryRange(queryIndex, count))
+    {
+        return SLANG_E_INVALID_ARG;
+    }
+
+    *outReady = false;
+    QueryRangeInfo queryInfo = getQueryRangeInfo(queryIndex, count);
+    if (queryInfo.state == QueryRangeState::Reset)
+    {
+        return SLANG_FAIL;
+    }
+    if (queryInfo.state == QueryRangeState::Resolved)
+    {
+        *outReady = true;
+        return SLANG_OK;
+    }
+
+    CommandQueueImpl* queue = getDevice<DeviceImpl>()->m_queue.get();
+    SLANG_RETURN_ON_FAIL(queue->retireCommandBuffers());
+
+    queryInfo = getQueryRangeInfo(queryIndex, count);
+    if (queryInfo.state == QueryRangeState::Reset)
+    {
+        return SLANG_FAIL;
+    }
+    if (queryInfo.state == QueryRangeState::Resolved)
+    {
+        *outReady = true;
+        return SLANG_OK;
+    }
+    if (queue->m_lastFinishedID < queryInfo.submissionID)
+    {
+        return SLANG_OK;
+    }
+
+    return SLANG_FAIL;
+}
+
 Result QueryPoolImpl::getResult(uint32_t queryIndex, uint32_t count, uint64_t* outData)
 {
+    if (!outData || !isValidQueryRange(queryIndex, count))
+    {
+        return SLANG_E_INVALID_ARG;
+    }
+    QueryRangeInfo queryInfo = getQueryRangeInfo(queryIndex, count);
+    if (queryInfo.state == QueryRangeState::Reset)
+    {
+        return SLANG_FAIL;
+    }
     if (count == 0)
     {
         return SLANG_OK;
     }
 
+    if (queryInfo.state != QueryRangeState::Resolved)
+    {
+        CommandQueueImpl* queue = getDevice<DeviceImpl>()->m_queue.get();
+        SLANG_RETURN_ON_FAIL(queue->waitOnHost());
+        queryInfo = getQueryRangeInfo(queryIndex, count);
+        if (queryInfo.state != QueryRangeState::Resolved)
+        {
+            return SLANG_FAIL;
+        }
+    }
+
     for (uint32_t i = 0; i < count; i++)
     {
-        float time = 0.0f;
-        SLANG_CUDA_RETURN_ON_FAIL_REPORT(cuEventSynchronize(m_events[i + queryIndex]), this);
-        SLANG_CUDA_RETURN_ON_FAIL_REPORT(cuEventElapsedTime(&time, m_startEvent, m_events[i + queryIndex]), this);
-        outData[i] = (uint64_t)((double)time * 1000.0f);
+        outData[i] = m_queries[queryIndex + i].resultData;
     }
     return SLANG_OK;
 }
@@ -72,21 +147,71 @@ Result PlainBufferProxyQueryPoolImpl::init()
 
 Result PlainBufferProxyQueryPoolImpl::reset()
 {
+    SLANG_RETURN_ON_FAIL(QueryPool::reset());
+    return SLANG_OK;
+}
+
+Result PlainBufferProxyQueryPoolImpl::isResultReady(uint32_t queryIndex, uint32_t count, bool* outReady)
+{
+    if (!outReady || !isValidQueryRange(queryIndex, count))
+    {
+        return SLANG_E_INVALID_ARG;
+    }
+
+    *outReady = false;
+    QueryRangeInfo queryInfo = getQueryRangeInfo(queryIndex, count);
+    if (queryInfo.state == QueryRangeState::Reset)
+    {
+        return SLANG_FAIL;
+    }
+    if (queryInfo.state == QueryRangeState::Resolved)
+    {
+        *outReady = true;
+        return SLANG_OK;
+    }
+
+    CommandQueueImpl* queue = getDevice<DeviceImpl>()->m_queue.get();
+    SLANG_RETURN_ON_FAIL(queue->retireCommandBuffers());
+    uint64_t submissionID = queryInfo.submissionID;
+    if (queue->m_lastFinishedID < submissionID)
+    {
+        return SLANG_OK;
+    }
+
+    markQueryRangeReady(queryIndex, count, queryInfo.submissionID);
+    *outReady = true;
+
     return SLANG_OK;
 }
 
 Result PlainBufferProxyQueryPoolImpl::getResult(uint32_t queryIndex, uint32_t count, uint64_t* outData)
 {
+    if (!outData || !isValidQueryRange(queryIndex, count))
+    {
+        return SLANG_E_INVALID_ARG;
+    }
+    QueryRangeInfo queryInfo = getQueryRangeInfo(queryIndex, count);
+    if (queryInfo.state == QueryRangeState::Reset)
+    {
+        return SLANG_FAIL;
+    }
     if (count == 0)
     {
         return SLANG_OK;
     }
 
-    SLANG_CUDA_RETURN_ON_FAIL_REPORT(cuCtxSynchronize(), this);
+    CommandQueueImpl* queue = getDevice<DeviceImpl>()->m_queue.get();
+    if (queue->m_lastFinishedID < queryInfo.submissionID)
+    {
+        SLANG_RETURN_ON_FAIL(queue->waitOnHost());
+    }
     SLANG_CUDA_RETURN_ON_FAIL_REPORT(
         cuMemcpyDtoH(outData, m_buffer + queryIndex * sizeof(uint64_t), count * sizeof(uint64_t)),
         this
     );
+
+    markQueryRangeReady(queryIndex, count, queryInfo.submissionID);
+
     return SLANG_OK;
 }
 

--- a/src/cuda/cuda-query.h
+++ b/src/cuda/cuda-query.h
@@ -7,17 +7,30 @@ namespace rhi::cuda {
 class QueryPoolImpl : public QueryPool
 {
 public:
-    /// The event object for each query. Owned by the pool.
-    std::vector<CUevent> m_events;
+    struct Query
+    {
+        /// The event object for this query. Owned by the pool.
+        CUevent event = nullptr;
+        /// The queue timestamp anchor generation that was current when this query event was recorded.
+        uint64_t anchorGeneration = kInvalidTimestampAnchorGeneration;
+        /// Cached host-readable timestamp result, resolved when queue progress retires the command buffer.
+        uint64_t resultData = 0;
+    };
 
-    /// The event that marks the starting point.
-    CUevent m_startEvent;
+    std::vector<Query> m_queries;
 
     QueryPoolImpl(Device* device, const QueryPoolDesc& desc);
     ~QueryPoolImpl();
 
     Result init();
 
+    virtual SLANG_NO_THROW Result SLANG_MCALL reset() override;
+    virtual SLANG_NO_THROW Result SLANG_MCALL reset(uint32_t queryIndex, uint32_t count) override;
+    virtual SLANG_NO_THROW Result SLANG_MCALL isResultReady(
+        uint32_t queryIndex,
+        uint32_t count,
+        bool* outReady
+    ) override;
     virtual SLANG_NO_THROW Result SLANG_MCALL getResult(
         uint32_t queryIndex,
         uint32_t count,
@@ -39,6 +52,11 @@ public:
     Result init();
 
     virtual SLANG_NO_THROW Result SLANG_MCALL reset() override;
+    virtual SLANG_NO_THROW Result SLANG_MCALL isResultReady(
+        uint32_t queryIndex,
+        uint32_t count,
+        bool* outReady
+    ) override;
     virtual SLANG_NO_THROW Result SLANG_MCALL getResult(
         uint32_t queryIndex,
         uint32_t count,

--- a/src/cuda/cuda-utils.h
+++ b/src/cuda/cuda-utils.h
@@ -4,6 +4,8 @@
 
 #include "cuda-api.h"
 
+#include <cmath>
+
 /// Enable CUDA context check.
 /// This is useful for debugging to ensure that the CUDA context is set correctly when calling CUDA APIs.
 #define SLANG_RHI_ENABLE_CUDA_CONTEXT_CHECK 0
@@ -100,5 +102,10 @@ void reportCUDAAssert(CUresult result, const char* call, const char* file, int l
     }
 
 AdapterLUID getAdapterLUID(int deviceIndex);
+
+inline uint64_t cudaEventMillisecondsToMicroseconds(float elapsedMs)
+{
+    return uint64_t(std::llround(double(elapsedMs) * 1000.0));
+}
 
 } // namespace rhi::cuda

--- a/src/d3d11/d3d11-command.cpp
+++ b/src/d3d11/d3d11-command.cpp
@@ -45,8 +45,7 @@ public:
 
     BindingDataImpl* m_bindingData = nullptr;
 
-    bool m_usedDisjointQuery = false;
-    ComPtr<ID3D11Query> m_disjointQuery;
+    ID3D11Query* m_disjointQuery = nullptr;
 
     CommandExecutor(DeviceImpl* device, uint64_t submissionID)
         : m_device(device)
@@ -104,6 +103,16 @@ public:
 Result CommandExecutor::execute(CommandBufferImpl* commandBuffer)
 {
     const CommandList& commandList = commandBuffer->m_commandList;
+    if (commandList.writesTimestamp())
+    {
+        m_disjointQuery = commandBuffer->m_disjointQuery;
+        if (!m_disjointQuery)
+        {
+            return SLANG_FAIL;
+        }
+        m_immediateContext->Begin(m_disjointQuery);
+    }
+
     auto command = commandList.getCommands();
     while (command)
     {
@@ -122,7 +131,7 @@ Result CommandExecutor::execute(CommandBufferImpl* commandBuffer)
         command = command->next;
     }
 
-    if (m_usedDisjointQuery)
+    if (m_disjointQuery)
     {
         m_immediateContext->End(m_disjointQuery);
     }
@@ -879,19 +888,6 @@ void CommandExecutor::cmdInsertDebugMarker(const commands::InsertDebugMarker& cm
 void CommandExecutor::cmdWriteTimestamp(const commands::WriteTimestamp& cmd)
 {
     auto queryPool = checked_cast<QueryPoolImpl*>(cmd.queryPool);
-    if (!m_usedDisjointQuery)
-    {
-        D3D11_QUERY_DESC queryDesc = {};
-        queryDesc.Query = D3D11_QUERY_TIMESTAMP_DISJOINT;
-        HRESULT hr = m_device->m_device->CreateQuery(&queryDesc, m_disjointQuery.writeRef());
-        if (FAILED(hr))
-        {
-            m_device->printError("Failed to create D3D11 timestamp disjoint query.");
-            return;
-        }
-        m_immediateContext->Begin(m_disjointQuery);
-        m_usedDisjointQuery = true;
-    }
     m_immediateContext->End(queryPool->getQuery(cmd.queryIndex));
     queryPool->setDisjointQuery(cmd.queryIndex, m_disjointQuery);
     queryPool->markQueryRangeSubmitted(cmd.queryIndex, 1, m_submissionID);
@@ -1018,6 +1014,14 @@ Result CommandEncoderImpl::finish(const CommandBufferDesc& desc, ICommandBuffer*
     m_commandBuffer->setDesc(desc);
     SLANG_RETURN_ON_FAIL(resolvePipelines(m_device));
     m_commandBuffer->m_constantBufferPool.finish();
+    if (m_commandBuffer->m_commandList.writesTimestamp() && !m_commandBuffer->m_disjointQuery)
+    {
+        D3D11_QUERY_DESC queryDesc = {};
+        queryDesc.Query = D3D11_QUERY_TIMESTAMP_DISJOINT;
+        SLANG_RETURN_ON_FAIL(
+            getDevice<DeviceImpl>()->m_device->CreateQuery(&queryDesc, m_commandBuffer->m_disjointQuery.writeRef())
+        );
+    }
     returnComPtr(outCommandBuffer, m_commandBuffer);
     m_commandBuffer = nullptr;
     m_commandList = nullptr;
@@ -1040,6 +1044,7 @@ CommandBufferImpl::CommandBufferImpl(Device* device)
 Result CommandBufferImpl::reset()
 {
     m_bindingCache.reset();
+    m_disjointQuery.setNull();
     return CommandBuffer::reset();
 }
 

--- a/src/d3d11/d3d11-command.cpp
+++ b/src/d3d11/d3d11-command.cpp
@@ -12,6 +12,9 @@
 #include "../strings.h"
 #include "../format-conversion.h"
 
+#include <chrono>
+#include <thread>
+
 namespace rhi::d3d11 {
 
 template<typename T>
@@ -25,6 +28,7 @@ class CommandExecutor
 public:
     DeviceImpl* m_device;
     ID3D11DeviceContext1* m_immediateContext;
+    uint64_t m_submissionID;
 
     short_vector<RefPtr<TextureViewImpl>> m_renderTargetViews;
     short_vector<RefPtr<TextureViewImpl>> m_resolveTargetViews;
@@ -42,10 +46,12 @@ public:
     BindingDataImpl* m_bindingData = nullptr;
 
     bool m_usedDisjointQuery = false;
+    ComPtr<ID3D11Query> m_disjointQuery;
 
-    CommandExecutor(DeviceImpl* device)
+    CommandExecutor(DeviceImpl* device, uint64_t submissionID)
         : m_device(device)
         , m_immediateContext(device->m_immediateContext1.get())
+        , m_submissionID(submissionID)
     {
     }
 
@@ -118,7 +124,7 @@ Result CommandExecutor::execute(CommandBufferImpl* commandBuffer)
 
     if (m_usedDisjointQuery)
     {
-        m_immediateContext->End(m_device->m_disjointQuery);
+        m_immediateContext->End(m_disjointQuery);
     }
 
     return SLANG_OK;
@@ -875,10 +881,20 @@ void CommandExecutor::cmdWriteTimestamp(const commands::WriteTimestamp& cmd)
     auto queryPool = checked_cast<QueryPoolImpl*>(cmd.queryPool);
     if (!m_usedDisjointQuery)
     {
-        m_immediateContext->Begin(m_device->m_disjointQuery);
+        D3D11_QUERY_DESC queryDesc = {};
+        queryDesc.Query = D3D11_QUERY_TIMESTAMP_DISJOINT;
+        HRESULT hr = m_device->m_device->CreateQuery(&queryDesc, m_disjointQuery.writeRef());
+        if (FAILED(hr))
+        {
+            m_device->printError("Failed to create D3D11 timestamp disjoint query.");
+            return;
+        }
+        m_immediateContext->Begin(m_disjointQuery);
         m_usedDisjointQuery = true;
     }
     m_immediateContext->End(queryPool->getQuery(cmd.queryIndex));
+    queryPool->setDisjointQuery(cmd.queryIndex, m_disjointQuery);
+    queryPool->markQueryRangeSubmitted(cmd.queryIndex, 1, m_submissionID);
 }
 
 void CommandExecutor::cmdExecuteCallback(const commands::ExecuteCallback& cmd)
@@ -924,9 +940,10 @@ Result CommandQueueImpl::createCommandEncoder(const CommandEncoderDesc& desc, IC
 
 Result CommandQueueImpl::submit(const SubmitDesc& desc)
 {
+    ++m_lastSubmittedID;
     for (uint32_t i = 0; i < desc.commandBufferCount; i++)
     {
-        CommandExecutor executor(getDevice<DeviceImpl>());
+        CommandExecutor executor(getDevice<DeviceImpl>(), m_lastSubmittedID);
         SLANG_RETURN_ON_FAIL(executor.execute(checked_cast<CommandBufferImpl*>(desc.commandBuffers[i])));
     }
     return SLANG_OK;
@@ -934,6 +951,26 @@ Result CommandQueueImpl::submit(const SubmitDesc& desc)
 
 Result CommandQueueImpl::waitOnHost()
 {
+    DeviceImpl* device = getDevice<DeviceImpl>();
+
+    if (!m_waitQuery)
+    {
+        D3D11_QUERY_DESC queryDesc = {};
+        queryDesc.Query = D3D11_QUERY_EVENT;
+        SLANG_RETURN_ON_FAIL(device->m_device->CreateQuery(&queryDesc, m_waitQuery.writeRef()));
+    }
+
+    device->m_immediateContext->End(m_waitQuery);
+    device->m_immediateContext->Flush();
+
+    HRESULT hr = S_FALSE;
+    while ((hr = device->m_immediateContext->GetData(m_waitQuery, nullptr, 0, D3D11_ASYNC_GETDATA_DONOTFLUSH)) ==
+           S_FALSE)
+    {
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    }
+    SLANG_RETURN_ON_FAIL(hr);
+
     return SLANG_OK;
 }
 

--- a/src/d3d11/d3d11-command.cpp
+++ b/src/d3d11/d3d11-command.cpp
@@ -80,8 +80,6 @@ public:
     void cmdBuildAccelerationStructure(const commands::BuildAccelerationStructure& cmd);
     void cmdCopyAccelerationStructure(const commands::CopyAccelerationStructure& cmd);
     void cmdQueryAccelerationStructureProperties(const commands::QueryAccelerationStructureProperties& cmd);
-    void cmdSerializeAccelerationStructure(const commands::SerializeAccelerationStructure& cmd);
-    void cmdDeserializeAccelerationStructure(const commands::DeserializeAccelerationStructure& cmd);
     void cmdExecuteClusterOperation(const commands::ExecuteClusterOperation& cmd);
     void cmdConvertCooperativeVectorMatrix(const commands::ConvertCooperativeVectorMatrix& cmd);
     void cmdSetBufferState(const commands::SetBufferState& cmd);
@@ -828,18 +826,6 @@ void CommandExecutor::cmdQueryAccelerationStructureProperties(const commands::Qu
 {
     SLANG_UNUSED(cmd);
     NOT_SUPPORTED(ICommandEncoder, queryAccelerationStructureProperties);
-}
-
-void CommandExecutor::cmdSerializeAccelerationStructure(const commands::SerializeAccelerationStructure& cmd)
-{
-    SLANG_UNUSED(cmd);
-    NOT_SUPPORTED(ICommandEncoder, serializeAccelerationStructure);
-}
-
-void CommandExecutor::cmdDeserializeAccelerationStructure(const commands::DeserializeAccelerationStructure& cmd)
-{
-    SLANG_UNUSED(cmd);
-    NOT_SUPPORTED(ICommandEncoder, deserializeAccelerationStructure);
 }
 
 void CommandExecutor::cmdExecuteClusterOperation(const commands::ExecuteClusterOperation& cmd)

--- a/src/d3d11/d3d11-command.h
+++ b/src/d3d11/d3d11-command.h
@@ -48,6 +48,7 @@ class CommandBufferImpl : public CommandBuffer
 public:
     ConstantBufferPool m_constantBufferPool;
     BindingCache m_bindingCache;
+    ComPtr<ID3D11Query> m_disjointQuery;
 
     CommandBufferImpl(Device* device);
 

--- a/src/d3d11/d3d11-command.h
+++ b/src/d3d11/d3d11-command.h
@@ -9,6 +9,9 @@ namespace rhi::d3d11 {
 class CommandQueueImpl : public CommandQueue
 {
 public:
+    ComPtr<ID3D11Query> m_waitQuery;
+    uint64_t m_lastSubmittedID = 0;
+
     CommandQueueImpl(Device* device, QueueType type);
 
     // ICommandQueue implementation

--- a/src/d3d11/d3d11-device.cpp
+++ b/src/d3d11/d3d11-device.cpp
@@ -17,6 +17,9 @@
 
 #include "core/string.h"
 
+#include <chrono>
+#include <thread>
+
 namespace rhi::d3d11 {
 
 DeviceImpl::DeviceImpl() {}
@@ -191,13 +194,21 @@ Result DeviceImpl::initialize(const DeviceDesc& desc, BackendImpl* backend)
     {
         D3D11_QUERY_DESC disjointQueryDesc = {};
         disjointQueryDesc.Query = D3D11_QUERY_TIMESTAMP_DISJOINT;
-        SLANG_RETURN_ON_FAIL(m_device->CreateQuery(&disjointQueryDesc, m_disjointQuery.writeRef()));
-        m_immediateContext->Begin(m_disjointQuery);
-        m_immediateContext->End(m_disjointQuery);
+        ComPtr<ID3D11Query> disjointQuery;
+        SLANG_RETURN_ON_FAIL(m_device->CreateQuery(&disjointQueryDesc, disjointQuery.writeRef()));
+        m_immediateContext->Begin(disjointQuery);
+        m_immediateContext->End(disjointQuery);
         D3D11_QUERY_DATA_TIMESTAMP_DISJOINT disjointData = {};
         m_immediateContext->Flush();
-        m_immediateContext->GetData(m_disjointQuery, &disjointData, sizeof(disjointData), 0);
-        m_info.timestampFrequency = disjointData.Frequency;
+        HRESULT hr = S_FALSE;
+        while ((hr = m_immediateContext->GetData(disjointQuery, &disjointData, sizeof(disjointData), 0)) == S_FALSE)
+        {
+            std::this_thread::sleep_for(std::chrono::milliseconds(1));
+        }
+        if (SUCCEEDED(hr) && !disjointData.Disjoint)
+        {
+            m_info.timestampFrequency = disjointData.Frequency;
+        }
     }
 
     // Query device limits

--- a/src/d3d11/d3d11-device.h
+++ b/src/d3d11/d3d11-device.h
@@ -107,7 +107,6 @@ public:
     ComPtr<ID3D11Device> m_device;
     ComPtr<ID3D11DeviceContext> m_immediateContext;
     ComPtr<ID3D11DeviceContext1> m_immediateContext1;
-    ComPtr<ID3D11Query> m_disjointQuery;
 
 #if SLANG_RHI_ENABLE_NVAPI
     NVAPIShaderExtension m_nvapiShaderExtension;

--- a/src/d3d11/d3d11-query.cpp
+++ b/src/d3d11/d3d11-query.cpp
@@ -29,34 +29,128 @@ Result QueryPoolImpl::init()
 ID3D11Query* QueryPoolImpl::getQuery(uint32_t index)
 {
     DeviceImpl* device = getDevice<DeviceImpl>();
-    if (!m_queries[index])
-        device->m_device->CreateQuery(&m_queryDesc, m_queries[index].writeRef());
-    return m_queries[index].get();
+    if (!m_queries[index].timestampQuery)
+        device->m_device->CreateQuery(&m_queryDesc, m_queries[index].timestampQuery.writeRef());
+    return m_queries[index].timestampQuery.get();
+}
+
+void QueryPoolImpl::setDisjointQuery(uint32_t index, ID3D11Query* disjointQuery)
+{
+    m_queries[index].disjointQuery = disjointQuery;
+}
+
+Result QueryPoolImpl::isResultReady(uint32_t queryIndex, uint32_t count, bool* outReady)
+{
+    if (!outReady || !isValidQueryRange(queryIndex, count))
+    {
+        return SLANG_E_INVALID_ARG;
+    }
+
+    *outReady = false;
+    QueryRangeInfo queryInfo = getQueryRangeInfo(queryIndex, count);
+    if (queryInfo.state == QueryRangeState::Reset)
+    {
+        return SLANG_FAIL;
+    }
+    if (queryInfo.state == QueryRangeState::Resolved)
+    {
+        *outReady = true;
+        return SLANG_OK;
+    }
+
+    DeviceImpl* device = getDevice<DeviceImpl>();
+    for (uint32_t i = 0; i < count; i++)
+    {
+        const Query& query = m_queries[queryIndex + i];
+        if (!query.timestampQuery || !query.disjointQuery)
+        {
+            return SLANG_FAIL;
+        }
+
+        D3D11_QUERY_DATA_TIMESTAMP_DISJOINT disjointData = {};
+        HRESULT hr =
+            device->m_immediateContext
+                ->GetData(query.disjointQuery, &disjointData, sizeof(disjointData), D3D11_ASYNC_GETDATA_DONOTFLUSH);
+        if (hr == S_FALSE)
+        {
+            return SLANG_OK;
+        }
+        SLANG_RETURN_ON_FAIL(hr);
+        if (disjointData.Disjoint || disjointData.Frequency == 0)
+        {
+            return SLANG_FAIL;
+        }
+        device->m_info.timestampFrequency = disjointData.Frequency;
+
+        uint64_t value = 0;
+        hr = device->m_immediateContext
+                 ->GetData(query.timestampQuery, &value, sizeof(value), D3D11_ASYNC_GETDATA_DONOTFLUSH);
+        if (hr == S_FALSE)
+        {
+            return SLANG_OK;
+        }
+        SLANG_RETURN_ON_FAIL(hr);
+    }
+
+    markQueryRangeReady(queryIndex, count, queryInfo.submissionID);
+    *outReady = true;
+
+    return SLANG_OK;
 }
 
 Result QueryPoolImpl::getResult(uint32_t queryIndex, uint32_t count, uint64_t* outData)
 {
+    if (!outData || !isValidQueryRange(queryIndex, count))
+    {
+        return SLANG_E_INVALID_ARG;
+    }
+
+    QueryRangeInfo queryInfo = getQueryRangeInfo(queryIndex, count);
+    if (queryInfo.state == QueryRangeState::Reset)
+    {
+        return SLANG_FAIL;
+    }
     if (count == 0)
     {
         return SLANG_OK;
     }
 
     DeviceImpl* device = getDevice<DeviceImpl>();
-    D3D11_QUERY_DATA_TIMESTAMP_DISJOINT disjointData;
-    while (S_OK !=
-           device->m_immediateContext
-               ->GetData(device->m_disjointQuery, &disjointData, sizeof(D3D11_QUERY_DATA_TIMESTAMP_DISJOINT), 0))
-    {
-        std::this_thread::sleep_for(std::chrono::milliseconds(1));
-    }
-    device->m_info.timestampFrequency = disjointData.Frequency;
-
     for (uint32_t i = 0; i < count; i++)
     {
-        SLANG_RETURN_ON_FAIL(
-            device->m_immediateContext->GetData(m_queries[queryIndex + i], outData + i, sizeof(uint64_t), 0)
-        );
+        const Query& query = m_queries[queryIndex + i];
+        if (!query.timestampQuery || !query.disjointQuery)
+        {
+            return SLANG_FAIL;
+        }
+
+        D3D11_QUERY_DATA_TIMESTAMP_DISJOINT disjointData = {};
+        HRESULT hr = S_FALSE;
+        while (
+            (hr = device->m_immediateContext
+                      ->GetData(query.disjointQuery, &disjointData, sizeof(D3D11_QUERY_DATA_TIMESTAMP_DISJOINT), 0)) ==
+            S_FALSE
+        )
+        {
+            std::this_thread::sleep_for(std::chrono::milliseconds(1));
+        }
+        SLANG_RETURN_ON_FAIL(hr);
+        if (disjointData.Disjoint || disjointData.Frequency == 0)
+        {
+            return SLANG_FAIL;
+        }
+        device->m_info.timestampFrequency = disjointData.Frequency;
+
+        while ((hr = device->m_immediateContext->GetData(query.timestampQuery, outData + i, sizeof(uint64_t), 0)) ==
+               S_FALSE)
+        {
+            std::this_thread::sleep_for(std::chrono::milliseconds(1));
+        }
+        SLANG_RETURN_ON_FAIL(hr);
     }
+
+    markQueryRangeReady(queryIndex, count, queryInfo.submissionID);
+
     return SLANG_OK;
 }
 

--- a/src/d3d11/d3d11-query.cpp
+++ b/src/d3d11/d3d11-query.cpp
@@ -36,6 +36,7 @@ ID3D11Query* QueryPoolImpl::getQuery(uint32_t index)
 
 void QueryPoolImpl::setDisjointQuery(uint32_t index, ID3D11Query* disjointQuery)
 {
+    SLANG_RHI_ASSERT(index < m_queries.size());
     m_queries[index].disjointQuery = disjointQuery;
 }
 

--- a/src/d3d11/d3d11-query.h
+++ b/src/d3d11/d3d11-query.h
@@ -7,7 +7,13 @@ namespace rhi::d3d11 {
 class QueryPoolImpl : public QueryPool
 {
 public:
-    std::vector<ComPtr<ID3D11Query>> m_queries;
+    struct Query
+    {
+        ComPtr<ID3D11Query> timestampQuery;
+        ComPtr<ID3D11Query> disjointQuery;
+    };
+
+    std::vector<Query> m_queries;
     D3D11_QUERY_DESC m_queryDesc;
 
     QueryPoolImpl(Device* device, const QueryPoolDesc& desc);
@@ -15,7 +21,13 @@ public:
     Result init();
 
     ID3D11Query* getQuery(uint32_t index);
+    void setDisjointQuery(uint32_t index, ID3D11Query* disjointQuery);
 
+    virtual SLANG_NO_THROW Result SLANG_MCALL isResultReady(
+        uint32_t queryIndex,
+        uint32_t count,
+        bool* outReady
+    ) override;
     virtual SLANG_NO_THROW Result SLANG_MCALL getResult(
         uint32_t queryIndex,
         uint32_t count,

--- a/src/d3d12/d3d12-command.cpp
+++ b/src/d3d12/d3d12-command.cpp
@@ -105,8 +105,6 @@ public:
     void cmdBuildAccelerationStructure(const commands::BuildAccelerationStructure& cmd);
     void cmdCopyAccelerationStructure(const commands::CopyAccelerationStructure& cmd);
     void cmdQueryAccelerationStructureProperties(const commands::QueryAccelerationStructureProperties& cmd);
-    void cmdSerializeAccelerationStructure(const commands::SerializeAccelerationStructure& cmd);
-    void cmdDeserializeAccelerationStructure(const commands::DeserializeAccelerationStructure& cmd);
     void cmdExecuteClusterOperation(const commands::ExecuteClusterOperation& cmd);
     void cmdConvertCooperativeVectorMatrix(const commands::ConvertCooperativeVectorMatrix& cmd);
     void cmdSetBufferState(const commands::SetBufferState& cmd);
@@ -130,6 +128,16 @@ public:
     void requireBufferState(BufferImpl* buffer, ResourceState state);
     void requireTextureState(TextureImpl* texture, SubresourceRange subresourceRange, ResourceState state);
     void commitBarriers();
+
+    void requireAccelerationStructureQueryResultBuffers(
+        uint32_t queryCount,
+        const AccelerationStructureQueryDesc* queryDescs
+    );
+    void copyAccelerationStructureQueryResults(
+        uint32_t queryCount,
+        const AccelerationStructureQueryDesc* queryDescs,
+        uint32_t resultCount
+    );
 };
 
 Result CommandRecorder::record(CommandBufferImpl* commandBuffer)
@@ -601,31 +609,20 @@ void CommandRecorder::cmdResolveQuery(const commands::ResolveQuery& cmd)
     {
     case QueryType::AccelerationStructureCompactedSize:
     case QueryType::AccelerationStructureCurrentSize:
-    case QueryType::AccelerationStructureSerializedSize:
     {
         auto queryPoolImpl = checked_cast<PlainBufferProxyQueryPoolImpl*>(queryPool);
         auto srcQueryBuffer = queryPoolImpl->m_buffer->m_resource.getResource();
 
-        D3D12_RESOURCE_BARRIER barrier = {};
-        barrier.Type = D3D12_RESOURCE_BARRIER_TYPE_TRANSITION;
-        barrier.Transition.StateBefore = D3D12_RESOURCE_STATE_UNORDERED_ACCESS;
-        barrier.Transition.StateAfter = D3D12_RESOURCE_STATE_COPY_SOURCE;
-        barrier.Transition.pResource = srcQueryBuffer;
-        m_cmdList->ResourceBarrier(1, &barrier);
+        requireBufferState(queryPoolImpl->m_buffer, ResourceState::CopySource);
+        commitBarriers();
 
         m_cmdList->CopyBufferRegion(
             buffer->m_resource.getResource(),
             cmd.offset,
             srcQueryBuffer,
-            cmd.index * sizeof(uint64_t),
-            cmd.count * sizeof(uint64_t)
+            uint64_t(cmd.index) * queryPoolImpl->m_stride,
+            uint64_t(cmd.count) * queryPoolImpl->m_stride
         );
-
-        barrier.Type = D3D12_RESOURCE_BARRIER_TYPE_TRANSITION;
-        barrier.Transition.StateBefore = D3D12_RESOURCE_STATE_COPY_SOURCE;
-        barrier.Transition.StateAfter = D3D12_RESOURCE_STATE_UNORDERED_ACCESS;
-        barrier.Transition.pResource = srcQueryBuffer;
-        m_cmdList->ResourceBarrier(1, &barrier);
     }
     break;
     default:
@@ -1340,6 +1337,7 @@ void CommandRecorder::cmdBuildAccelerationStructure(const commands::BuildAcceler
         }
     }
 
+    requireAccelerationStructureQueryResultBuffers(cmd.propertyQueryCount, cmd.queryDescs);
     commitBarriers();
 
 #if SLANG_RHI_ENABLE_NVAPI
@@ -1383,6 +1381,8 @@ void CommandRecorder::cmdBuildAccelerationStructure(const commands::BuildAcceler
 
         m_cmdList4->BuildRaytracingAccelerationStructure(&buildDesc, cmd.propertyQueryCount, postBuildInfoDescs.data());
     }
+
+    copyAccelerationStructureQueryResults(cmd.propertyQueryCount, cmd.queryDescs, 1);
 }
 
 void CommandRecorder::cmdCopyAccelerationStructure(const commands::CopyAccelerationStructure& cmd)
@@ -1417,12 +1417,14 @@ void CommandRecorder::cmdQueryAccelerationStructureProperties(const commands::Qu
     for (uint32_t i = 0; i < cmd.accelerationStructureCount; i++)
         asAddresses[i] = cmd.accelerationStructures[i]->getDeviceAddress();
     translatePostBuildInfoDescs(cmd.queryCount, cmd.queryDescs, postBuildInfoDescs);
+    requireAccelerationStructureQueryResultBuffers(cmd.queryCount, cmd.queryDescs);
+    commitBarriers();
     m_cmdList4->EmitRaytracingAccelerationStructurePostbuildInfo(
         postBuildInfoDescs.data(),
         cmd.accelerationStructureCount,
         asAddresses.data()
     );
-    
+    copyAccelerationStructureQueryResults(cmd.queryCount, cmd.queryDescs, cmd.accelerationStructureCount);
 }
 
 void CommandRecorder::cmdExecuteClusterOperation(const commands::ExecuteClusterOperation& cmd)
@@ -1806,6 +1808,53 @@ void CommandRecorder::commitBarriers()
     m_stateTracking.clearBarriers();
 }
 
+void CommandRecorder::requireAccelerationStructureQueryResultBuffers(
+    uint32_t queryCount,
+    const AccelerationStructureQueryDesc* queryDescs
+)
+{
+    if (!queryDescs)
+        return;
+
+    for (uint32_t i = 0; i < queryCount; ++i)
+    {
+        auto queryPool = checked_cast<PlainBufferProxyQueryPoolImpl*>(queryDescs[i].queryPool);
+        requireBufferState(queryPool->m_buffer, ResourceState::UnorderedAccess);
+    }
+}
+
+void CommandRecorder::copyAccelerationStructureQueryResults(
+    uint32_t queryCount,
+    const AccelerationStructureQueryDesc* queryDescs,
+    uint32_t resultCount
+)
+{
+    if (!queryDescs || queryCount == 0 || resultCount == 0)
+        return;
+
+    for (uint32_t i = 0; i < queryCount; ++i)
+    {
+        auto queryPool = checked_cast<PlainBufferProxyQueryPoolImpl*>(queryDescs[i].queryPool);
+        requireBufferState(queryPool->m_buffer, ResourceState::CopySource);
+    }
+    commitBarriers();
+
+    for (uint32_t i = 0; i < queryCount; ++i)
+    {
+        auto queryPool = checked_cast<PlainBufferProxyQueryPoolImpl*>(queryDescs[i].queryPool);
+        uint64_t offset = uint64_t(queryDescs[i].firstQueryIndex) * queryPool->m_stride;
+        uint64_t size = uint64_t(resultCount) * queryPool->m_stride;
+        m_cmdList->CopyBufferRegion(
+            queryPool->m_readBackBuffer.getResource(),
+            offset,
+            queryPool->m_buffer->m_resource.getResource(),
+            offset,
+            size
+        );
+    }
+}
+
+
 // CommandQueueImpl
 
 CommandQueueImpl::CommandQueueImpl(Device* device, QueueType type)
@@ -1963,6 +2012,11 @@ Result CommandQueueImpl::submit(const SubmitDesc& desc)
     {
         CommandBufferImpl* commandBuffer = checked_cast<CommandBufferImpl*>(desc.commandBuffers[i]);
         commandBuffer->m_submissionID = m_lastSubmittedID;
+        for (const auto& queryWrite : commandBuffer->m_commandList.getQueryWrites())
+        {
+            checked_cast<QueryPool*>(queryWrite.queryPool)
+                ->markQueryRangeSubmitted(queryWrite.index, queryWrite.count, m_lastSubmittedID);
+        }
         m_commandBuffersInFlight.push_back(commandBuffer);
         commandLists.push_back(commandBuffer->m_d3dCommandList);
     }

--- a/src/d3d12/d3d12-command.cpp
+++ b/src/d3d12/d3d12-command.cpp
@@ -1422,38 +1422,7 @@ void CommandRecorder::cmdQueryAccelerationStructureProperties(const commands::Qu
         cmd.accelerationStructureCount,
         asAddresses.data()
     );
-}
-
-void CommandRecorder::cmdSerializeAccelerationStructure(const commands::SerializeAccelerationStructure& cmd)
-{
-    BufferImpl* dstBuffer = checked_cast<BufferImpl*>(cmd.dst.buffer);
-    AccelerationStructureImpl* src = checked_cast<AccelerationStructureImpl*>(cmd.src);
-
-    requireBufferState(dstBuffer, ResourceState::UnorderedAccess);
-    requireBufferState(src->m_buffer, ResourceState::AccelerationStructureRead);
-    commitBarriers();
-
-    m_cmdList4->CopyRaytracingAccelerationStructure(
-        cmd.dst.getDeviceAddress(),
-        src->getDeviceAddress(),
-        D3D12_RAYTRACING_ACCELERATION_STRUCTURE_COPY_MODE_SERIALIZE
-    );
-}
-
-void CommandRecorder::cmdDeserializeAccelerationStructure(const commands::DeserializeAccelerationStructure& cmd)
-{
-    AccelerationStructureImpl* dst = checked_cast<AccelerationStructureImpl*>(cmd.dst);
-    BufferImpl* srcBuffer = checked_cast<BufferImpl*>(cmd.src.buffer);
-
-    requireBufferState(dst->m_buffer, ResourceState::AccelerationStructureWrite);
-    requireBufferState(srcBuffer, ResourceState::ShaderResource);
-    commitBarriers();
-
-    m_cmdList4->CopyRaytracingAccelerationStructure(
-        dst->getDeviceAddress(),
-        cmd.src.getDeviceAddress(),
-        D3D12_RAYTRACING_ACCELERATION_STRUCTURE_COPY_MODE_DESERIALIZE
-    );
+    
 }
 
 void CommandRecorder::cmdExecuteClusterOperation(const commands::ExecuteClusterOperation& cmd)

--- a/src/d3d12/d3d12-device.cpp
+++ b/src/d3d12/d3d12-device.cpp
@@ -1769,14 +1769,10 @@ Result DeviceImpl::createQueryPool(const QueryPoolDesc& desc, IQueryPool** outSt
     switch (desc.type)
     {
     case QueryType::AccelerationStructureCompactedSize:
-    case QueryType::AccelerationStructureSerializedSize:
     case QueryType::AccelerationStructureCurrentSize:
     {
         RefPtr<PlainBufferProxyQueryPoolImpl> queryPoolImpl = new PlainBufferProxyQueryPoolImpl(this, desc);
-        uint32_t stride = 8;
-        if (desc.type == QueryType::AccelerationStructureSerializedSize)
-            stride = 16;
-        SLANG_RETURN_ON_FAIL(queryPoolImpl->init(stride));
+        SLANG_RETURN_ON_FAIL(queryPoolImpl->init(8));
         returnComPtr(outState, queryPoolImpl);
         return SLANG_OK;
     }

--- a/src/d3d12/d3d12-query.cpp
+++ b/src/d3d12/d3d12-query.cpp
@@ -11,6 +11,16 @@ QueryPoolImpl::QueryPoolImpl(Device* device, const QueryPoolDesc& desc)
 {
 }
 
+QueryPoolImpl::~QueryPoolImpl()
+{
+    if (m_mappedReadBackData)
+    {
+        D3D12_RANGE writtenRange = {0, 0};
+        m_readBackBuffer.getResource()->Unmap(0, &writtenRange);
+        m_mappedReadBackData = nullptr;
+    }
+}
+
 Result QueryPoolImpl::init()
 {
     DeviceImpl* device = getDevice<DeviceImpl>();
@@ -52,69 +62,84 @@ Result QueryPoolImpl::init()
         device->m_allocator
     ));
 
-    // Create command allocator.
+    D3D12_RANGE readRange = {0, sizeof(uint64_t) * m_desc.count};
     SLANG_RETURN_ON_FAIL(
-        d3dDevice->CreateCommandAllocator(D3D12_COMMAND_LIST_TYPE_DIRECT, IID_PPV_ARGS(m_commandAllocator.writeRef()))
+        m_readBackBuffer.getResource()->Map(0, &readRange, reinterpret_cast<void**>(&m_mappedReadBackData))
     );
 
-    // Create command list.
-    SLANG_RETURN_ON_FAIL(d3dDevice->CreateCommandList(
-        0,
-        D3D12_COMMAND_LIST_TYPE_DIRECT,
-        m_commandAllocator,
-        nullptr,
-        IID_PPV_ARGS(m_commandList.writeRef())
-    ));
-    m_commandList->Close();
+    return SLANG_OK;
+}
 
-    // Create fence.
-    SLANG_RETURN_ON_FAIL(d3dDevice->CreateFence(0, D3D12_FENCE_FLAG_NONE, IID_PPV_ARGS(m_fence.writeRef())));
+Result QueryPoolImpl::isResultReady(uint32_t queryIndex, uint32_t count, bool* outReady)
+{
+    if (!outReady || !isValidQueryRange(queryIndex, count))
+    {
+        return SLANG_E_INVALID_ARG;
+    }
 
-    // Get command queue from device.
-    m_commandQueue = device->m_queue->m_d3dQueue;
+    *outReady = false;
+    QueryRangeInfo queryInfo = getQueryRangeInfo(queryIndex, count);
+    if (queryInfo.state == QueryRangeState::Reset)
+    {
+        return SLANG_FAIL;
+    }
+    if (queryInfo.state == QueryRangeState::Resolved)
+    {
+        *outReady = true;
+        return SLANG_OK;
+    }
 
-    // Create wait event.
-    m_waitEvent = CreateEventEx(nullptr, FALSE, 0, EVENT_ALL_ACCESS);
+    CommandQueueImpl* queue = getDevice<DeviceImpl>()->m_queue.get();
+    uint64_t submissionID = queryInfo.submissionID;
+    if (queue->updateLastFinishedID() < submissionID)
+    {
+        return SLANG_OK;
+    }
+
+    markQueryRangeReady(queryIndex, count, queryInfo.submissionID);
+    *outReady = true;
 
     return SLANG_OK;
 }
 
 Result QueryPoolImpl::getResult(uint32_t queryIndex, uint32_t count, uint64_t* outData)
 {
+    if (!outData || !isValidQueryRange(queryIndex, count))
+    {
+        return SLANG_E_INVALID_ARG;
+    }
+
+    QueryRangeInfo queryInfo = getQueryRangeInfo(queryIndex, count);
+    if (queryInfo.state == QueryRangeState::Reset)
+    {
+        return SLANG_FAIL;
+    }
     if (count == 0)
     {
         return SLANG_OK;
     }
 
-    m_commandList->Reset(m_commandAllocator, nullptr);
-    m_commandList->ResolveQueryData(
-        m_queryHeap,
-        m_queryType,
-        (UINT)queryIndex,
-        (UINT)count,
-        m_readBackBuffer,
-        sizeof(uint64_t) * queryIndex
-    );
-    m_commandList->Close();
-    ID3D12CommandList* cmdList = m_commandList;
-    m_commandQueue->ExecuteCommandLists(1, &cmdList);
-    m_eventValue++;
-    m_fence->SetEventOnCompletion(m_eventValue, m_waitEvent);
-    m_commandQueue->Signal(m_fence, m_eventValue);
-    WaitForSingleObject(m_waitEvent, INFINITE);
-    m_commandAllocator->Reset();
+    CommandQueueImpl* queue = getDevice<DeviceImpl>()->m_queue.get();
+    uint64_t submissionID = queryInfo.submissionID;
+    if (queue->updateLastFinishedID() < submissionID)
+    {
+        ResetEvent(queue->m_globalWaitHandle);
+        SLANG_RETURN_ON_FAIL(queue->m_trackingFence->SetEventOnCompletion(submissionID, queue->m_globalWaitHandle));
+        WaitForSingleObject(queue->m_globalWaitHandle, INFINITE);
+        queue->updateLastFinishedID();
+        queue->retireCommandBuffers();
+    }
 
-    int8_t* mappedData = nullptr;
-    D3D12_RANGE readRange = {sizeof(uint64_t) * queryIndex, sizeof(uint64_t) * (queryIndex + count)};
-    m_readBackBuffer.getResource()->Map(0, &readRange, (void**)&mappedData);
-    memcpy(outData, mappedData + sizeof(uint64_t) * queryIndex, sizeof(uint64_t) * count);
-    m_readBackBuffer.getResource()->Unmap(0, nullptr);
+    memcpy(outData, m_mappedReadBackData + sizeof(uint64_t) * queryIndex, sizeof(uint64_t) * count);
+    markQueryRangeReady(queryIndex, count, queryInfo.submissionID);
+
     return SLANG_OK;
 }
 
 void QueryPoolImpl::writeTimestamp(ID3D12GraphicsCommandList* cmdList, uint32_t index)
 {
     cmdList->EndQuery(m_queryHeap, D3D12_QUERY_TYPE_TIMESTAMP, index);
+    cmdList->ResolveQueryData(m_queryHeap, m_queryType, index, 1, m_readBackBuffer, sizeof(uint64_t) * index);
 }
 
 IQueryPool* PlainBufferProxyQueryPoolImpl::getInterface(const Guid& guid)
@@ -129,19 +154,49 @@ PlainBufferProxyQueryPoolImpl::PlainBufferProxyQueryPoolImpl(Device* device, con
 {
 }
 
+PlainBufferProxyQueryPoolImpl::~PlainBufferProxyQueryPoolImpl()
+{
+    if (m_mappedReadBackData)
+    {
+        D3D12_RANGE writtenRange = {0, 0};
+        m_readBackBuffer.getResource()->Unmap(0, &writtenRange);
+        m_mappedReadBackData = nullptr;
+    }
+}
+
 Result PlainBufferProxyQueryPoolImpl::init(uint32_t stride)
 {
     DeviceImpl* device = getDevice<DeviceImpl>();
+    uint64_t size = uint64_t(m_desc.count) * stride;
 
     ComPtr<IBuffer> buffer;
     BufferDesc bufferDesc = {};
     bufferDesc.defaultState = ResourceState::CopySource;
     bufferDesc.elementSize = 0;
-    bufferDesc.size = m_desc.count * stride;
+    bufferDesc.size = size;
     bufferDesc.format = Format::Undefined;
     bufferDesc.usage = BufferUsage::UnorderedAccess;
     SLANG_RETURN_ON_FAIL(device->createBuffer(bufferDesc, nullptr, buffer.writeRef()));
     m_buffer = checked_cast<BufferImpl*>(buffer.get());
+
+    D3D12_HEAP_PROPERTIES heapProps = makeHeapProperties(D3D12_HEAP_TYPE_READBACK);
+    D3D12_RESOURCE_DESC resourceDesc = {};
+    initBufferDesc(size, resourceDesc);
+    SLANG_RETURN_ON_FAIL(m_readBackBuffer.initCommitted(
+        device->m_device,
+        heapProps,
+        D3D12_HEAP_FLAG_NONE,
+        resourceDesc,
+        D3D12_RESOURCE_STATE_COPY_DEST,
+        nullptr,
+        device->m_allocator
+    ));
+
+    D3D12_RANGE readRange = {0, size};
+    SLANG_RETURN_ON_FAIL(
+        m_readBackBuffer.getResource()->Map(0, &readRange, reinterpret_cast<void**>(&m_mappedReadBackData))
+    );
+
     m_queryType = m_desc.type;
     m_device = device;
     m_stride = stride;
@@ -149,70 +204,69 @@ Result PlainBufferProxyQueryPoolImpl::init(uint32_t stride)
     return SLANG_OK;
 }
 
-Result PlainBufferProxyQueryPoolImpl::reset()
+Result PlainBufferProxyQueryPoolImpl::isResultReady(uint32_t queryIndex, uint32_t count, bool* outReady)
 {
-    DeviceImpl* device = getDevice<DeviceImpl>();
+    if (!outReady || !isValidQueryRange(queryIndex, count))
+    {
+        return SLANG_E_INVALID_ARG;
+    }
 
-    m_resultDirty = true;
-    ID3D12GraphicsCommandList* commandList = device->beginImmediateCommandList();
-    D3D12_RESOURCE_BARRIER barrier = {};
-    barrier.Type = D3D12_RESOURCE_BARRIER_TYPE_TRANSITION;
-    barrier.Transition.StateBefore = D3D12_RESOURCE_STATE_COPY_SOURCE;
-    barrier.Transition.StateAfter = D3D12_RESOURCE_STATE_UNORDERED_ACCESS;
-    barrier.Transition.pResource = m_buffer->m_resource.getResource();
-    commandList->ResourceBarrier(1, &barrier);
-    device->endImmediateCommandList();
+    *outReady = false;
+    QueryRangeInfo queryInfo = getQueryRangeInfo(queryIndex, count);
+    if (queryInfo.state == QueryRangeState::Reset)
+    {
+        return SLANG_FAIL;
+    }
+    if (queryInfo.state == QueryRangeState::Resolved)
+    {
+        *outReady = true;
+        return SLANG_OK;
+    }
+
+    CommandQueueImpl* queue = getDevice<DeviceImpl>()->m_queue.get();
+    uint64_t submissionID = queryInfo.submissionID;
+    if (queue->updateLastFinishedID() < submissionID)
+    {
+        return SLANG_OK;
+    }
+
+    markQueryRangeReady(queryIndex, count, queryInfo.submissionID);
+    *outReady = true;
+
     return SLANG_OK;
 }
 
 Result PlainBufferProxyQueryPoolImpl::getResult(uint32_t queryIndex, uint32_t count, uint64_t* outData)
 {
+    if (!outData || !isValidQueryRange(queryIndex, count))
+    {
+        return SLANG_E_INVALID_ARG;
+    }
+
+    QueryRangeInfo queryInfo = getQueryRangeInfo(queryIndex, count);
+    if (queryInfo.state == QueryRangeState::Reset)
+    {
+        return SLANG_FAIL;
+    }
     if (count == 0)
     {
         return SLANG_OK;
     }
 
     DeviceImpl* device = getDevice<DeviceImpl>();
-
-    if (m_resultDirty)
+    CommandQueueImpl* queue = device->m_queue.get();
+    uint64_t submissionID = queryInfo.submissionID;
+    if (queue->updateLastFinishedID() < submissionID)
     {
-        ID3D12GraphicsCommandList* commandList = device->beginImmediateCommandList();
-        D3D12_RESOURCE_BARRIER barrier = {};
-        barrier.Type = D3D12_RESOURCE_BARRIER_TYPE_TRANSITION;
-        barrier.Transition.StateBefore = D3D12_RESOURCE_STATE_UNORDERED_ACCESS;
-        barrier.Transition.StateAfter = D3D12_RESOURCE_STATE_COPY_SOURCE;
-        barrier.Transition.pResource = m_buffer->m_resource.getResource();
-        commandList->ResourceBarrier(1, &barrier);
-
-        D3D12Resource stageBuf;
-
-        uint64_t size = uint64_t(m_count) * m_stride;
-        D3D12_HEAP_PROPERTIES heapProps = makeHeapProperties(D3D12_HEAP_TYPE_READBACK);
-
-        D3D12_RESOURCE_DESC stagingDesc;
-        initBufferDesc(size, stagingDesc);
-
-        SLANG_RETURN_ON_FAIL(stageBuf.initCommitted(
-            device->m_device,
-            heapProps,
-            D3D12_HEAP_FLAG_NONE,
-            stagingDesc,
-            D3D12_RESOURCE_STATE_COPY_DEST,
-            nullptr,
-            device->m_allocator
-        ));
-
-        commandList->CopyBufferRegion(stageBuf, 0, m_buffer->m_resource.getResource(), 0, size);
-        device->endImmediateCommandList();
-        void* ptr = nullptr;
-        stageBuf.getResource()->Map(0, nullptr, &ptr);
-        m_result.resize(m_count * m_stride);
-        memcpy(m_result.data(), ptr, m_result.size());
-
-        m_resultDirty = false;
+        ResetEvent(queue->m_globalWaitHandle);
+        SLANG_RETURN_ON_FAIL(queue->m_trackingFence->SetEventOnCompletion(submissionID, queue->m_globalWaitHandle));
+        WaitForSingleObject(queue->m_globalWaitHandle, INFINITE);
+        queue->updateLastFinishedID();
+        queue->retireCommandBuffers();
     }
 
-    memcpy(outData, m_result.data() + queryIndex * m_stride, count * m_stride);
+    memcpy(outData, m_mappedReadBackData + uint64_t(m_stride) * queryIndex, uint64_t(m_stride) * count);
+    markQueryRangeReady(queryIndex, count, queryInfo.submissionID);
 
     return SLANG_OK;
 }

--- a/src/d3d12/d3d12-query.h
+++ b/src/d3d12/d3d12-query.h
@@ -8,9 +8,15 @@ class QueryPoolImpl : public QueryPool
 {
 public:
     QueryPoolImpl(Device* device, const QueryPoolDesc& desc);
+    ~QueryPoolImpl();
 
     Result init();
 
+    virtual SLANG_NO_THROW Result SLANG_MCALL isResultReady(
+        uint32_t queryIndex,
+        uint32_t count,
+        bool* outReady
+    ) override;
     virtual SLANG_NO_THROW Result SLANG_MCALL getResult(
         uint32_t queryIndex,
         uint32_t count,
@@ -23,12 +29,7 @@ public:
     D3D12_QUERY_TYPE m_queryType;
     ComPtr<ID3D12QueryHeap> m_queryHeap;
     D3D12Resource m_readBackBuffer;
-    ComPtr<ID3D12CommandAllocator> m_commandAllocator;
-    ComPtr<ID3D12GraphicsCommandList> m_commandList;
-    ComPtr<ID3D12Fence> m_fence;
-    ComPtr<ID3D12CommandQueue> m_commandQueue;
-    HANDLE m_waitEvent;
-    UINT64 m_eventValue = 0;
+    uint8_t* m_mappedReadBackData = nullptr;
 };
 
 /// Implements the IQueryPool interface with a plain buffer.
@@ -42,10 +43,15 @@ public:
 
 public:
     PlainBufferProxyQueryPoolImpl(Device* device, const QueryPoolDesc& desc);
+    ~PlainBufferProxyQueryPoolImpl();
 
     Result init(uint32_t stride);
 
-    virtual SLANG_NO_THROW Result SLANG_MCALL reset() override;
+    virtual SLANG_NO_THROW Result SLANG_MCALL isResultReady(
+        uint32_t queryIndex,
+        uint32_t count,
+        bool* outReady
+    ) override;
     virtual SLANG_NO_THROW Result SLANG_MCALL getResult(
         uint32_t queryIndex,
         uint32_t count,
@@ -55,8 +61,8 @@ public:
 public:
     QueryType m_queryType;
     RefPtr<BufferImpl> m_buffer;
-    std::vector<uint8_t> m_result;
-    bool m_resultDirty = true;
+    D3D12Resource m_readBackBuffer;
+    uint8_t* m_mappedReadBackData = nullptr;
     uint32_t m_stride = 0;
     uint32_t m_count = 0;
 };

--- a/src/d3d12/d3d12-utils.cpp
+++ b/src/d3d12/d3d12-utils.cpp
@@ -570,13 +570,6 @@ void translatePostBuildInfoDescs(
                 sizeof(D3D12_RAYTRACING_ACCELERATION_STRUCTURE_POSTBUILD_INFO_COMPACTED_SIZE_DESC) *
                     queryDescs[i].firstQueryIndex;
             break;
-        case QueryType::AccelerationStructureSerializedSize:
-            postBuildInfoDescs[i].InfoType = D3D12_RAYTRACING_ACCELERATION_STRUCTURE_POSTBUILD_INFO_SERIALIZATION;
-            postBuildInfoDescs[i].DestBuffer =
-                checked_cast<PlainBufferProxyQueryPoolImpl*>(queryDescs[i].queryPool)->m_buffer->getDeviceAddress() +
-                sizeof(D3D12_RAYTRACING_ACCELERATION_STRUCTURE_POSTBUILD_INFO_SERIALIZATION_DESC) *
-                    queryDescs[i].firstQueryIndex;
-            break;
         default:
             break;
         }

--- a/src/debug-layer/debug-command-encoder.cpp
+++ b/src/debug-layer/debug-command-encoder.cpp
@@ -1610,48 +1610,6 @@ void DebugCommandEncoder::queryAccelerationStructureProperties(
     );
 }
 
-void DebugCommandEncoder::serializeAccelerationStructure(BufferOffsetPair dst, IAccelerationStructure* src)
-{
-    SLANG_RHI_DEBUG_API(ICommandEncoder, serializeAccelerationStructure);
-
-    requireOpen();
-    requireNoPass();
-
-    if (!src)
-    {
-        RHI_VALIDATION_ERROR("'src' must not be null.");
-        return;
-    }
-    if (!dst.buffer)
-    {
-        RHI_VALIDATION_ERROR("'dst.buffer' must not be null.");
-        return;
-    }
-
-    baseObject->serializeAccelerationStructure(dst, src);
-}
-
-void DebugCommandEncoder::deserializeAccelerationStructure(IAccelerationStructure* dst, BufferOffsetPair src)
-{
-    SLANG_RHI_DEBUG_API(ICommandEncoder, deserializeAccelerationStructure);
-
-    requireOpen();
-    requireNoPass();
-
-    if (!dst)
-    {
-        RHI_VALIDATION_ERROR("'dst' must not be null.");
-        return;
-    }
-    if (!src.buffer)
-    {
-        RHI_VALIDATION_ERROR("'src.buffer' must not be null.");
-        return;
-    }
-
-    baseObject->deserializeAccelerationStructure(dst, src);
-}
-
 void DebugCommandEncoder::executeClusterOperation(const ClusterOperationDesc& desc)
 {
     SLANG_RHI_DEBUG_API(ICommandEncoder, executeClusterOperation);

--- a/src/debug-layer/debug-command-encoder.cpp
+++ b/src/debug-layer/debug-command-encoder.cpp
@@ -7,6 +7,52 @@
 
 namespace rhi::debug {
 
+namespace {
+
+bool isAccelerationStructureQueryType(QueryType queryType)
+{
+    return queryType == QueryType::AccelerationStructureCompactedSize ||
+           queryType == QueryType::AccelerationStructureCurrentSize;
+}
+
+bool validateAccelerationStructureQueryDescs(
+    DebugContext* ctx,
+    uint32_t queryCount,
+    const AccelerationStructureQueryDesc* queryDescs,
+    uint32_t resultCount
+)
+{
+    for (uint32_t i = 0; i < queryCount; ++i)
+    {
+        const AccelerationStructureQueryDesc& queryDesc = queryDescs[i];
+        if (!queryDesc.queryPool)
+        {
+            RHI_VALIDATION_ERROR_FORMAT("'queryDescs[%u].queryPool' must not be null.", i);
+            return false;
+        }
+        if (!isAccelerationStructureQueryType(queryDesc.queryType))
+        {
+            RHI_VALIDATION_ERROR_FORMAT("'queryDescs[%u].queryType' is not valid for acceleration structures.", i);
+            return false;
+        }
+
+        const QueryPoolDesc& queryPoolDesc = queryDesc.queryPool->getDesc();
+        if (queryPoolDesc.type != queryDesc.queryType)
+        {
+            RHI_VALIDATION_ERROR_FORMAT("'queryDescs[%u].queryPool' type must match 'queryType'.", i);
+            return false;
+        }
+        if (resultCount > 0 && !isValidSubrange(queryDesc.firstQueryIndex, resultCount, queryPoolDesc.count))
+        {
+            RHI_VALIDATION_ERROR_FORMAT("'queryDescs[%u]' query range exceeds the query pool size.", i);
+            return false;
+        }
+    }
+    return true;
+}
+
+} // namespace
+
 // ----------------------------------------------------------------------------
 // DebugRenderPassEncoder
 // ----------------------------------------------------------------------------
@@ -1525,6 +1571,10 @@ void DebugCommandEncoder::buildAccelerationStructure(
             return;
         }
     }
+    if (!validateAccelerationStructureQueryDescs(ctx, propertyQueryCount, queryDescs, 1))
+    {
+        return;
+    }
 
     std::vector<AccelerationStructureQueryDesc> innerQueryDescs;
     for (uint32_t i = 0; i < propertyQueryCount; ++i)
@@ -1589,6 +1639,10 @@ void DebugCommandEncoder::queryAccelerationStructureProperties(
     if (queryCount > 0 && !queryDescs)
     {
         RHI_VALIDATION_ERROR("'queryDescs' must not be null when 'queryCount' > 0.");
+        return;
+    }
+    if (!validateAccelerationStructureQueryDescs(ctx, queryCount, queryDescs, accelerationStructureCount))
+    {
         return;
     }
 

--- a/src/debug-layer/debug-command-encoder.h
+++ b/src/debug-layer/debug-command-encoder.h
@@ -261,16 +261,6 @@ public:
         const AccelerationStructureQueryDesc* queryDescs
     ) override;
 
-    virtual SLANG_NO_THROW void SLANG_MCALL serializeAccelerationStructure(
-        BufferOffsetPair dst,
-        IAccelerationStructure* src
-    ) override;
-
-    virtual SLANG_NO_THROW void SLANG_MCALL deserializeAccelerationStructure(
-        IAccelerationStructure* dst,
-        BufferOffsetPair src
-    ) override;
-
     virtual SLANG_NO_THROW void SLANG_MCALL executeClusterOperation(const ClusterOperationDesc& desc) override;
 
     virtual SLANG_NO_THROW void SLANG_MCALL convertCooperativeVectorMatrix(

--- a/src/debug-layer/debug-query.cpp
+++ b/src/debug-layer/debug-query.cpp
@@ -10,18 +10,36 @@ const QueryPoolDesc& DebugQueryPool::getDesc()
     return baseObject->getDesc();
 }
 
+Result DebugQueryPool::isResultReady(uint32_t queryIndex, uint32_t count, bool* outReady)
+{
+    SLANG_RHI_DEBUG_API(IQueryPool, isResultReady);
+
+    if (!isValidSubrange(queryIndex, count, baseObject->getDesc().count))
+    {
+        RHI_VALIDATION_ERROR("'queryIndex' and 'count' must specify a valid range within the query pool.");
+        return SLANG_E_INVALID_ARG;
+    }
+    if (!outReady)
+    {
+        RHI_VALIDATION_ERROR("'outReady' must not be null.");
+        return SLANG_E_INVALID_ARG;
+    }
+
+    return baseObject->isResultReady(queryIndex, count, outReady);
+}
+
 Result DebugQueryPool::getResult(uint32_t queryIndex, uint32_t count, uint64_t* outData)
 {
     SLANG_RHI_DEBUG_API(IQueryPool, getResult);
 
-    if (!outData)
-    {
-        RHI_VALIDATION_ERROR("'outData' must not be null.");
-        return SLANG_E_INVALID_ARG;
-    }
     if (!isValidSubrange(queryIndex, count, baseObject->getDesc().count))
     {
         RHI_VALIDATION_ERROR("'queryIndex' and 'count' must specify a valid range within the query pool.");
+        return SLANG_E_INVALID_ARG;
+    }
+    if (!outData)
+    {
+        RHI_VALIDATION_ERROR("'outData' must not be null.");
         return SLANG_E_INVALID_ARG;
     }
 
@@ -33,6 +51,19 @@ Result DebugQueryPool::reset()
     SLANG_RHI_DEBUG_API(IQueryPool, reset);
 
     return baseObject->reset();
+}
+
+Result DebugQueryPool::reset(uint32_t queryIndex, uint32_t count)
+{
+    SLANG_RHI_DEBUG_API(IQueryPool, reset);
+
+    if (!isValidSubrange(queryIndex, count, baseObject->getDesc().count))
+    {
+        RHI_VALIDATION_ERROR("'queryIndex' and 'count' must specify a valid range within the query pool.");
+        return SLANG_E_INVALID_ARG;
+    }
+
+    return baseObject->reset(queryIndex, count);
 }
 
 } // namespace rhi::debug

--- a/src/debug-layer/debug-query.h
+++ b/src/debug-layer/debug-query.h
@@ -15,12 +15,18 @@ public:
 public:
     // IQueryPool implementation
     virtual SLANG_NO_THROW const QueryPoolDesc& SLANG_MCALL getDesc() override;
+    virtual SLANG_NO_THROW Result SLANG_MCALL isResultReady(
+        uint32_t queryIndex,
+        uint32_t count,
+        bool* outReady
+    ) override;
     virtual SLANG_NO_THROW Result SLANG_MCALL getResult(
         uint32_t queryIndex,
         uint32_t count,
         uint64_t* outData
     ) override;
     virtual SLANG_NO_THROW Result SLANG_MCALL reset() override;
+    virtual SLANG_NO_THROW Result SLANG_MCALL reset(uint32_t queryIndex, uint32_t count) override;
 };
 
 } // namespace rhi::debug

--- a/src/enum-strings.cpp
+++ b/src/enum-strings.cpp
@@ -399,8 +399,6 @@ const char* enumToString(QueryType value)
         return S_QueryType_Timestamp;
     case QueryType::AccelerationStructureCompactedSize:
         return S_QueryType_AccelerationStructureCompactedSize;
-    case QueryType::AccelerationStructureSerializedSize:
-        return S_QueryType_AccelerationStructureSerializedSize;
     case QueryType::AccelerationStructureCurrentSize:
         return S_QueryType_AccelerationStructureCurrentSize;
     }

--- a/src/metal/metal-command.cpp
+++ b/src/metal/metal-command.cpp
@@ -129,8 +129,6 @@ public:
     void cmdBuildAccelerationStructure(const commands::BuildAccelerationStructure& cmd);
     void cmdCopyAccelerationStructure(const commands::CopyAccelerationStructure& cmd);
     void cmdQueryAccelerationStructureProperties(const commands::QueryAccelerationStructureProperties& cmd);
-    void cmdSerializeAccelerationStructure(const commands::SerializeAccelerationStructure& cmd);
-    void cmdDeserializeAccelerationStructure(const commands::DeserializeAccelerationStructure& cmd);
     void cmdExecuteClusterOperation(const commands::ExecuteClusterOperation& cmd);
     void cmdConvertCooperativeVectorMatrix(const commands::ConvertCooperativeVectorMatrix& cmd);
     void cmdSetBufferState(const commands::SetBufferState& cmd);
@@ -945,18 +943,6 @@ void CommandRecorder::cmdQueryAccelerationStructureProperties(const commands::Qu
 {
     SLANG_UNUSED(cmd);
     NOT_SUPPORTED(ICommandEncoder, queryAccelerationStructureProperties);
-}
-
-void CommandRecorder::cmdSerializeAccelerationStructure(const commands::SerializeAccelerationStructure& cmd)
-{
-    SLANG_UNUSED(cmd);
-    NOT_SUPPORTED(ICommandEncoder, serializeAccelerationStructure);
-}
-
-void CommandRecorder::cmdDeserializeAccelerationStructure(const commands::DeserializeAccelerationStructure& cmd)
-{
-    SLANG_UNUSED(cmd);
-    NOT_SUPPORTED(ICommandEncoder, deserializeAccelerationStructure);
 }
 
 void CommandRecorder::cmdExecuteClusterOperation(const commands::ExecuteClusterOperation& cmd)

--- a/src/metal/metal-query.cpp
+++ b/src/metal/metal-query.cpp
@@ -64,26 +64,14 @@ Result QueryPoolImpl::init()
     return m_counterSampleBuffer ? SLANG_OK : SLANG_FAIL;
 }
 
+Result QueryPoolImpl::isResultReady(uint32_t queryIndex, uint32_t count, bool* outReady)
+{
+    return SLANG_E_NOT_AVAILABLE;
+}
+
 Result QueryPoolImpl::getResult(uint32_t queryIndex, uint32_t count, uint64_t* outData)
 {
-    if (count == 0)
-    {
-        return SLANG_OK;
-    }
-
-    NS::Data* rawData = m_counterSampleBuffer->resolveCounterRange(NS::Range(queryIndex, count));
-    if (!rawData)
-    {
-        return SLANG_FAIL;
-    }
-    static_assert(sizeof(MTL::CounterResultTimestamp) == sizeof(uint64_t));
-    if (rawData->length() < count * sizeof(uint64_t))
-    {
-        return SLANG_FAIL;
-    }
-    std::memcpy(outData, rawData->mutableBytes(), count * sizeof(uint64_t));
-
-    return SLANG_OK;
+    return SLANG_E_NOT_AVAILABLE;
 }
 
 } // namespace rhi::metal

--- a/src/metal/metal-query.h
+++ b/src/metal/metal-query.h
@@ -14,6 +14,11 @@ public:
 
     Result init();
 
+    virtual SLANG_NO_THROW Result SLANG_MCALL isResultReady(
+        uint32_t queryIndex,
+        uint32_t count,
+        bool* outReady
+    ) override;
     virtual SLANG_NO_THROW Result SLANG_MCALL getResult(
         uint32_t queryIndex,
         uint32_t count,

--- a/src/rhi-shared.cpp
+++ b/src/rhi-shared.cpp
@@ -412,7 +412,10 @@ void QueryPool::markQueryRangeReady(uint32_t queryIndex, uint32_t count, uint64_
 
 QueryPool::QueryRangeInfo QueryPool::getQueryRangeInfo(uint32_t queryIndex, uint32_t count) const
 {
-    SLANG_RHI_ASSERT(isValidQueryRange(queryIndex, count));
+    if (!isValidQueryRange(queryIndex, count))
+    {
+        return {QueryRangeState::Reset, 0};
+    }
 
     if (count == 0)
     {
@@ -427,7 +430,7 @@ QueryPool::QueryRangeInfo QueryPool::getQueryRangeInfo(uint32_t queryIndex, uint
         QueryStatus status = state.getStatus();
         if (status == QueryStatus::Reset)
         {
-            return {};
+            return {QueryRangeState::Reset, 0};
         }
         if (status == QueryStatus::Pending)
         {

--- a/src/rhi-shared.cpp
+++ b/src/rhi-shared.cpp
@@ -360,7 +360,7 @@ Result QueryPool::reset(uint32_t queryIndex, uint32_t count)
     for (uint32_t i = 0; i < count; ++i)
     {
         QueryState& state = m_queryStates[queryIndex + i];
-        state.set(QueryState::Status::Reset, 0);
+        state.set(QueryStatus::Reset, 0);
     }
 
     return SLANG_OK;
@@ -386,7 +386,7 @@ void QueryPool::markQueryRangeSubmitted(uint32_t queryIndex, uint32_t count, uin
     for (uint32_t i = 0; i < count; ++i)
     {
         QueryState& state = m_queryStates[queryIndex + i];
-        state.set(QueryState::Status::Pending, submissionID);
+        state.set(QueryStatus::Pending, submissionID);
     }
 }
 
@@ -401,11 +401,11 @@ void QueryPool::markQueryRangeReady(uint32_t queryIndex, uint32_t count, uint64_
     for (uint32_t i = 0; i < count; ++i)
     {
         QueryState& state = m_queryStates[queryIndex + i];
-        QueryState::Status status = state.getStatus();
+        QueryStatus status = state.getStatus();
         uint64_t submissionID = state.getSubmissionID();
-        if (status == QueryState::Status::Pending && submissionID <= completedSubmissionID)
+        if (status == QueryStatus::Pending && submissionID <= completedSubmissionID)
         {
-            state.set(QueryState::Status::Resolved, submissionID);
+            state.set(QueryStatus::Resolved, submissionID);
         }
     }
 }
@@ -424,12 +424,12 @@ QueryPool::QueryRangeInfo QueryPool::getQueryRangeInfo(uint32_t queryIndex, uint
     for (uint32_t i = 0; i < count; ++i)
     {
         const QueryState& state = m_queryStates[queryIndex + i];
-        QueryState::Status status = state.getStatus();
-        if (status == QueryState::Status::Reset)
+        QueryStatus status = state.getStatus();
+        if (status == QueryStatus::Reset)
         {
             return {};
         }
-        if (status == QueryState::Status::Pending)
+        if (status == QueryStatus::Pending)
         {
             info.state = QueryRangeState::Pending;
         }

--- a/src/rhi-shared.cpp
+++ b/src/rhi-shared.cpp
@@ -341,6 +341,105 @@ QueryPool::QueryPool(Device* device, const QueryPoolDesc& desc)
     , m_desc(desc)
 {
     m_descHolder.holdString(m_desc.label);
+    m_queryStates.resize(m_desc.count);
+}
+
+Result QueryPool::reset()
+{
+    return reset(0, m_desc.count);
+}
+
+Result QueryPool::reset(uint32_t queryIndex, uint32_t count)
+{
+    if (!isValidQueryRange(queryIndex, count))
+    {
+        return SLANG_E_INVALID_ARG;
+    }
+
+    std::lock_guard<std::mutex> lock(m_queryStateMutex);
+    for (uint32_t i = 0; i < count; ++i)
+    {
+        QueryState& state = m_queryStates[queryIndex + i];
+        state.set(QueryState::Status::Reset, 0);
+    }
+
+    return SLANG_OK;
+}
+
+bool QueryPool::isValidQueryRange(uint32_t queryIndex, uint32_t count) const
+{
+    if (count == 0)
+    {
+        return queryIndex <= m_desc.count;
+    }
+    return queryIndex < m_desc.count && count <= m_desc.count - queryIndex;
+}
+
+void QueryPool::markQueryRangeSubmitted(uint32_t queryIndex, uint32_t count, uint64_t submissionID)
+{
+    if (!isValidQueryRange(queryIndex, count))
+    {
+        return;
+    }
+
+    std::lock_guard<std::mutex> lock(m_queryStateMutex);
+    for (uint32_t i = 0; i < count; ++i)
+    {
+        QueryState& state = m_queryStates[queryIndex + i];
+        state.set(QueryState::Status::Pending, submissionID);
+    }
+}
+
+void QueryPool::markQueryRangeReady(uint32_t queryIndex, uint32_t count, uint64_t completedSubmissionID)
+{
+    if (!isValidQueryRange(queryIndex, count))
+    {
+        return;
+    }
+
+    std::lock_guard<std::mutex> lock(m_queryStateMutex);
+    for (uint32_t i = 0; i < count; ++i)
+    {
+        QueryState& state = m_queryStates[queryIndex + i];
+        QueryState::Status status = state.getStatus();
+        uint64_t submissionID = state.getSubmissionID();
+        if (status == QueryState::Status::Pending && submissionID <= completedSubmissionID)
+        {
+            state.set(QueryState::Status::Resolved, submissionID);
+        }
+    }
+}
+
+QueryPool::QueryRangeInfo QueryPool::getQueryRangeInfo(uint32_t queryIndex, uint32_t count) const
+{
+    SLANG_RHI_ASSERT(isValidQueryRange(queryIndex, count));
+
+    if (count == 0)
+    {
+        return {QueryRangeState::Resolved, 0};
+    }
+
+    QueryRangeInfo info;
+    std::lock_guard<std::mutex> lock(m_queryStateMutex);
+    for (uint32_t i = 0; i < count; ++i)
+    {
+        const QueryState& state = m_queryStates[queryIndex + i];
+        QueryState::Status status = state.getStatus();
+        if (status == QueryState::Status::Reset)
+        {
+            return {};
+        }
+        if (status == QueryState::Status::Pending)
+        {
+            info.state = QueryRangeState::Pending;
+        }
+        info.submissionID = std::max(info.submissionID, state.getSubmissionID());
+    }
+    if (info.state != QueryRangeState::Pending)
+    {
+        info.state = QueryRangeState::Resolved;
+    }
+    return info;
 }
 
 // ----------------------------------------------------------------------------

--- a/src/rhi-shared.h
+++ b/src/rhi-shared.h
@@ -21,6 +21,7 @@
 #include <map>
 #include <set>
 #include <memory>
+#include <mutex>
 #include <string>
 #include <string_view>
 #include <unordered_map>
@@ -250,11 +251,59 @@ public:
     QueryPool(Device* device, const QueryPoolDesc& desc);
 
     virtual SLANG_NO_THROW const QueryPoolDesc& SLANG_MCALL getDesc() override { return m_desc; }
-    virtual SLANG_NO_THROW Result SLANG_MCALL reset() override { return SLANG_OK; }
+    virtual SLANG_NO_THROW Result SLANG_MCALL reset() override;
+    virtual SLANG_NO_THROW Result SLANG_MCALL reset(uint32_t queryIndex, uint32_t count) override;
+
+    enum class QueryRangeState
+    {
+        Reset,
+        Pending,
+        Resolved,
+    };
+
+    struct QueryRangeInfo
+    {
+        QueryRangeState state = QueryRangeState::Reset;
+        uint64_t submissionID = 0;
+    };
+
+    bool isValidQueryRange(uint32_t queryIndex, uint32_t count) const;
+    void markQueryRangeSubmitted(uint32_t queryIndex, uint32_t count, uint64_t submissionID);
+    void markQueryRangeReady(uint32_t queryIndex, uint32_t count, uint64_t completedSubmissionID);
+    QueryRangeInfo getQueryRangeInfo(uint32_t queryIndex, uint32_t count) const;
 
 public:
+    struct QueryState
+    {
+        enum class Status : uint64_t
+        {
+            Reset = 0,
+            Pending = 1,
+            Resolved = 2,
+        };
+
+        static constexpr uint64_t kStatusShift = 62;
+        static constexpr uint64_t kSubmissionIDMask = (uint64_t(1) << kStatusShift) - 1;
+
+        uint64_t state = 0;
+
+        void set(Status status, uint64_t submissionID)
+        {
+            SLANG_RHI_ASSERT((submissionID & ~kSubmissionIDMask) == 0);
+            state = (uint64_t(status) << kStatusShift) | (submissionID & kSubmissionIDMask);
+        }
+
+        Status getStatus() const { return Status(state >> kStatusShift); }
+
+        uint64_t getSubmissionID() const { return state & kSubmissionIDMask; }
+    };
+
+    static_assert(sizeof(QueryState) == 8, "QueryState should remain compact.");
+
     QueryPoolDesc m_desc;
     StructHolder m_descHolder;
+    std::vector<QueryState> m_queryStates;
+    mutable std::mutex m_queryStateMutex;
 };
 
 class ShaderTable : public IShaderTable, public DeviceChild

--- a/src/rhi-shared.h
+++ b/src/rhi-shared.h
@@ -273,27 +273,27 @@ public:
     QueryRangeInfo getQueryRangeInfo(uint32_t queryIndex, uint32_t count) const;
 
 public:
+    enum class QueryStatus : uint64_t
+    {
+        Reset = 0,
+        Pending = 1,
+        Resolved = 2,
+    };
+
     struct QueryState
     {
-        enum class Status : uint64_t
-        {
-            Reset = 0,
-            Pending = 1,
-            Resolved = 2,
-        };
-
         static constexpr uint64_t kStatusShift = 62;
         static constexpr uint64_t kSubmissionIDMask = (uint64_t(1) << kStatusShift) - 1;
 
         uint64_t state = 0;
 
-        void set(Status status, uint64_t submissionID)
+        void set(QueryStatus status, uint64_t submissionID)
         {
             SLANG_RHI_ASSERT((submissionID & ~kSubmissionIDMask) == 0);
             state = (uint64_t(status) << kStatusShift) | (submissionID & kSubmissionIDMask);
         }
 
-        Status getStatus() const { return Status(state >> kStatusShift); }
+        QueryStatus getStatus() const { return QueryStatus(state >> kStatusShift); }
 
         uint64_t getSubmissionID() const { return state & kSubmissionIDMask; }
     };

--- a/src/strings.h
+++ b/src/strings.h
@@ -154,7 +154,6 @@
 // QueryType
 #define S_QueryType_Timestamp "Timestamp"
 #define S_QueryType_AccelerationStructureCompactedSize "AccelerationStructureCompactedSize"
-#define S_QueryType_AccelerationStructureSerializedSize "AccelerationStructureSerializedSize"
 #define S_QueryType_AccelerationStructureCurrentSize "AccelerationStructureCurrentSize"
 
 // CooperativeVectorComponentType

--- a/src/vulkan/vk-command.cpp
+++ b/src/vulkan/vk-command.cpp
@@ -106,8 +106,6 @@ public:
     void cmdBuildAccelerationStructure(const commands::BuildAccelerationStructure& cmd);
     void cmdCopyAccelerationStructure(const commands::CopyAccelerationStructure& cmd);
     void cmdQueryAccelerationStructureProperties(const commands::QueryAccelerationStructureProperties& cmd);
-    void cmdSerializeAccelerationStructure(const commands::SerializeAccelerationStructure& cmd);
-    void cmdDeserializeAccelerationStructure(const commands::DeserializeAccelerationStructure& cmd);
     void cmdExecuteClusterOperation(const commands::ExecuteClusterOperation& cmd);
     void cmdConvertCooperativeVectorMatrix(const commands::ConvertCooperativeVectorMatrix& cmd);
     void cmdSetBufferState(const commands::SetBufferState& cmd);
@@ -1394,42 +1392,6 @@ void CommandRecorder::cmdQueryAccelerationStructureProperties(const commands::Qu
         cmd.queryCount,
         cmd.queryDescs
     );
-}
-
-void CommandRecorder::cmdSerializeAccelerationStructure(const commands::SerializeAccelerationStructure& cmd)
-{
-    BufferImpl* dstBuffer = checked_cast<BufferImpl*>(cmd.dst.buffer);
-    AccelerationStructureImpl* src = checked_cast<AccelerationStructureImpl*>(cmd.src);
-
-    requireBufferState(dstBuffer, ResourceState::UnorderedAccess);
-    requireBufferState(src->m_buffer, ResourceState::AccelerationStructureRead);
-    commitBarriers();
-
-    VkCopyAccelerationStructureToMemoryInfoKHR copyInfo = {
-        VK_STRUCTURE_TYPE_COPY_ACCELERATION_STRUCTURE_TO_MEMORY_INFO_KHR
-    };
-    copyInfo.src = src->m_vkHandle;
-    copyInfo.dst.deviceAddress = cmd.dst.getDeviceAddress();
-    copyInfo.mode = VK_COPY_ACCELERATION_STRUCTURE_MODE_SERIALIZE_KHR;
-    m_api.vkCmdCopyAccelerationStructureToMemoryKHR(m_cmdBuffer, &copyInfo);
-}
-
-void CommandRecorder::cmdDeserializeAccelerationStructure(const commands::DeserializeAccelerationStructure& cmd)
-{
-    AccelerationStructureImpl* dst = checked_cast<AccelerationStructureImpl*>(cmd.dst);
-    BufferImpl* srcBuffer = checked_cast<BufferImpl*>(cmd.src.buffer);
-
-    requireBufferState(dst->m_buffer, ResourceState::AccelerationStructureWrite);
-    requireBufferState(srcBuffer, ResourceState::ShaderResource);
-    commitBarriers();
-
-    VkCopyMemoryToAccelerationStructureInfoKHR copyInfo = {
-        VK_STRUCTURE_TYPE_COPY_MEMORY_TO_ACCELERATION_STRUCTURE_INFO_KHR
-    };
-    copyInfo.src.deviceAddress = cmd.src.getDeviceAddress();
-    copyInfo.dst = dst->m_vkHandle;
-    copyInfo.mode = VK_COPY_ACCELERATION_STRUCTURE_MODE_DESERIALIZE_KHR;
-    m_api.vkCmdCopyMemoryToAccelerationStructureKHR(m_cmdBuffer, &copyInfo);
 }
 
 void CommandRecorder::cmdExecuteClusterOperation(const commands::ExecuteClusterOperation& cmd)

--- a/src/vulkan/vk-command.cpp
+++ b/src/vulkan/vk-command.cpp
@@ -1823,9 +1823,6 @@ void CommandRecorder::queryAccelerationStructureProperties(
         case QueryType::AccelerationStructureCompactedSize:
             queryType = VK_QUERY_TYPE_ACCELERATION_STRUCTURE_COMPACTED_SIZE_KHR;
             break;
-        case QueryType::AccelerationStructureSerializedSize:
-            queryType = VK_QUERY_TYPE_ACCELERATION_STRUCTURE_SERIALIZATION_SIZE_KHR;
-            break;
         case QueryType::AccelerationStructureCurrentSize:
             continue;
         default:
@@ -1836,15 +1833,17 @@ void CommandRecorder::queryAccelerationStructureProperties(
             );
             return;
         }
-        auto queryPool = checked_cast<QueryPoolImpl*>(queryDescs[i].queryPool)->m_pool;
-        m_device->m_api.vkCmdResetQueryPool(m_cmdBuffer, queryPool, (uint32_t)queryDescs[i].firstQueryIndex, 1);
+        auto queryPoolImpl = checked_cast<QueryPoolImpl*>(queryDescs[i].queryPool);
+        auto queryPool = queryPoolImpl->m_pool;
+        uint32_t queryIndex = (uint32_t)queryDescs[i].firstQueryIndex;
+        m_device->m_api.vkCmdResetQueryPool(m_cmdBuffer, queryPool, queryIndex, accelerationStructureCount);
         m_device->m_api.vkCmdWriteAccelerationStructuresPropertiesKHR(
             m_cmdBuffer,
             accelerationStructureCount,
             vkHandles.data(),
             queryType,
             queryPool,
-            queryDescs[i].firstQueryIndex
+            queryIndex
         );
     }
 }
@@ -1991,6 +1990,11 @@ Result CommandQueueImpl::submit(const SubmitDesc& desc)
     {
         CommandBufferImpl* commandBuffer = checked_cast<CommandBufferImpl*>(desc.commandBuffers[i]);
         commandBuffer->m_submissionID = m_lastSubmittedID;
+        for (const auto& queryWrite : commandBuffer->m_commandList.getQueryWrites())
+        {
+            checked_cast<QueryPool*>(queryWrite.queryPool)
+                ->markQueryRangeSubmitted(queryWrite.index, queryWrite.count, m_lastSubmittedID);
+        }
         m_commandBuffersInFlight.push_back(commandBuffer);
         vkCommandBuffers.push_back(commandBuffer->m_commandBuffer);
     }

--- a/src/vulkan/vk-query.cpp
+++ b/src/vulkan/vk-query.cpp
@@ -56,6 +56,16 @@ Result QueryPoolImpl::isResultReady(uint32_t queryIndex, uint32_t count, bool* o
     }
 
     *outReady = false;
+    if (count == 0)
+    {
+        *outReady = true;
+        return SLANG_OK;
+    }
+    if (m_pool == VK_NULL_HANDLE)
+    {
+        return SLANG_E_NOT_AVAILABLE;
+    }
+
     QueryRangeInfo queryInfo = getQueryRangeInfo(queryIndex, count);
     if (queryInfo.state == QueryRangeState::Reset)
     {
@@ -98,14 +108,19 @@ Result QueryPoolImpl::getResult(uint32_t queryIndex, uint32_t count, uint64_t* o
         return SLANG_E_INVALID_ARG;
     }
 
+    if (count == 0)
+    {
+        return SLANG_OK;
+    }
+    if (m_pool == VK_NULL_HANDLE)
+    {
+        return SLANG_E_NOT_AVAILABLE;
+    }
+
     QueryRangeInfo queryInfo = getQueryRangeInfo(queryIndex, count);
     if (queryInfo.state == QueryRangeState::Reset)
     {
         return SLANG_FAIL;
-    }
-    if (count == 0)
-    {
-        return SLANG_OK;
     }
 
     DeviceImpl* device = getDevice<DeviceImpl>();

--- a/src/vulkan/vk-query.cpp
+++ b/src/vulkan/vk-query.cpp
@@ -20,9 +20,6 @@ Result QueryPoolImpl::init()
     case QueryType::AccelerationStructureCompactedSize:
         createInfo.queryType = VK_QUERY_TYPE_ACCELERATION_STRUCTURE_COMPACTED_SIZE_KHR;
         break;
-    case QueryType::AccelerationStructureSerializedSize:
-        createInfo.queryType = VK_QUERY_TYPE_ACCELERATION_STRUCTURE_SERIALIZATION_SIZE_KHR;
-        break;
     case QueryType::AccelerationStructureCurrentSize:
         // Vulkan does not support CurrentSize query, will not create actual pools here.
         return SLANG_OK;
@@ -45,18 +42,73 @@ QueryPoolImpl::~QueryPoolImpl()
 {
     DeviceImpl* device = getDevice<DeviceImpl>();
 
-    device->m_api.vkDestroyQueryPool(device->m_api.m_device, m_pool, nullptr);
+    if (m_pool != VK_NULL_HANDLE)
+    {
+        device->m_api.vkDestroyQueryPool(device->m_api.m_device, m_pool, nullptr);
+    }
+}
+
+Result QueryPoolImpl::isResultReady(uint32_t queryIndex, uint32_t count, bool* outReady)
+{
+    if (!outReady || !isValidQueryRange(queryIndex, count))
+    {
+        return SLANG_E_INVALID_ARG;
+    }
+
+    *outReady = false;
+    QueryRangeInfo queryInfo = getQueryRangeInfo(queryIndex, count);
+    if (queryInfo.state == QueryRangeState::Reset)
+    {
+        return SLANG_FAIL;
+    }
+    if (queryInfo.state == QueryRangeState::Resolved)
+    {
+        *outReady = true;
+        return SLANG_OK;
+    }
+
+    DeviceImpl* device = getDevice<DeviceImpl>();
+    std::vector<uint64_t> data(count);
+    VkResult result = device->m_api.vkGetQueryPoolResults(
+        device->m_api.m_device,
+        m_pool,
+        queryIndex,
+        count,
+        sizeof(uint64_t) * count,
+        data.data(),
+        sizeof(uint64_t),
+        VK_QUERY_RESULT_64_BIT
+    );
+    if (result == VK_NOT_READY)
+    {
+        return SLANG_OK;
+    }
+    SLANG_VK_RETURN_ON_FAIL(result);
+
+    markQueryRangeReady(queryIndex, count, queryInfo.submissionID);
+    *outReady = true;
+
+    return SLANG_OK;
 }
 
 Result QueryPoolImpl::getResult(uint32_t queryIndex, uint32_t count, uint64_t* outData)
 {
+    if (!outData || !isValidQueryRange(queryIndex, count))
+    {
+        return SLANG_E_INVALID_ARG;
+    }
+
+    QueryRangeInfo queryInfo = getQueryRangeInfo(queryIndex, count);
+    if (queryInfo.state == QueryRangeState::Reset)
+    {
+        return SLANG_FAIL;
+    }
     if (count == 0)
     {
         return SLANG_OK;
     }
 
     DeviceImpl* device = getDevice<DeviceImpl>();
-
     SLANG_VK_RETURN_ON_FAIL(device->m_api.vkGetQueryPoolResults(
         device->m_api.m_device,
         m_pool,
@@ -67,6 +119,9 @@ Result QueryPoolImpl::getResult(uint32_t queryIndex, uint32_t count, uint64_t* o
         sizeof(uint64_t),
         VK_QUERY_RESULT_64_BIT | VK_QUERY_RESULT_WAIT_BIT
     ));
+
+    markQueryRangeReady(queryIndex, count, queryInfo.submissionID);
+
     return SLANG_OK;
 }
 

--- a/src/vulkan/vk-query.h
+++ b/src/vulkan/vk-query.h
@@ -14,6 +14,11 @@ public:
 
     Result init();
 
+    virtual SLANG_NO_THROW Result SLANG_MCALL isResultReady(
+        uint32_t queryIndex,
+        uint32_t count,
+        bool* outReady
+    ) override;
     virtual SLANG_NO_THROW Result SLANG_MCALL getResult(
         uint32_t queryIndex,
         uint32_t count,

--- a/src/wgpu/wgpu-command.cpp
+++ b/src/wgpu/wgpu-command.cpp
@@ -80,8 +80,6 @@ public:
     void cmdBuildAccelerationStructure(const commands::BuildAccelerationStructure& cmd);
     void cmdCopyAccelerationStructure(const commands::CopyAccelerationStructure& cmd);
     void cmdQueryAccelerationStructureProperties(const commands::QueryAccelerationStructureProperties& cmd);
-    void cmdSerializeAccelerationStructure(const commands::SerializeAccelerationStructure& cmd);
-    void cmdDeserializeAccelerationStructure(const commands::DeserializeAccelerationStructure& cmd);
     void cmdExecuteClusterOperation(const commands::ExecuteClusterOperation& cmd);
     void cmdConvertCooperativeVectorMatrix(const commands::ConvertCooperativeVectorMatrix& cmd);
     void cmdSetBufferState(const commands::SetBufferState& cmd);
@@ -766,18 +764,6 @@ void CommandRecorder::cmdQueryAccelerationStructureProperties(const commands::Qu
 {
     SLANG_UNUSED(cmd);
     NOT_SUPPORTED(ICommandEncoder, queryAccelerationStructureProperties);
-}
-
-void CommandRecorder::cmdSerializeAccelerationStructure(const commands::SerializeAccelerationStructure& cmd)
-{
-    SLANG_UNUSED(cmd);
-    NOT_SUPPORTED(ICommandEncoder, serializeAccelerationStructure);
-}
-
-void CommandRecorder::cmdDeserializeAccelerationStructure(const commands::DeserializeAccelerationStructure& cmd)
-{
-    SLANG_UNUSED(cmd);
-    NOT_SUPPORTED(ICommandEncoder, deserializeAccelerationStructure);
 }
 
 void CommandRecorder::cmdExecuteClusterOperation(const commands::ExecuteClusterOperation& cmd)

--- a/src/wgpu/wgpu-query.cpp
+++ b/src/wgpu/wgpu-query.cpp
@@ -16,6 +16,11 @@ QueryPoolImpl::~QueryPoolImpl()
     }
 }
 
+Result QueryPoolImpl::isResultReady(uint32_t queryIndex, uint32_t count, bool* outReady)
+{
+    return SLANG_E_NOT_IMPLEMENTED;
+}
+
 Result QueryPoolImpl::getResult(uint32_t queryIndex, uint32_t count, uint64_t* outData)
 {
     return SLANG_E_NOT_IMPLEMENTED;

--- a/src/wgpu/wgpu-query.h
+++ b/src/wgpu/wgpu-query.h
@@ -13,6 +13,11 @@ public:
     ~QueryPoolImpl();
 
     // IQueryPool implementation
+    virtual SLANG_NO_THROW Result SLANG_MCALL isResultReady(
+        uint32_t queryIndex,
+        uint32_t count,
+        bool* outReady
+    ) override;
     virtual SLANG_NO_THROW Result SLANG_MCALL getResult(
         uint32_t queryIndex,
         uint32_t count,

--- a/tests/test-cmd-query.cpp
+++ b/tests/test-cmd-query.cpp
@@ -1,9 +1,134 @@
 #include "testing.h"
 
 #include <chrono>
+#include <initializer_list>
 
 using namespace rhi;
 using namespace rhi::testing;
+
+static ComPtr<IQueryPool> createTimestampQueryPool(IDevice* device, uint32_t count)
+{
+    QueryPoolDesc queryPoolDesc = {};
+    queryPoolDesc.type = QueryType::Timestamp;
+    queryPoolDesc.count = count;
+
+    ComPtr<IQueryPool> queryPool;
+    REQUIRE_CALL(device->createQueryPool(queryPoolDesc, queryPool.writeRef()));
+    return queryPool;
+}
+
+static ComPtr<ICommandBuffer> createTimestampCommandBuffer(
+    ICommandQueue* queue,
+    IQueryPool* queryPool,
+    std::initializer_list<uint32_t> queryIndices
+)
+{
+    auto commandEncoder = queue->createCommandEncoder();
+    for (uint32_t queryIndex : queryIndices)
+    {
+        commandEncoder->writeTimestamp(queryPool, queryIndex);
+    }
+    return commandEncoder->finish();
+}
+
+static void checkQueryResultReady(IQueryPool* queryPool, uint32_t queryIndex, uint32_t count)
+{
+    bool ready = false;
+    REQUIRE_CALL(queryPool->isResultReady(queryIndex, count, &ready));
+    CHECK(ready);
+}
+
+static void checkQueryResultUnavailable(IQueryPool* queryPool, uint32_t queryIndex, uint32_t count)
+{
+    bool ready = true;
+    CHECK(queryPool->isResultReady(queryIndex, count, &ready) == SLANG_FAIL);
+}
+
+struct AccelerationStructureQueryBuild
+{
+    ComPtr<IQueryPool> queryPool;
+    ComPtr<ICommandBuffer> commandBuffer;
+};
+
+static AccelerationStructureQueryBuild createAccelerationStructureCompactionQueryBuild(
+    IDevice* device,
+    ICommandQueue* queue
+)
+{
+    struct Vertex
+    {
+        float position[3];
+    };
+
+    const Vertex vertices[] = {
+        {{0.0f, 0.0f, 0.0f}},
+        {{1.0f, 0.0f, 0.0f}},
+        {{0.0f, 1.0f, 0.0f}},
+    };
+    const uint32_t indices[] = {0, 1, 2};
+
+    BufferDesc vertexBufferDesc = {};
+    vertexBufferDesc.size = sizeof(vertices);
+    vertexBufferDesc.usage = BufferUsage::AccelerationStructureBuildInput;
+    vertexBufferDesc.defaultState = ResourceState::AccelerationStructureBuildInput;
+    ComPtr<IBuffer> vertexBuffer = device->createBuffer(vertexBufferDesc, vertices);
+    REQUIRE(vertexBuffer != nullptr);
+
+    BufferDesc indexBufferDesc = {};
+    indexBufferDesc.size = sizeof(indices);
+    indexBufferDesc.usage = BufferUsage::AccelerationStructureBuildInput;
+    indexBufferDesc.defaultState = ResourceState::AccelerationStructureBuildInput;
+    ComPtr<IBuffer> indexBuffer = device->createBuffer(indexBufferDesc, indices);
+    REQUIRE(indexBuffer != nullptr);
+
+    AccelerationStructureBuildInput buildInput = {};
+    buildInput.type = AccelerationStructureBuildInputType::Triangles;
+    buildInput.triangles.vertexBuffers[0] = vertexBuffer;
+    buildInput.triangles.vertexBufferCount = 1;
+    buildInput.triangles.vertexFormat = Format::RGB32Float;
+    buildInput.triangles.vertexCount = SLANG_COUNT_OF(vertices);
+    buildInput.triangles.vertexStride = sizeof(Vertex);
+    buildInput.triangles.indexBuffer = indexBuffer;
+    buildInput.triangles.indexFormat = IndexFormat::Uint32;
+    buildInput.triangles.indexCount = SLANG_COUNT_OF(indices);
+    buildInput.triangles.flags = AccelerationStructureGeometryFlags::Opaque;
+
+    AccelerationStructureBuildDesc buildDesc = {};
+    buildDesc.inputs = &buildInput;
+    buildDesc.inputCount = 1;
+    buildDesc.flags = AccelerationStructureBuildFlags::AllowCompaction;
+
+    AccelerationStructureSizes sizes = {};
+    REQUIRE_CALL(device->getAccelerationStructureSizes(buildDesc, &sizes));
+
+    BufferDesc scratchBufferDesc = {};
+    scratchBufferDesc.usage = BufferUsage::UnorderedAccess;
+    scratchBufferDesc.defaultState = ResourceState::UnorderedAccess;
+    scratchBufferDesc.size = sizes.scratchSize;
+    ComPtr<IBuffer> scratchBuffer = device->createBuffer(scratchBufferDesc);
+    REQUIRE(scratchBuffer != nullptr);
+
+    AccelerationStructureDesc draftDesc = {};
+    draftDesc.kind = AccelerationStructureKind::BottomLevel;
+    draftDesc.size = sizes.accelerationStructureSize;
+    ComPtr<IAccelerationStructure> draftAS;
+    REQUIRE_CALL(device->createAccelerationStructure(draftDesc, draftAS.writeRef()));
+
+    QueryPoolDesc queryPoolDesc = {};
+    queryPoolDesc.type = QueryType::AccelerationStructureCompactedSize;
+    queryPoolDesc.count = 1;
+    ComPtr<IQueryPool> queryPool;
+    REQUIRE_CALL(device->createQueryPool(queryPoolDesc, queryPool.writeRef()));
+
+    AccelerationStructureQueryDesc queryDesc = {};
+    queryDesc.queryType = QueryType::AccelerationStructureCompactedSize;
+    queryDesc.queryPool = queryPool;
+
+    auto commandEncoder = queue->createCommandEncoder();
+    commandEncoder->buildAccelerationStructure(buildDesc, draftAS, nullptr, scratchBuffer, 1, &queryDesc);
+
+    return {queryPool, commandEncoder->finish()};
+}
 
 GPU_TEST_CASE("cmd-query-resolve-host", ALL)
 {
@@ -15,11 +140,8 @@ GPU_TEST_CASE("cmd-query-resolve-host", ALL)
     uint64_t timestampFrequency = device->getInfo().timestampFrequency;
     CHECK(timestampFrequency > 0);
 
-    QueryPoolDesc queryPoolDesc;
-    queryPoolDesc.type = QueryType::Timestamp;
-    queryPoolDesc.count = 16;
-    ComPtr<IQueryPool> queryPool;
-    REQUIRE_CALL(device->createQueryPool(queryPoolDesc, queryPool.writeRef()));
+    const uint32_t queryCount = 16;
+    auto queryPool = createTimestampQueryPool(device, queryCount);
 
     const uint32_t N = 16;
     std::vector<uint64_t> results(N * 2);
@@ -28,20 +150,15 @@ GPU_TEST_CASE("cmd-query-resolve-host", ALL)
 
     for (uint32_t i = 0; i < N; ++i)
     {
-        uint32_t queryIndex = (i % (queryPoolDesc.count - 2));
+        uint32_t queryIndex = (i % (queryCount - 2));
         {
             auto queue = device->getQueue(QueueType::Graphics);
-            auto commandEncoder = queue->createCommandEncoder();
-
-            commandEncoder->writeTimestamp(queryPool, queryIndex);
-            commandEncoder->writeTimestamp(queryPool, queryIndex + 1);
-
-            queue->submit(commandEncoder->finish());
-            queue->waitOnHost();
+            REQUIRE_CALL(queue->submit(createTimestampCommandBuffer(queue, queryPool, {queryIndex, queryIndex + 1})));
+            REQUIRE_CALL(queue->waitOnHost());
         }
 
-        queryPool->getResult(queryIndex, 2, &results[i * 2]);
-        queryPool->reset();
+        REQUIRE_CALL(queryPool->getResult(queryIndex, 2, &results[i * 2]));
+        REQUIRE_CALL(queryPool->reset());
     }
 
     std::chrono::high_resolution_clock::time_point end = std::chrono::high_resolution_clock::now();
@@ -66,6 +183,293 @@ GPU_TEST_CASE("cmd-query-resolve-host", ALL)
     // printf("Duration CPU: %.3f ms, GPU: %.3f\n", durationCPU * 1000.0, durationGPU * 1000.0);
 }
 
+GPU_TEST_CASE("cmd-query-zero-count-range", ALL)
+{
+    if (!device->hasFeature(Feature::TimestampQuery))
+    {
+        SKIP("Timestamp queries not supported");
+    }
+
+    auto queryPool = createTimestampQueryPool(device, 1);
+
+    checkQueryResultReady(queryPool, 0, 0);
+    checkQueryResultReady(queryPool, 1, 0);
+    uint64_t emptyResult = 0;
+    CHECK(queryPool->getResult(0, 0, &emptyResult) == SLANG_OK);
+    CHECK(queryPool->getResult(1, 0, &emptyResult) == SLANG_OK);
+    CHECK(queryPool->reset(0, 0) == SLANG_OK);
+    CHECK(queryPool->reset(1, 0) == SLANG_OK);
+}
+
+GPU_TEST_CASE("cmd-query-result-readiness", ALL)
+{
+    if (!device->hasFeature(Feature::TimestampQuery))
+    {
+        SKIP("Timestamp queries not supported");
+    }
+
+    auto queryPool = createTimestampQueryPool(device, 1);
+    auto queue = device->getQueue(QueueType::Graphics);
+
+    checkQueryResultUnavailable(queryPool, 0, 1);
+
+    auto commandBuffer = createTimestampCommandBuffer(queue, queryPool, {0});
+    checkQueryResultUnavailable(queryPool, 0, 1);
+
+    REQUIRE_CALL(queryPool->reset());
+    checkQueryResultUnavailable(queryPool, 0, 1);
+
+    REQUIRE_CALL(queue->submit(commandBuffer));
+
+    bool ready = true;
+    REQUIRE_CALL(queryPool->isResultReady(0, 1, &ready));
+
+    REQUIRE_CALL(queue->waitOnHost());
+    checkQueryResultReady(queryPool, 0, 1);
+
+    uint64_t timestamp = 0;
+    REQUIRE_CALL(queryPool->getResult(0, 1, &timestamp));
+    REQUIRE_CALL(queryPool->reset());
+    checkQueryResultUnavailable(queryPool, 0, 1);
+}
+
+GPU_TEST_CASE("cmd-query-partial-range-readiness", ALL)
+{
+    if (!device->hasFeature(Feature::TimestampQuery))
+    {
+        SKIP("Timestamp queries not supported");
+    }
+
+    auto queryPool = createTimestampQueryPool(device, 2);
+    auto queue = device->getQueue(QueueType::Graphics);
+
+    REQUIRE_CALL(queue->submit(createTimestampCommandBuffer(queue, queryPool, {0})));
+    REQUIRE_CALL(queue->waitOnHost());
+
+    uint64_t timestamp = 0;
+    checkQueryResultReady(queryPool, 0, 1);
+    REQUIRE_CALL(queryPool->getResult(0, 1, &timestamp));
+
+    checkQueryResultUnavailable(queryPool, 1, 1);
+    checkQueryResultUnavailable(queryPool, 0, 2);
+    CHECK(queryPool->getResult(0, 2, &timestamp) == SLANG_FAIL);
+}
+
+GPU_TEST_CASE("cmd-query-ready-result-ranges", ALL)
+{
+    if (!device->hasFeature(Feature::TimestampQuery))
+    {
+        SKIP("Timestamp queries not supported");
+    }
+
+    auto queryPool = createTimestampQueryPool(device, 3);
+    auto queue = device->getQueue(QueueType::Graphics);
+
+    REQUIRE_CALL(queue->submit(createTimestampCommandBuffer(queue, queryPool, {0, 1, 2})));
+    REQUIRE_CALL(queue->waitOnHost());
+
+    uint64_t timestamps[3] = {};
+    checkQueryResultReady(queryPool, 0, 3);
+    checkQueryResultReady(queryPool, 1, 1);
+    checkQueryResultReady(queryPool, 1, 2);
+    REQUIRE_CALL(queryPool->getResult(0, 3, timestamps));
+
+    CHECK(timestamps[1] >= timestamps[0]);
+    CHECK(timestamps[2] >= timestamps[1]);
+}
+
+GPU_TEST_CASE("cmd-query-reuse-slot-without-reset", ALL)
+{
+    if (!device->hasFeature(Feature::TimestampQuery))
+    {
+        SKIP("Timestamp queries not supported");
+    }
+
+    auto queryPool = createTimestampQueryPool(device, 1);
+    auto queue = device->getQueue(QueueType::Graphics);
+
+    REQUIRE_CALL(queue->submit(createTimestampCommandBuffer(queue, queryPool, {0})));
+    REQUIRE_CALL(queue->waitOnHost());
+
+    uint64_t firstTimestamp = 0;
+    checkQueryResultReady(queryPool, 0, 1);
+    REQUIRE_CALL(queryPool->getResult(0, 1, &firstTimestamp));
+
+    REQUIRE_CALL(queue->submit(createTimestampCommandBuffer(queue, queryPool, {0})));
+    REQUIRE_CALL(queue->waitOnHost());
+
+    uint64_t secondTimestamp = 0;
+    checkQueryResultReady(queryPool, 0, 1);
+    REQUIRE_CALL(queryPool->getResult(0, 1, &secondTimestamp));
+    CHECK(secondTimestamp >= firstTimestamp);
+}
+
+GPU_TEST_CASE("cmd-query-reset-invalidates-ready-result", ALL)
+{
+    if (!device->hasFeature(Feature::TimestampQuery))
+    {
+        SKIP("Timestamp queries not supported");
+    }
+
+    auto queryPool = createTimestampQueryPool(device, 1);
+    auto queue = device->getQueue(QueueType::Graphics);
+
+    REQUIRE_CALL(queue->submit(createTimestampCommandBuffer(queue, queryPool, {0})));
+    REQUIRE_CALL(queue->waitOnHost());
+
+    uint64_t timestamp = 0;
+    checkQueryResultReady(queryPool, 0, 1);
+    REQUIRE_CALL(queryPool->getResult(0, 1, &timestamp));
+
+    REQUIRE_CALL(queryPool->reset());
+    checkQueryResultUnavailable(queryPool, 0, 1);
+    CHECK(queryPool->getResult(0, 1, &timestamp) == SLANG_FAIL);
+}
+
+GPU_TEST_CASE("cmd-query-reset-range", ALL)
+{
+    if (!device->hasFeature(Feature::TimestampQuery))
+    {
+        SKIP("Timestamp queries not supported");
+    }
+
+    auto queryPool = createTimestampQueryPool(device, 3);
+    auto queue = device->getQueue(QueueType::Graphics);
+
+    REQUIRE_CALL(queue->submit(createTimestampCommandBuffer(queue, queryPool, {0, 1, 2})));
+    REQUIRE_CALL(queue->waitOnHost());
+    checkQueryResultReady(queryPool, 0, 3);
+
+    REQUIRE_CALL(queryPool->reset(1, 1));
+    checkQueryResultReady(queryPool, 0, 1);
+    checkQueryResultUnavailable(queryPool, 1, 1);
+    checkQueryResultReady(queryPool, 2, 1);
+    checkQueryResultUnavailable(queryPool, 0, 3);
+
+    uint64_t timestamp = 0;
+    REQUIRE_CALL(queryPool->getResult(0, 1, &timestamp));
+    REQUIRE_CALL(queryPool->getResult(2, 1, &timestamp));
+    CHECK(queryPool->getResult(1, 1, &timestamp) == SLANG_FAIL);
+
+    REQUIRE_CALL(queue->submit(createTimestampCommandBuffer(queue, queryPool, {1})));
+    REQUIRE_CALL(queue->waitOnHost());
+    checkQueryResultReady(queryPool, 0, 3);
+
+    uint64_t timestamps[3] = {};
+    REQUIRE_CALL(queryPool->getResult(0, 3, timestamps));
+}
+
+GPU_TEST_CASE("cmd-query-get-result-without-wait", ALL)
+{
+    if (!device->hasFeature(Feature::TimestampQuery))
+    {
+        SKIP("Timestamp queries not supported");
+    }
+
+    auto queryPool = createTimestampQueryPool(device, 1);
+    auto queue = device->getQueue(QueueType::Graphics);
+
+    REQUIRE_CALL(queue->submit(createTimestampCommandBuffer(queue, queryPool, {0})));
+
+    uint64_t timestamp = 0;
+    REQUIRE_CALL(queryPool->getResult(0, 1, &timestamp));
+    checkQueryResultReady(queryPool, 0, 1);
+}
+
+GPU_TEST_CASE("cmd-query-acceleration-structure-get-result-without-wait", D3D12 | Vulkan | CUDA)
+{
+    if (!device->hasFeature(Feature::AccelerationStructure))
+    {
+        SKIP("Acceleration structures not supported");
+    }
+
+    auto queue = device->getQueue(QueueType::Graphics);
+    auto build = createAccelerationStructureCompactionQueryBuild(device, queue);
+
+    checkQueryResultUnavailable(build.queryPool, 0, 1);
+    REQUIRE_CALL(queue->submit(build.commandBuffer));
+
+    uint64_t compactedSize = 0;
+    REQUIRE_CALL(build.queryPool->getResult(0, 1, &compactedSize));
+    CHECK(compactedSize > 0);
+    checkQueryResultReady(build.queryPool, 0, 1);
+
+    REQUIRE_CALL(build.queryPool->reset(0, 1));
+    checkQueryResultUnavailable(build.queryPool, 0, 1);
+}
+
+GPU_TEST_CASE("cmd-query-range-across-command-buffers", ALL)
+{
+    if (!device->hasFeature(Feature::TimestampQuery))
+    {
+        SKIP("Timestamp queries not supported");
+    }
+
+    auto queryPool = createTimestampQueryPool(device, 2);
+    auto queue = device->getQueue(QueueType::Graphics);
+
+    ComPtr<ICommandBuffer> commandBuffers[2] = {
+        createTimestampCommandBuffer(queue, queryPool, {0}),
+        createTimestampCommandBuffer(queue, queryPool, {1}),
+    };
+    ICommandBuffer* commandBufferPtrs[2] = {commandBuffers[0], commandBuffers[1]};
+
+    SubmitDesc submitDesc = {};
+    submitDesc.commandBufferCount = 2;
+    submitDesc.commandBuffers = commandBufferPtrs;
+    REQUIRE_CALL(queue->submit(submitDesc));
+    REQUIRE_CALL(queue->waitOnHost());
+
+    uint64_t timestamps[2] = {};
+    checkQueryResultReady(queryPool, 0, 2);
+    REQUIRE_CALL(queryPool->getResult(0, 2, timestamps));
+    CHECK(timestamps[1] >= timestamps[0]);
+}
+
+GPU_TEST_CASE("cmd-query-range-across-submissions", ALL)
+{
+    if (!device->hasFeature(Feature::TimestampQuery))
+    {
+        SKIP("Timestamp queries not supported");
+    }
+
+    auto queryPool = createTimestampQueryPool(device, 2);
+    auto queue = device->getQueue(QueueType::Graphics);
+
+    REQUIRE_CALL(queue->submit(createTimestampCommandBuffer(queue, queryPool, {0})));
+    REQUIRE_CALL(queue->waitOnHost());
+    checkQueryResultReady(queryPool, 0, 1);
+    checkQueryResultUnavailable(queryPool, 0, 2);
+
+    REQUIRE_CALL(queue->submit(createTimestampCommandBuffer(queue, queryPool, {1})));
+    REQUIRE_CALL(queue->waitOnHost());
+
+    uint64_t timestamps[2] = {};
+    checkQueryResultReady(queryPool, 0, 2);
+    REQUIRE_CALL(queryPool->getResult(0, 2, timestamps));
+    CHECK(timestamps[1] >= timestamps[0]);
+}
+
+GPU_TEST_CASE("cmd-query-d3d12-get-result-requires-submission", D3D12)
+{
+    if (!device->hasFeature(Feature::TimestampQuery))
+    {
+        SKIP("Timestamp queries not supported");
+    }
+
+    auto queryPool = createTimestampQueryPool(device, 1);
+    auto queue = device->getQueue(QueueType::Graphics);
+    auto commandBuffer = createTimestampCommandBuffer(queue, queryPool, {0});
+
+    uint64_t timestamp = 0;
+    checkQueryResultUnavailable(queryPool, 0, 1);
+    CHECK(queryPool->getResult(0, 1, &timestamp) == SLANG_FAIL);
+
+    REQUIRE_CALL(queue->submit(commandBuffer));
+    REQUIRE_CALL(queue->waitOnHost());
+    REQUIRE_CALL(queryPool->getResult(0, 1, &timestamp));
+}
+
 GPU_TEST_CASE("cmd-query-resolve-device", ALL & ~(D3D11 | CPU | CUDA))
 {
     if (!device->hasFeature(Feature::TimestampQuery))
@@ -76,11 +480,8 @@ GPU_TEST_CASE("cmd-query-resolve-device", ALL & ~(D3D11 | CPU | CUDA))
     uint64_t timestampFrequency = device->getInfo().timestampFrequency;
     CHECK(timestampFrequency > 0);
 
-    QueryPoolDesc queryPoolDesc = {};
-    queryPoolDesc.type = QueryType::Timestamp;
-    queryPoolDesc.count = 16;
-    ComPtr<IQueryPool> queryPool;
-    REQUIRE_CALL(device->createQueryPool(queryPoolDesc, queryPool.writeRef()));
+    const uint32_t queryCount = 16;
+    auto queryPool = createTimestampQueryPool(device, queryCount);
 
     const uint32_t N = 16;
     std::vector<uint64_t> results(N * 2);
@@ -95,7 +496,7 @@ GPU_TEST_CASE("cmd-query-resolve-device", ALL & ~(D3D11 | CPU | CUDA))
 
     for (uint32_t i = 0; i < N; ++i)
     {
-        uint32_t queryIndex = (i % (queryPoolDesc.count - 2));
+        uint32_t queryIndex = (i % (queryCount - 2));
         {
             auto queue = device->getQueue(QueueType::Graphics);
             auto commandEncoder = queue->createCommandEncoder();
@@ -104,11 +505,11 @@ GPU_TEST_CASE("cmd-query-resolve-device", ALL & ~(D3D11 | CPU | CUDA))
             commandEncoder->writeTimestamp(queryPool, queryIndex + 1);
             commandEncoder->resolveQuery(queryPool, queryIndex, 2, resultBuffer, i * 2 * sizeof(uint64_t));
 
-            queue->submit(commandEncoder->finish());
-            queue->waitOnHost();
+            REQUIRE_CALL(queue->submit(commandEncoder->finish()));
+            REQUIRE_CALL(queue->waitOnHost());
         }
 
-        queryPool->reset();
+        REQUIRE_CALL(queryPool->reset());
     }
 
     std::chrono::high_resolution_clock::time_point end = std::chrono::high_resolution_clock::now();


### PR DESCRIPTION
- Refactor query pools to track reset, pending, and resolved query ranges across submissions.
- Add `IQueryPool::isResultReady()` and range-based `reset(queryIndex, count)`.
- Update CPU, CUDA, D3D11, D3D12, and Vulkan query handling for consistent host-read behavior.
- Expand query tests for readiness, range resets, reuse, partial ranges, and blocking `getResult()`.
- Remove acceleration-structure serialize/deserialize APIs and serialized-size query support.