### PR TITLE
Replace IQueryPool::isResultReady with IQueryPool::getResultState

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -156,7 +156,7 @@
 | API                         | CPU | CUDA | D3D11 | D3D12 | Vulkan | Metal | WGPU |
 |-----------------------------|-----|------|-------|-------|--------|-------|------|
 | `getDesc`                   | yes | yes  | yes   | yes   | yes    | yes   | yes  |
-| `isResultReady`             | yes | yes  | yes   | yes   | yes    | :x:   | :x:  |
+| `getResultState`            | yes | yes  | yes   | yes   | yes    | :x:   | :x:  |
 | `getResult`                 | yes | yes  | yes   | yes   | yes    | :x:   | :x:  |
 | `reset`                     | yes | yes  | yes   | yes   | yes    | :x:   | :x:  |
 | `reset(queryIndex, count)`  | yes | yes  | yes   | yes   | yes    | :x:   | :x:  |

--- a/include/slang-rhi.h
+++ b/include/slang-rhi.h
@@ -2238,6 +2238,13 @@ enum class QueryType
     AccelerationStructureCurrentSize,
 };
 
+enum class QueryResultState
+{
+    Reset,
+    Pending,
+    Resolved,
+};
+
 struct QueryPoolDesc
 {
     StructType structType = StructType::QueryPoolDesc;
@@ -2256,15 +2263,21 @@ class IQueryPool : public ISlangUnknown
 public:
     virtual SLANG_NO_THROW const QueryPoolDesc& SLANG_MCALL getDesc() = 0;
 
-    /// Non-blocking host-readiness check for query results.
+    /// Non-blocking host-state check for query results.
     ///
-    /// Sets outReady to true when every requested query result is ready to read on the host,
-    /// and false when submitted query work is still pending. Returns SLANG_FAIL when the
-    /// requested range has no valid submitted result, and SLANG_E_INVALID_ARG for invalid
-    /// ranges or a null outReady pointer. A valid zero-count readiness check succeeds and
-    /// returns true. This call does not wait for GPU work and does not make reset or
-    /// never-submitted queries valid.
-    virtual SLANG_NO_THROW Result SLANG_MCALL isResultReady(uint32_t queryIndex, uint32_t count, bool* outReady) = 0;
+    /// Sets outState to Reset when any query in the range has no valid submitted result,
+    /// including newly-created, reset, or never-submitted queries. Sets outState to Pending
+    /// when every query in the range has valid submitted work, but at least one result is not
+    /// host-readable yet. Sets outState to Resolved when every result in the range is
+    /// host-readable. A valid zero-count state check succeeds and returns Resolved.
+    ///
+    /// This call may poll or otherwise progress backend readiness, but it does not wait for
+    /// GPU work. Returns SLANG_E_INVALID_ARG for invalid ranges or a null outState pointer.
+    virtual SLANG_NO_THROW Result SLANG_MCALL getResultState(
+        uint32_t queryIndex,
+        uint32_t count,
+        QueryResultState* outState
+    ) = 0;
 
     /// Read query results on the host.
     ///

--- a/src/cpu/cpu-command.cpp
+++ b/src/cpu/cpu-command.cpp
@@ -321,7 +321,7 @@ void CommandExecutor::cmdWriteTimestamp(const commands::WriteTimestamp& cmd)
     auto queryPool = checked_cast<QueryPoolImpl*>(cmd.queryPool);
     queryPool->m_queries[cmd.queryIndex] = getCpuTimestamp();
     queryPool->markQueryRangeSubmitted(cmd.queryIndex, 1, m_submissionID);
-    queryPool->markQueryRangeReady(cmd.queryIndex, 1, m_submissionID);
+    queryPool->markQueryRangeResolved(cmd.queryIndex, 1, m_submissionID);
 }
 
 void CommandExecutor::cmdExecuteCallback(const commands::ExecuteCallback& cmd)

--- a/src/cpu/cpu-query.cpp
+++ b/src/cpu/cpu-query.cpp
@@ -8,26 +8,6 @@ QueryPoolImpl::QueryPoolImpl(Device* device, const QueryPoolDesc& desc)
 {
 }
 
