### PR TITLE
Improve diagnostics

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -754,6 +754,7 @@ target_sources(slang-rhi PRIVATE
     src/staging-heap.cpp
     src/core/assert.cpp
     src/core/blob.cpp
+    src/core/diagnostics.cpp
     src/core/offset-allocator.cpp
     src/core/platform.cpp
     src/core/sha1.cpp

--- a/docs/error-handling.md
+++ b/docs/error-handling.md
@@ -145,13 +145,13 @@ The shared helper records the failing call expression, native result value, nati
 The backend-specific wrappers add native result names and details:
 
 - D3D11/D3D12 use `reportD3DError()`, `getHRESULTName()`, and `SLANG_D3D_RETURN_ON_FAIL_REPORT()`.
-- Vulkan uses `reportVulkanError()`, `getVkResultName()`, `SLANG_VK_RETURN_ON_FAIL_REPORT()`, and `SLANG_VK_CHECK_REPORT()`. `VK_ERROR_DEVICE_LOST` also gives Aftermath a chance to write a crash dump when Aftermath is enabled.
+- Vulkan uses `reportVulkanError()`, `getVkResultName()`, `SLANG_VK_RETURN_ON_FAIL_REPORT()`, and `SLANG_VK_ASSERT_ON_FAIL()`. `VK_ERROR_DEVICE_LOST` also gives Aftermath a chance to write a crash dump when Aftermath is enabled.
 - CUDA uses `reportCUDAError()` and `SLANG_CUDA_RETURN_ON_FAIL_REPORT()`, including `cuGetErrorName()` and `cuGetErrorString()` detail text.
 - OptiX uses `reportOptixError()` and `SLANG_OPTIX_RETURN_ON_FAIL_REPORT()`, including OptiX error names and strings.
 - WGPU reports device-lost, uncaptured-error, and callback-specific errors directly through the device callback.
 - Metal reports Objective-C and Metal API errors directly through the device callback.
 
-The `_REPORT` macros should be used whenever a diagnostic callback can be reached from the current object. They route diagnostics to the application's callback. Plain `RETURN_ON_FAIL` variants deliberately do not report; use them for backend probing, pre-device setup, or paths where another layer will emit the diagnostic.
+The `_REPORT` macros should be used whenever a diagnostic is useful. Pass the backend's supported device object when available to route diagnostics to the application's callback; pass `nullptr` to write the diagnostic to `stderr`. Plain `RETURN_ON_FAIL` variants deliberately do not report; use them for backend probing or paths where another layer will emit the diagnostic.
 
 ## Internal guidelines
 

--- a/docs/error-handling.md
+++ b/docs/error-handling.md
@@ -151,7 +151,7 @@ The backend-specific wrappers add native result names and details:
 - WGPU reports device-lost, uncaptured-error, and callback-specific errors directly through the device callback.
 - Metal reports Objective-C and Metal API errors directly through the device callback.
 
-The `_REPORT` macros should be used whenever a diagnostic callback can be reached from the current object. They route diagnostics to the application's callback. Non-reporting variants are only appropriate during backend probing or before a device exists.
+The `_REPORT` macros should be used whenever a diagnostic callback can be reached from the current object. They route diagnostics to the application's callback. Plain `RETURN_ON_FAIL` variants deliberately do not report; use them for backend probing, pre-device setup, or paths where another layer will emit the diagnostic.
 
 ## Internal guidelines
 

--- a/docs/error-handling.md
+++ b/docs/error-handling.md
@@ -1,0 +1,170 @@
+# Error handling and diagnostics
+
+Slang RHI reports errors through two related mechanisms:
+
+- API calls return `rhi::Result`, which is a typedef of `SlangResult`.
+- Diagnostic text is delivered out of band through `IDebugCallback` and, for some shader APIs, `ISlangBlob` outputs.
+
+For APIs that return `Result`, treat it as the authoritative success or failure signal. Treat diagnostics as explanatory context that helps a user or developer understand why the result was returned.
+
+## Client API perspective
+
+Most public interfaces in `include/slang-rhi.h` that can fail synchronously return `rhi::Result`. Always check returned results with `SLANG_SUCCEEDED(result)` or `SLANG_FAILED(result)`.
+
+Common result values include, but are not limited to:
+
+- `SLANG_OK`: the operation succeeded.
+- `SLANG_FAIL`: a generic failure, often from a backend or native API call.
+- `SLANG_E_INVALID_ARG`: an invalid pointer, descriptor, range, enum, or other client argument.
+- `SLANG_E_INVALID_HANDLE`: an invalid native or platform handle.
+- `SLANG_E_NOT_AVAILABLE`: the requested feature or operation is not available on this backend, device, or platform.
+- `SLANG_E_NOT_IMPLEMENTED`: the API exists but the backend has no implementation.
+- `SLANG_E_OUT_OF_MEMORY`: an allocation failed.
+- `SLANG_E_BUFFER_TOO_SMALL`: the provided output buffer is too small.
+- `SLANG_E_NOT_FOUND`: the requested item was not found.
+- `SLANG_E_TIME_OUT`: a wait operation timed out.
+
+Some command-recording interfaces, such as draw, dispatch, copy, barrier, and debug-marker methods, return `void`. When validation is enabled, invalid use of those methods is reported through the debug callback and the debug layer may skip the invalid command. For these APIs, the callback message can be the only immediate failure signal.
+
+Not every failure result carries a detailed machine-readable reason. For detailed text, install a debug callback before creating the device.
+
+```cpp
+class MyDebugCallback : public rhi::IDebugCallback
+{
+public:
+    virtual SLANG_NO_THROW void SLANG_MCALL handleMessage(
+        rhi::DebugMessageType type,
+        rhi::DebugMessageSource source,
+        const char* message
+    ) override
+    {
+        // Copy or log the message here.
+        // The callback object is owned by the application.
+    }
+};
+
+MyDebugCallback callback;
+
+rhi::DeviceDesc desc = {};
+desc.deviceType = rhi::DeviceType::D3D12;
+desc.debugCallback = &callback;
+desc.enableValidation = true;
+
+Slang::ComPtr<rhi::IDevice> device;
+rhi::Result result = rhi::getRHI()->createDevice(desc, device.writeRef());
+if (SLANG_FAILED(result))
+{
+    // Use any messages collected by the callback to explain the failure.
+}
+```
+
+`DeviceDesc::debugCallback` is a raw pointer. Slang RHI does not take ownership of it, so the application must keep the callback alive for at least as long as any device that uses it. If no callback is provided, devices use an internal no-op callback, so most diagnostics are silently ignored.
+
+Callbacks may be invoked from the thread making an RHI call or from a backend/driver callback. Keep callback implementations thread-safe, avoid heavy work inside them, and copy the message text if it must be retained.
+
+## Message types and sources
+
+Each callback message has a severity:
+
+- `DebugMessageType::Info`: informational status.
+- `DebugMessageType::Warning`: suspicious behavior or optional functionality that could not be enabled.
+- `DebugMessageType::Error`: invalid API usage, failed compilation, native API failure, device loss, or another operation failure.
+
+Each callback message also has a source:
+
+- `DebugMessageSource::Layer`: Slang RHI validation or infrastructure. Examples include null output pointers, invalid descriptors, unsupported validation options, or "debug layer is enabled" status.
+- `DebugMessageSource::Driver`: backend, native graphics API, or downstream API debug layer output. Examples include failed D3D/Vulkan/CUDA/OptiX calls, Vulkan validation messages, D3D12 debug messages, WGPU uncaptured errors, and Metal compiler or runtime errors.
+- `DebugMessageSource::Slang`: Slang compiler diagnostics from shader linking, specialization, or code generation.
+
+Message text is intended for humans. It is not a stable parse format.
+
+## Validation and downstream debug layers
+
+Slang RHI has several separate validation and diagnostic controls.
+
+`DeviceDesc::enableValidation` enables the Slang RHI validation layer for that device. The validation layer wraps the concrete backend device and checks RHI-level usage such as null pointers, invalid ranges, incompatible resource usage, invalid enum values, missing pipeline state, and command encoding mistakes. Validation errors from `Result`-returning APIs usually return `SLANG_E_INVALID_ARG` or `SLANG_FAIL` and emit `DebugMessageSource::Layer` messages. Validation errors from `void` command-recording APIs emit `DebugMessageSource::Layer` messages and may cause the invalid command to be skipped.
+
+`IRHI::setDebugLayerOptions()` controls downstream API debug layers for supported native APIs. `coreValidation` applies to D3D11, D3D12, and Vulkan. `GPUAssistedValidation` applies to D3D12 and Vulkan.
+
+```cpp
+rhi::DebugLayerOptions options = {};
+options.coreValidation = true;
+options.GPUAssistedValidation = true;
+options.required = false;
+rhi::Result result = rhi::getRHI()->setDebugLayerOptions(options);
+if (SLANG_FAILED(result))
+{
+    // Devices are already alive, or the options could not be changed.
+}
+```
+
+These options are global to the RHI instance and must be changed before any devices are alive. If `required` is true, device creation fails when requested downstream debug layers cannot be enabled. If `required` is false, Slang RHI reports a warning and attempts to continue without the unavailable layer.
+
+The legacy `IRHI::enableDebugLayers()` only requests core validation and is less precise than `setDebugLayerOptions()`.
+
+`DeviceDesc::enableRayTracingValidation` requests downstream ray tracing validation for supported backends, currently CUDA/OptiX, D3D12 through NVAPI, and Vulkan through `VK_NV_ray_tracing_validation`. This is a per-device option and is separate from both the Slang RHI validation layer and `DebugLayerOptions`. If the requested validation mode is unavailable, backends report a warning or error through the callback and may continue without it.
+
+`DeviceDesc::enableAftermath` enables NVIDIA Aftermath diagnostics for supported D3D11, D3D12, and Vulkan devices when Slang RHI is built with Aftermath support. `DeviceDesc::aftermathFlags` controls markers, resource tracking, call-stack capture, shader debug information, and shader error reporting. Aftermath is a crash-diagnostic facility, not a general validation layer, and some backends place additional constraints on when it can be combined with downstream debug layers.
+
+## Shader diagnostics
+
+Shader-related failures can report diagnostics through both callbacks and explicit blobs.
+
+When an API has an `ISlangBlob** outDiagnosticBlob` parameter, pass a blob pointer and inspect it after failure:
+
+```cpp
+Slang::ComPtr<rhi::IShaderProgram> program;
+Slang::ComPtr<ISlangBlob> diagnostics;
+rhi::Result result = device->createShaderProgram(desc, program.writeRef(), diagnostics.writeRef());
+if (diagnostics)
+{
+    const char* text = static_cast<const char*>(diagnostics->getBufferPointer());
+    // Log text.
+}
+```
+
+The callback path is still useful because shader compilation can also happen later, for example when creating pipelines or specializing shader programs. In those cases Slang diagnostics are emitted as `DebugMessageSource::Slang` messages.
+
+`DeviceDesc::enableCompilationReports` is a performance reporting feature, not an error reporting feature. When enabled, `IShaderProgram::getCompilationReport()` and `IDevice::getCompilationReportList()` expose timing and cache-hit data for shader compilation and pipeline creation.
+
+## Native backend diagnostics
+
+Native-call diagnostics are implemented through `src/core/diagnostics.h` and `src/core/diagnostics.cpp`.
+
+The shared helper records the failing call expression, native result value, native result name, optional detail text, and source location. The formatted message has this shape:
+
+```text
+<call> call failed
+  result: <numeric-value> (<native-result-name>)
+  detail: <optional-detail>
+  location: <source-file>:<line>
+```
+
+`reportNativeCallError()` sends this text as `DebugMessageType::Error` and `DebugMessageSource::Driver` when a `Device*` is available. If no device is available, it prints to `stderr`.
+
+The backend-specific wrappers add native result names and details:
+
+- D3D11/D3D12 use `reportD3DError()`, `getHRESULTName()`, and `SLANG_D3D_RETURN_ON_FAIL_REPORT()`.
+- Vulkan uses `reportVulkanError()`, `getVkResultName()`, `SLANG_VK_RETURN_ON_FAIL_REPORT()`, and `SLANG_VK_CHECK_REPORT()`. `VK_ERROR_DEVICE_LOST` also gives Aftermath a chance to write a crash dump when Aftermath is enabled.
+- CUDA uses `reportCUDAError()` and `SLANG_CUDA_RETURN_ON_FAIL_REPORT()`, including `cuGetErrorName()` and `cuGetErrorString()` detail text.
+- OptiX uses `reportOptixError()` and `SLANG_OPTIX_RETURN_ON_FAIL_REPORT()`, including OptiX error names and strings.
+- WGPU reports device-lost, uncaptured-error, and callback-specific errors directly through the device callback.
+- Metal reports Objective-C and Metal API errors directly through the device callback.
+
+The `_REPORT` macros should be used whenever a diagnostic callback can be reached from the current object. They route diagnostics to the application's callback. Non-reporting variants are only appropriate during backend probing or before a device exists.
+
+## Internal guidelines
+
+When adding or changing backend code:
+
+- Return a specific `Result` when one is meaningful. Prefer `SLANG_E_INVALID_ARG` for invalid client input, `SLANG_E_NOT_AVAILABLE` for unavailable features, and `SLANG_FAIL` for native API failures that do not map cleanly to a public result.
+- Validate inexpensive RHI-level preconditions before making native API calls, especially null output pointers, descriptor ranges, resource usage flags, and unsupported enum values.
+- Use `Device::handleMessage()` or `Device::printInfo()`, `printWarning()`, and `printError()` for Slang RHI messages.
+- Use the backend native-call macros for D3D, Vulkan, CUDA, and OptiX calls so the call expression, native result name, and source location are captured.
+- Pass the most specific supported object available to reporting macros. CUDA reporting helpers accept both `Device*` and `DeviceChild*` through `getDiagnosticDevice()`; D3D, Vulkan, and OptiX reporting helpers currently expect a `Device*`.
+- Avoid emitting duplicate diagnostics for the same failure. A single clear callback message plus the returned `Result` is usually enough.
+- Do not depend on diagnostics for control flow. The returned `Result` must fully represent success or failure.
+- Use `SLANG_RETURN_ON_FAIL()` to preserve and propagate failures from helper calls.
+- Use `SLANG_RHI_DISABLE_NATIVE_CALL_ERROR_SCOPE()` only around intentional native probes where failure is expected and would otherwise create noisy diagnostics.
+
+Assertions remain a separate mechanism for internal invariants. They are useful for impossible states during development, but public API error handling should return `Result` values and, when helpful, emit diagnostics through the callback.

--- a/src/core/assert.cpp
+++ b/src/core/assert.cpp
@@ -5,22 +5,22 @@
 
 namespace rhi {
 
-thread_local int gDisableAssert;
+thread_local int tls_disableAssert = 0;
 
 ScopedDisableAssert::ScopedDisableAssert()
 {
-    gDisableAssert++;
+    tls_disableAssert++;
 }
 
 ScopedDisableAssert::~ScopedDisableAssert()
 {
-    gDisableAssert--;
+    tls_disableAssert--;
 }
 
 
 void handleAssert(const char* message, const char* file, int line)
 {
-    if (gDisableAssert == 0)
+    if (tls_disableAssert == 0)
     {
         std::fprintf(stderr, "Assertion failed: %s\n", message);
         std::fprintf(stderr, "At %s:%d\n", file, line);

--- a/src/core/diagnostics.cpp
+++ b/src/core/diagnostics.cpp
@@ -8,7 +8,7 @@
 
 namespace rhi {
 
-thread_local int gDisableNativeCallError;
+thread_local int tls_disableNativeCallError = 0;
 
 void formatNativeCallError(
     char* buffer,
@@ -71,7 +71,7 @@ void reportNativeCallError(
     const char* detail
 )
 {
-    if (gDisableNativeCallError > 0)
+    if (tls_disableNativeCallError > 0)
         return;
 
     char message[4096];
@@ -90,12 +90,12 @@ void reportNativeCallError(
 
 ScopedDisableNativeCallError::ScopedDisableNativeCallError()
 {
-    gDisableNativeCallError++;
+    tls_disableNativeCallError++;
 }
 
 ScopedDisableNativeCallError::~ScopedDisableNativeCallError()
 {
-    gDisableNativeCallError--;
+    tls_disableNativeCallError--;
 }
 
 

--- a/src/core/diagnostics.cpp
+++ b/src/core/diagnostics.cpp
@@ -1,0 +1,86 @@
+#include "diagnostics.h"
+
+#include "rhi-shared.h"
+
+#include <cstdarg>
+#include <cstdio>
+#include <cstring>
+
+namespace rhi {
+
+void formatNativeCallError(
+    char* buffer,
+    size_t bufferSize,
+    const char* call,
+    int64_t result,
+    const char* resultName,
+    const SourceLocation& location,
+    const char* detail
+)
+{
+    if (!buffer || bufferSize == 0)
+        return;
+
+    if (!call)
+        call = "<unknown>";
+    if (!resultName)
+        resultName = "<unknown>";
+
+    buffer[0] = 0;
+    size_t length = 0;
+    auto append = [&](const char* format, ...)
+    {
+        if (length >= bufferSize - 1)
+            return;
+
+        va_list args;
+        va_start(args, format);
+        int written = std::vsnprintf(buffer + length, bufferSize - length, format, args);
+        va_end(args);
+
+        if (written <= 0)
+            return;
+
+        size_t remaining = bufferSize - length;
+        size_t count = static_cast<size_t>(written);
+        length += count < remaining ? count : remaining - 1;
+    };
+
+    append("%s call failed\n  result: %lld (%s)\n", call, static_cast<long long>(result), resultName);
+
+    if (detail && detail[0])
+    {
+        size_t detailLength = std::strlen(detail);
+        append("  detail: %s%s", detail, detail[detailLength - 1] == '\n' ? "" : "\n");
+    }
+
+    if (location.file)
+    {
+        append("  location: %s:%d\n", location.file, location.line);
+    }
+}
+
+void reportNativeCallError(
+    Device* device,
+    const char* call,
+    int64_t result,
+    const char* resultName,
+    const SourceLocation& location,
+    const char* detail
+)
+{
+    char message[4096];
+    formatNativeCallError(message, sizeof(message), call, result, resultName, location, detail);
+
+    if (device)
+    {
+        device->handleMessage(DebugMessageType::Error, DebugMessageSource::Driver, message);
+    }
+    else
+    {
+        // If we don't have a device, just print to stderr.
+        std::fprintf(stderr, "%s\n", message);
+    }
+}
+
+} // namespace rhi

--- a/src/core/diagnostics.cpp
+++ b/src/core/diagnostics.cpp
@@ -8,6 +8,8 @@
 
 namespace rhi {
 
+thread_local int gDisableNativeCallError;
+
 void formatNativeCallError(
     char* buffer,
     size_t bufferSize,
@@ -69,6 +71,9 @@ void reportNativeCallError(
     const char* detail
 )
 {
+    if (gDisableNativeCallError > 0)
+        return;
+
     char message[4096];
     formatNativeCallError(message, sizeof(message), call, result, resultName, location, detail);
 
@@ -82,5 +87,16 @@ void reportNativeCallError(
         std::fprintf(stderr, "%s\n", message);
     }
 }
+
+ScopedDisableNativeCallError::ScopedDisableNativeCallError()
+{
+    gDisableNativeCallError++;
+}
+
+ScopedDisableNativeCallError::~ScopedDisableNativeCallError()
+{
+    gDisableNativeCallError--;
+}
+
 
 } // namespace rhi

--- a/src/core/diagnostics.h
+++ b/src/core/diagnostics.h
@@ -15,6 +15,12 @@ struct SourceLocation
     int line = 0;
 };
 
+#define SLANG_RHI_SOURCE_LOCATION()                                                                                    \
+    ::rhi::SourceLocation                                                                                              \
+    {                                                                                                                  \
+        __FILE__, __LINE__                                                                                             \
+    }
+
 void formatNativeCallError(
     char* buffer,
     size_t bufferSize,
@@ -36,10 +42,14 @@ void reportNativeCallError(
     const char* detail = nullptr
 );
 
-} // namespace rhi
+class ScopedDisableNativeCallError
+{
+public:
+    ScopedDisableNativeCallError();
+    ~ScopedDisableNativeCallError();
+};
 
-#define SLANG_RHI_SOURCE_LOCATION()                                                                                    \
-    ::rhi::SourceLocation                                                                                              \
-    {                                                                                                                  \
-        __FILE__, __LINE__                                                                                             \
-    }
+#define SLANG_RHI_DISABLE_NATIVE_CALL_ERROR_SCOPE() ::rhi::ScopedDisableNativeCallError disable_native_call_error__;
+
+
+} // namespace rhi

--- a/src/core/diagnostics.h
+++ b/src/core/diagnostics.h
@@ -1,0 +1,45 @@
+#pragma once
+
+#include <slang-rhi.h>
+
+#include <cstdint>
+#include <cstddef>
+
+namespace rhi {
+
+class Device;
+
+struct SourceLocation
+{
+    const char* file = nullptr;
+    int line = 0;
+};
+
+void formatNativeCallError(
+    char* buffer,
+    size_t bufferSize,
+    const char* call,
+    int64_t result,
+    const char* resultName,
+    const SourceLocation& location,
+    const char* detail = nullptr
+);
+
+/// Reports a native API call error either through the device's debug message callback
+/// or by printing to stderr if no device is available.
+void reportNativeCallError(
+    Device* device,
+    const char* call,
+    int64_t result,
+    const char* resultName,
+    const SourceLocation& location,
+    const char* detail = nullptr
+);
+
+} // namespace rhi
+
+#define SLANG_RHI_SOURCE_LOCATION()                                                                                    \
+    ::rhi::SourceLocation                                                                                              \
+    {                                                                                                                  \
+        __FILE__, __LINE__                                                                                             \
+    }

--- a/src/cuda/cuda-command.cpp
+++ b/src/cuda/cuda-command.cpp
@@ -1173,8 +1173,8 @@ Result CommandQueueImpl::signalFence(CUstream stream, uint64_t* outId)
     // Record submission event so we can detect completion
     SubmitEvent ev;
     ev.submitID = m_lastSubmittedID;
-    SLANG_CUDA_RETURN_ON_FAIL(cuEventCreate(&ev.event, CU_EVENT_DISABLE_TIMING));
-    SLANG_CUDA_RETURN_ON_FAIL(cuEventRecord(ev.event, stream));
+    SLANG_CUDA_RETURN_ON_FAIL_REPORT(cuEventCreate(&ev.event, CU_EVENT_DISABLE_TIMING), this);
+    SLANG_CUDA_RETURN_ON_FAIL_REPORT(cuEventRecord(ev.event, stream), this);
     m_submitEvents.push_back(ev);
 
     if (outId)

--- a/src/cuda/cuda-utils.cpp
+++ b/src/cuda/cuda-utils.cpp
@@ -94,22 +94,13 @@ void checkCudaSyncErrorReport(bool pre, const char* call, const SourceLocation l
     if (isCUDASyncError(result))
     {
         reportCUDAError(result, call, location, device);
-        if (pre)
-        {
-            device->handleMessage(
-                DebugMessageType::Error,
-                DebugMessageSource::Driver,
-                "Error detected BEFORE the call, suggesting a prior, uncaptured CUDA call is responsible\n"
-            );
-        }
+        const char* message =
+            pre ? "Error detected BEFORE the call, suggesting a prior, uncaptured CUDA call is responsible\n"
+                : "Error detected AFTER the call, suggesting it is responsible\n";
+        if (device)
+            device->handleMessage(DebugMessageType::Error, DebugMessageSource::Driver, message);
         else
-        {
-            device->handleMessage(
-                DebugMessageType::Error,
-                DebugMessageSource::Driver,
-                "Error detected AFTER the call, suggesting it is responsible\n"
-            );
-        }
+            std::fprintf(stderr, "%s", message);
     }
 }
 #endif

--- a/src/cuda/cuda-utils.cpp
+++ b/src/cuda/cuda-utils.cpp
@@ -6,8 +6,8 @@
 namespace rhi::cuda {
 
 #if SLANG_RHI_ENABLE_CUDA_CONTEXT_CHECK
-static thread_local CUcontext g_currentContext = nullptr;
-static thread_local std::atomic<uint32_t> g_contextStackDepth = 0;
+static thread_local CUcontext tls_currentContext = nullptr;
+static thread_local std::atomic<uint32_t> tls_contextStackDepth = 0;
 #endif
 
 ContextScope::ContextScope(const DeviceImpl* device)
@@ -19,8 +19,8 @@ ContextScope::ContextScope(const DeviceImpl* device)
         m_didPush = true;
         SLANG_CUDA_ASSERT_ON_FAIL(cuCtxPushCurrent(device->m_ctx.context));
 #if SLANG_RHI_ENABLE_CUDA_CONTEXT_CHECK
-        g_currentContext = device->m_ctx.context;
-        g_contextStackDepth++;
+        tls_currentContext = device->m_ctx.context;
+        tls_contextStackDepth++;
 #endif
     }
 }
@@ -32,8 +32,8 @@ ContextScope::~ContextScope()
         CUcontext ctx;
         SLANG_CUDA_ASSERT_ON_FAIL(cuCtxPopCurrent(&ctx));
 #if SLANG_RHI_ENABLE_CUDA_CONTEXT_CHECK
-        g_currentContext = ctx;
-        g_contextStackDepth--;
+        tls_currentContext = ctx;
+        tls_contextStackDepth--;
 #endif
     }
 }
@@ -41,7 +41,7 @@ ContextScope::~ContextScope()
 #if SLANG_RHI_ENABLE_CUDA_CONTEXT_CHECK
 CUcontext getCurrentContext()
 {
-    return g_contextStackDepth.load() > 0 ? g_currentContext : nullptr;
+    return tls_contextStackDepth.load() > 0 ? tls_currentContext : nullptr;
 }
 
 void checkCurrentContext()

--- a/src/cuda/cuda-utils.cpp
+++ b/src/cuda/cuda-utils.cpp
@@ -1,6 +1,8 @@
 #include "cuda-utils.h"
 #include "cuda-device.h"
 
+#include <cstdio>
+
 namespace rhi::cuda {
 
 #if SLANG_RHI_ENABLE_CUDA_CONTEXT_CHECK
@@ -58,18 +60,18 @@ void checkCurrentContext()
 
 // Helper to check if a result is an error, filtering out ones that occur when cuCtxSynchronize is called
 // outside of a valid context.
-bool isCUDASyncError(CUresult result)
+static bool isCUDASyncError(CUresult result)
 {
-    return isCUDAError(result) && result != CUDA_ERROR_NOT_INITIALIZED && result != CUDA_ERROR_INVALID_CONTEXT;
+    return result != CUDA_SUCCESS && result != CUDA_ERROR_NOT_INITIALIZED && result != CUDA_ERROR_INVALID_CONTEXT;
 }
 
 // Sync full CUDA and check for errors, asserting if any are found.
-void checkCudaSyncError(bool pre, const char* call, const char* file, int line)
+void checkCudaSyncError(bool pre, const char* call, const SourceLocation location)
 {
     CUresult result = cuCtxSynchronize();
     if (isCUDASyncError(result))
     {
-        reportCUDAAssert(result, call, file, line);
+        reportCUDAError(result, call, location);
         if (pre)
         {
             std::fprintf(
@@ -81,17 +83,17 @@ void checkCudaSyncError(bool pre, const char* call, const char* file, int line)
         {
             std::fprintf(stderr, "Error detected AFTER the call, suggesting it is responsible\n");
         }
-        ::rhi::handleAssert("CUDA error detected", file, line);
+        ::rhi::handleAssert("CUDA error detected", location.file, location.line);
     }
 }
 
 // Sync full CUDA and check for errors, reporting to device if any are found.
-void checkCudaSyncErrorReport(bool pre, const char* call, const char* file, int line, DeviceAdapter device)
+void checkCudaSyncErrorReport(bool pre, const char* call, const SourceLocation location, Device* device)
 {
     CUresult result = cuCtxSynchronize();
     if (isCUDASyncError(result))
     {
-        reportCUDAError(result, call, file, line, device);
+        reportCUDAError(result, call, location, device);
         if (pre)
         {
             device->handleMessage(
@@ -112,28 +114,13 @@ void checkCudaSyncErrorReport(bool pre, const char* call, const char* file, int 
 }
 #endif
 
-void reportCUDAError(CUresult result, const char* call, const char* file, int line, DeviceAdapter device)
+void reportCUDAError(CUresult result, const char* call, const SourceLocation location, Device* device)
 {
-    if (!device)
-        return;
-
-    const char* errorString = nullptr;
     const char* errorName = nullptr;
-    cuGetErrorString(result, &errorString);
-    cuGetErrorName(result, &errorName);
-    char buf[4096];
-    snprintf(buf, sizeof(buf), "%s failed: %s (%s)\nAt %s:%d\n", call, errorString, errorName, file, line);
-    buf[sizeof(buf) - 1] = 0; // Ensure null termination
-    device->handleMessage(DebugMessageType::Error, DebugMessageSource::Driver, buf);
-}
-
-void reportCUDAAssert(CUresult result, const char* call, const char* file, int line)
-{
     const char* errorString = nullptr;
-    const char* errorName = nullptr;
-    cuGetErrorString(result, &errorString);
     cuGetErrorName(result, &errorName);
-    std::fprintf(stderr, "%s failed: %s (%s)\n", call, errorString, errorName);
+    cuGetErrorString(result, &errorString);
+    reportNativeCallError(device, call, result, errorName, location, errorString);
 }
 
 AdapterLUID getAdapterLUID(int deviceIndex)

--- a/src/cuda/cuda-utils.h
+++ b/src/cuda/cuda-utils.h
@@ -43,6 +43,7 @@ void checkCurrentContext();
 void checkCudaSyncError(bool pre, const char* call, const SourceLocation location);
 void checkCudaSyncErrorReport(bool pre, const char* call, const SourceLocation location, Device* device);
 #define SLANG_CUDA_CHECK_SYNC_ERROR(pre, call) ::rhi::cuda::checkCudaSyncError(pre, call, SLANG_RHI_SOURCE_LOCATION())
+/// Pass nullptr for device to write the diagnostic to stderr.
 #define SLANG_CUDA_CHECK_SYNC_ERROR_REPORT(pre, call, device)                                                          \
     ::rhi::cuda::checkCudaSyncErrorReport(pre, call, SLANG_RHI_SOURCE_LOCATION(), getDiagnosticDevice(device))
 #else
@@ -70,6 +71,7 @@ void reportCUDAError(CUresult result, const char* call, const SourceLocation loc
         SLANG_CUDA_CHECK_SYNC_ERROR(false, #x);                                                                        \
     }
 
+/// Pass nullptr for device to write the diagnostic to stderr.
 #define SLANG_CUDA_RETURN_ON_FAIL_REPORT(x, device)                                                                    \
     {                                                                                                                  \
         SLANG_RHI_CHECK_CUDA_CTX();                                                                                    \

--- a/src/cuda/cuda-utils.h
+++ b/src/cuda/cuda-utils.h
@@ -4,6 +4,8 @@
 
 #include "cuda-api.h"
 
+#include "core/diagnostics.h"
+
 #include <cmath>
 
 /// Enable CUDA context check.
@@ -38,11 +40,11 @@ void checkCurrentContext();
 #endif
 
 #if SLANG_RHI_ENABLE_CUDA_SYNC_ERROR_CHECK
-void checkCudaSyncError(bool pre, const char* call, const char* file, int line);
-void checkCudaSyncErrorReport(bool pre, const char* call, const char* file, int line, DeviceAdapter device);
-#define SLANG_CUDA_CHECK_SYNC_ERROR(pre, call) ::rhi::cuda::checkCudaSyncError(pre, call, __FILE__, __LINE__)
+void checkCudaSyncError(bool pre, const char* call, const SourceLocation location);
+void checkCudaSyncErrorReport(bool pre, const char* call, const SourceLocation location, Device* device);
+#define SLANG_CUDA_CHECK_SYNC_ERROR(pre, call) ::rhi::cuda::checkCudaSyncError(pre, call, SLANG_RHI_SOURCE_LOCATION())
 #define SLANG_CUDA_CHECK_SYNC_ERROR_REPORT(pre, call, device)                                                          \
-    ::rhi::cuda::checkCudaSyncErrorReport(pre, call, __FILE__, __LINE__, device)
+    ::rhi::cuda::checkCudaSyncErrorReport(pre, call, SLANG_RHI_SOURCE_LOCATION(), getDiagnosticDevice(device))
 #else
 #define SLANG_CUDA_CHECK_SYNC_ERROR(pre, call)
 #define SLANG_CUDA_CHECK_SYNC_ERROR_REPORT(pre, call, device)
@@ -54,21 +56,14 @@ void checkCudaSyncErrorReport(bool pre, const char* call, const char* file, int 
 #define SLANG_RHI_CHECK_CUDA_CTX()
 #endif
 
-inline bool isCUDAError(CUresult result)
-{
-    return result != 0;
-}
-
-void reportCUDAError(CUresult result, const char* call, const char* file, int line, DeviceAdapter device);
-
-void reportCUDAAssert(CUresult result, const char* call, const char* file, int line);
+void reportCUDAError(CUresult result, const char* call, const SourceLocation location, Device* device = nullptr);
 
 #define SLANG_CUDA_RETURN_ON_FAIL(x)                                                                                   \
     {                                                                                                                  \
         SLANG_RHI_CHECK_CUDA_CTX();                                                                                    \
         SLANG_CUDA_CHECK_SYNC_ERROR(true, #x);                                                                         \
-        auto _res = x;                                                                                                 \
-        if (::rhi::cuda::isCUDAError(_res))                                                                            \
+        CUresult _res = x;                                                                                             \
+        if (_res != CUDA_SUCCESS)                                                                                      \
         {                                                                                                              \
             return SLANG_FAIL;                                                                                         \
         }                                                                                                              \
@@ -79,10 +74,10 @@ void reportCUDAAssert(CUresult result, const char* call, const char* file, int l
     {                                                                                                                  \
         SLANG_RHI_CHECK_CUDA_CTX();                                                                                    \
         SLANG_CUDA_CHECK_SYNC_ERROR_REPORT(true, #x, device);                                                          \
-        auto _res = x;                                                                                                 \
-        if (::rhi::cuda::isCUDAError(_res))                                                                            \
+        CUresult _res = x;                                                                                             \
+        if (_res != CUDA_SUCCESS)                                                                                      \
         {                                                                                                              \
-            ::rhi::cuda::reportCUDAError(_res, #x, __FILE__, __LINE__, device);                                        \
+            ::rhi::cuda::reportCUDAError(_res, #x, SLANG_RHI_SOURCE_LOCATION(), getDiagnosticDevice(device));          \
             return SLANG_FAIL;                                                                                         \
         }                                                                                                              \
         SLANG_CUDA_CHECK_SYNC_ERROR_REPORT(false, #x, device);                                                         \
@@ -92,10 +87,10 @@ void reportCUDAAssert(CUresult result, const char* call, const char* file, int l
     {                                                                                                                  \
         SLANG_RHI_CHECK_CUDA_CTX();                                                                                    \
         SLANG_CUDA_CHECK_SYNC_ERROR(true, #x);                                                                         \
-        auto _res = x;                                                                                                 \
-        if (::rhi::cuda::isCUDAError(_res))                                                                            \
+        CUresult _res = x;                                                                                             \
+        if (_res != CUDA_SUCCESS)                                                                                      \
         {                                                                                                              \
-            ::rhi::cuda::reportCUDAAssert(_res, #x, __FILE__, __LINE__);                                               \
+            ::rhi::cuda::reportCUDAError(_res, #x, SLANG_RHI_SOURCE_LOCATION());                                       \
             SLANG_RHI_ASSERT_FAILURE("CUDA call failed");                                                              \
         }                                                                                                              \
         SLANG_CUDA_CHECK_SYNC_ERROR(false, #x);                                                                        \

--- a/src/cuda/optix-api-impl.cpp
+++ b/src/cuda/optix-api-impl.cpp
@@ -35,48 +35,17 @@
 
 namespace rhi::cuda::optix::VERSION_TAG {
 
-inline bool isOptixError(OptixResult result)
+void reportOptixError(OptixResult result, const char* call, const SourceLocation location, Device* device = nullptr)
 {
-    return result != OPTIX_SUCCESS;
-}
-
-void reportOptixError(OptixResult result, const char* call, const char* file, int line, DeviceAdapter device)
-{
-    if (!device)
-        return;
-
-    char buf[4096];
-    snprintf(
-        buf,
-        sizeof(buf),
-        "%s failed: %s (%s)\nAt %s:%d\n",
-        call,
-        optixGetErrorName(result),
-        optixGetErrorName(result),
-        file,
-        line
-    );
-    buf[sizeof(buf) - 1] = 0; // Ensure null termination
-    device->handleMessage(DebugMessageType::Error, DebugMessageSource::Driver, buf);
-}
-
-void reportOptixAssert(OptixResult result, const char* call, const char* file, int line)
-{
-    std::fprintf(
-        stderr,
-        "%s:%d: %s failed: %s (%s)\n",
-        file,
-        line,
-        call,
-        optixGetErrorString(result),
-        optixGetErrorName(result)
-    );
+    const char* errorString = optixGetErrorString(result);
+    const char* errorName = optixGetErrorName(result);
+    reportNativeCallError(device, call, result, errorName, location, errorString);
 }
 
 #define SLANG_OPTIX_RETURN_ON_FAIL(x)                                                                                  \
     {                                                                                                                  \
         auto _res = x;                                                                                                 \
-        if (::rhi::cuda::optix::VERSION_TAG::isOptixError(_res))                                                       \
+        if (_res != OPTIX_SUCCESS)                                                                                     \
         {                                                                                                              \
             return SLANG_FAIL;                                                                                         \
         }                                                                                                              \
@@ -85,9 +54,9 @@ void reportOptixAssert(OptixResult result, const char* call, const char* file, i
 #define SLANG_OPTIX_RETURN_ON_FAIL_REPORT(x, device)                                                                   \
     {                                                                                                                  \
         auto _res = x;                                                                                                 \
-        if (::rhi::cuda::optix::VERSION_TAG::isOptixError(_res))                                                       \
+        if (_res != OPTIX_SUCCESS)                                                                                     \
         {                                                                                                              \
-            ::rhi::cuda::optix::VERSION_TAG::reportOptixError(_res, #x, __FILE__, __LINE__, device);                   \
+            ::rhi::cuda::optix::VERSION_TAG::reportOptixError(_res, #x, SLANG_RHI_SOURCE_LOCATION(), device);          \
             return SLANG_FAIL;                                                                                         \
         }                                                                                                              \
     }
@@ -95,9 +64,9 @@ void reportOptixAssert(OptixResult result, const char* call, const char* file, i
 #define SLANG_OPTIX_ASSERT_ON_FAIL(x)                                                                                  \
     {                                                                                                                  \
         auto _res = x;                                                                                                 \
-        if (::rhi::cuda::optix::VERSION_TAG::isOptixError(_res))                                                       \
+        if (_res != OPTIX_SUCCESS)                                                                                     \
         {                                                                                                              \
-            ::rhi::cuda::optix::VERSION_TAG::reportOptixAssert(_res, #x, __FILE__, __LINE__);                          \
+            ::rhi::cuda::optix::VERSION_TAG::reportOptixError(_res, #x, SLANG_RHI_SOURCE_LOCATION());                  \
             SLANG_RHI_ASSERT_FAILURE("OptiX call failed");                                                             \
         }                                                                                                              \
     }

--- a/src/cuda/optix-api-impl.cpp
+++ b/src/cuda/optix-api-impl.cpp
@@ -51,6 +51,7 @@ void reportOptixError(OptixResult result, const char* call, const SourceLocation
         }                                                                                                              \
     }
 
+/// Pass nullptr for device to write the diagnostic to stderr.
 #define SLANG_OPTIX_RETURN_ON_FAIL_REPORT(x, device)                                                                   \
     {                                                                                                                  \
         OptixResult _res = x;                                                                                          \

--- a/src/cuda/optix-api-impl.cpp
+++ b/src/cuda/optix-api-impl.cpp
@@ -44,7 +44,7 @@ void reportOptixError(OptixResult result, const char* call, const SourceLocation
 
 #define SLANG_OPTIX_RETURN_ON_FAIL(x)                                                                                  \
     {                                                                                                                  \
-        auto _res = x;                                                                                                 \
+        OptixResult _res = x;                                                                                          \
         if (_res != OPTIX_SUCCESS)                                                                                     \
         {                                                                                                              \
             return SLANG_FAIL;                                                                                         \
@@ -53,7 +53,7 @@ void reportOptixError(OptixResult result, const char* call, const SourceLocation
 
 #define SLANG_OPTIX_RETURN_ON_FAIL_REPORT(x, device)                                                                   \
     {                                                                                                                  \
-        auto _res = x;                                                                                                 \
+        OptixResult _res = x;                                                                                          \
         if (_res != OPTIX_SUCCESS)                                                                                     \
         {                                                                                                              \
             ::rhi::cuda::optix::VERSION_TAG::reportOptixError(_res, #x, SLANG_RHI_SOURCE_LOCATION(), device);          \
@@ -63,7 +63,7 @@ void reportOptixError(OptixResult result, const char* call, const SourceLocation
 
 #define SLANG_OPTIX_ASSERT_ON_FAIL(x)                                                                                  \
     {                                                                                                                  \
-        auto _res = x;                                                                                                 \
+        OptixResult _res = x;                                                                                          \
         if (_res != OPTIX_SUCCESS)                                                                                     \
         {                                                                                                              \
             ::rhi::cuda::optix::VERSION_TAG::reportOptixError(_res, #x, SLANG_RHI_SOURCE_LOCATION());                  \

--- a/src/d3d/d3d-surface.h
+++ b/src/d3d/d3d-surface.h
@@ -67,11 +67,11 @@ public:
         if (!dxgiFactory2)
         {
             ComPtr<IDXGISwapChain> swapChain;
-            SLANG_RETURN_ON_FAIL(
+            SLANG_D3D_RETURN_ON_FAIL(
                 getDXGIFactory()->CreateSwapChain(getOwningDevice(), &swapChainDesc, swapChain.writeRef())
             );
-            SLANG_RETURN_ON_FAIL(getDXGIFactory()->MakeWindowAssociation(m_windowHandle, DXGI_MWA_NO_ALT_ENTER));
-            SLANG_RETURN_ON_FAIL(swapChain->QueryInterface(m_swapChain.writeRef()));
+            SLANG_D3D_RETURN_ON_FAIL(getDXGIFactory()->MakeWindowAssociation(m_windowHandle, DXGI_MWA_NO_ALT_ENTER));
+            SLANG_D3D_RETURN_ON_FAIL(swapChain->QueryInterface(m_swapChain.writeRef()));
         }
         else
         {
@@ -85,7 +85,7 @@ public:
             desc1.SampleDesc = swapChainDesc.SampleDesc;
             desc1.SwapEffect = swapChainDesc.SwapEffect;
             ComPtr<IDXGISwapChain1> swapChain1;
-            SLANG_RETURN_ON_FAIL(dxgiFactory2->CreateSwapChainForHwnd(
+            SLANG_D3D_RETURN_ON_FAIL(dxgiFactory2->CreateSwapChainForHwnd(
                 getOwningDevice(),
                 m_windowHandle,
                 &desc1,
@@ -93,7 +93,7 @@ public:
                 nullptr,
                 swapChain1.writeRef()
             ));
-            SLANG_RETURN_ON_FAIL(swapChain1->QueryInterface(m_swapChain.writeRef()));
+            SLANG_D3D_RETURN_ON_FAIL(swapChain1->QueryInterface(m_swapChain.writeRef()));
         }
 
         createSwapchainTextures(m_config.desiredImageCount);

--- a/src/d3d/d3d-utils.cpp
+++ b/src/d3d/d3d-utils.cpp
@@ -502,6 +502,39 @@ AdapterLUID getAdapterLUID(LUID luid)
     return adapterLUID;
 }
 
+const char* getHRESULTName(HRESULT res)
+{
+#define CASE(x)                                                                                                        \
+    case x:                                                                                                            \
+        return #x;
+    switch (res)
+    {
+        CASE(S_OK)
+        CASE(S_FALSE)
+        CASE(E_FAIL)
+        CASE(E_INVALIDARG)
+        CASE(E_OUTOFMEMORY)
+        CASE(E_NOTIMPL)
+        CASE(E_NOINTERFACE)
+        CASE(DXGI_ERROR_INVALID_CALL)
+        CASE(DXGI_ERROR_NOT_FOUND)
+        CASE(DXGI_ERROR_MORE_DATA)
+        CASE(DXGI_ERROR_UNSUPPORTED)
+        CASE(DXGI_ERROR_DEVICE_REMOVED)
+        CASE(DXGI_ERROR_DEVICE_HUNG)
+        CASE(DXGI_ERROR_DEVICE_RESET)
+        CASE(DXGI_ERROR_WAIT_TIMEOUT)
+    default:
+        return "<unknown>";
+    }
+#undef CASE
+}
+
+void reportD3DError(HRESULT result, const char* call, const SourceLocation location, Device* device)
+{
+    reportNativeCallError(device, call, result, getHRESULTName(result), location);
+}
+
 uint32_t getPlaneSliceCount(DXGI_FORMAT format)
 {
     switch (format)

--- a/src/d3d/d3d-utils.h
+++ b/src/d3d/d3d-utils.h
@@ -66,7 +66,6 @@ void reportD3DError(HRESULT result, const char* call, const SourceLocation locat
         HRESULT _res = x;                                                                                              \
         if (FAILED(_res))                                                                                              \
         {                                                                                                              \
-            ::rhi::reportD3DError(_res, #x, SLANG_RHI_SOURCE_LOCATION());                                              \
             return SLANG_FAIL;                                                                                         \
         }                                                                                                              \
     }

--- a/src/d3d/d3d-utils.h
+++ b/src/d3d/d3d-utils.h
@@ -2,6 +2,7 @@
 
 #include "device.h"
 #include "core/common.h"
+#include "core/diagnostics.h"
 
 #include <slang-com-helper.h>
 #include <slang-com-ptr.h>
@@ -55,6 +56,30 @@ Result enumAdapters(std::vector<ComPtr<IDXGIAdapter>>& outAdapters);
 AdapterInfo getAdapterInfo(IDXGIAdapter* dxgiAdapter);
 
 AdapterLUID getAdapterLUID(LUID luid);
+
+const char* getHRESULTName(HRESULT result);
+
+void reportD3DError(HRESULT result, const char* call, const SourceLocation location, Device* device = nullptr);
+
+#define SLANG_D3D_RETURN_ON_FAIL(x)                                                                                    \
+    {                                                                                                                  \
+        HRESULT _res = x;                                                                                              \
+        if (FAILED(_res))                                                                                              \
+        {                                                                                                              \
+            ::rhi::reportD3DError(_res, #x, SLANG_RHI_SOURCE_LOCATION());                                              \
+            return SLANG_FAIL;                                                                                         \
+        }                                                                                                              \
+    }
+
+#define SLANG_D3D_RETURN_ON_FAIL_REPORT(x, device)                                                                     \
+    {                                                                                                                  \
+        HRESULT _res = x;                                                                                              \
+        if (FAILED(_res))                                                                                              \
+        {                                                                                                              \
+            ::rhi::reportD3DError(_res, #x, SLANG_RHI_SOURCE_LOCATION(), device);                                      \
+            return SLANG_FAIL;                                                                                         \
+        }                                                                                                              \
+    }
 
 uint32_t getPlaneSlice(DXGI_FORMAT format, TextureAspect aspect);
 

--- a/src/d3d/d3d-utils.h
+++ b/src/d3d/d3d-utils.h
@@ -70,6 +70,7 @@ void reportD3DError(HRESULT result, const char* call, const SourceLocation locat
         }                                                                                                              \
     }
 
+/// Pass nullptr for device to write the diagnostic to stderr.
 #define SLANG_D3D_RETURN_ON_FAIL_REPORT(x, device)                                                                     \
     {                                                                                                                  \
         HRESULT _res = x;                                                                                              \

--- a/src/d3d11/d3d11-buffer.cpp
+++ b/src/d3d11/d3d11-buffer.cpp
@@ -184,8 +184,9 @@ Result DeviceImpl::createBuffer(const BufferDesc& desc_, const void* initData, I
 
     RefPtr<BufferImpl> buffer(new BufferImpl(this, desc));
 
-    SLANG_RETURN_ON_FAIL(
-        m_device->CreateBuffer(&bufferDesc, initData ? &subresourceData : nullptr, buffer->m_buffer.writeRef())
+    SLANG_D3D_RETURN_ON_FAIL_REPORT(
+        m_device->CreateBuffer(&bufferDesc, initData ? &subresourceData : nullptr, buffer->m_buffer.writeRef()),
+        this
     );
     buffer->m_d3dUsage = bufferDesc.Usage;
 
@@ -212,7 +213,10 @@ Result DeviceImpl::mapBuffer(IBuffer* buffer, CpuAccessMode mode, void** outData
     }
 
     D3D11_MAPPED_SUBRESOURCE mappedResource;
-    SLANG_RETURN_ON_FAIL(m_immediateContext->Map(bufferImpl->m_buffer, 0, mapType, 0, &mappedResource));
+    SLANG_D3D_RETURN_ON_FAIL_REPORT(
+        m_immediateContext->Map(bufferImpl->m_buffer, 0, mapType, 0, &mappedResource),
+        this
+    );
     *outData = mappedResource.pData;
     return SLANG_OK;
 }

--- a/src/d3d11/d3d11-command.cpp
+++ b/src/d3d11/d3d11-command.cpp
@@ -955,7 +955,7 @@ Result CommandQueueImpl::waitOnHost()
     {
         D3D11_QUERY_DESC queryDesc = {};
         queryDesc.Query = D3D11_QUERY_EVENT;
-        SLANG_RETURN_ON_FAIL(device->m_device->CreateQuery(&queryDesc, m_waitQuery.writeRef()));
+        SLANG_D3D_RETURN_ON_FAIL_REPORT(device->m_device->CreateQuery(&queryDesc, m_waitQuery.writeRef()), device);
     }
 
     device->m_immediateContext->End(m_waitQuery);
@@ -968,7 +968,7 @@ Result CommandQueueImpl::waitOnHost()
     {
         std::this_thread::sleep_for(std::chrono::milliseconds(1));
     }
-    SLANG_RETURN_ON_FAIL(hr);
+    SLANG_D3D_RETURN_ON_FAIL_REPORT(hr, device);
 
     return SLANG_OK;
 }
@@ -991,12 +991,18 @@ Result CommandQueueImpl::getTimestampCalibration(TimestampCalibration* outCalibr
     D3D11_QUERY_DESC timestampQueryDesc = {};
     timestampQueryDesc.Query = D3D11_QUERY_TIMESTAMP;
     ComPtr<ID3D11Query> timestampQuery;
-    SLANG_RETURN_ON_FAIL(device->m_device->CreateQuery(&timestampQueryDesc, timestampQuery.writeRef()));
+    SLANG_D3D_RETURN_ON_FAIL_REPORT(
+        device->m_device->CreateQuery(&timestampQueryDesc, timestampQuery.writeRef()),
+        device
+    );
 
     D3D11_QUERY_DESC disjointQueryDesc = {};
     disjointQueryDesc.Query = D3D11_QUERY_TIMESTAMP_DISJOINT;
     ComPtr<ID3D11Query> disjointQuery;
-    SLANG_RETURN_ON_FAIL(device->m_device->CreateQuery(&disjointQueryDesc, disjointQuery.writeRef()));
+    SLANG_D3D_RETURN_ON_FAIL_REPORT(
+        device->m_device->CreateQuery(&disjointQueryDesc, disjointQuery.writeRef()),
+        device
+    );
 
     device->m_immediateContext->Begin(disjointQuery);
     const uint64_t before = getCpuTimestamp();
@@ -1010,7 +1016,7 @@ Result CommandQueueImpl::getTimestampCalibration(TimestampCalibration* outCalibr
     {
         std::this_thread::sleep_for(std::chrono::milliseconds(1));
     }
-    SLANG_RETURN_ON_FAIL(hr);
+    SLANG_D3D_RETURN_ON_FAIL_REPORT(hr, device);
     const uint64_t after = getCpuTimestamp();
 
     if (disjointData.Disjoint || disjointData.Frequency == 0)
@@ -1025,7 +1031,7 @@ Result CommandQueueImpl::getTimestampCalibration(TimestampCalibration* outCalibr
     {
         std::this_thread::sleep_for(std::chrono::milliseconds(1));
     }
-    SLANG_RETURN_ON_FAIL(hr);
+    SLANG_D3D_RETURN_ON_FAIL_REPORT(hr, device);
 
     if (after < before)
     {
@@ -1087,8 +1093,10 @@ Result CommandEncoderImpl::finish(const CommandBufferDesc& desc, ICommandBuffer*
     {
         D3D11_QUERY_DESC queryDesc = {};
         queryDesc.Query = D3D11_QUERY_TIMESTAMP_DISJOINT;
-        SLANG_RETURN_ON_FAIL(
-            getDevice<DeviceImpl>()->m_device->CreateQuery(&queryDesc, m_commandBuffer->m_disjointQuery.writeRef())
+        DeviceImpl* device = getDevice<DeviceImpl>();
+        SLANG_D3D_RETURN_ON_FAIL_REPORT(
+            device->m_device->CreateQuery(&queryDesc, m_commandBuffer->m_disjointQuery.writeRef()),
+            device
         );
     }
     returnComPtr(outCommandBuffer, m_commandBuffer);

--- a/src/d3d11/d3d11-command.cpp
+++ b/src/d3d11/d3d11-command.cpp
@@ -962,8 +962,9 @@ Result CommandQueueImpl::waitOnHost()
     device->m_immediateContext->Flush();
 
     HRESULT hr = S_FALSE;
-    while ((hr = device->m_immediateContext->GetData(m_waitQuery, nullptr, 0, D3D11_ASYNC_GETDATA_DONOTFLUSH)) ==
-           S_FALSE)
+    // Let GetData flush/progress the runtime; DONOTFLUSH can leave event queries pending
+    // for seconds on some D3D11 drivers even after an explicit Flush above.
+    while ((hr = device->m_immediateContext->GetData(m_waitQuery, nullptr, 0, 0)) == S_FALSE)
     {
         std::this_thread::sleep_for(std::chrono::milliseconds(1));
     }

--- a/src/d3d11/d3d11-device.cpp
+++ b/src/d3d11/d3d11-device.cpp
@@ -173,7 +173,7 @@ Result DeviceImpl::initialize(const DeviceDesc& desc, BackendImpl* backend)
 #endif
 
     SLANG_RHI_ASSERT(m_device && m_immediateContext);
-    SLANG_RETURN_ON_FAIL(m_immediateContext->QueryInterface(m_immediateContext1.writeRef()));
+    SLANG_D3D_RETURN_ON_FAIL_REPORT(m_immediateContext->QueryInterface(m_immediateContext1.writeRef()), this);
 
     // Initialize device info
     {
@@ -195,7 +195,7 @@ Result DeviceImpl::initialize(const DeviceDesc& desc, BackendImpl* backend)
         D3D11_QUERY_DESC disjointQueryDesc = {};
         disjointQueryDesc.Query = D3D11_QUERY_TIMESTAMP_DISJOINT;
         ComPtr<ID3D11Query> disjointQuery;
-        SLANG_RETURN_ON_FAIL(m_device->CreateQuery(&disjointQueryDesc, disjointQuery.writeRef()));
+        SLANG_D3D_RETURN_ON_FAIL_REPORT(m_device->CreateQuery(&disjointQueryDesc, disjointQuery.writeRef()), this);
         m_immediateContext->Begin(disjointQuery);
         m_immediateContext->End(disjointQuery);
         D3D11_QUERY_DATA_TIMESTAMP_DISJOINT disjointData = {};
@@ -525,9 +525,10 @@ Result DeviceImpl::readTexture(
     // Now just read back texels from the staging textures
     {
         D3D11_MAPPED_SUBRESOURCE mappedResource;
-        SLANG_RETURN_ON_FAIL(
+        SLANG_D3D_RETURN_ON_FAIL_REPORT(
             m_immediateContext
-                ->Map(stagingTextureImpl->m_resource.get(), subResourceIdx, D3D11_MAP_READ, 0, &mappedResource)
+                ->Map(stagingTextureImpl->m_resource.get(), subResourceIdx, D3D11_MAP_READ, 0, &mappedResource),
+            this
         );
 
         auto blob = OwnedBlob::create(layout.sizeInBytes);
@@ -574,7 +575,10 @@ Result DeviceImpl::readBuffer(IBuffer* buffer, Offset offset, Size size, void* o
     stagingBufferDesc.ByteWidth = size;
     stagingBufferDesc.CPUAccessFlags = D3D11_CPU_ACCESS_READ;
     stagingBufferDesc.Usage = D3D11_USAGE_STAGING;
-    SLANG_RETURN_ON_FAIL(m_device->CreateBuffer(&stagingBufferDesc, nullptr, stagingBuffer.writeRef()));
+    SLANG_D3D_RETURN_ON_FAIL_REPORT(
+        m_device->CreateBuffer(&stagingBufferDesc, nullptr, stagingBuffer.writeRef()),
+        this
+    );
 
     // Copy to staging buffer.
     D3D11_BOX srcBox = {};
@@ -585,7 +589,10 @@ Result DeviceImpl::readBuffer(IBuffer* buffer, Offset offset, Size size, void* o
 
     // Map the staging buffer and copy data.
     D3D11_MAPPED_SUBRESOURCE mappedResource;
-    SLANG_RETURN_ON_FAIL(m_immediateContext->Map(stagingBuffer, 0, D3D11_MAP_READ, 0, &mappedResource));
+    SLANG_D3D_RETURN_ON_FAIL_REPORT(
+        m_immediateContext->Map(stagingBuffer, 0, D3D11_MAP_READ, 0, &mappedResource),
+        this
+    );
     std::memcpy(outData, mappedResource.pData, size);
     m_immediateContext->Unmap(stagingBuffer, 0);
 

--- a/src/d3d11/d3d11-input-layout.cpp
+++ b/src/d3d11/d3d11-input-layout.cpp
@@ -76,13 +76,16 @@ Result DeviceImpl::createInputLayout(const InputLayoutDesc& desc, IInputLayout**
     SLANG_RETURN_ON_FAIL(compileHLSLShader("inputLayout", hlslBuffer, "main", "vs_5_0", vertexShaderBlob));
 
     ComPtr<ID3D11InputLayout> inputLayout;
-    SLANG_RETURN_ON_FAIL(m_device->CreateInputLayout(
-        &inputElements[0],
-        (UINT)desc.inputElementCount,
-        vertexShaderBlob->GetBufferPointer(),
-        vertexShaderBlob->GetBufferSize(),
-        inputLayout.writeRef()
-    ));
+    SLANG_D3D_RETURN_ON_FAIL_REPORT(
+        m_device->CreateInputLayout(
+            &inputElements[0],
+            (UINT)desc.inputElementCount,
+            vertexShaderBlob->GetBufferPointer(),
+            vertexShaderBlob->GetBufferSize(),
+            inputLayout.writeRef()
+        ),
+        this
+    );
 
     RefPtr<InputLayoutImpl> layout = new InputLayoutImpl();
     layout->m_layout.swap(inputLayout);

--- a/src/d3d11/d3d11-pipeline.cpp
+++ b/src/d3d11/d3d11-pipeline.cpp
@@ -43,12 +43,15 @@ Result DeviceImpl::createRenderPipeline2(const RenderPipelineDesc& desc, IRender
         auto module = program->findModule(SLANG_STAGE_VERTEX);
         if (!module)
             return SLANG_FAIL;
-        SLANG_RETURN_ON_FAIL(m_device->CreateVertexShader(
-            module->code->getBufferPointer(),
-            module->code->getBufferSize(),
-            nullptr,
-            vertexShader.writeRef()
-        ));
+        SLANG_D3D_RETURN_ON_FAIL_REPORT(
+            m_device->CreateVertexShader(
+                module->code->getBufferPointer(),
+                module->code->getBufferSize(),
+                nullptr,
+                vertexShader.writeRef()
+            ),
+            this
+        );
     }
 
     ComPtr<ID3D11PixelShader> pixelShader;
@@ -56,12 +59,15 @@ Result DeviceImpl::createRenderPipeline2(const RenderPipelineDesc& desc, IRender
         auto module = program->findModule(SLANG_STAGE_FRAGMENT);
         if (!module)
             return SLANG_FAIL;
-        SLANG_RETURN_ON_FAIL(m_device->CreatePixelShader(
-            module->code->getBufferPointer(),
-            module->code->getBufferSize(),
-            nullptr,
-            pixelShader.writeRef()
-        ));
+        SLANG_D3D_RETURN_ON_FAIL_REPORT(
+            m_device->CreatePixelShader(
+                module->code->getBufferPointer(),
+                module->code->getBufferSize(),
+                nullptr,
+                pixelShader.writeRef()
+            ),
+            this
+        );
     }
 
     ComPtr<ID3D11DepthStencilState> depthStencilState;
@@ -85,7 +91,7 @@ Result DeviceImpl::createRenderPipeline2(const RenderPipelineDesc& desc, IRender
         FACE(FrontFace, frontFace);
         FACE(BackFace, backFace);
 
-        SLANG_RETURN_ON_FAIL(m_device->CreateDepthStencilState(&dsDesc, depthStencilState.writeRef()));
+        SLANG_D3D_RETURN_ON_FAIL_REPORT(m_device->CreateDepthStencilState(&dsDesc, depthStencilState.writeRef()), this);
     }
 
     ComPtr<ID3D11RasterizerState> rasterizerState;
@@ -102,7 +108,7 @@ Result DeviceImpl::createRenderPipeline2(const RenderPipelineDesc& desc, IRender
         rsDesc.MultisampleEnable = desc.rasterizer.multisampleEnable;
         rsDesc.AntialiasedLineEnable = desc.rasterizer.antialiasedLineEnable;
 
-        SLANG_RETURN_ON_FAIL(m_device->CreateRasterizerState(&rsDesc, rasterizerState.writeRef()));
+        SLANG_D3D_RETURN_ON_FAIL_REPORT(m_device->CreateRasterizerState(&rsDesc, rasterizerState.writeRef()), this);
     }
 
     ComPtr<ID3D11BlendState> blendState;
@@ -162,7 +168,7 @@ Result DeviceImpl::createRenderPipeline2(const RenderPipelineDesc& desc, IRender
         dstDesc.IndependentBlendEnable = targetCount > 1;
         dstDesc.AlphaToCoverageEnable = desc.multisample.alphaToCoverageEnable;
 
-        SLANG_RETURN_ON_FAIL(m_device->CreateBlendState(&dstDesc, blendState.writeRef()));
+        SLANG_D3D_RETURN_ON_FAIL_REPORT(m_device->CreateBlendState(&dstDesc, blendState.writeRef()), this);
     }
 
     // Report the pipeline creation time.
@@ -232,12 +238,15 @@ Result DeviceImpl::createComputePipeline2(const ComputePipelineDesc& desc, IComp
         auto module = program->findModule(SLANG_STAGE_COMPUTE);
         if (!module)
             return SLANG_FAIL;
-        SLANG_RETURN_ON_FAIL(m_device->CreateComputeShader(
-            module->code->getBufferPointer(),
-            module->code->getBufferSize(),
-            nullptr,
-            computeShader.writeRef()
-        ));
+        SLANG_D3D_RETURN_ON_FAIL_REPORT(
+            m_device->CreateComputeShader(
+                module->code->getBufferPointer(),
+                module->code->getBufferSize(),
+                nullptr,
+                computeShader.writeRef()
+            ),
+            this
+        );
     }
 
     // Report the pipeline creation time.

--- a/src/d3d11/d3d11-query.cpp
+++ b/src/d3d11/d3d11-query.cpp
@@ -1,6 +1,8 @@
 #include "d3d11-query.h"
 #include "d3d11-device.h"
 
+#include "d3d/d3d-utils.h"
+
 #include <thread>
 #include <chrono>
 
@@ -76,7 +78,7 @@ Result QueryPoolImpl::isResultReady(uint32_t queryIndex, uint32_t count, bool* o
         {
             return SLANG_OK;
         }
-        SLANG_RETURN_ON_FAIL(hr);
+        SLANG_D3D_RETURN_ON_FAIL_REPORT(hr, device);
         if (disjointData.Disjoint || disjointData.Frequency == 0)
         {
             return SLANG_FAIL;
@@ -90,7 +92,7 @@ Result QueryPoolImpl::isResultReady(uint32_t queryIndex, uint32_t count, bool* o
         {
             return SLANG_OK;
         }
-        SLANG_RETURN_ON_FAIL(hr);
+        SLANG_D3D_RETURN_ON_FAIL_REPORT(hr, device);
     }
 
     markQueryRangeReady(queryIndex, count, queryInfo.submissionID);
@@ -135,7 +137,7 @@ Result QueryPoolImpl::getResult(uint32_t queryIndex, uint32_t count, uint64_t* o
         {
             std::this_thread::sleep_for(std::chrono::milliseconds(1));
         }
-        SLANG_RETURN_ON_FAIL(hr);
+        SLANG_D3D_RETURN_ON_FAIL_REPORT(hr, device);
         if (disjointData.Disjoint || disjointData.Frequency == 0)
         {
             return SLANG_FAIL;
@@ -147,7 +149,7 @@ Result QueryPoolImpl::getResult(uint32_t queryIndex, uint32_t count, uint64_t* o
         {
             std::this_thread::sleep_for(std::chrono::milliseconds(1));
         }
-        SLANG_RETURN_ON_FAIL(hr);
+        SLANG_D3D_RETURN_ON_FAIL_REPORT(hr, device);
     }
 
     markQueryRangeReady(queryIndex, count, queryInfo.submissionID);

--- a/src/d3d11/d3d11-sampler.cpp
+++ b/src/d3d11/d3d11-sampler.cpp
@@ -40,7 +40,7 @@ Result DeviceImpl::createSampler(const SamplerDesc& desc, ISampler** outSampler)
     dxDesc.MaxLOD = desc.maxLOD;
 
     ComPtr<ID3D11SamplerState> sampler;
-    SLANG_RETURN_ON_FAIL(m_device->CreateSamplerState(&dxDesc, sampler.writeRef()));
+    SLANG_D3D_RETURN_ON_FAIL_REPORT(m_device->CreateSamplerState(&dxDesc, sampler.writeRef()), this);
 
     RefPtr<SamplerImpl> samplerImpl = new SamplerImpl(this, desc);
     samplerImpl->m_sampler = sampler;

--- a/src/d3d11/d3d11-texture.cpp
+++ b/src/d3d11/d3d11-texture.cpp
@@ -360,7 +360,10 @@ Result DeviceImpl::createTexture(const TextureDesc& desc_, const SubresourceData
         d3dDesc.Usage = d3dUsage;
 
         ComPtr<ID3D11Texture1D> texture1D;
-        SLANG_RETURN_ON_FAIL(m_device->CreateTexture1D(&d3dDesc, subresourcesPtr, texture1D.writeRef()));
+        SLANG_D3D_RETURN_ON_FAIL_REPORT(
+            m_device->CreateTexture1D(&d3dDesc, subresourcesPtr, texture1D.writeRef()),
+            this
+        );
 
         texture->m_resource = texture1D;
         break;
@@ -391,7 +394,10 @@ Result DeviceImpl::createTexture(const TextureDesc& desc_, const SubresourceData
         }
 
         ComPtr<ID3D11Texture2D> texture2D;
-        SLANG_RETURN_ON_FAIL(m_device->CreateTexture2D(&d3dDesc, subresourcesPtr, texture2D.writeRef()));
+        SLANG_D3D_RETURN_ON_FAIL_REPORT(
+            m_device->CreateTexture2D(&d3dDesc, subresourcesPtr, texture2D.writeRef()),
+            this
+        );
 
         texture->m_resource = texture2D;
         break;
@@ -410,7 +416,10 @@ Result DeviceImpl::createTexture(const TextureDesc& desc_, const SubresourceData
         d3dDesc.Usage = d3dUsage;
 
         ComPtr<ID3D11Texture3D> texture3D;
-        SLANG_RETURN_ON_FAIL(m_device->CreateTexture3D(&d3dDesc, subresourcesPtr, texture3D.writeRef()));
+        SLANG_D3D_RETURN_ON_FAIL_REPORT(
+            m_device->CreateTexture3D(&d3dDesc, subresourcesPtr, texture3D.writeRef()),
+            this
+        );
 
         texture->m_resource = texture3D;
         break;

--- a/src/d3d12/d3d12-buffer.cpp
+++ b/src/d3d12/d3d12-buffer.cpp
@@ -72,8 +72,9 @@ Result BufferImpl::getSharedHandle(NativeHandle* outHandle)
     if (!m_sharedHandle)
     {
         HANDLE handle = NULL;
-        SLANG_RETURN_ON_FAIL(
-            device->m_device->CreateSharedHandle(m_resource.getResource(), NULL, GENERIC_ALL, nullptr, &handle)
+        SLANG_D3D_RETURN_ON_FAIL_REPORT(
+            device->m_device->CreateSharedHandle(m_resource.getResource(), NULL, GENERIC_ALL, nullptr, &handle),
+            device
         );
         m_sharedHandle = {NativeHandleType::Win32, (uint64_t)handle};
     }
@@ -210,7 +211,7 @@ D3D12_CPU_DESCRIPTOR_HANDLE BufferImpl::getUAV(
 Result DeviceImpl::mapBuffer(IBuffer* buffer, CpuAccessMode mode, void** outData)
 {
     BufferImpl* bufferImpl = checked_cast<BufferImpl*>(buffer);
-    SLANG_RETURN_ON_FAIL(bufferImpl->m_resource.getResource()->Map(0, nullptr, outData));
+    SLANG_D3D_RETURN_ON_FAIL_REPORT(bufferImpl->m_resource.getResource()->Map(0, nullptr, outData), this);
     return SLANG_OK;
 }
 

--- a/src/d3d12/d3d12-command.cpp
+++ b/src/d3d12/d3d12-command.cpp
@@ -181,7 +181,7 @@ Result CommandRecorder::record(CommandBufferImpl* commandBuffer)
     commitBarriers();
     m_stateTracking.clear();
 
-    SLANG_RETURN_ON_FAIL(m_cmdList->Close());
+    SLANG_D3D_RETURN_ON_FAIL_REPORT(m_cmdList->Close(), m_device);
 
     return SLANG_OK;
 }
@@ -1873,7 +1873,10 @@ Result CommandQueueImpl::init(uint32_t queueIndex)
 
     D3D12_COMMAND_QUEUE_DESC queueDesc = {};
     queueDesc.Type = D3D12_COMMAND_LIST_TYPE_DIRECT;
-    SLANG_RETURN_ON_FAIL(m_d3dDevice->CreateCommandQueue(&queueDesc, IID_PPV_ARGS(m_d3dQueue.writeRef())));
+    SLANG_D3D_RETURN_ON_FAIL_REPORT(
+        m_d3dDevice->CreateCommandQueue(&queueDesc, IID_PPV_ARGS(m_d3dQueue.writeRef())),
+        m_device
+    );
 
 #if SLANG_RHI_ENABLE_AFTERMATH
     if (device->m_aftermathCrashDumper)
@@ -1882,7 +1885,10 @@ Result CommandQueueImpl::init(uint32_t queueIndex)
     }
 #endif
 
-    SLANG_RETURN_ON_FAIL(m_d3dDevice->CreateFence(0, D3D12_FENCE_FLAG_NONE, IID_PPV_ARGS(m_trackingFence.writeRef())));
+    SLANG_D3D_RETURN_ON_FAIL_REPORT(
+        m_d3dDevice->CreateFence(0, D3D12_FENCE_FLAG_NONE, IID_PPV_ARGS(m_trackingFence.writeRef())),
+        m_device
+    );
     m_globalWaitHandle =
         CreateEventEx(nullptr, nullptr, CREATE_EVENT_INITIAL_SET | CREATE_EVENT_MANUAL_RESET, EVENT_ALL_ACCESS);
     return SLANG_OK;
@@ -2004,7 +2010,7 @@ Result CommandQueueImpl::submit(const SubmitDesc& desc)
     for (uint32_t i = 0; i < desc.waitFenceCount; ++i)
     {
         FenceImpl* fence = checked_cast<FenceImpl*>(desc.waitFences[i]);
-        SLANG_RETURN_ON_FAIL(m_d3dQueue->Wait(fence->m_fence.get(), desc.waitFenceValues[i]));
+        SLANG_D3D_RETURN_ON_FAIL_REPORT(m_d3dQueue->Wait(fence->m_fence.get(), desc.waitFenceValues[i]), m_device);
     }
 
     // Execute command lists.
@@ -2030,10 +2036,10 @@ Result CommandQueueImpl::submit(const SubmitDesc& desc)
     for (uint32_t i = 0; i < desc.signalFenceCount; ++i)
     {
         FenceImpl* fence = checked_cast<FenceImpl*>(desc.signalFences[i]);
-        SLANG_RETURN_ON_FAIL(m_d3dQueue->Signal(fence->m_fence.get(), desc.signalFenceValues[i]));
+        SLANG_D3D_RETURN_ON_FAIL_REPORT(m_d3dQueue->Signal(fence->m_fence.get(), desc.signalFenceValues[i]), m_device);
     }
 
-    SLANG_RETURN_ON_FAIL(m_d3dQueue->Signal(m_trackingFence.get(), m_lastSubmittedID));
+    SLANG_D3D_RETURN_ON_FAIL_REPORT(m_d3dQueue->Signal(m_trackingFence.get(), m_lastSubmittedID), m_device);
 
     retireCommandBuffers();
 
@@ -2055,9 +2061,12 @@ Result CommandQueueImpl::waitOnHost()
 {
     DeviceImpl* device = getDevice<DeviceImpl>();
     m_lastSubmittedID++;
-    SLANG_RETURN_ON_FAIL(m_d3dQueue->Signal(m_trackingFence.get(), m_lastSubmittedID));
+    SLANG_D3D_RETURN_ON_FAIL_REPORT(m_d3dQueue->Signal(m_trackingFence.get(), m_lastSubmittedID), m_device);
     ResetEvent(m_globalWaitHandle);
-    SLANG_RETURN_ON_FAIL(m_trackingFence->SetEventOnCompletion(m_lastSubmittedID, m_globalWaitHandle));
+    SLANG_D3D_RETURN_ON_FAIL_REPORT(
+        m_trackingFence->SetEventOnCompletion(m_lastSubmittedID, m_globalWaitHandle),
+        m_device
+    );
     WaitForSingleObject(m_globalWaitHandle, INFINITE);
     device->flushValidationMessages();
     retireCommandBuffers();
@@ -2087,12 +2096,12 @@ Result CommandQueueImpl::getTimestampCalibration(TimestampCalibration* outCalibr
 
     UINT64 gpuTimestamp = 0;
     UINT64 cpuTimestamp = 0;
-    SLANG_RETURN_ON_FAIL(m_d3dQueue->GetClockCalibration(&gpuTimestamp, &cpuTimestamp));
+    SLANG_D3D_RETURN_ON_FAIL_REPORT(m_d3dQueue->GetClockCalibration(&gpuTimestamp, &cpuTimestamp), m_device);
 
     const uint64_t after = getCpuTimestamp();
 
     UINT64 gpuFrequency = 0;
-    SLANG_RETURN_ON_FAIL(m_d3dQueue->GetTimestampFrequency(&gpuFrequency));
+    SLANG_D3D_RETURN_ON_FAIL_REPORT(m_d3dQueue->GetTimestampFrequency(&gpuFrequency), m_device);
 
     const uint64_t cpuFrequency = getCpuTimestampFrequency();
 
@@ -2203,17 +2212,21 @@ CommandBufferImpl::~CommandBufferImpl()
 Result CommandBufferImpl::init()
 {
     DeviceImpl* device = getDevice<DeviceImpl>();
-    SLANG_RETURN_ON_FAIL(device->m_device->CreateCommandAllocator(
-        D3D12_COMMAND_LIST_TYPE_DIRECT,
-        IID_PPV_ARGS(m_d3dCommandAllocator.writeRef())
-    ));
-    SLANG_RETURN_ON_FAIL(device->m_device->CreateCommandList(
-        0,
-        D3D12_COMMAND_LIST_TYPE_DIRECT,
-        m_d3dCommandAllocator,
-        nullptr,
-        IID_PPV_ARGS(m_d3dCommandList.writeRef())
-    ));
+    SLANG_D3D_RETURN_ON_FAIL_REPORT(
+        device->m_device
+            ->CreateCommandAllocator(D3D12_COMMAND_LIST_TYPE_DIRECT, IID_PPV_ARGS(m_d3dCommandAllocator.writeRef())),
+        device
+    );
+    SLANG_D3D_RETURN_ON_FAIL_REPORT(
+        device->m_device->CreateCommandList(
+            0,
+            D3D12_COMMAND_LIST_TYPE_DIRECT,
+            m_d3dCommandAllocator,
+            nullptr,
+            IID_PPV_ARGS(m_d3dCommandList.writeRef())
+        ),
+        device
+    );
 
 #if SLANG_RHI_ENABLE_AFTERMATH
     if (device->m_aftermathCrashDumper)
@@ -2239,8 +2252,8 @@ Result CommandBufferImpl::init()
 Result CommandBufferImpl::reset()
 {
     DeviceImpl* device = getDevice<DeviceImpl>();
-    SLANG_RETURN_ON_FAIL(m_d3dCommandAllocator->Reset());
-    SLANG_RETURN_ON_FAIL(m_d3dCommandList->Reset(m_d3dCommandAllocator, nullptr));
+    SLANG_D3D_RETURN_ON_FAIL_REPORT(m_d3dCommandAllocator->Reset(), device);
+    SLANG_D3D_RETURN_ON_FAIL_REPORT(m_d3dCommandList->Reset(m_d3dCommandAllocator, nullptr), device);
     ID3D12DescriptorHeap* heaps[] = {
         device->m_gpuCbvSrvUavHeap->getHeap(),
         device->m_gpuSamplerHeap->getHeap(),

--- a/src/d3d12/d3d12-descriptor-heap.cpp
+++ b/src/d3d12/d3d12-descriptor-heap.cpp
@@ -19,7 +19,7 @@ Result DescriptorHeap::init(
     heapDesc.NumDescriptors = size;
     heapDesc.Flags = flags;
     heapDesc.Type = type;
-    SLANG_RETURN_ON_FAIL(m_device->CreateDescriptorHeap(&heapDesc, IID_PPV_ARGS(m_heap.writeRef())));
+    SLANG_D3D_RETURN_ON_FAIL(m_device->CreateDescriptorHeap(&heapDesc, IID_PPV_ARGS(m_heap.writeRef())));
 
     m_cpuStart = m_heap->GetCPUDescriptorHandleForHeapStart();
     if (flags & D3D12_DESCRIPTOR_HEAP_FLAG_SHADER_VISIBLE)

--- a/src/d3d12/d3d12-device.cpp
+++ b/src/d3d12/d3d12-device.cpp
@@ -21,6 +21,8 @@
 #include "core/string.h"
 
 #include <algorithm>
+#include <cstdarg>
+#include <cstdio>
 
 namespace rhi::d3d12 {
 
@@ -67,6 +69,151 @@ static ShaderModelInfo kKnownShaderModels[] = {
     SHADER_MODEL_INFO_DXIL(6, 9)
 #undef SHADER_MODEL_INFO_DXIL
 };
+
+struct D3D12CreateDeviceAttempt
+{
+    D3D_FEATURE_LEVEL featureLevel;
+    HRESULT result;
+};
+
+struct D3D12ShaderModelAttempt
+{
+    D3D_SHADER_MODEL requested;
+    D3D_SHADER_MODEL detected;
+    HRESULT result;
+};
+
+static const char* getAdapterTypeName(AdapterType adapterType)
+{
+    switch (adapterType)
+    {
+    case AdapterType::Discrete:
+        return "discrete";
+    case AdapterType::Integrated:
+        return "integrated";
+    case AdapterType::Software:
+        return "software";
+    case AdapterType::Unknown:
+        return "unknown";
+    }
+    return "unknown";
+}
+
+static const char* getFeatureLevelName(D3D_FEATURE_LEVEL featureLevel)
+{
+    switch (featureLevel)
+    {
+    case D3D_FEATURE_LEVEL_12_2:
+        return "D3D_FEATURE_LEVEL_12_2";
+    case D3D_FEATURE_LEVEL_12_1:
+        return "D3D_FEATURE_LEVEL_12_1";
+    case D3D_FEATURE_LEVEL_12_0:
+        return "D3D_FEATURE_LEVEL_12_0";
+    case D3D_FEATURE_LEVEL_11_1:
+        return "D3D_FEATURE_LEVEL_11_1";
+    case D3D_FEATURE_LEVEL_11_0:
+        return "D3D_FEATURE_LEVEL_11_0";
+    default:
+        return "D3D_FEATURE_LEVEL_UNKNOWN";
+    }
+}
+
+static const char* getShaderModelName(D3D_SHADER_MODEL shaderModel)
+{
+    for (const ShaderModelInfo& info : kKnownShaderModels)
+    {
+        if (info.shaderModel == shaderModel)
+            return info.profileName;
+    }
+    return "unknown";
+}
+
+static std::string formatAdapterLUID(const AdapterLUID& luid)
+{
+    char buffer[sizeof(AdapterLUID::luid) * 2 + 1];
+    for (size_t i = 0; i < sizeof(AdapterLUID::luid); ++i)
+    {
+        snprintf(buffer + i * 2, 3, "%02x", uint32_t(luid.luid[i]));
+    }
+    return std::string(buffer);
+}
+
+static void appendFormatLine(std::string& message, const char* format, ...)
+{
+    char buffer[1024];
+    va_list args;
+    va_start(args, format);
+    vsnprintf(buffer, sizeof(buffer), format, args);
+    va_end(args);
+    message += buffer;
+}
+
+static void appendShaderModelAttempts(
+    std::string& message,
+    const D3D12ShaderModelAttempt* attempts,
+    size_t attemptCount
+)
+{
+    for (size_t i = 0; i < attemptCount; ++i)
+    {
+        const D3D12ShaderModelAttempt& attempt = attempts[i];
+        appendFormatLine(
+            message,
+            "  - requested %s (0x%04x): %s (0x%08x), detected %s (0x%04x)\n",
+            getShaderModelName(attempt.requested),
+            uint32_t(attempt.requested),
+            getHRESULTName(attempt.result),
+            uint32_t(attempt.result),
+            getShaderModelName(attempt.detected),
+            uint32_t(attempt.detected)
+        );
+    }
+}
+
+static void reportD3D12DeviceCreationFailure(
+    DeviceImpl* device,
+    const AdapterImpl* adapter,
+    int64_t adapterIndex,
+    const D3D12CreateDeviceAttempt* attempts,
+    size_t attemptCount
+)
+{
+    std::string message = "D3D12CreateDevice failed.\n";
+    if (adapter)
+    {
+        const AdapterInfo& info = adapter->m_info;
+        appendFormatLine(
+            message,
+            "Selected adapter: index=%lld, name=\"%s\", type=%s, vendorID=0x%04x, deviceID=0x%04x, LUID=%s\n",
+            static_cast<long long>(adapterIndex),
+            info.name,
+            getAdapterTypeName(info.adapterType),
+            info.vendorID,
+            info.deviceID,
+            formatAdapterLUID(info.luid).c_str()
+        );
+    }
+    else
+    {
+        message += "Selected adapter: <none>\n";
+    }
+
+    message += "Feature-level attempts:\n";
+    for (size_t i = 0; i < attemptCount; ++i)
+    {
+        const D3D12CreateDeviceAttempt& attempt = attempts[i];
+        appendFormatLine(
+            message,
+            "  - %s (0x%04x): %s (0x%08x)\n",
+            getFeatureLevelName(attempt.featureLevel),
+            uint32_t(attempt.featureLevel),
+            getHRESULTName(attempt.result),
+            uint32_t(attempt.result)
+        );
+    }
+    message += "Shader model probing: unavailable because no D3D12 device was created.\n";
+    device->handleMessage(DebugMessageType::Error, DebugMessageSource::Driver, message.c_str());
+}
 
 inline int getShaderModelFromProfileName(const char* name)
 {
@@ -347,15 +494,30 @@ Result DeviceImpl::initialize(const DeviceDesc& desc, BackendImpl* backend)
 
         const D3D_FEATURE_LEVEL featureLevels[] =
             {D3D_FEATURE_LEVEL_12_2, D3D_FEATURE_LEVEL_12_1, D3D_FEATURE_LEVEL_12_0};
+        D3D12CreateDeviceAttempt createDeviceAttempts[SLANG_COUNT_OF(featureLevels)] = {};
+        size_t createDeviceAttemptCount = 0;
         for (auto featureLevel : featureLevels)
         {
-            if (SUCCEEDED(m_D3D12CreateDevice(m_dxgiAdapter, featureLevel, IID_PPV_ARGS(m_device.writeRef()))))
+            HRESULT result = m_D3D12CreateDevice(m_dxgiAdapter, featureLevel, IID_PPV_ARGS(m_device.writeRef()));
+            createDeviceAttempts[createDeviceAttemptCount++] = {featureLevel, result};
+            if (SUCCEEDED(result))
             {
                 break;
             }
         }
         if (!m_device)
         {
+            auto adapters = backend->getAdapters();
+            int64_t adapterIndex = -1;
+            if (adapter && adapters.data())
+                adapterIndex = adapter - adapters.data();
+            reportD3D12DeviceCreationFailure(
+                this,
+                adapter,
+                adapterIndex,
+                createDeviceAttempts,
+                createDeviceAttemptCount
+            );
             return SLANG_FAIL;
         }
     }
@@ -501,7 +663,7 @@ Result DeviceImpl::initialize(const DeviceDesc& desc, BackendImpl* backend)
         allocatorDesc.Flags = D3D12MA::ALLOCATOR_FLAGS(D3D12MA_RECOMMENDED_ALLOCATOR_FLAGS);
         allocatorDesc.pDevice = m_device.get();
         allocatorDesc.pAdapter = m_dxgiAdapter.get();
-        SLANG_RETURN_ON_FAIL(D3D12MA::CreateAllocator(&allocatorDesc, m_allocator.writeRef()));
+        SLANG_D3D_RETURN_ON_FAIL_REPORT(D3D12MA::CreateAllocator(&allocatorDesc, m_allocator.writeRef()), this);
     }
 
     // Initialize descriptor heaps.
@@ -561,8 +723,10 @@ Result DeviceImpl::initialize(const DeviceDesc& desc, BackendImpl* backend)
         signatureDesc.pArgumentDescs = &args;
         signatureDesc.NodeMask = 0;
 
-        SLANG_RETURN_ON_FAIL(
-            m_device->CreateCommandSignature(&signatureDesc, nullptr, IID_PPV_ARGS(drawIndirectCmdSignature.writeRef()))
+        SLANG_D3D_RETURN_ON_FAIL_REPORT(
+            m_device
+                ->CreateCommandSignature(&signatureDesc, nullptr, IID_PPV_ARGS(drawIndirectCmdSignature.writeRef())),
+            this
         );
     }
 
@@ -578,11 +742,14 @@ Result DeviceImpl::initialize(const DeviceDesc& desc, BackendImpl* backend)
         signatureDesc.pArgumentDescs = &args;
         signatureDesc.NodeMask = 0;
 
-        SLANG_RETURN_ON_FAIL(m_device->CreateCommandSignature(
-            &signatureDesc,
-            nullptr,
-            IID_PPV_ARGS(drawIndexedIndirectCmdSignature.writeRef())
-        ));
+        SLANG_D3D_RETURN_ON_FAIL_REPORT(
+            m_device->CreateCommandSignature(
+                &signatureDesc,
+                nullptr,
+                IID_PPV_ARGS(drawIndexedIndirectCmdSignature.writeRef())
+            ),
+            this
+        );
     }
 
     // Allocate a D3D12 "command signature" object that matches the behavior
@@ -597,11 +764,14 @@ Result DeviceImpl::initialize(const DeviceDesc& desc, BackendImpl* backend)
         signatureDesc.pArgumentDescs = &args;
         signatureDesc.NodeMask = 0;
 
-        SLANG_RETURN_ON_FAIL(m_device->CreateCommandSignature(
-            &signatureDesc,
-            nullptr,
-            IID_PPV_ARGS(dispatchIndirectCmdSignature.writeRef())
-        ));
+        SLANG_D3D_RETURN_ON_FAIL_REPORT(
+            m_device->CreateCommandSignature(
+                &signatureDesc,
+                nullptr,
+                IID_PPV_ARGS(dispatchIndirectCmdSignature.writeRef())
+            ),
+            this
+        );
     }
 
     // Initialize device info.
@@ -668,6 +838,9 @@ Result DeviceImpl::initialize(const DeviceDesc& desc, BackendImpl* backend)
     addCapability(Capability::hlsl);
 
     D3D12_FEATURE_DATA_SHADER_MODEL shaderModelData = {};
+    D3D12ShaderModelAttempt shaderModelAttempts[SLANG_COUNT_OF(kKnownShaderModels) + 1] = {};
+    size_t shaderModelAttemptCount = 0;
+    bool shaderModelDetected = false;
 
     {
         // CheckFeatureSupport(D3D12_FEATURE_SHADER_MODEL) can fail if the runtime/driver does not yet know the
@@ -681,10 +854,15 @@ Result DeviceImpl::initialize(const DeviceDesc& desc, BackendImpl* backend)
         for (D3D_SHADER_MODEL shaderModel : shaderModels)
         {
             shaderModelData.HighestShaderModel = shaderModel;
-            if (SLANG_SUCCEEDED(
-                    m_device->CheckFeatureSupport(D3D12_FEATURE_SHADER_MODEL, &shaderModelData, sizeof(shaderModelData))
-                ))
+            HRESULT result =
+                m_device->CheckFeatureSupport(D3D12_FEATURE_SHADER_MODEL, &shaderModelData, sizeof(shaderModelData));
+            shaderModelAttempts[shaderModelAttemptCount++] =
+                D3D12ShaderModelAttempt{shaderModel, shaderModelData.HighestShaderModel, result};
+            if (SLANG_SUCCEEDED(result))
+            {
+                shaderModelDetected = true;
                 break;
+            }
         }
     }
     {
@@ -1006,11 +1184,22 @@ Result DeviceImpl::initialize(const DeviceDesc& desc, BackendImpl* backend)
     int userSpecifiedShaderModel = getShaderModelFromProfileName(desc.slang.targetProfile);
     if (userSpecifiedShaderModel > shaderModelData.HighestShaderModel)
     {
-        handleMessage(
-            DebugMessageType::Error,
-            DebugMessageSource::Layer,
-            "The requested shader model is not supported by the system."
+        std::string message;
+        appendFormatLine(
+            message,
+            "The requested shader model is not supported by the system.\n"
+            "Requested shader model: %s (0x%04x)\n"
+            "Highest detected shader model: %s (0x%04x)\n"
+            "Shader model detected successfully: %s\n"
+            "Shader model probing attempts:\n",
+            getShaderModelName(D3D_SHADER_MODEL(userSpecifiedShaderModel)),
+            uint32_t(userSpecifiedShaderModel),
+            getShaderModelName(shaderModelData.HighestShaderModel),
+            uint32_t(shaderModelData.HighestShaderModel),
+            shaderModelDetected ? "yes" : "no"
         );
+        appendShaderModelAttempts(message, shaderModelAttempts, shaderModelAttemptCount);
+        handleMessage(DebugMessageType::Error, DebugMessageSource::Layer, message.c_str());
         return SLANG_E_NOT_AVAILABLE;
     }
 
@@ -1171,7 +1360,7 @@ Result DeviceImpl::createBuffer(
 
         ID3D12Resource* dxUploadResource = uploadResourceRef.getResource();
 
-        SLANG_RETURN_ON_FAIL(dxUploadResource->Map(0, &readRange, reinterpret_cast<void**>(&dstData)));
+        SLANG_D3D_RETURN_ON_FAIL_REPORT(dxUploadResource->Map(0, &readRange, reinterpret_cast<void**>(&dstData)), this);
         ::memcpy(dstData, srcData, srcDataSize);
         dxUploadResource->Unmap(0, nullptr);
 
@@ -1567,7 +1756,10 @@ Result DeviceImpl::readBuffer(IBuffer* buffer, Offset offset, Size size, void* o
         UINT8* data;
         D3D12_RANGE readRange = {0, size};
 
-        SLANG_RETURN_ON_FAIL(stageBufRef.getResource()->Map(0, &readRange, reinterpret_cast<void**>(&data)));
+        SLANG_D3D_RETURN_ON_FAIL_REPORT(
+            stageBufRef.getResource()->Map(0, &readRange, reinterpret_cast<void**>(&data)),
+            this
+        );
 
         // Copy to memory buffer
         std::memcpy(outData, data, size);
@@ -1808,7 +2000,10 @@ Result DeviceImpl::waitForFences(
     {
         auto fenceImpl = checked_cast<FenceImpl*>(fences[i]);
         waitHandles.push_back(fenceImpl->getWaitEvent());
-        SLANG_RETURN_ON_FAIL(fenceImpl->m_fence->SetEventOnCompletion(fenceValues[i], fenceImpl->getWaitEvent()));
+        SLANG_D3D_RETURN_ON_FAIL_REPORT(
+            fenceImpl->m_fence->SetEventOnCompletion(fenceValues[i], fenceImpl->getWaitEvent()),
+            this
+        );
     }
     auto result = WaitForMultipleObjects(
         fenceCount,

--- a/src/d3d12/d3d12-fence.cpp
+++ b/src/d3d12/d3d12-fence.cpp
@@ -26,11 +26,14 @@ Result FenceImpl::init()
 {
     DeviceImpl* device = getDevice<DeviceImpl>();
 
-    SLANG_RETURN_ON_FAIL(device->m_device->CreateFence(
-        m_desc.initialValue,
-        m_desc.isShared ? D3D12_FENCE_FLAG_SHARED : D3D12_FENCE_FLAG_NONE,
-        IID_PPV_ARGS(m_fence.writeRef())
-    ));
+    SLANG_D3D_RETURN_ON_FAIL_REPORT(
+        device->m_device->CreateFence(
+            m_desc.initialValue,
+            m_desc.isShared ? D3D12_FENCE_FLAG_SHARED : D3D12_FENCE_FLAG_NONE,
+            IID_PPV_ARGS(m_fence.writeRef())
+        ),
+        device
+    );
     if (m_desc.label)
     {
         m_fence->SetName(string::to_wstring(m_desc.label).c_str());
@@ -54,7 +57,7 @@ Result FenceImpl::getCurrentValue(uint64_t* outValue)
 
 Result FenceImpl::setCurrentValue(uint64_t value)
 {
-    SLANG_RETURN_ON_FAIL(m_fence->Signal(value));
+    SLANG_D3D_RETURN_ON_FAIL_REPORT(m_fence->Signal(value), m_device);
     return SLANG_OK;
 }
 
@@ -75,7 +78,10 @@ Result FenceImpl::getSharedHandle(NativeHandle* outHandle)
     if (!m_sharedHandle)
     {
         HANDLE handle = NULL;
-        SLANG_RETURN_ON_FAIL(device->m_device->CreateSharedHandle(m_fence, NULL, GENERIC_ALL, nullptr, &handle));
+        SLANG_D3D_RETURN_ON_FAIL_REPORT(
+            device->m_device->CreateSharedHandle(m_fence, NULL, GENERIC_ALL, nullptr, &handle),
+            device
+        );
         m_sharedHandle = NativeHandle{NativeHandleType::Win32, (uint64_t)handle};
     }
 

--- a/src/d3d12/d3d12-pipeline.cpp
+++ b/src/d3d12/d3d12-pipeline.cpp
@@ -354,7 +354,10 @@ Result DeviceImpl::createRenderPipeline2(const RenderPipelineDesc& desc, IRender
         fillCommonGraphicsState(meshDesc);
         CD3DX12_PIPELINE_STATE_STREAM2 meshStateStream{meshDesc};
         D3D12_PIPELINE_STATE_STREAM_DESC streamDesc{sizeof(meshStateStream), &meshStateStream};
-        SLANG_RETURN_ON_FAIL(m_device5->CreatePipelineState(&streamDesc, IID_PPV_ARGS(pipelineState.writeRef())));
+        SLANG_D3D_RETURN_ON_FAIL_REPORT(
+            m_device5->CreatePipelineState(&streamDesc, IID_PPV_ARGS(pipelineState.writeRef())),
+            this
+        );
     }
     else
     {
@@ -707,7 +710,10 @@ Result DeviceImpl::createRayTracingPipeline2(const RayTracingPipelineDesc& desc,
     rtpsoDesc.Type = D3D12_STATE_OBJECT_TYPE_RAYTRACING_PIPELINE;
     rtpsoDesc.NumSubobjects = (UINT)subObjects.size();
     rtpsoDesc.pSubobjects = subObjects.data();
-    SLANG_RETURN_ON_FAIL(m_device5->CreateStateObject(&rtpsoDesc, IID_PPV_ARGS(stateObject.writeRef())));
+    SLANG_D3D_RETURN_ON_FAIL_REPORT(
+        m_device5->CreateStateObject(&rtpsoDesc, IID_PPV_ARGS(stateObject.writeRef())),
+        this
+    );
 
 #if SLANG_RHI_ENABLE_NVAPI
     if (m_nvapiShaderExtension)

--- a/src/d3d12/d3d12-query.cpp
+++ b/src/d3d12/d3d12-query.cpp
@@ -41,7 +41,10 @@ Result QueryPoolImpl::init()
 
     // Create query heap.
     auto d3dDevice = device->m_device;
-    SLANG_RETURN_ON_FAIL(d3dDevice->CreateQueryHeap(&heapDesc, IID_PPV_ARGS(m_queryHeap.writeRef())));
+    SLANG_D3D_RETURN_ON_FAIL_REPORT(
+        d3dDevice->CreateQueryHeap(&heapDesc, IID_PPV_ARGS(m_queryHeap.writeRef())),
+        device
+    );
 
     if (m_desc.label)
     {
@@ -63,8 +66,9 @@ Result QueryPoolImpl::init()
     ));
 
     D3D12_RANGE readRange = {0, sizeof(uint64_t) * m_desc.count};
-    SLANG_RETURN_ON_FAIL(
-        m_readBackBuffer.getResource()->Map(0, &readRange, reinterpret_cast<void**>(&m_mappedReadBackData))
+    SLANG_D3D_RETURN_ON_FAIL_REPORT(
+        m_readBackBuffer.getResource()->Map(0, &readRange, reinterpret_cast<void**>(&m_mappedReadBackData)),
+        device
     );
 
     return SLANG_OK;
@@ -124,7 +128,10 @@ Result QueryPoolImpl::getResult(uint32_t queryIndex, uint32_t count, uint64_t* o
     if (queue->updateLastFinishedID() < submissionID)
     {
         ResetEvent(queue->m_globalWaitHandle);
-        SLANG_RETURN_ON_FAIL(queue->m_trackingFence->SetEventOnCompletion(submissionID, queue->m_globalWaitHandle));
+        SLANG_D3D_RETURN_ON_FAIL_REPORT(
+            queue->m_trackingFence->SetEventOnCompletion(submissionID, queue->m_globalWaitHandle),
+            getDevice<DeviceImpl>()
+        );
         WaitForSingleObject(queue->m_globalWaitHandle, INFINITE);
         queue->updateLastFinishedID();
         queue->retireCommandBuffers();
@@ -193,8 +200,9 @@ Result PlainBufferProxyQueryPoolImpl::init(uint32_t stride)
     ));
 
     D3D12_RANGE readRange = {0, size};
-    SLANG_RETURN_ON_FAIL(
-        m_readBackBuffer.getResource()->Map(0, &readRange, reinterpret_cast<void**>(&m_mappedReadBackData))
+    SLANG_D3D_RETURN_ON_FAIL_REPORT(
+        m_readBackBuffer.getResource()->Map(0, &readRange, reinterpret_cast<void**>(&m_mappedReadBackData)),
+        device
     );
 
     m_queryType = m_desc.type;
@@ -259,7 +267,10 @@ Result PlainBufferProxyQueryPoolImpl::getResult(uint32_t queryIndex, uint32_t co
     if (queue->updateLastFinishedID() < submissionID)
     {
         ResetEvent(queue->m_globalWaitHandle);
-        SLANG_RETURN_ON_FAIL(queue->m_trackingFence->SetEventOnCompletion(submissionID, queue->m_globalWaitHandle));
+        SLANG_D3D_RETURN_ON_FAIL_REPORT(
+            queue->m_trackingFence->SetEventOnCompletion(submissionID, queue->m_globalWaitHandle),
+            device
+        );
         WaitForSingleObject(queue->m_globalWaitHandle, INFINITE);
         queue->updateLastFinishedID();
         queue->retireCommandBuffers();

--- a/src/d3d12/d3d12-resource.cpp
+++ b/src/d3d12/d3d12-resource.cpp
@@ -122,7 +122,7 @@ Result D3D12Resource::initCommitted(
         if (desc.Alignment == 0 && (isPlanarFormat(desc.Format) || desc.SampleDesc.Count > 1))
             desc.Alignment = D3D12_DEFAULT_RESOURCE_PLACEMENT_ALIGNMENT;
 
-        SLANG_RETURN_ON_FAIL(
+        SLANG_D3D_RETURN_ON_FAIL(
             allocator
                 ->CreateResource(&allocDesc, &desc, initState, clearValue, m_allocation.writeRef(), IID_NULL, nullptr)
         );
@@ -132,7 +132,7 @@ Result D3D12Resource::initCommitted(
     }
 
     ComPtr<ID3D12Resource> resource;
-    SLANG_RETURN_ON_FAIL(device->CreateCommittedResource(
+    SLANG_D3D_RETURN_ON_FAIL(device->CreateCommittedResource(
         &heapProps,
         heapFlags,
         &resourceDesc,

--- a/src/d3d12/d3d12-shader-object-layout.cpp
+++ b/src/d3d12/d3d12-shader-object-layout.cpp
@@ -944,12 +944,15 @@ Result RootShaderObjectLayoutImpl::createRootSignatureFromSlang(
         return SLANG_FAIL;
     }
 
-    SLANG_RETURN_ON_FAIL(device->m_device->CreateRootSignature(
-        0,
-        signature->GetBufferPointer(),
-        signature->GetBufferSize(),
-        IID_PPV_ARGS(outRootSignature)
-    ));
+    SLANG_D3D_RETURN_ON_FAIL_REPORT(
+        device->m_device->CreateRootSignature(
+            0,
+            signature->GetBufferPointer(),
+            signature->GetBufferSize(),
+            IID_PPV_ARGS(outRootSignature)
+        ),
+        device
+    );
     return SLANG_OK;
 }
 

--- a/src/d3d12/d3d12-surface.cpp
+++ b/src/d3d12/d3d12-surface.cpp
@@ -10,7 +10,10 @@ Result SurfaceImpl::init(DeviceImpl* device, WindowHandle windowHandle)
     m_queue = m_device->m_queue->m_d3dQueue;
     m_dxgiFactory = device->m_dxgiFactory;
     SLANG_RETURN_ON_FAIL(D3DSurface::init(windowHandle, DXGI_SWAP_EFFECT_FLIP_DISCARD, false));
-    SLANG_RETURN_ON_FAIL(m_device->m_device->CreateFence(0, D3D12_FENCE_FLAG_NONE, IID_PPV_ARGS(m_fence.writeRef())));
+    SLANG_D3D_RETURN_ON_FAIL_REPORT(
+        m_device->m_device->CreateFence(0, D3D12_FENCE_FLAG_NONE, IID_PPV_ARGS(m_fence.writeRef())),
+        m_device
+    );
     return SLANG_OK;
 }
 
@@ -84,7 +87,10 @@ Result SurfaceImpl::present()
     {
         return SLANG_FAIL;
     }
-    m_fence->SetEventOnCompletion(fenceValue, m_frameEvents[m_swapChain3->GetCurrentBackBufferIndex()]);
+    SLANG_D3D_RETURN_ON_FAIL_REPORT(
+        m_fence->SetEventOnCompletion(fenceValue, m_frameEvents[m_swapChain3->GetCurrentBackBufferIndex()]),
+        m_device
+    );
     SLANG_RETURN_ON_FAIL(D3DSurface::present());
     fenceValue++;
     m_queue->Signal(m_fence, fenceValue);

--- a/src/d3d12/d3d12-texture.cpp
+++ b/src/d3d12/d3d12-texture.cpp
@@ -76,8 +76,9 @@ Result TextureImpl::getSharedHandle(NativeHandle* outHandle)
     if (!m_sharedHandle)
     {
         HANDLE handle = NULL;
-        SLANG_RETURN_ON_FAIL(
-            device->m_device->CreateSharedHandle(m_resource.getResource(), NULL, GENERIC_ALL, nullptr, &handle)
+        SLANG_D3D_RETURN_ON_FAIL_REPORT(
+            device->m_device->CreateSharedHandle(m_resource.getResource(), NULL, GENERIC_ALL, nullptr, &handle),
+            device
         );
         m_sharedHandle = NativeHandle{NativeHandleType::Win32, (uint64_t)handle};
     }

--- a/src/debug-layer/debug-helper-functions.cpp
+++ b/src/debug-layer/debug-helper-functions.cpp
@@ -6,7 +6,7 @@
 
 namespace rhi::debug {
 
-thread_local const char* _currentFunctionName = nullptr;
+thread_local const char* tls_currentFunctionName = nullptr;
 
 SLANG_RHI_DEBUG_GET_INTERFACE_IMPL(Device)
 SLANG_RHI_DEBUG_GET_INTERFACE_IMPL(CommandQueue)

--- a/src/debug-layer/debug-helper-functions.h
+++ b/src/debug-layer/debug-helper-functions.h
@@ -16,19 +16,19 @@
 
 namespace rhi::debug {
 
-extern thread_local const char* _currentFunctionName;
+extern thread_local const char* tls_currentFunctionName;
 
 struct ScopedAPIName
 {
-    ScopedAPIName(const char* name) { _currentFunctionName = name; }
-    ~ScopedAPIName() { _currentFunctionName = nullptr; }
+    ScopedAPIName(const char* name) { tls_currentFunctionName = name; }
+    ~ScopedAPIName() { tls_currentFunctionName = nullptr; }
 };
 
 #define SLANG_RHI_DEBUG_API(interface, method) ScopedAPIName scopedAPIName(#interface "::" #method)
 
 inline const char* getAPIName()
 {
-    return _currentFunctionName ? _currentFunctionName : "<unknown function>";
+    return tls_currentFunctionName ? tls_currentFunctionName : "<unknown function>";
 }
 
 template<typename... TArgs>

--- a/src/rhi-shared.h
+++ b/src/rhi-shared.h
@@ -18,10 +18,11 @@
 #include "shader.h"
 #include "pipeline.h"
 
+#include <cstddef>
 #include <map>
-#include <set>
 #include <memory>
 #include <mutex>
+#include <set>
 #include <string>
 #include <string_view>
 #include <unordered_map>
@@ -363,6 +364,11 @@ public:
 inline Device* getDiagnosticDevice(Device* device)
 {
     return device;
+}
+
+inline Device* getDiagnosticDevice(std::nullptr_t)
+{
+    return nullptr;
 }
 
 inline Device* getDiagnosticDevice(DeviceChild* deviceChild)

--- a/src/rhi-shared.h
+++ b/src/rhi-shared.h
@@ -360,20 +360,15 @@ public:
     bool m_configured = false;
 };
 
-struct DeviceAdapter
+inline Device* getDiagnosticDevice(Device* device)
 {
-    Device* device;
-    DeviceAdapter(Device* device)
-        : device(device)
-    {
-    }
-    DeviceAdapter(DeviceChild* deviceChild)
-        : device(deviceChild && deviceChild->getDevice() ? deviceChild->getDevice() : nullptr)
-    {
-    }
-    explicit operator bool() const { return device != nullptr; }
-    Device* operator->() const { return device; }
-};
+    return device;
+}
+
+inline Device* getDiagnosticDevice(DeviceChild* deviceChild)
+{
+    return deviceChild ? deviceChild->getDevice() : nullptr;
+}
 
 bool isDepthFormat(Format format);
 bool isStencilFormat(Format format);

--- a/src/vulkan/vk-bindless-descriptor-set.cpp
+++ b/src/vulkan/vk-bindless-descriptor-set.cpp
@@ -62,7 +62,10 @@ Result BindlessDescriptorSet::initialize()
         createInfo.flags =
             VK_DESCRIPTOR_POOL_CREATE_FREE_DESCRIPTOR_SET_BIT | VK_DESCRIPTOR_POOL_CREATE_UPDATE_AFTER_BIND_BIT;
 
-        SLANG_VK_RETURN_ON_FAIL(api.vkCreateDescriptorPool(api.m_device, &createInfo, nullptr, &m_descriptorPool));
+        SLANG_VK_RETURN_ON_FAIL_REPORT(
+            api.vkCreateDescriptorPool(api.m_device, &createInfo, nullptr, &m_descriptorPool),
+            m_device
+        );
     }
 
     // Create descriptor set layout
@@ -128,8 +131,9 @@ Result BindlessDescriptorSet::initialize()
         createInfo.bindingCount = 3;
         createInfo.pBindings = bindings;
 
-        SLANG_VK_RETURN_ON_FAIL(
-            api.vkCreateDescriptorSetLayout(api.m_device, &createInfo, nullptr, &m_descriptorSetLayout)
+        SLANG_VK_RETURN_ON_FAIL_REPORT(
+            api.vkCreateDescriptorSetLayout(api.m_device, &createInfo, nullptr, &m_descriptorSetLayout),
+            m_device
         );
     }
 
@@ -139,7 +143,10 @@ Result BindlessDescriptorSet::initialize()
         allocInfo.descriptorPool = m_descriptorPool;
         allocInfo.descriptorSetCount = 1;
         allocInfo.pSetLayouts = &m_descriptorSetLayout;
-        SLANG_VK_RETURN_ON_FAIL(api.vkAllocateDescriptorSets(api.m_device, &allocInfo, &m_descriptorSet));
+        SLANG_VK_RETURN_ON_FAIL_REPORT(
+            api.vkAllocateDescriptorSets(api.m_device, &allocInfo, &m_descriptorSet),
+            m_device
+        );
     }
 
     m_bufferAllocator.capacity = m_desc.bufferCount;

--- a/src/vulkan/vk-buffer.cpp
+++ b/src/vulkan/vk-buffer.cpp
@@ -400,7 +400,7 @@ Result DeviceImpl::createBuffer(const BufferDesc& desc_, const void* initData, I
             ));
             // Copy into staging buffer
             void* mappedData = nullptr;
-            SLANG_VK_CHECK_REPORT(
+            SLANG_VK_RETURN_ON_FAIL_REPORT(
                 m_api.vkMapMemory(m_device, buffer->m_uploadBuffer.m_memory, 0, bufferSize, 0, &mappedData),
                 this
             );
@@ -425,7 +425,7 @@ Result DeviceImpl::createBuffer(const BufferDesc& desc_, const void* initData, I
         {
             // Copy into mapped buffer directly
             void* mappedData = nullptr;
-            SLANG_VK_CHECK_REPORT(
+            SLANG_VK_RETURN_ON_FAIL_REPORT(
                 m_api.vkMapMemory(m_device, buffer->m_buffer.m_memory, 0, bufferSize, 0, &mappedData),
                 this
             );

--- a/src/vulkan/vk-buffer.cpp
+++ b/src/vulkan/vk-buffer.cpp
@@ -217,7 +217,7 @@ Result BufferImpl::getSharedHandle(NativeHandle* outHandle)
             return SLANG_FAIL;
         }
         HANDLE handle = NULL;
-        SLANG_VK_RETURN_ON_FAIL(api.vkGetMemoryWin32HandleKHR(api.m_device, &info, &handle));
+        SLANG_VK_RETURN_ON_FAIL_REPORT(api.vkGetMemoryWin32HandleKHR(api.m_device, &info, &handle), device);
         m_sharedHandle = NativeHandle{NativeHandleType::Win32, (uint64_t)handle};
 #else
         VkMemoryGetFdInfoKHR info = {};
@@ -231,7 +231,7 @@ Result BufferImpl::getSharedHandle(NativeHandle* outHandle)
             return SLANG_FAIL;
         }
         int handle = 0;
-        SLANG_VK_RETURN_ON_FAIL(api.vkGetMemoryFdKHR(api.m_device, &info, &handle));
+        SLANG_VK_RETURN_ON_FAIL_REPORT(api.vkGetMemoryFdKHR(api.m_device, &info, &handle), device);
         m_sharedHandle = NativeHandle{NativeHandleType::FileDescriptor, (uint64_t)handle};
 #endif
     }
@@ -400,7 +400,10 @@ Result DeviceImpl::createBuffer(const BufferDesc& desc_, const void* initData, I
             ));
             // Copy into staging buffer
             void* mappedData = nullptr;
-            SLANG_VK_CHECK(m_api.vkMapMemory(m_device, buffer->m_uploadBuffer.m_memory, 0, bufferSize, 0, &mappedData));
+            SLANG_VK_CHECK_REPORT(
+                m_api.vkMapMemory(m_device, buffer->m_uploadBuffer.m_memory, 0, bufferSize, 0, &mappedData),
+                this
+            );
             ::memcpy(mappedData, initData, bufferSize);
             m_api.vkUnmapMemory(m_device, buffer->m_uploadBuffer.m_memory);
 
@@ -422,7 +425,10 @@ Result DeviceImpl::createBuffer(const BufferDesc& desc_, const void* initData, I
         {
             // Copy into mapped buffer directly
             void* mappedData = nullptr;
-            SLANG_VK_CHECK(m_api.vkMapMemory(m_device, buffer->m_buffer.m_memory, 0, bufferSize, 0, &mappedData));
+            SLANG_VK_CHECK_REPORT(
+                m_api.vkMapMemory(m_device, buffer->m_buffer.m_memory, 0, bufferSize, 0, &mappedData),
+                this
+            );
             ::memcpy(mappedData, initData, bufferSize);
             m_api.vkUnmapMemory(m_device, buffer->m_buffer.m_memory);
         }
@@ -452,8 +458,9 @@ Result DeviceImpl::createBufferFromNativeHandle(NativeHandle handle, const Buffe
 Result DeviceImpl::mapBuffer(IBuffer* buffer, CpuAccessMode mode, void** outData)
 {
     BufferImpl* bufferImpl = checked_cast<BufferImpl*>(buffer);
-    SLANG_VK_RETURN_ON_FAIL(
-        m_api.vkMapMemory(m_api.m_device, bufferImpl->m_buffer.m_memory, 0, VK_WHOLE_SIZE, 0, outData)
+    SLANG_VK_RETURN_ON_FAIL_REPORT(
+        m_api.vkMapMemory(m_api.m_device, bufferImpl->m_buffer.m_memory, 0, VK_WHOLE_SIZE, 0, outData),
+        this
     );
     return SLANG_OK;
 }

--- a/src/vulkan/vk-command.cpp
+++ b/src/vulkan/vk-command.cpp
@@ -148,7 +148,7 @@ Result CommandRecorder::record(CommandBufferImpl* commandBuffer)
 
     VkCommandBufferBeginInfo beginInfo = {VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO};
     beginInfo.flags = VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT;
-    SLANG_VK_RETURN_ON_FAIL(m_api.vkBeginCommandBuffer(m_cmdBuffer, &beginInfo));
+    SLANG_VK_RETURN_ON_FAIL_REPORT(m_api.vkBeginCommandBuffer(m_cmdBuffer, &beginInfo), m_device);
 
     CommandList& commandList = commandBuffer->m_commandList;
 
@@ -193,7 +193,7 @@ Result CommandRecorder::record(CommandBufferImpl* commandBuffer)
     commitBarriers();
     m_stateTracking.clear();
 
-    SLANG_VK_RETURN_ON_FAIL(m_api.vkEndCommandBuffer(m_cmdBuffer));
+    SLANG_VK_RETURN_ON_FAIL_REPORT(m_api.vkEndCommandBuffer(m_cmdBuffer), m_device);
 
     return SLANG_OK;
 }
@@ -2073,7 +2073,7 @@ Result CommandQueueImpl::submit(const SubmitDesc& desc)
         timelineSubmitInfo.pSignalSemaphoreValues = signalValues.data();
     }
 
-    SLANG_VK_RETURN_ON_FAIL(m_api.vkQueueSubmit(m_queue, 1, &submitInfo, m_surfaceSync.fence));
+    SLANG_VK_RETURN_ON_FAIL_REPORT(m_api.vkQueueSubmit(m_queue, 1, &submitInfo, m_surfaceSync.fence), m_device);
     m_surfaceSync.fence = VK_NULL_HANDLE;
 
     retireCommandBuffers();
@@ -2085,7 +2085,7 @@ Result CommandQueueImpl::waitOnHost()
 {
     DeviceImpl* device = getDevice<DeviceImpl>();
     auto& api = device->m_api;
-    api.vkQueueWaitIdle(m_queue);
+    SLANG_VK_RETURN_ON_FAIL_REPORT(api.vkQueueWaitIdle(m_queue), device);
     retireCommandBuffers();
     return SLANG_OK;
 }
@@ -2119,8 +2119,9 @@ Result CommandQueueImpl::getTimestampCalibration(TimestampCalibration* outCalibr
 
     uint64_t timestamps[2] = {};
     uint64_t maxDeviation = 0;
-    SLANG_VK_RETURN_ON_FAIL(
-        m_api.vkGetCalibratedTimestampsKHR(m_api.m_device, 2, timestampInfos, timestamps, &maxDeviation)
+    SLANG_VK_RETURN_ON_FAIL_REPORT(
+        m_api.vkGetCalibratedTimestampsKHR(m_api.m_device, 2, timestampInfos, timestamps, &maxDeviation),
+        m_device
     );
 
     outCalibration->cpuDomain = timestampSupport.cpuTimestampDomain;
@@ -2242,16 +2243,18 @@ Result CommandBufferImpl::init()
     VkCommandPoolCreateInfo createInfo = {VK_STRUCTURE_TYPE_COMMAND_POOL_CREATE_INFO};
     createInfo.flags = VK_COMMAND_POOL_CREATE_TRANSIENT_BIT;
     createInfo.queueFamilyIndex = m_queue->m_queueFamilyIndex;
-    SLANG_VK_RETURN_ON_FAIL(
-        device->m_api.vkCreateCommandPool(device->m_api.m_device, &createInfo, nullptr, &m_commandPool)
+    SLANG_VK_RETURN_ON_FAIL_REPORT(
+        device->m_api.vkCreateCommandPool(device->m_api.m_device, &createInfo, nullptr, &m_commandPool),
+        device
     );
 
     VkCommandBufferAllocateInfo allocInfo = {VK_STRUCTURE_TYPE_COMMAND_BUFFER_ALLOCATE_INFO};
     allocInfo.commandPool = m_commandPool;
     allocInfo.level = VK_COMMAND_BUFFER_LEVEL_PRIMARY;
     allocInfo.commandBufferCount = 1;
-    SLANG_VK_RETURN_ON_FAIL(
-        device->m_api.vkAllocateCommandBuffers(device->m_api.m_device, &allocInfo, &m_commandBuffer)
+    SLANG_VK_RETURN_ON_FAIL_REPORT(
+        device->m_api.vkAllocateCommandBuffers(device->m_api.m_device, &allocInfo, &m_commandBuffer),
+        device
     );
 
     return SLANG_OK;
@@ -2261,7 +2264,7 @@ Result CommandBufferImpl::reset()
 {
     DeviceImpl* device = getDevice<DeviceImpl>();
     m_commandList.reset();
-    SLANG_VK_RETURN_ON_FAIL(device->m_api.vkResetCommandPool(device->m_device, m_commandPool, 0));
+    SLANG_VK_RETURN_ON_FAIL_REPORT(device->m_api.vkResetCommandPool(device->m_device, m_commandPool, 0), device);
     m_constantBufferPool.reset();
     m_descriptorSetAllocator.reset();
     m_bindingCache.reset();

--- a/src/vulkan/vk-descriptor-allocator.cpp
+++ b/src/vulkan/vk-descriptor-allocator.cpp
@@ -40,7 +40,9 @@ VkDescriptorPool DescriptorSetAllocator::newPool()
     descriptorPoolInfo.pNext = &inlineUniformBlockInfo;
 
     VkDescriptorPool descriptorPool = VK_NULL_HANDLE;
-    SLANG_VK_CHECK(m_api->vkCreateDescriptorPool(m_api->m_device, &descriptorPoolInfo, nullptr, &descriptorPool));
+    SLANG_VK_ASSERT_ON_FAIL(
+        m_api->vkCreateDescriptorPool(m_api->m_device, &descriptorPoolInfo, nullptr, &descriptorPool)
+    );
     pools.push_back(descriptorPool);
     return descriptorPool;
 }

--- a/src/vulkan/vk-device.cpp
+++ b/src/vulkan/vk-device.cpp
@@ -481,8 +481,9 @@ Result DeviceImpl::initVulkanInstance(
         messengerCreateInfo.pfnUserCallback = &debugMessageCallback;
         messengerCreateInfo.pUserData = this;
 
-        SLANG_VK_RETURN_ON_FAIL(
-            m_api.vkCreateDebugUtilsMessengerEXT(instance, &messengerCreateInfo, nullptr, &m_debugReportCallback)
+        SLANG_VK_RETURN_ON_FAIL_REPORT(
+            m_api.vkCreateDebugUtilsMessengerEXT(instance, &messengerCreateInfo, nullptr, &m_debugReportCallback),
+            this
         );
     }
     return SLANG_OK;
@@ -509,10 +510,14 @@ Result DeviceImpl::initVulkanDevice(
         SLANG_RETURN_ON_FAIL(selectAdapter(this, backend->getAdapters(), desc, adapter));
 
         uint32_t physicalDeviceCount = 0;
-        SLANG_VK_RETURN_ON_FAIL(m_api.vkEnumeratePhysicalDevices(m_api.m_instance, &physicalDeviceCount, nullptr));
+        SLANG_VK_RETURN_ON_FAIL_REPORT(
+            m_api.vkEnumeratePhysicalDevices(m_api.m_instance, &physicalDeviceCount, nullptr),
+            this
+        );
         std::vector<VkPhysicalDevice> physicalDevices(physicalDeviceCount);
-        SLANG_VK_RETURN_ON_FAIL(
-            m_api.vkEnumeratePhysicalDevices(m_api.m_instance, &physicalDeviceCount, physicalDevices.data())
+        SLANG_VK_RETURN_ON_FAIL_REPORT(
+            m_api.vkEnumeratePhysicalDevices(m_api.m_instance, &physicalDeviceCount, physicalDevices.data()),
+            this
         );
 
         // Find the physical device that matches the selected adapter UUID.
@@ -1694,7 +1699,7 @@ Result DeviceImpl::initialize(const DeviceDesc& desc, BackendImpl* backend)
         samplerInfo.mipmapMode = VK_SAMPLER_MIPMAP_MODE_NEAREST;
         samplerInfo.minLod = 0.0f;
         samplerInfo.maxLod = 0.0f;
-        SLANG_VK_RETURN_ON_FAIL(m_api.vkCreateSampler(m_device, &samplerInfo, nullptr, &m_defaultSampler));
+        SLANG_VK_RETURN_ON_FAIL_REPORT(m_api.vkCreateSampler(m_device, &samplerInfo, nullptr, &m_defaultSampler), this);
     }
 
     // Create bindless descriptor set if needed.
@@ -1901,8 +1906,9 @@ Result DeviceImpl::createAccelerationStructure(
             createInfo.pNext = &motionInfo;
         }
     }
-    SLANG_VK_RETURN_ON_FAIL(
-        m_api.vkCreateAccelerationStructureKHR(m_api.m_device, &createInfo, nullptr, &result->m_vkHandle)
+    SLANG_VK_RETURN_ON_FAIL_REPORT(
+        m_api.vkCreateAccelerationStructureKHR(m_api.m_device, &createInfo, nullptr, &result->m_vkHandle),
+        this
     );
     returnComPtr(outAccelerationStructure, result);
     return SLANG_OK;
@@ -2036,7 +2042,7 @@ Result DeviceImpl::getTextureAllocationInfo(const TextureDesc& desc_, Size* outS
     imageInfo.samples = (VkSampleCountFlagBits)desc.sampleCount;
 
     VkImage image;
-    SLANG_VK_RETURN_ON_FAIL(m_api.vkCreateImage(m_device, &imageInfo, nullptr, &image));
+    SLANG_VK_RETURN_ON_FAIL_REPORT(m_api.vkCreateImage(m_device, &imageInfo, nullptr, &image), this);
 
     VkMemoryRequirements memRequirements;
     m_api.vkGetImageMemoryRequirements(m_device, image, &memRequirements);
@@ -2238,11 +2244,14 @@ Result DeviceImpl::getCooperativeVectorProperties(CooperativeVectorProperties* p
             vkPropertyCount,
             {VK_STRUCTURE_TYPE_COOPERATIVE_VECTOR_PROPERTIES_NV}
         );
-        SLANG_VK_RETURN_ON_FAIL(m_api.vkGetPhysicalDeviceCooperativeVectorPropertiesNV(
-            m_api.m_physicalDevice,
-            &vkPropertyCount,
-            vkProperties.data()
-        ));
+        SLANG_VK_RETURN_ON_FAIL_REPORT(
+            m_api.vkGetPhysicalDeviceCooperativeVectorPropertiesNV(
+                m_api.m_physicalDevice,
+                &vkPropertyCount,
+                vkProperties.data()
+            ),
+            this
+        );
         for (const auto& vkProps : vkProperties)
         {
             CooperativeVectorProperties props;
@@ -2287,7 +2296,7 @@ Result DeviceImpl::getCooperativeVectorMatrixSize(
     info.srcStride = rowColumnStride;
     info.dstLayout = translateCooperativeVectorMatrixLayout(layout);
     info.dstStride = rowColumnStride;
-    SLANG_VK_RETURN_ON_FAIL(m_api.vkConvertCooperativeVectorMatrixNV(m_api.m_device, &info));
+    SLANG_VK_RETURN_ON_FAIL_REPORT(m_api.vkConvertCooperativeVectorMatrixNV(m_api.m_device, &info), this);
     return SLANG_OK;
 }
 
@@ -2322,7 +2331,7 @@ Result DeviceImpl::convertCooperativeVectorMatrix(
         info.srcStride = srcDesc.rowColumnStride;
         info.dstLayout = translateCooperativeVectorMatrixLayout(dstDesc.layout);
         info.dstStride = dstDesc.rowColumnStride;
-        SLANG_VK_RETURN_ON_FAIL(m_api.vkConvertCooperativeVectorMatrixNV(m_api.m_device, &info));
+        SLANG_VK_RETURN_ON_FAIL_REPORT(m_api.vkConvertCooperativeVectorMatrixNV(m_api.m_device, &info), this);
     }
     return SLANG_OK;
 }

--- a/src/vulkan/vk-fence.cpp
+++ b/src/vulkan/vk-fence.cpp
@@ -61,8 +61,9 @@ Result FenceImpl::init()
         timelineCreateInfo.pNext = &exportSemaphoreCreateInfo;
     }
 
-    SLANG_VK_RETURN_ON_FAIL(
-        device->m_api.vkCreateSemaphore(device->m_api.m_device, &createInfo, nullptr, &m_semaphore)
+    SLANG_VK_RETURN_ON_FAIL_REPORT(
+        device->m_api.vkCreateSemaphore(device->m_api.m_device, &createInfo, nullptr, &m_semaphore),
+        device
     );
 
     device->_labelObject((uint64_t)m_semaphore, VK_OBJECT_TYPE_SEMAPHORE, m_desc.label);
@@ -73,7 +74,10 @@ Result FenceImpl::init()
 Result FenceImpl::getCurrentValue(uint64_t* outValue)
 {
     DeviceImpl* device = getDevice<DeviceImpl>();
-    SLANG_VK_RETURN_ON_FAIL(device->m_api.vkGetSemaphoreCounterValue(device->m_api.m_device, m_semaphore, outValue));
+    SLANG_VK_RETURN_ON_FAIL_REPORT(
+        device->m_api.vkGetSemaphoreCounterValue(device->m_api.m_device, m_semaphore, outValue),
+        device
+    );
     return SLANG_OK;
 }
 
@@ -81,8 +85,9 @@ Result FenceImpl::setCurrentValue(uint64_t value)
 {
     DeviceImpl* device = getDevice<DeviceImpl>();
     uint64_t currentValue = 0;
-    SLANG_VK_RETURN_ON_FAIL(
-        device->m_api.vkGetSemaphoreCounterValue(device->m_api.m_device, m_semaphore, &currentValue)
+    SLANG_VK_RETURN_ON_FAIL_REPORT(
+        device->m_api.vkGetSemaphoreCounterValue(device->m_api.m_device, m_semaphore, &currentValue),
+        device
     );
     if (currentValue < value)
     {
@@ -92,7 +97,7 @@ Result FenceImpl::setCurrentValue(uint64_t value)
         signalInfo.semaphore = m_semaphore;
         signalInfo.value = value;
 
-        SLANG_VK_RETURN_ON_FAIL(device->m_api.vkSignalSemaphore(device->m_api.m_device, &signalInfo));
+        SLANG_VK_RETURN_ON_FAIL_REPORT(device->m_api.vkSignalSemaphore(device->m_api.m_device, &signalInfo), device);
     }
     return SLANG_OK;
 }
@@ -117,8 +122,9 @@ Result FenceImpl::getSharedHandle(NativeHandle* outHandle)
         handleInfo.handleType = VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_OPAQUE_WIN32_BIT;
 
         HANDLE handle = NULL;
-        SLANG_VK_RETURN_ON_FAIL(
-            device->m_api.vkGetSemaphoreWin32HandleKHR(device->m_api.m_device, &handleInfo, &handle)
+        SLANG_VK_RETURN_ON_FAIL_REPORT(
+            device->m_api.vkGetSemaphoreWin32HandleKHR(device->m_api.m_device, &handleInfo, &handle),
+            device
         );
         m_sharedHandle = NativeHandle{NativeHandleType::Win32, (uint64_t)handle};
 #else
@@ -128,7 +134,7 @@ Result FenceImpl::getSharedHandle(NativeHandle* outHandle)
         fdInfo.handleType = VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_OPAQUE_FD_BIT;
 
         int fd = 0;
-        SLANG_VK_RETURN_ON_FAIL(device->m_api.vkGetSemaphoreFdKHR(device->m_api.m_device, &fdInfo, &fd));
+        SLANG_VK_RETURN_ON_FAIL_REPORT(device->m_api.vkGetSemaphoreFdKHR(device->m_api.m_device, &fdInfo, &fd), device);
         m_sharedHandle = NativeHandle{NativeHandleType::FileDescriptor, (uint64_t)fd};
 #endif
     }

--- a/src/vulkan/vk-pipeline.cpp
+++ b/src/vulkan/vk-pipeline.cpp
@@ -62,7 +62,7 @@ Result getPipelineCacheKey(DeviceImpl* device, void* createInfo, ISlangBlob** ou
     // Hash global key.
     {
         VkPipelineBinaryKeyKHR pipelineKey = {VK_STRUCTURE_TYPE_PIPELINE_BINARY_KEY_KHR};
-        SLANG_VK_RETURN_ON_FAIL(api.vkGetPipelineKeyKHR(device->m_device, nullptr, &pipelineKey));
+        SLANG_VK_RETURN_ON_FAIL_REPORT(api.vkGetPipelineKeyKHR(device->m_device, nullptr, &pipelineKey), device);
         sha1.update(pipelineKey.key, pipelineKey.keySize);
     }
     // Hash pipeline key.
@@ -70,7 +70,10 @@ Result getPipelineCacheKey(DeviceImpl* device, void* createInfo, ISlangBlob** ou
         VkPipelineCreateInfoKHR pipelineCreateInfo = {VK_STRUCTURE_TYPE_PIPELINE_CREATE_INFO_KHR};
         pipelineCreateInfo.pNext = createInfo;
         VkPipelineBinaryKeyKHR pipelineKey = {VK_STRUCTURE_TYPE_PIPELINE_BINARY_KEY_KHR};
-        SLANG_VK_RETURN_ON_FAIL(api.vkGetPipelineKeyKHR(device->m_device, &pipelineCreateInfo, &pipelineKey));
+        SLANG_VK_RETURN_ON_FAIL_REPORT(
+            api.vkGetPipelineKeyKHR(device->m_device, &pipelineCreateInfo, &pipelineKey),
+            device
+        );
         sha1.update(pipelineKey.key, pipelineKey.keySize);
     }
     SHA1::Digest digest = sha1.getDigest();
@@ -89,14 +92,16 @@ Result serializePipelineBinaries(DeviceImpl* device, VkPipeline pipeline, ISlang
 
     VkPipelineBinaryHandlesInfoKHR binaryHandlesInfo = {VK_STRUCTURE_TYPE_PIPELINE_BINARY_HANDLES_INFO_KHR};
 
-    SLANG_VK_RETURN_ON_FAIL(
-        api.vkCreatePipelineBinariesKHR(device->m_device, &binaryCreateInfo, nullptr, &binaryHandlesInfo)
+    SLANG_VK_RETURN_ON_FAIL_REPORT(
+        api.vkCreatePipelineBinariesKHR(device->m_device, &binaryCreateInfo, nullptr, &binaryHandlesInfo),
+        device
     );
 
     short_vector<VkPipelineBinaryKHR> pipelineBinaries(binaryHandlesInfo.pipelineBinaryCount, VK_NULL_HANDLE);
     binaryHandlesInfo.pPipelineBinaries = pipelineBinaries.data();
-    SLANG_VK_RETURN_ON_FAIL(
-        api.vkCreatePipelineBinariesKHR(device->m_device, &binaryCreateInfo, nullptr, &binaryHandlesInfo)
+    SLANG_VK_RETURN_ON_FAIL_REPORT(
+        api.vkCreatePipelineBinariesKHR(device->m_device, &binaryCreateInfo, nullptr, &binaryHandlesInfo),
+        device
     );
 
     // Compute total size of the cache data blob.
@@ -108,8 +113,9 @@ Result serializePipelineBinaries(DeviceImpl* device, VkPipeline pipeline, ISlang
         binaryInfo.pipelineBinary = pipelineBinaries[i];
         VkPipelineBinaryKeyKHR binaryKey = {VK_STRUCTURE_TYPE_PIPELINE_BINARY_KEY_KHR};
         size_t binaryDataSize = 0;
-        SLANG_VK_RETURN_ON_FAIL(
-            api.vkGetPipelineBinaryDataKHR(device->m_device, &binaryInfo, &binaryKey, &binaryDataSize, nullptr)
+        SLANG_VK_RETURN_ON_FAIL_REPORT(
+            api.vkGetPipelineBinaryDataKHR(device->m_device, &binaryInfo, &binaryKey, &binaryDataSize, nullptr),
+            device
         );
         dataSize += binaryDataSize;
     }
@@ -135,17 +141,21 @@ Result serializePipelineBinaries(DeviceImpl* device, VkPipeline pipeline, ISlang
 
         VkPipelineBinaryKeyKHR binaryKey = {VK_STRUCTURE_TYPE_PIPELINE_BINARY_KEY_KHR};
         size_t binaryDataSize = 0;
-        SLANG_VK_RETURN_ON_FAIL(
-            api.vkGetPipelineBinaryDataKHR(device->m_device, &binaryInfo, &binaryKey, &binaryDataSize, nullptr)
+        SLANG_VK_RETURN_ON_FAIL_REPORT(
+            api.vkGetPipelineBinaryDataKHR(device->m_device, &binaryInfo, &binaryKey, &binaryDataSize, nullptr),
+            device
         );
 
-        SLANG_VK_RETURN_ON_FAIL(api.vkGetPipelineBinaryDataKHR(
-            device->m_device,
-            &binaryInfo,
-            &binaryKey,
-            &binaryDataSize,
-            data + binaryDataOffset
-        ));
+        SLANG_VK_RETURN_ON_FAIL_REPORT(
+            api.vkGetPipelineBinaryDataKHR(
+                device->m_device,
+                &binaryInfo,
+                &binaryKey,
+                &binaryDataSize,
+                data + binaryDataOffset
+            ),
+            device
+        );
 
         PipelineCacheBinaryHeader* binaryHeader = (PipelineCacheBinaryHeader*)dataPtr;
         std::memset(binaryHeader->key, 0, sizeof(PipelineCacheBinaryHeader::key));
@@ -215,7 +225,10 @@ Result deserializePipelineBinaries(DeviceImpl* device, ISlangBlob* blob, short_v
     handlesInfo.pipelineBinaryCount = binaries.size();
     handlesInfo.pPipelineBinaries = binaries.data();
 
-    SLANG_VK_RETURN_ON_FAIL(api.vkCreatePipelineBinariesKHR(device->m_device, &createInfo, nullptr, &handlesInfo));
+    SLANG_VK_RETURN_ON_FAIL_REPORT(
+        api.vkCreatePipelineBinariesKHR(device->m_device, &createInfo, nullptr, &handlesInfo),
+        device
+    );
 
     outBinaries = binaries;
     return SLANG_OK;
@@ -324,7 +337,7 @@ Result createPipelineWithCache(
                 createInfo->pNext = &createFlags;
             }
         }
-        SLANG_VK_RETURN_ON_FAIL(createPipelineFunc(device, createInfo, &pipeline));
+        SLANG_VK_RETURN_ON_FAIL_REPORT(createPipelineFunc(device, createInfo, &pipeline), device);
     }
 
     // Write to the cache.
@@ -346,7 +359,10 @@ Result createPipelineWithCache(
     {
         VkReleaseCapturedPipelineDataInfoKHR releaseInfo = {VK_STRUCTURE_TYPE_RELEASE_CAPTURED_PIPELINE_DATA_INFO_KHR};
         releaseInfo.pipeline = pipeline;
-        SLANG_VK_RETURN_ON_FAIL(api.vkReleaseCapturedPipelineDataKHR(device->m_device, &releaseInfo, nullptr));
+        SLANG_VK_RETURN_ON_FAIL_REPORT(
+            api.vkReleaseCapturedPipelineDataKHR(device->m_device, &releaseInfo, nullptr),
+            device
+        );
     }
 
     *outPipeline = pipeline;

--- a/src/vulkan/vk-query.cpp
+++ b/src/vulkan/vk-query.cpp
@@ -26,7 +26,10 @@ Result QueryPoolImpl::init()
     default:
         return SLANG_E_INVALID_ARG;
     }
-    SLANG_VK_RETURN_ON_FAIL(device->m_api.vkCreateQueryPool(device->m_api.m_device, &createInfo, nullptr, &m_pool));
+    SLANG_VK_RETURN_ON_FAIL_REPORT(
+        device->m_api.vkCreateQueryPool(device->m_api.m_device, &createInfo, nullptr, &m_pool),
+        device
+    );
 
     device->_labelObject((uint64_t)m_pool, VK_OBJECT_TYPE_QUERY_POOL, m_desc.label);
 
@@ -93,7 +96,7 @@ Result QueryPoolImpl::isResultReady(uint32_t queryIndex, uint32_t count, bool* o
     {
         return SLANG_OK;
     }
-    SLANG_VK_RETURN_ON_FAIL(result);
+    SLANG_VK_RETURN_ON_FAIL_REPORT(result, device);
 
     markQueryRangeReady(queryIndex, count, queryInfo.submissionID);
     *outReady = true;
@@ -124,16 +127,19 @@ Result QueryPoolImpl::getResult(uint32_t queryIndex, uint32_t count, uint64_t* o
     }
 
     DeviceImpl* device = getDevice<DeviceImpl>();
-    SLANG_VK_RETURN_ON_FAIL(device->m_api.vkGetQueryPoolResults(
-        device->m_api.m_device,
-        m_pool,
-        queryIndex,
-        count,
-        sizeof(uint64_t) * count,
-        outData,
-        sizeof(uint64_t),
-        VK_QUERY_RESULT_64_BIT | VK_QUERY_RESULT_WAIT_BIT
-    ));
+    SLANG_VK_RETURN_ON_FAIL_REPORT(
+        device->m_api.vkGetQueryPoolResults(
+            device->m_api.m_device,
+            m_pool,
+            queryIndex,
+            count,
+            sizeof(uint64_t) * count,
+            outData,
+            sizeof(uint64_t),
+            VK_QUERY_RESULT_64_BIT | VK_QUERY_RESULT_WAIT_BIT
+        ),
+        device
+    );
 
     markQueryRangeReady(queryIndex, count, queryInfo.submissionID);
 

--- a/src/vulkan/vk-sampler.cpp
+++ b/src/vulkan/vk-sampler.cpp
@@ -132,7 +132,7 @@ Result DeviceImpl::createSampler(const SamplerDesc& desc, ISampler** outSampler)
     samplerInfo.pNext = &reductionInfo;
 
     VkSampler sampler;
-    SLANG_VK_RETURN_ON_FAIL(m_api.vkCreateSampler(m_device, &samplerInfo, nullptr, &sampler));
+    SLANG_VK_RETURN_ON_FAIL_REPORT(m_api.vkCreateSampler(m_device, &samplerInfo, nullptr, &sampler), this);
 
     _labelObject((uint64_t)sampler, VK_OBJECT_TYPE_SAMPLER, desc.label);
 

--- a/src/vulkan/vk-shader-program.cpp
+++ b/src/vulkan/vk-shader-program.cpp
@@ -144,8 +144,9 @@ Result ShaderProgramImpl::createShaderModule(slang::EntryPointReflection* entryP
     VkShaderModuleCreateInfo moduleCreateInfo = {VK_STRUCTURE_TYPE_SHADER_MODULE_CREATE_INFO};
     moduleCreateInfo.pCode = (uint32_t*)module.code->getBufferPointer();
     moduleCreateInfo.codeSize = module.code->getBufferSize();
-    SLANG_VK_RETURN_ON_FAIL(
-        device->m_api.vkCreateShaderModule(device->m_device, &moduleCreateInfo, nullptr, &module.shaderModule)
+    SLANG_VK_RETURN_ON_FAIL_REPORT(
+        device->m_api.vkCreateShaderModule(device->m_device, &moduleCreateInfo, nullptr, &module.shaderModule),
+        device
     );
 
 #if SLANG_RHI_ENABLE_AFTERMATH

--- a/src/vulkan/vk-surface.cpp
+++ b/src/vulkan/vk-surface.cpp
@@ -50,7 +50,10 @@ Result SurfaceImpl::init(DeviceImpl* device, WindowHandle windowHandle)
         surfaceCreateInfo.sType = VK_STRUCTURE_TYPE_WIN32_SURFACE_CREATE_INFO_KHR;
         surfaceCreateInfo.hinstance = ::GetModuleHandle(nullptr);
         surfaceCreateInfo.hwnd = (HWND)windowHandle.handleValues[0];
-        SLANG_VK_RETURN_ON_FAIL(api.vkCreateWin32SurfaceKHR(api.m_instance, &surfaceCreateInfo, nullptr, &m_surface));
+        SLANG_VK_RETURN_ON_FAIL_REPORT(
+            api.vkCreateWin32SurfaceKHR(api.m_instance, &surfaceCreateInfo, nullptr, &m_surface),
+            m_device
+        );
         break;
     }
 #elif SLANG_APPLE_FAMILY
@@ -60,7 +63,10 @@ Result SurfaceImpl::init(DeviceImpl* device, WindowHandle windowHandle)
         VkMetalSurfaceCreateInfoEXT surfaceCreateInfo = {};
         surfaceCreateInfo.sType = VK_STRUCTURE_TYPE_METAL_SURFACE_CREATE_INFO_EXT;
         surfaceCreateInfo.pLayer = (CAMetalLayer*)m_metalLayer;
-        SLANG_VK_RETURN_ON_FAIL(api.vkCreateMetalSurfaceEXT(api.m_instance, &surfaceCreateInfo, nullptr, &m_surface));
+        SLANG_VK_RETURN_ON_FAIL_REPORT(
+            api.vkCreateMetalSurfaceEXT(api.m_instance, &surfaceCreateInfo, nullptr, &m_surface),
+            m_device
+        );
         break;
     }
 #elif SLANG_LINUX_FAMILY
@@ -71,7 +77,10 @@ Result SurfaceImpl::init(DeviceImpl* device, WindowHandle windowHandle)
         VkAndroidSurfaceCreateInfoKHR surfaceCreateInfo = {};
         surfaceCreateInfo.sType = VK_STRUCTURE_TYPE_ANDROID_SURFACE_CREATE_INFO_KHR;
         surfaceCreateInfo.window = (ANativeWindow*)windowHandle.handleValues[0];
-        SLANG_VK_RETURN_ON_FAIL(api.vkCreateAndroidSurfaceKHR(api.m_instance, &surfaceCreateInfo, nullptr, &m_surface));
+        SLANG_VK_RETURN_ON_FAIL_REPORT(
+            api.vkCreateAndroidSurfaceKHR(api.m_instance, &surfaceCreateInfo, nullptr, &m_surface),
+            m_device
+        );
         break;
     }
 #else
@@ -81,7 +90,10 @@ Result SurfaceImpl::init(DeviceImpl* device, WindowHandle windowHandle)
         surfaceCreateInfo.sType = VK_STRUCTURE_TYPE_XLIB_SURFACE_CREATE_INFO_KHR;
         surfaceCreateInfo.dpy = (Display*)windowHandle.handleValues[0];
         surfaceCreateInfo.window = (Window)windowHandle.handleValues[1];
-        SLANG_VK_RETURN_ON_FAIL(api.vkCreateXlibSurfaceKHR(api.m_instance, &surfaceCreateInfo, nullptr, &m_surface));
+        SLANG_VK_RETURN_ON_FAIL_REPORT(
+            api.vkCreateXlibSurfaceKHR(api.m_instance, &surfaceCreateInfo, nullptr, &m_surface),
+            m_device
+        );
         break;
     }
 #endif
@@ -144,8 +156,9 @@ Result SurfaceImpl::createSwapchain()
     // issue an error. The reported supportedUsageFlags are also used below to clamp the
     // requested image usage.
     VkSurfaceCapabilitiesKHR surfaceCaps;
-    SLANG_VK_RETURN_ON_FAIL(
-        api.vkGetPhysicalDeviceSurfaceCapabilitiesKHR(api.m_physicalDevice, m_surface, &surfaceCaps)
+    SLANG_VK_RETURN_ON_FAIL_REPORT(
+        api.vkGetPhysicalDeviceSurfaceCapabilitiesKHR(api.m_physicalDevice, m_surface, &surfaceCaps),
+        m_device
     );
 
     // Query available present modes.
@@ -209,7 +222,10 @@ Result SurfaceImpl::createSwapchain()
     swapchainDesc.clipped = VK_TRUE;
     swapchainDesc.oldSwapchain = oldSwapchain;
 
-    SLANG_VK_RETURN_ON_FAIL(api.vkCreateSwapchainKHR(api.m_device, &swapchainDesc, nullptr, &m_swapchain));
+    SLANG_VK_RETURN_ON_FAIL_REPORT(
+        api.vkCreateSwapchainKHR(api.m_device, &swapchainDesc, nullptr, &m_swapchain),
+        m_device
+    );
 
     uint32_t swapchainImageCount = 0;
     api.vkGetSwapchainImagesKHR(api.m_device, m_swapchain, &swapchainImageCount, nullptr);
@@ -245,17 +261,22 @@ Result SurfaceImpl::createSwapchain()
         {
             VkFenceCreateInfo createInfo = {VK_STRUCTURE_TYPE_FENCE_CREATE_INFO};
             createInfo.flags = VK_FENCE_CREATE_SIGNALED_BIT;
-            SLANG_VK_RETURN_ON_FAIL(api.vkCreateFence(api.m_device, &createInfo, nullptr, &frameData.fence));
+            SLANG_VK_RETURN_ON_FAIL_REPORT(
+                api.vkCreateFence(api.m_device, &createInfo, nullptr, &frameData.fence),
+                m_device
+            );
         }
 
         // Create semaphores.
         {
             VkSemaphoreCreateInfo createInfo = {VK_STRUCTURE_TYPE_SEMAPHORE_CREATE_INFO};
-            SLANG_VK_RETURN_ON_FAIL(
-                api.vkCreateSemaphore(api.m_device, &createInfo, nullptr, &frameData.imageAvailableSemaphore)
+            SLANG_VK_RETURN_ON_FAIL_REPORT(
+                api.vkCreateSemaphore(api.m_device, &createInfo, nullptr, &frameData.imageAvailableSemaphore),
+                m_device
             );
-            SLANG_VK_RETURN_ON_FAIL(
-                api.vkCreateSemaphore(api.m_device, &createInfo, nullptr, &frameData.renderFinishedSemaphore)
+            SLANG_VK_RETURN_ON_FAIL_REPORT(
+                api.vkCreateSemaphore(api.m_device, &createInfo, nullptr, &frameData.renderFinishedSemaphore),
+                m_device
             );
         }
     }
@@ -370,8 +391,11 @@ Result SurfaceImpl::acquireNextImage(ITexture** outTexture)
     auto& api = m_device->m_api;
 
     FrameData& frameData = m_frameData[m_currentFrameIndex];
-    SLANG_VK_RETURN_ON_FAIL(api.vkWaitForFences(api.m_device, 1, &frameData.fence, VK_TRUE, UINT64_MAX));
-    SLANG_VK_RETURN_ON_FAIL(api.vkResetFences(api.m_device, 1, &frameData.fence));
+    SLANG_VK_RETURN_ON_FAIL_REPORT(
+        api.vkWaitForFences(api.m_device, 1, &frameData.fence, VK_TRUE, UINT64_MAX),
+        m_device
+    );
+    SLANG_VK_RETURN_ON_FAIL_REPORT(api.vkResetFences(api.m_device, 1, &frameData.fence), m_device);
 
     m_currentTextureIndex = -1;
     VkResult result = api.vkAcquireNextImageKHR(

--- a/src/vulkan/vk-texture.cpp
+++ b/src/vulkan/vk-texture.cpp
@@ -86,7 +86,7 @@ Result TextureImpl::getSharedHandle(NativeHandle* outHandle)
             return SLANG_FAIL;
         }
         HANDLE handle = NULL;
-        SLANG_VK_RETURN_ON_FAIL(api.vkGetMemoryWin32HandleKHR(device->m_device, &info, &handle));
+        SLANG_VK_RETURN_ON_FAIL_REPORT(api.vkGetMemoryWin32HandleKHR(device->m_device, &info, &handle), device);
         m_sharedHandle = NativeHandle{NativeHandleType::Win32, (uint64_t)handle};
 #else
         VkMemoryGetFdInfoKHR info = {};
@@ -100,7 +100,7 @@ Result TextureImpl::getSharedHandle(NativeHandle* outHandle)
             return SLANG_FAIL;
         }
         int handle = 0;
-        SLANG_VK_RETURN_ON_FAIL(api.vkGetMemoryFdKHR(device->m_device, &info, &handle));
+        SLANG_VK_RETURN_ON_FAIL_REPORT(api.vkGetMemoryFdKHR(device->m_device, &info, &handle), device);
         m_sharedHandle = NativeHandle{NativeHandleType::FileDescriptor, (uint64_t)handle};
 #endif
     }
@@ -375,7 +375,7 @@ Result DeviceImpl::createTexture(const TextureDesc& desc_, const SubresourceData
         externalMemoryImageCreateInfo.handleTypes = extMemoryHandleType;
         imageInfo.pNext = &externalMemoryImageCreateInfo;
     }
-    SLANG_VK_RETURN_ON_FAIL(m_api.vkCreateImage(m_device, &imageInfo, nullptr, &texture->m_image));
+    SLANG_VK_RETURN_ON_FAIL_REPORT(m_api.vkCreateImage(m_device, &imageInfo, nullptr, &texture->m_image), this);
 
     VkMemoryRequirements memRequirements;
     m_api.vkGetImageMemoryRequirements(m_device, texture->m_image, &memRequirements);
@@ -409,7 +409,10 @@ Result DeviceImpl::createTexture(const TextureDesc& desc_, const SubresourceData
         exportMemoryAllocateInfo.handleTypes = extMemoryHandleType;
         allocInfo.pNext = &exportMemoryAllocateInfo;
     }
-    SLANG_VK_RETURN_ON_FAIL(m_api.vkAllocateMemory(m_device, &allocInfo, nullptr, &texture->m_imageMemory));
+    SLANG_VK_RETURN_ON_FAIL_REPORT(
+        m_api.vkAllocateMemory(m_device, &allocInfo, nullptr, &texture->m_imageMemory),
+        this
+    );
 
     // Bind the memory to the image
     m_api.vkBindImageMemory(m_device, texture->m_image, texture->m_imageMemory, 0);

--- a/src/vulkan/vk-utils.cpp
+++ b/src/vulkan/vk-utils.cpp
@@ -2,19 +2,85 @@
 
 #include "aftermath.h"
 #include "core/common.h"
+#include "core/diagnostics.h"
+#include "device.h"
+
+#include <cstdio>
 
 namespace rhi::vk {
 
-void reportVulkanError(VkResult res)
+const char* getVkResultName(VkResult res)
+{
+#define CASE(x)                                                                                                        \
+    case x:                                                                                                            \
+        return #x;
+    switch (res)
+    {
+        CASE(VK_SUCCESS)
+        CASE(VK_NOT_READY)
+        CASE(VK_TIMEOUT)
+        CASE(VK_EVENT_SET)
+        CASE(VK_EVENT_RESET)
+        CASE(VK_INCOMPLETE)
+        CASE(VK_ERROR_OUT_OF_HOST_MEMORY)
+        CASE(VK_ERROR_OUT_OF_DEVICE_MEMORY)
+        CASE(VK_ERROR_INITIALIZATION_FAILED)
+        CASE(VK_ERROR_DEVICE_LOST)
+        CASE(VK_ERROR_MEMORY_MAP_FAILED)
+        CASE(VK_ERROR_LAYER_NOT_PRESENT)
+        CASE(VK_ERROR_EXTENSION_NOT_PRESENT)
+        CASE(VK_ERROR_FEATURE_NOT_PRESENT)
+        CASE(VK_ERROR_INCOMPATIBLE_DRIVER)
+        CASE(VK_ERROR_TOO_MANY_OBJECTS)
+        CASE(VK_ERROR_FORMAT_NOT_SUPPORTED)
+        CASE(VK_ERROR_FRAGMENTED_POOL)
+        CASE(VK_ERROR_UNKNOWN)
+        CASE(VK_ERROR_OUT_OF_POOL_MEMORY)
+        CASE(VK_ERROR_INVALID_EXTERNAL_HANDLE)
+        CASE(VK_ERROR_FRAGMENTATION)
+        CASE(VK_ERROR_INVALID_OPAQUE_CAPTURE_ADDRESS)
+        CASE(VK_PIPELINE_COMPILE_REQUIRED)
+        CASE(VK_ERROR_NOT_PERMITTED)
+        CASE(VK_ERROR_SURFACE_LOST_KHR)
+        CASE(VK_ERROR_NATIVE_WINDOW_IN_USE_KHR)
+        CASE(VK_SUBOPTIMAL_KHR)
+        CASE(VK_ERROR_OUT_OF_DATE_KHR)
+        CASE(VK_ERROR_INCOMPATIBLE_DISPLAY_KHR)
+        CASE(VK_ERROR_VALIDATION_FAILED_EXT)
+        CASE(VK_ERROR_INVALID_SHADER_NV)
+        CASE(VK_ERROR_IMAGE_USAGE_NOT_SUPPORTED_KHR)
+        CASE(VK_ERROR_VIDEO_PICTURE_LAYOUT_NOT_SUPPORTED_KHR)
+        CASE(VK_ERROR_VIDEO_PROFILE_OPERATION_NOT_SUPPORTED_KHR)
+        CASE(VK_ERROR_VIDEO_PROFILE_FORMAT_NOT_SUPPORTED_KHR)
+        CASE(VK_ERROR_VIDEO_PROFILE_CODEC_NOT_SUPPORTED_KHR)
+        CASE(VK_ERROR_VIDEO_STD_VERSION_NOT_SUPPORTED_KHR)
+        CASE(VK_ERROR_INVALID_DRM_FORMAT_MODIFIER_PLANE_LAYOUT_EXT)
+        CASE(VK_ERROR_FULL_SCREEN_EXCLUSIVE_MODE_LOST_EXT)
+        CASE(VK_THREAD_IDLE_KHR)
+        CASE(VK_THREAD_DONE_KHR)
+        CASE(VK_OPERATION_DEFERRED_KHR)
+        CASE(VK_OPERATION_NOT_DEFERRED_KHR)
+        CASE(VK_ERROR_INVALID_VIDEO_STD_PARAMETERS_KHR)
+        CASE(VK_ERROR_COMPRESSION_EXHAUSTED_EXT)
+        CASE(VK_INCOMPATIBLE_SHADER_BINARY_EXT)
+        CASE(VK_PIPELINE_BINARY_MISSING_KHR)
+        CASE(VK_ERROR_NOT_ENOUGH_SPACE_KHR)
+    default:
+        return "<unknown>";
+    }
+#undef CASE
+}
+
+void reportVulkanError(VkResult res, const char* call, const SourceLocation location, Device* device)
 {
     if (res == VK_ERROR_DEVICE_LOST)
     {
 #if SLANG_RHI_ENABLE_AFTERMATH
         AftermathCrashDumper::waitForDump();
 #endif
-        SLANG_RHI_ASSERT_FAILURE("Vulkan device lost");
     }
-    SLANG_RHI_ASSERT_FAILURE("Vulkan returned a failure");
+
+    reportNativeCallError(device, call, res, getVkResultName(res), location);
 }
 
 VkFormat getVkFormat(Format format)

--- a/src/vulkan/vk-utils.h
+++ b/src/vulkan/vk-utils.h
@@ -5,21 +5,36 @@
 #include "vk-api.h"
 
 #include "core/common.h"
+#include "core/diagnostics.h"
+
+namespace rhi {
+class Device;
+}
 
 namespace rhi::vk {
 
 // Macros to make testing vulkan return codes simpler
 
-void reportVulkanError(VkResult res);
+const char* getVkResultName(VkResult res);
+void reportVulkanError(VkResult res, const char* call, const SourceLocation location, Device* device = nullptr);
 
 /// SLANG_VK_RETURN_ON_FAIL can be used in a similar way to SLANG_RETURN_ON_FAIL macro.
-/// Asserts on debug builds.
 #define SLANG_VK_RETURN_ON_FAIL(x)                                                                                     \
     {                                                                                                                  \
         VkResult _res = x;                                                                                             \
         if (_res != VK_SUCCESS)                                                                                        \
         {                                                                                                              \
-            ::rhi::vk::reportVulkanError(_res);                                                                        \
+            ::rhi::vk::reportVulkanError(_res, #x, SLANG_RHI_SOURCE_LOCATION());                                       \
+            return SLANG_FAIL;                                                                                         \
+        }                                                                                                              \
+    }
+
+#define SLANG_VK_RETURN_ON_FAIL_REPORT(x, device)                                                                      \
+    {                                                                                                                  \
+        VkResult _res = x;                                                                                             \
+        if (_res != VK_SUCCESS)                                                                                        \
+        {                                                                                                              \
+            ::rhi::vk::reportVulkanError(_res, #x, SLANG_RHI_SOURCE_LOCATION(), device);                               \
             return SLANG_FAIL;                                                                                         \
         }                                                                                                              \
     }
@@ -30,7 +45,16 @@ void reportVulkanError(VkResult res);
         VkResult _res = x;                                                                                             \
         if (_res != VK_SUCCESS)                                                                                        \
         {                                                                                                              \
-            ::rhi::vk::reportVulkanError(_res);                                                                        \
+            ::rhi::vk::reportVulkanError(_res, #x, SLANG_RHI_SOURCE_LOCATION());                                       \
+        }                                                                                                              \
+    }
+
+#define SLANG_VK_CHECK_REPORT(x, device)                                                                               \
+    {                                                                                                                  \
+        VkResult _res = x;                                                                                             \
+        if (_res != VK_SUCCESS)                                                                                        \
+        {                                                                                                              \
+            ::rhi::vk::reportVulkanError(_res, #x, SLANG_RHI_SOURCE_LOCATION(), device);                               \
         }                                                                                                              \
     }
 

--- a/src/vulkan/vk-utils.h
+++ b/src/vulkan/vk-utils.h
@@ -28,6 +28,7 @@ void reportVulkanError(VkResult res, const char* call, const SourceLocation loca
         }                                                                                                              \
     }
 
+/// Pass nullptr for device to write the diagnostic to stderr.
 #define SLANG_VK_RETURN_ON_FAIL_REPORT(x, device)                                                                      \
     {                                                                                                                  \
         VkResult _res = x;                                                                                             \
@@ -38,22 +39,14 @@ void reportVulkanError(VkResult res, const char* call, const SourceLocation loca
         }                                                                                                              \
     }
 
-/// Is similar to SLANG_VK_RETURN_ON_FAIL, but does not return.
-#define SLANG_VK_CHECK(x)                                                                                              \
+/// Report and assert if a Vulkan call fails.
+#define SLANG_VK_ASSERT_ON_FAIL(x)                                                                                     \
     {                                                                                                                  \
         VkResult _res = x;                                                                                             \
         if (_res != VK_SUCCESS)                                                                                        \
         {                                                                                                              \
             ::rhi::vk::reportVulkanError(_res, #x, SLANG_RHI_SOURCE_LOCATION());                                       \
-        }                                                                                                              \
-    }
-
-#define SLANG_VK_CHECK_REPORT(x, device)                                                                               \
-    {                                                                                                                  \
-        VkResult _res = x;                                                                                             \
-        if (_res != VK_SUCCESS)                                                                                        \
-        {                                                                                                              \
-            ::rhi::vk::reportVulkanError(_res, #x, SLANG_RHI_SOURCE_LOCATION(), device);                               \
+            SLANG_RHI_ASSERT_FAILURE("Vulkan call failed");                                                            \
         }                                                                                                              \
     }
 

--- a/src/vulkan/vk-utils.h
+++ b/src/vulkan/vk-utils.h
@@ -24,7 +24,6 @@ void reportVulkanError(VkResult res, const char* call, const SourceLocation loca
         VkResult _res = x;                                                                                             \
         if (_res != VK_SUCCESS)                                                                                        \
         {                                                                                                              \
-            ::rhi::vk::reportVulkanError(_res, #x, SLANG_RHI_SOURCE_LOCATION());                                       \
             return SLANG_FAIL;                                                                                         \
         }                                                                                                              \
     }

--- a/tests/test-cuda-external-devices.cpp
+++ b/tests/test-cuda-external-devices.cpp
@@ -6,6 +6,7 @@
 #include "../src/cuda/cuda-device.h"
 #include "../src/cuda/cuda-api.h"
 #include "../src/cuda/cuda-utils.h"
+#include "../src/core/diagnostics.h"
 #include "debug-layer/debug-device.h"
 
 using namespace rhi;
@@ -94,6 +95,7 @@ void runPointerCopyTest(rhi::cuda::DeviceImpl* device, CUstream stream, bool exp
         // the result comparison should detect the real error.
         {
             SLANG_RHI_DISABLE_ASSERT_SCOPE();
+            SLANG_RHI_DISABLE_NATIVE_CALL_ERROR_SCOPE();
             queue->submit(desc);
         }
 


### PR DESCRIPTION
Adds a shared native-call diagnostics path and updates D3D, Vulkan, CUDA, and OptiX call-site handling to report richer backend failures through the RHI debug callback. Diagnostics now include the failed call expression, native result value/name, optional detail text, and source location.

Also adds error-handling documentation covering `Result`, debug callbacks, validation controls, shader diagnostics, native backend diagnostics, ray tracing validation, and Aftermath. Includes small CI/fetch cleanup for authenticated GitHub package fetches and CUDA test noise suppression.
