### PR TITLE
modernized kTimeoutInfinite using constexpr and uniform initialization

### DIFF
--- a/include/slang-rhi.h
+++ b/include/slang-rhi.h
@@ -57,7 +57,7 @@ typedef SlangResult Result;
 typedef size_t Size;
 typedef size_t Offset;
 
-constexpr uint64_t kTimeoutInfinite {0xFFFFFFFFFFFFFFFFU};
+constexpr uint64_t kTimeoutInfinite{0xFFFFFFFFFFFFFFFFU};
 
 
 enum class StructType

--- a/include/slang-rhi.h
+++ b/include/slang-rhi.h
@@ -57,7 +57,7 @@ typedef SlangResult Result;
 typedef size_t Size;
 typedef size_t Offset;
 
-const uint64_t kTimeoutInfinite = 0xFFFFFFFFFFFFFFFF;
+constexpr uint64_t kTimeoutInfinite {0xFFFFFFFFFFFFFFFFU};
 
 
 enum class StructType


### PR DESCRIPTION
I modernizes the `kTimeoutInfinite` constant in `include/slang-rhi.h` by changing it from `const` to `constexpr` and applying uniform initialization `{0xFFFFFFFFFFFFFFFFU}`.
Since `kTimeoutInfinite` is a constant value, it makes perfect sense to enforce compile-time evaluation for it rather than leaving it as a standard runtime constant.
I thought it might be a nice touch.

I checked the codebase and found that `kTimeoutInfinite` is initialized in this two paths :

`slang/include/slang-gfx.h`
`slang/external/slang-rhi/include/slang-rhi.h`

I already opened a PR for slang-gfx.h