-Result QueryPoolImpl::isResultReady(uint32_t queryIndex, uint32_t count, bool* outReady)
-{
-    if (!outReady || !isValidQueryRange(queryIndex, count))
-    {
-        return SLANG_E_INVALID_ARG;
-    }
-
-    *outReady = false;
-    QueryRangeInfo queryInfo = getQueryRangeInfo(queryIndex, count);
-    if (queryInfo.state == QueryRangeState::Reset)
-    {
-        return SLANG_FAIL;
-    }
-    if (queryInfo.state == QueryRangeState::Resolved)
-    {
-        *outReady = true;
-    }
-    return SLANG_OK;
-}
-
 Result QueryPoolImpl::getResult(uint32_t queryIndex, uint32_t count, uint64_t* outData)
 {
     if (!outData || !isValidQueryRange(queryIndex, count))
@@ -35,7 +15,7 @@ Result QueryPoolImpl::getResult(uint32_t queryIndex, uint32_t count, uint64_t* o
         return SLANG_E_INVALID_ARG;
     }
 
-    if (getQueryRangeInfo(queryIndex, count).state != QueryRangeState::Resolved)
+    if (getQueryRangeInfo(queryIndex, count).state != QueryResultState::Resolved)
     {
         return SLANG_FAIL;
     }

--- a/src/cpu/cpu-query.h
+++ b/src/cpu/cpu-query.h
@@ -11,11 +11,6 @@ public:
 
     QueryPoolImpl(Device* device, const QueryPoolDesc& desc);
 
-    virtual SLANG_NO_THROW Result SLANG_MCALL isResultReady(
-        uint32_t queryIndex,
-        uint32_t count,
-        bool* outReady
-    ) override;
     virtual SLANG_NO_THROW Result SLANG_MCALL getResult(
         uint32_t queryIndex,
         uint32_t count,

--- a/src/cuda/cuda-command.cpp
+++ b/src/cuda/cuda-command.cpp
@@ -1086,8 +1086,7 @@ Result CommandQueueImpl::resolveTimestampQueries(CommandBufferImpl* commandBuffe
         {
             uint32_t queryIndex = queryWrite.index + i;
             QueryPool::QueryRangeInfo queryInfo = pool->getQueryRangeInfo(queryIndex, 1);
-            if (queryInfo.state != QueryPool::QueryRangeState::Pending ||
-                queryInfo.submissionID != commandBuffer->m_submissionID)
+            if (queryInfo.state != QueryResultState::Pending || queryInfo.submissionID != commandBuffer->m_submissionID)
             {
                 continue;
             }
@@ -1096,7 +1095,7 @@ Result CommandQueueImpl::resolveTimestampQueries(CommandBufferImpl* commandBuffe
             SLANG_RETURN_ON_FAIL(resolveTimestampEvent(this, query.event, query.anchorGeneration, &query.resultData));
         }
 
-        pool->markQueryRangeReady(queryWrite.index, queryWrite.count, commandBuffer->m_submissionID);
+        pool->markQueryRangeResolved(queryWrite.index, queryWrite.count, commandBuffer->m_submissionID);
     }
 
     return SLANG_OK;
@@ -1272,7 +1271,7 @@ Result CommandQueueImpl::submit(const SubmitDesc& desc)
         CommandExecutor executor(getDevice<DeviceImpl>(), requestedStream, timestampAnchorGeneration);
         SLANG_RETURN_ON_FAIL(executor.execute(commandBuffer));
 
-        // Lazy events: timestamp writes need per-submission completion so isResultReady can make
+        // Lazy events: timestamp writes need per-submission completion so getResultState can make
         // progress without waiting for unrelated later work to drain the whole stream.
         bool needsEvent =
             writesTimestamp || (requestedStream != m_stream) || m_submitsSinceEvent > kMaxSubmitsWithoutEvent;

--- a/src/cuda/cuda-query.cpp
+++ b/src/cuda/cuda-query.cpp
@@ -50,22 +50,22 @@ Result QueryPoolImpl::reset(uint32_t queryIndex, uint32_t count)
     return SLANG_OK;
 }
 
-Result QueryPoolImpl::isResultReady(uint32_t queryIndex, uint32_t count, bool* outReady)
+Result QueryPoolImpl::getResultState(uint32_t queryIndex, uint32_t count, QueryResultState* outState)
 {
-    if (!outReady || !isValidQueryRange(queryIndex, count))
+    if (!outState || !isValidQueryRange(queryIndex, count))
     {
         return SLANG_E_INVALID_ARG;
     }
 
-    *outReady = false;
     QueryRangeInfo queryInfo = getQueryRangeInfo(queryIndex, count);
-    if (queryInfo.state == QueryRangeState::Reset)
+    if (queryInfo.state == QueryResultState::Reset)
     {
-        return SLANG_FAIL;
+        *outState = QueryResultState::Reset;
+        return SLANG_OK;
     }
-    if (queryInfo.state == QueryRangeState::Resolved)
+    if (queryInfo.state == QueryResultState::Resolved)
     {
-        *outReady = true;
+        *outState = QueryResultState::Resolved;
         return SLANG_OK;
     }
 
@@ -73,17 +73,19 @@ Result QueryPoolImpl::isResultReady(uint32_t queryIndex, uint32_t count, bool* o
     SLANG_RETURN_ON_FAIL(queue->retireCommandBuffers());
 
     queryInfo = getQueryRangeInfo(queryIndex, count);
-    if (queryInfo.state == QueryRangeState::Reset)
+    if (queryInfo.state == QueryResultState::Reset)
     {
-        return SLANG_FAIL;
+        *outState = QueryResultState::Reset;
+        return SLANG_OK;
     }
-    if (queryInfo.state == QueryRangeState::Resolved)
+    if (queryInfo.state == QueryResultState::Resolved)
     {
-        *outReady = true;
+        *outState = QueryResultState::Resolved;
         return SLANG_OK;
     }
     if (queue->m_lastFinishedID < queryInfo.submissionID)
     {
+        *outState = QueryResultState::Pending;
         return SLANG_OK;
     }
 
@@ -97,7 +99,7 @@ Result QueryPoolImpl::getResult(uint32_t queryIndex, uint32_t count, uint64_t* o
         return SLANG_E_INVALID_ARG;
     }
     QueryRangeInfo queryInfo = getQueryRangeInfo(queryIndex, count);
-    if (queryInfo.state == QueryRangeState::Reset)
+    if (queryInfo.state == QueryResultState::Reset)
     {
         return SLANG_FAIL;
     }
@@ -106,12 +108,12 @@ Result QueryPoolImpl::getResult(uint32_t queryIndex, uint32_t count, uint64_t* o
         return SLANG_OK;
     }
 
-    if (queryInfo.state != QueryRangeState::Resolved)
+    if (queryInfo.state != QueryResultState::Resolved)
     {
         CommandQueueImpl* queue = getDevice<DeviceImpl>()->m_queue.get();
         SLANG_RETURN_ON_FAIL(queue->waitOnHost());
         queryInfo = getQueryRangeInfo(queryIndex, count);
-        if (queryInfo.state != QueryRangeState::Resolved)
+        if (queryInfo.state != QueryResultState::Resolved)
         {
             return SLANG_FAIL;
         }
@@ -151,22 +153,22 @@ Result PlainBufferProxyQueryPoolImpl::reset()
     return SLANG_OK;
 }
 
-Result PlainBufferProxyQueryPoolImpl::isResultReady(uint32_t queryIndex, uint32_t count, bool* outReady)
+Result PlainBufferProxyQueryPoolImpl::getResultState(uint32_t queryIndex, uint32_t count, QueryResultState* outState)
 {
-    if (!outReady || !isValidQueryRange(queryIndex, count))
+    if (!outState || !isValidQueryRange(queryIndex, count))
     {
         return SLANG_E_INVALID_ARG;
     }
 
-    *outReady = false;
     QueryRangeInfo queryInfo = getQueryRangeInfo(queryIndex, count);
-    if (queryInfo.state == QueryRangeState::Reset)
+    if (queryInfo.state == QueryResultState::Reset)
     {
-        return SLANG_FAIL;
+        *outState = QueryResultState::Reset;
+        return SLANG_OK;
     }
-    if (queryInfo.state == QueryRangeState::Resolved)
+    if (queryInfo.state == QueryResultState::Resolved)
     {
-        *outReady = true;
+        *outState = QueryResultState::Resolved;
         return SLANG_OK;
     }
 
@@ -175,11 +177,12 @@ Result PlainBufferProxyQueryPoolImpl::isResultReady(uint32_t queryIndex, uint32_
     uint64_t submissionID = queryInfo.submissionID;
     if (queue->m_lastFinishedID < submissionID)
     {
+        *outState = QueryResultState::Pending;
         return SLANG_OK;
     }
 
-    markQueryRangeReady(queryIndex, count, queryInfo.submissionID);
-    *outReady = true;
+    markQueryRangeResolved(queryIndex, count, queryInfo.submissionID);
+    *outState = QueryResultState::Resolved;
 
     return SLANG_OK;
 }
@@ -191,7 +194,7 @@ Result PlainBufferProxyQueryPoolImpl::getResult(uint32_t queryIndex, uint32_t co
         return SLANG_E_INVALID_ARG;
     }
     QueryRangeInfo queryInfo = getQueryRangeInfo(queryIndex, count);
-    if (queryInfo.state == QueryRangeState::Reset)
+    if (queryInfo.state == QueryResultState::Reset)
     {
         return SLANG_FAIL;
     }
@@ -210,7 +213,7 @@ Result PlainBufferProxyQueryPoolImpl::getResult(uint32_t queryIndex, uint32_t co
         this
     );
 
-    markQueryRangeReady(queryIndex, count, queryInfo.submissionID);
+    markQueryRangeResolved(queryIndex, count, queryInfo.submissionID);
 
     return SLANG_OK;
 }

--- a/src/cuda/cuda-query.h
+++ b/src/cuda/cuda-query.h
@@ -26,10 +26,10 @@ public:
 
     virtual SLANG_NO_THROW Result SLANG_MCALL reset() override;
     virtual SLANG_NO_THROW Result SLANG_MCALL reset(uint32_t queryIndex, uint32_t count) override;
-    virtual SLANG_NO_THROW Result SLANG_MCALL isResultReady(
+    virtual SLANG_NO_THROW Result SLANG_MCALL getResultState(
         uint32_t queryIndex,
         uint32_t count,
-        bool* outReady
+        QueryResultState* outState
     ) override;
     virtual SLANG_NO_THROW Result SLANG_MCALL getResult(
         uint32_t queryIndex,
@@ -52,10 +52,10 @@ public:
     Result init();
 
     virtual SLANG_NO_THROW Result SLANG_MCALL reset() override;
-    virtual SLANG_NO_THROW Result SLANG_MCALL isResultReady(
+    virtual SLANG_NO_THROW Result SLANG_MCALL getResultState(
         uint32_t queryIndex,
         uint32_t count,
-        bool* outReady
+        QueryResultState* outState
     ) override;
     virtual SLANG_NO_THROW Result SLANG_MCALL getResult(
         uint32_t queryIndex,

--- a/src/d3d11/d3d11-query.cpp
+++ b/src/d3d11/d3d11-query.cpp
@@ -42,22 +42,22 @@ void QueryPoolImpl::setDisjointQuery(uint32_t index, ID3D11Query* disjointQuery)
     m_queries[index].disjointQuery = disjointQuery;
 }
 
-Result QueryPoolImpl::isResultReady(uint32_t queryIndex, uint32_t count, bool* outReady)
+Result QueryPoolImpl::getResultState(uint32_t queryIndex, uint32_t count, QueryResultState* outState)
 {
-    if (!outReady || !isValidQueryRange(queryIndex, count))
+    if (!outState || !isValidQueryRange(queryIndex, count))
     {
         return SLANG_E_INVALID_ARG;
     }
 
-    *outReady = false;
     QueryRangeInfo queryInfo = getQueryRangeInfo(queryIndex, count);
-    if (queryInfo.state == QueryRangeState::Reset)
+    if (queryInfo.state == QueryResultState::Reset)
     {
-        return SLANG_FAIL;
+        *outState = QueryResultState::Reset;
+        return SLANG_OK;
     }
-    if (queryInfo.state == QueryRangeState::Resolved)
+    if (queryInfo.state == QueryResultState::Resolved)
     {
-        *outReady = true;
+        *outState = QueryResultState::Resolved;
         return SLANG_OK;
     }
 
@@ -76,6 +76,7 @@ Result QueryPoolImpl::isResultReady(uint32_t queryIndex, uint32_t count, bool* o
                 ->GetData(query.disjointQuery, &disjointData, sizeof(disjointData), D3D11_ASYNC_GETDATA_DONOTFLUSH);
         if (hr == S_FALSE)
         {
+            *outState = QueryResultState::Pending;
             return SLANG_OK;
         }
         SLANG_D3D_RETURN_ON_FAIL_REPORT(hr, device);
@@ -90,13 +91,14 @@ Result QueryPoolImpl::isResultReady(uint32_t queryIndex, uint32_t count, bool* o
                  ->GetData(query.timestampQuery, &value, sizeof(value), D3D11_ASYNC_GETDATA_DONOTFLUSH);
         if (hr == S_FALSE)
         {
+            *outState = QueryResultState::Pending;
             return SLANG_OK;
         }
         SLANG_D3D_RETURN_ON_FAIL_REPORT(hr, device);
     }
 
-    markQueryRangeReady(queryIndex, count, queryInfo.submissionID);
-    *outReady = true;
+    markQueryRangeResolved(queryIndex, count, queryInfo.submissionID);
+    *outState = QueryResultState::Resolved;
 
     return SLANG_OK;
 }
@@ -109,7 +111,7 @@ Result QueryPoolImpl::getResult(uint32_t queryIndex, uint32_t count, uint64_t* o
     }
 
     QueryRangeInfo queryInfo = getQueryRangeInfo(queryIndex, count);
-    if (queryInfo.state == QueryRangeState::Reset)
+    if (queryInfo.state == QueryResultState::Reset)
     {
         return SLANG_FAIL;
     }
@@ -152,7 +154,7 @@ Result QueryPoolImpl::getResult(uint32_t queryIndex, uint32_t count, uint64_t* o
         SLANG_D3D_RETURN_ON_FAIL_REPORT(hr, device);
     }
 
-    markQueryRangeReady(queryIndex, count, queryInfo.submissionID);
+    markQueryRangeResolved(queryIndex, count, queryInfo.submissionID);
 
     return SLANG_OK;
 }

--- a/src/d3d11/d3d11-query.h
+++ b/src/d3d11/d3d11-query.h
@@ -23,10 +23,10 @@ public:
     ID3D11Query* getQuery(uint32_t index);
     void setDisjointQuery(uint32_t index, ID3D11Query* disjointQuery);
 
-    virtual SLANG_NO_THROW Result SLANG_MCALL isResultReady(
+    virtual SLANG_NO_THROW Result SLANG_MCALL getResultState(
         uint32_t queryIndex,
         uint32_t count,
-        bool* outReady
+        QueryResultState* outState
     ) override;
     virtual SLANG_NO_THROW Result SLANG_MCALL getResult(
         uint32_t queryIndex,

--- a/src/d3d12/d3d12-query.cpp
+++ b/src/d3d12/d3d12-query.cpp
@@ -74,22 +74,22 @@ Result QueryPoolImpl::init()
     return SLANG_OK;
 }
 
-Result QueryPoolImpl::isResultReady(uint32_t queryIndex, uint32_t count, bool* outReady)
+Result QueryPoolImpl::getResultState(uint32_t queryIndex, uint32_t count, QueryResultState* outState)
 {
-    if (!outReady || !isValidQueryRange(queryIndex, count))
+    if (!outState || !isValidQueryRange(queryIndex, count))
     {
         return SLANG_E_INVALID_ARG;
     }
 
-    *outReady = false;
     QueryRangeInfo queryInfo = getQueryRangeInfo(queryIndex, count);
-    if (queryInfo.state == QueryRangeState::Reset)
+    if (queryInfo.state == QueryResultState::Reset)
     {
-        return SLANG_FAIL;
+        *outState = QueryResultState::Reset;
+        return SLANG_OK;
     }
-    if (queryInfo.state == QueryRangeState::Resolved)
+    if (queryInfo.state == QueryResultState::Resolved)
     {
-        *outReady = true;
+        *outState = QueryResultState::Resolved;
         return SLANG_OK;
     }
 
@@ -97,11 +97,12 @@ Result QueryPoolImpl::isResultReady(uint32_t queryIndex, uint32_t count, bool* o
     uint64_t submissionID = queryInfo.submissionID;
     if (queue->updateLastFinishedID() < submissionID)
     {
+        *outState = QueryResultState::Pending;
         return SLANG_OK;
     }
 
-    markQueryRangeReady(queryIndex, count, queryInfo.submissionID);
-    *outReady = true;
+    markQueryRangeResolved(queryIndex, count, queryInfo.submissionID);
+    *outState = QueryResultState::Resolved;
 
     return SLANG_OK;
 }
@@ -114,7 +115,7 @@ Result QueryPoolImpl::getResult(uint32_t queryIndex, uint32_t count, uint64_t* o
     }
 
     QueryRangeInfo queryInfo = getQueryRangeInfo(queryIndex, count);
-    if (queryInfo.state == QueryRangeState::Reset)
+    if (queryInfo.state == QueryResultState::Reset)
     {
         return SLANG_FAIL;
     }
@@ -138,7 +139,7 @@ Result QueryPoolImpl::getResult(uint32_t queryIndex, uint32_t count, uint64_t* o
     }
 
     memcpy(outData, m_mappedReadBackData + sizeof(uint64_t) * queryIndex, sizeof(uint64_t) * count);
-    markQueryRangeReady(queryIndex, count, queryInfo.submissionID);
+    markQueryRangeResolved(queryIndex, count, queryInfo.submissionID);
 
     return SLANG_OK;
 }
@@ -212,22 +213,22 @@ Result PlainBufferProxyQueryPoolImpl::init(uint32_t stride)
     return SLANG_OK;
 }
 
-Result PlainBufferProxyQueryPoolImpl::isResultReady(uint32_t queryIndex, uint32_t count, bool* outReady)
+Result PlainBufferProxyQueryPoolImpl::getResultState(uint32_t queryIndex, uint32_t count, QueryResultState* outState)
 {
-    if (!outReady || !isValidQueryRange(queryIndex, count))
+    if (!outState || !isValidQueryRange(queryIndex, count))
     {
         return SLANG_E_INVALID_ARG;
     }
 
-    *outReady = false;
     QueryRangeInfo queryInfo = getQueryRangeInfo(queryIndex, count);
-    if (queryInfo.state == QueryRangeState::Reset)
+    if (queryInfo.state == QueryResultState::Reset)
     {
-        return SLANG_FAIL;
+        *outState = QueryResultState::Reset;
+        return SLANG_OK;
     }
-    if (queryInfo.state == QueryRangeState::Resolved)
+    if (queryInfo.state == QueryResultState::Resolved)
     {
-        *outReady = true;
+        *outState = QueryResultState::Resolved;
         return SLANG_OK;
     }
 
@@ -235,11 +236,12 @@ Result PlainBufferProxyQueryPoolImpl::isResultReady(uint32_t queryIndex, uint32_
     uint64_t submissionID = queryInfo.submissionID;
     if (queue->updateLastFinishedID() < submissionID)
     {
+        *outState = QueryResultState::Pending;
         return SLANG_OK;
     }
 
-    markQueryRangeReady(queryIndex, count, queryInfo.submissionID);
-    *outReady = true;
+    markQueryRangeResolved(queryIndex, count, queryInfo.submissionID);
+    *outState = QueryResultState::Resolved;
 
     return SLANG_OK;
 }
@@ -252,7 +254,7 @@ Result PlainBufferProxyQueryPoolImpl::getResult(uint32_t queryIndex, uint32_t co
     }
 
     QueryRangeInfo queryInfo = getQueryRangeInfo(queryIndex, count);
-    if (queryInfo.state == QueryRangeState::Reset)
+    if (queryInfo.state == QueryResultState::Reset)
     {
         return SLANG_FAIL;
     }
@@ -277,7 +279,7 @@ Result PlainBufferProxyQueryPoolImpl::getResult(uint32_t queryIndex, uint32_t co
     }
 
     memcpy(outData, m_mappedReadBackData + uint64_t(m_stride) * queryIndex, uint64_t(m_stride) * count);
-    markQueryRangeReady(queryIndex, count, queryInfo.submissionID);
+    markQueryRangeResolved(queryIndex, count, queryInfo.submissionID);
 
     return SLANG_OK;
 }

--- a/src/d3d12/d3d12-query.h
+++ b/src/d3d12/d3d12-query.h
@@ -12,10 +12,10 @@ public:
 
     Result init();
 
-    virtual SLANG_NO_THROW Result SLANG_MCALL isResultReady(
+    virtual SLANG_NO_THROW Result SLANG_MCALL getResultState(
         uint32_t queryIndex,
         uint32_t count,
-        bool* outReady
+        QueryResultState* outState
     ) override;
     virtual SLANG_NO_THROW Result SLANG_MCALL getResult(
         uint32_t queryIndex,
@@ -47,10 +47,10 @@ public:
 
     Result init(uint32_t stride);
 
-    virtual SLANG_NO_THROW Result SLANG_MCALL isResultReady(
+    virtual SLANG_NO_THROW Result SLANG_MCALL getResultState(
         uint32_t queryIndex,
         uint32_t count,
-        bool* outReady
+        QueryResultState* outState
     ) override;
     virtual SLANG_NO_THROW Result SLANG_MCALL getResult(
         uint32_t queryIndex,

--- a/src/debug-layer/debug-query.cpp
+++ b/src/debug-layer/debug-query.cpp
@@ -10,22 +10,22 @@ const QueryPoolDesc& DebugQueryPool::getDesc()
     return baseObject->getDesc();
 }
 
-Result DebugQueryPool::isResultReady(uint32_t queryIndex, uint32_t count, bool* outReady)
+Result DebugQueryPool::getResultState(uint32_t queryIndex, uint32_t count, QueryResultState* outState)
 {
-    SLANG_RHI_DEBUG_API(IQueryPool, isResultReady);
+    SLANG_RHI_DEBUG_API(IQueryPool, getResultState);
 
     if (!isValidSubrange(queryIndex, count, baseObject->getDesc().count))
     {
         RHI_VALIDATION_ERROR("'queryIndex' and 'count' must specify a valid range within the query pool.");
         return SLANG_E_INVALID_ARG;
     }
-    if (!outReady)
+    if (!outState)
     {
-        RHI_VALIDATION_ERROR("'outReady' must not be null.");
+        RHI_VALIDATION_ERROR("'outState' must not be null.");
         return SLANG_E_INVALID_ARG;
     }
 
-    return baseObject->isResultReady(queryIndex, count, outReady);
+    return baseObject->getResultState(queryIndex, count, outState);
 }
 
 Result DebugQueryPool::getResult(uint32_t queryIndex, uint32_t count, uint64_t* outData)

--- a/src/debug-layer/debug-query.h
+++ b/src/debug-layer/debug-query.h
@@ -15,10 +15,10 @@ public:
 public:
     // IQueryPool implementation
     virtual SLANG_NO_THROW const QueryPoolDesc& SLANG_MCALL getDesc() override;
-    virtual SLANG_NO_THROW Result SLANG_MCALL isResultReady(
+    virtual SLANG_NO_THROW Result SLANG_MCALL getResultState(
         uint32_t queryIndex,
         uint32_t count,
-        bool* outReady
+        QueryResultState* outState
     ) override;
     virtual SLANG_NO_THROW Result SLANG_MCALL getResult(
         uint32_t queryIndex,

--- a/src/metal/metal-query.cpp
+++ b/src/metal/metal-query.cpp
@@ -64,7 +64,7 @@ Result QueryPoolImpl::init()
     return m_counterSampleBuffer ? SLANG_OK : SLANG_FAIL;
 }
 
-Result QueryPoolImpl::isResultReady(uint32_t queryIndex, uint32_t count, bool* outReady)
+Result QueryPoolImpl::getResultState(uint32_t queryIndex, uint32_t count, QueryResultState* outState)
 {
     return SLANG_E_NOT_AVAILABLE;
 }

--- a/src/metal/metal-query.h
+++ b/src/metal/metal-query.h
@@ -14,10 +14,10 @@ public:
 
     Result init();
 
-    virtual SLANG_NO_THROW Result SLANG_MCALL isResultReady(
+    virtual SLANG_NO_THROW Result SLANG_MCALL getResultState(
         uint32_t queryIndex,
         uint32_t count,
-        bool* outReady
+        QueryResultState* outState
     ) override;
     virtual SLANG_NO_THROW Result SLANG_MCALL getResult(
         uint32_t queryIndex,

--- a/src/rhi-shared.cpp
+++ b/src/rhi-shared.cpp
@@ -341,7 +341,19 @@ QueryPool::QueryPool(Device* device, const QueryPoolDesc& desc)
     , m_desc(desc)
 {
     m_descHolder.holdString(m_desc.label);
-    m_queryStates.resize(m_desc.count);
+    m_querySlotStates.resize(m_desc.count);
+}
+
+Result QueryPool::getResultState(uint32_t queryIndex, uint32_t count, QueryResultState* outState)
+{
+    if (!outState || !isValidQueryRange(queryIndex, count))
+    {
+        return SLANG_E_INVALID_ARG;
+    }
+
+    *outState = getQueryRangeInfo(queryIndex, count).state;
+
+    return SLANG_OK;
 }
 
 Result QueryPool::reset()
@@ -359,8 +371,8 @@ Result QueryPool::reset(uint32_t queryIndex, uint32_t count)
     std::lock_guard<std::mutex> lock(m_queryStateMutex);
     for (uint32_t i = 0; i < count; ++i)
     {
-        QueryState& state = m_queryStates[queryIndex + i];
-        state.set(QueryStatus::Reset, 0);
+        QuerySlotState& slotState = m_querySlotStates[queryIndex + i];
+        slotState.set(QueryResultState::Reset, 0);
     }
 
     return SLANG_OK;
@@ -385,12 +397,12 @@ void QueryPool::markQueryRangeSubmitted(uint32_t queryIndex, uint32_t count, uin
     std::lock_guard<std::mutex> lock(m_queryStateMutex);
     for (uint32_t i = 0; i < count; ++i)
     {
-        QueryState& state = m_queryStates[queryIndex + i];
-        state.set(QueryStatus::Pending, submissionID);
+        QuerySlotState& slotState = m_querySlotStates[queryIndex + i];
+        slotState.set(QueryResultState::Pending, submissionID);
     }
 }
 
-void QueryPool::markQueryRangeReady(uint32_t queryIndex, uint32_t count, uint64_t completedSubmissionID)
+void QueryPool::markQueryRangeResolved(uint32_t queryIndex, uint32_t count, uint64_t completedSubmissionID)
 {
     if (!isValidQueryRange(queryIndex, count))
     {
@@ -400,12 +412,12 @@ void QueryPool::markQueryRangeReady(uint32_t queryIndex, uint32_t count, uint64_
     std::lock_guard<std::mutex> lock(m_queryStateMutex);
     for (uint32_t i = 0; i < count; ++i)
     {
-        QueryState& state = m_queryStates[queryIndex + i];
-        QueryStatus status = state.getStatus();
-        uint64_t submissionID = state.getSubmissionID();
-        if (status == QueryStatus::Pending && submissionID <= completedSubmissionID)
+        QuerySlotState& slotState = m_querySlotStates[queryIndex + i];
+        QueryResultState state = slotState.getState();
+        uint64_t submissionID = slotState.getSubmissionID();
+        if (state == QueryResultState::Pending && submissionID <= completedSubmissionID)
         {
-            state.set(QueryStatus::Resolved, submissionID);
+            slotState.set(QueryResultState::Resolved, submissionID);
         }
     }
 }
@@ -414,33 +426,33 @@ QueryPool::QueryRangeInfo QueryPool::getQueryRangeInfo(uint32_t queryIndex, uint
 {
     if (!isValidQueryRange(queryIndex, count))
     {
-        return {QueryRangeState::Reset, 0};
+        return {QueryResultState::Reset, 0};
     }
 
     if (count == 0)
     {
-        return {QueryRangeState::Resolved, 0};
+        return {QueryResultState::Resolved, 0};
     }
 
     QueryRangeInfo info;
     std::lock_guard<std::mutex> lock(m_queryStateMutex);
     for (uint32_t i = 0; i < count; ++i)
     {
-        const QueryState& state = m_queryStates[queryIndex + i];
-        QueryStatus status = state.getStatus();
-        if (status == QueryStatus::Reset)
+        const QuerySlotState& slotState = m_querySlotStates[queryIndex + i];
+        QueryResultState state = slotState.getState();
+        if (state == QueryResultState::Reset)
         {
-            return {QueryRangeState::Reset, 0};
+            return {QueryResultState::Reset, 0};
         }
-        if (status == QueryStatus::Pending)
+        if (state == QueryResultState::Pending)
         {
-            info.state = QueryRangeState::Pending;
+            info.state = QueryResultState::Pending;
         }
-        info.submissionID = std::max(info.submissionID, state.getSubmissionID());
+        info.submissionID = std::max(info.submissionID, slotState.getSubmissionID());
     }
-    if (info.state != QueryRangeState::Pending)
+    if (info.state != QueryResultState::Pending)
     {
-        info.state = QueryRangeState::Resolved;
+        info.state = QueryResultState::Resolved;
     }
     return info;
 }

--- a/src/rhi-shared.h
+++ b/src/rhi-shared.h
@@ -252,58 +252,50 @@ public:
     QueryPool(Device* device, const QueryPoolDesc& desc);
 
     virtual SLANG_NO_THROW const QueryPoolDesc& SLANG_MCALL getDesc() override { return m_desc; }
+    virtual SLANG_NO_THROW Result SLANG_MCALL getResultState(
+        uint32_t queryIndex,
+        uint32_t count,
+        QueryResultState* outState
+    ) override;
     virtual SLANG_NO_THROW Result SLANG_MCALL reset() override;
     virtual SLANG_NO_THROW Result SLANG_MCALL reset(uint32_t queryIndex, uint32_t count) override;
 
-    enum class QueryRangeState
-    {
-        Reset,
-        Pending,
-        Resolved,
-    };
-
     struct QueryRangeInfo
     {
-        QueryRangeState state = QueryRangeState::Reset;
+        QueryResultState state = QueryResultState::Reset;
         uint64_t submissionID = 0;
     };
 
     bool isValidQueryRange(uint32_t queryIndex, uint32_t count) const;
     void markQueryRangeSubmitted(uint32_t queryIndex, uint32_t count, uint64_t submissionID);
-    void markQueryRangeReady(uint32_t queryIndex, uint32_t count, uint64_t completedSubmissionID);
+    void markQueryRangeResolved(uint32_t queryIndex, uint32_t count, uint64_t completedSubmissionID);
     QueryRangeInfo getQueryRangeInfo(uint32_t queryIndex, uint32_t count) const;
 
 public:
-    enum class QueryStatus : uint64_t
+    struct QuerySlotState
     {
-        Reset = 0,
-        Pending = 1,
-        Resolved = 2,
-    };
+        static constexpr uint64_t kStateShift = 62;
+        static constexpr uint64_t kStateMask = uint64_t(3) << kStateShift;
+        static constexpr uint64_t kSubmissionIDMask = (uint64_t(1) << kStateShift) - 1;
 
-    struct QueryState
-    {
-        static constexpr uint64_t kStatusShift = 62;
-        static constexpr uint64_t kSubmissionIDMask = (uint64_t(1) << kStatusShift) - 1;
+        uint64_t packedState = 0;
 
-        uint64_t state = 0;
-
-        void set(QueryStatus status, uint64_t submissionID)
+        void set(QueryResultState state, uint64_t submissionID)
         {
             SLANG_RHI_ASSERT((submissionID & ~kSubmissionIDMask) == 0);
-            state = (uint64_t(status) << kStatusShift) | (submissionID & kSubmissionIDMask);
+            packedState = (uint64_t(state) << kStateShift) | (submissionID & kSubmissionIDMask);
         }
 
-        QueryStatus getStatus() const { return QueryStatus(state >> kStatusShift); }
+        QueryResultState getState() const { return QueryResultState((packedState & kStateMask) >> kStateShift); }
 
-        uint64_t getSubmissionID() const { return state & kSubmissionIDMask; }
+        uint64_t getSubmissionID() const { return packedState & kSubmissionIDMask; }
     };
 
-    static_assert(sizeof(QueryState) == 8, "QueryState should remain compact.");
+    static_assert(sizeof(QuerySlotState) == 8, "QuerySlotState should remain compact.");
 
     QueryPoolDesc m_desc;
     StructHolder m_descHolder;
-    std::vector<QueryState> m_queryStates;
+    std::vector<QuerySlotState> m_querySlotStates;
     mutable std::mutex m_queryStateMutex;
 };
 

--- a/src/vulkan/vk-query.cpp
+++ b/src/vulkan/vk-query.cpp
@@ -51,17 +51,16 @@ QueryPoolImpl::~QueryPoolImpl()
     }
 }
 
-Result QueryPoolImpl::isResultReady(uint32_t queryIndex, uint32_t count, bool* outReady)
+Result QueryPoolImpl::getResultState(uint32_t queryIndex, uint32_t count, QueryResultState* outState)
 {
-    if (!outReady || !isValidQueryRange(queryIndex, count))
+    if (!outState || !isValidQueryRange(queryIndex, count))
     {
         return SLANG_E_INVALID_ARG;
     }
 
-    *outReady = false;
     if (count == 0)
     {
-        *outReady = true;
+        *outState = QueryResultState::Resolved;
         return SLANG_OK;
     }
     if (m_pool == VK_NULL_HANDLE)
@@ -70,13 +69,14 @@ Result QueryPoolImpl::isResultReady(uint32_t queryIndex, uint32_t count, bool* o
     }
 
     QueryRangeInfo queryInfo = getQueryRangeInfo(queryIndex, count);
-    if (queryInfo.state == QueryRangeState::Reset)
+    if (queryInfo.state == QueryResultState::Reset)
     {
-        return SLANG_FAIL;
+        *outState = QueryResultState::Reset;
+        return SLANG_OK;
     }
-    if (queryInfo.state == QueryRangeState::Resolved)
+    if (queryInfo.state == QueryResultState::Resolved)
     {
-        *outReady = true;
+        *outState = QueryResultState::Resolved;
         return SLANG_OK;
     }
 
@@ -94,12 +94,13 @@ Result QueryPoolImpl::isResultReady(uint32_t queryIndex, uint32_t count, bool* o
     );
     if (result == VK_NOT_READY)
     {
+        *outState = QueryResultState::Pending;
         return SLANG_OK;
     }
     SLANG_VK_RETURN_ON_FAIL_REPORT(result, device);
 
-    markQueryRangeReady(queryIndex, count, queryInfo.submissionID);
-    *outReady = true;
+    markQueryRangeResolved(queryIndex, count, queryInfo.submissionID);
+    *outState = QueryResultState::Resolved;
 
     return SLANG_OK;
 }
@@ -121,7 +122,7 @@ Result QueryPoolImpl::getResult(uint32_t queryIndex, uint32_t count, uint64_t* o
     }
 
     QueryRangeInfo queryInfo = getQueryRangeInfo(queryIndex, count);
-    if (queryInfo.state == QueryRangeState::Reset)
+    if (queryInfo.state == QueryResultState::Reset)
     {
         return SLANG_FAIL;
     }
@@ -141,7 +142,7 @@ Result QueryPoolImpl::getResult(uint32_t queryIndex, uint32_t count, uint64_t* o
         device
     );
 
-    markQueryRangeReady(queryIndex, count, queryInfo.submissionID);
+    markQueryRangeResolved(queryIndex, count, queryInfo.submissionID);
 
     return SLANG_OK;
 }

--- a/src/vulkan/vk-query.h
+++ b/src/vulkan/vk-query.h
@@ -14,10 +14,10 @@ public:
 
     Result init();
 
-    virtual SLANG_NO_THROW Result SLANG_MCALL isResultReady(
+    virtual SLANG_NO_THROW Result SLANG_MCALL getResultState(
         uint32_t queryIndex,
         uint32_t count,
-        bool* outReady
+        QueryResultState* outState
     ) override;
     virtual SLANG_NO_THROW Result SLANG_MCALL getResult(
         uint32_t queryIndex,

--- a/src/wgpu/wgpu-query.cpp
+++ b/src/wgpu/wgpu-query.cpp
@@ -16,7 +16,7 @@ QueryPoolImpl::~QueryPoolImpl()
     }
 }
 
-Result QueryPoolImpl::isResultReady(uint32_t queryIndex, uint32_t count, bool* outReady)
+Result QueryPoolImpl::getResultState(uint32_t queryIndex, uint32_t count, QueryResultState* outState)
 {
     return SLANG_E_NOT_IMPLEMENTED;
 }

--- a/src/wgpu/wgpu-query.h
+++ b/src/wgpu/wgpu-query.h
@@ -13,10 +13,10 @@ public:
     ~QueryPoolImpl();
 
     // IQueryPool implementation
-    virtual SLANG_NO_THROW Result SLANG_MCALL isResultReady(
+    virtual SLANG_NO_THROW Result SLANG_MCALL getResultState(
         uint32_t queryIndex,
         uint32_t count,
-        bool* outReady
+        QueryResultState* outState
     ) override;
     virtual SLANG_NO_THROW Result SLANG_MCALL getResult(
         uint32_t queryIndex,

--- a/tests/test-cmd-query.cpp
+++ b/tests/test-cmd-query.cpp
@@ -34,15 +34,16 @@ static ComPtr<ICommandBuffer> createTimestampCommandBuffer(
 
 static void checkQueryResultReady(IQueryPool* queryPool, uint32_t queryIndex, uint32_t count)
 {
-    bool ready = false;
-    REQUIRE_CALL(queryPool->isResultReady(queryIndex, count, &ready));
-    CHECK(ready);
+    QueryResultState state = QueryResultState::Reset;
+    REQUIRE_CALL(queryPool->getResultState(queryIndex, count, &state));
+    CHECK(state == QueryResultState::Resolved);
 }
 
-static void checkQueryResultUnavailable(IQueryPool* queryPool, uint32_t queryIndex, uint32_t count)
+static void checkQueryResultReset(IQueryPool* queryPool, uint32_t queryIndex, uint32_t count)
 {
-    bool ready = true;
-    CHECK(queryPool->isResultReady(queryIndex, count, &ready) == SLANG_FAIL);
+    QueryResultState state = QueryResultState::Resolved;
+    REQUIRE_CALL(queryPool->getResultState(queryIndex, count, &state));
+    CHECK(state == QueryResultState::Reset);
 }
 
 struct AccelerationStructureQueryBuild
@@ -218,18 +219,19 @@ GPU_TEST_CASE("cmd-query-result-readiness", ALL)
     auto queryPool = createTimestampQueryPool(device, 1);
     auto queue = device->getQueue(QueueType::Graphics);
 
-    checkQueryResultUnavailable(queryPool, 0, 1);
+    checkQueryResultReset(queryPool, 0, 1);
 
     auto commandBuffer = createTimestampCommandBuffer(queue, queryPool, {0});
-    checkQueryResultUnavailable(queryPool, 0, 1);
+    checkQueryResultReset(queryPool, 0, 1);
 
     REQUIRE_CALL(queryPool->reset());
-    checkQueryResultUnavailable(queryPool, 0, 1);
+    checkQueryResultReset(queryPool, 0, 1);
 
     REQUIRE_CALL(queue->submit(commandBuffer));
 
-    bool ready = true;
-    REQUIRE_CALL(queryPool->isResultReady(0, 1, &ready));
+    QueryResultState state = QueryResultState::Reset;
+    REQUIRE_CALL(queryPool->getResultState(0, 1, &state));
+    CHECK((state == QueryResultState::Pending || state == QueryResultState::Resolved));
 
     REQUIRE_CALL(queue->waitOnHost());
     checkQueryResultReady(queryPool, 0, 1);
@@ -237,7 +239,7 @@ GPU_TEST_CASE("cmd-query-result-readiness", ALL)
     uint64_t timestamp = 0;
     REQUIRE_CALL(queryPool->getResult(0, 1, &timestamp));
     REQUIRE_CALL(queryPool->reset());
-    checkQueryResultUnavailable(queryPool, 0, 1);
+    checkQueryResultReset(queryPool, 0, 1);
 }
 
 GPU_TEST_CASE("cmd-query-partial-range-readiness", ALL)
@@ -257,8 +259,8 @@ GPU_TEST_CASE("cmd-query-partial-range-readiness", ALL)
     checkQueryResultReady(queryPool, 0, 1);
     REQUIRE_CALL(queryPool->getResult(0, 1, &timestamp));
 
-    checkQueryResultUnavailable(queryPool, 1, 1);
-    checkQueryResultUnavailable(queryPool, 0, 2);
+    checkQueryResultReset(queryPool, 1, 1);
+    checkQueryResultReset(queryPool, 0, 2);
     CHECK(queryPool->getResult(0, 2, &timestamp) == SLANG_FAIL);
 }
 
@@ -329,7 +331,7 @@ GPU_TEST_CASE("cmd-query-reset-invalidates-ready-result", ALL)
     REQUIRE_CALL(queryPool->getResult(0, 1, &timestamp));
 
     REQUIRE_CALL(queryPool->reset());
-    checkQueryResultUnavailable(queryPool, 0, 1);
+    checkQueryResultReset(queryPool, 0, 1);
     CHECK(queryPool->getResult(0, 1, &timestamp) == SLANG_FAIL);
 }
 
@@ -349,9 +351,9 @@ GPU_TEST_CASE("cmd-query-reset-range", ALL)
 
     REQUIRE_CALL(queryPool->reset(1, 1));
     checkQueryResultReady(queryPool, 0, 1);
-    checkQueryResultUnavailable(queryPool, 1, 1);
+    checkQueryResultReset(queryPool, 1, 1);
     checkQueryResultReady(queryPool, 2, 1);
-    checkQueryResultUnavailable(queryPool, 0, 3);
+    checkQueryResultReset(queryPool, 0, 3);
 
     uint64_t timestamp = 0;
     REQUIRE_CALL(queryPool->getResult(0, 1, &timestamp));
@@ -393,7 +395,7 @@ GPU_TEST_CASE("cmd-query-acceleration-structure-get-result-without-wait", D3D12 
     auto queue = device->getQueue(QueueType::Graphics);
     auto build = createAccelerationStructureCompactionQueryBuild(device, queue);
 
-    checkQueryResultUnavailable(build.queryPool, 0, 1);
+    checkQueryResultReset(build.queryPool, 0, 1);
     REQUIRE_CALL(queue->submit(build.commandBuffer));
 
     uint64_t compactedSize = 0;
@@ -402,7 +404,7 @@ GPU_TEST_CASE("cmd-query-acceleration-structure-get-result-without-wait", D3D12 
     checkQueryResultReady(build.queryPool, 0, 1);
 
     REQUIRE_CALL(build.queryPool->reset(0, 1));
-    checkQueryResultUnavailable(build.queryPool, 0, 1);
+    checkQueryResultReset(build.queryPool, 0, 1);
 }
 
 GPU_TEST_CASE("cmd-query-range-across-command-buffers", ALL)
@@ -446,7 +448,7 @@ GPU_TEST_CASE("cmd-query-range-across-submissions", ALL)
     REQUIRE_CALL(queue->submit(createTimestampCommandBuffer(queue, queryPool, {0})));
     REQUIRE_CALL(queue->waitOnHost());
     checkQueryResultReady(queryPool, 0, 1);
-    checkQueryResultUnavailable(queryPool, 0, 2);
+    checkQueryResultReset(queryPool, 0, 2);
 
     REQUIRE_CALL(queue->submit(createTimestampCommandBuffer(queue, queryPool, {1})));
     REQUIRE_CALL(queue->waitOnHost());
@@ -469,7 +471,7 @@ GPU_TEST_CASE("cmd-query-d3d12-get-result-requires-submission", D3D12)
     auto commandBuffer = createTimestampCommandBuffer(queue, queryPool, {0});
 
     uint64_t timestamp = 0;
-    checkQueryResultUnavailable(queryPool, 0, 1);
+    checkQueryResultReset(queryPool, 0, 1);
     CHECK(queryPool->getResult(0, 1, &timestamp) == SLANG_FAIL);
 
     REQUIRE_CALL(queue->submit(commandBuffer));


### PR DESCRIPTION
Replaces `IQueryPool::isResultReady` with `getResultState`, exposing query result lifecycle directly as `Reset`, `Pending`, or `Resolved`.

Also cleans up internal query state naming so the shared query tracking uses the public `QueryResultState` enum directly, with per-slot packed state represented by `QuerySlotState`.