### PR TITLE
CUDA: route hoisted entry-point uniforms to SLANG_globalParams at dispatch

### DIFF
--- a/src/cuda/cuda-command.cpp
+++ b/src/cuda/cuda-command.cpp
@@ -640,38 +640,64 @@ void CommandExecutor::cmdDispatchCompute(const commands::DispatchCompute& cmd)
     SLANG_RHI_ASSERT(computePipeline->m_entryPointIndex < bindingData->entryPointCount);
     const auto& entryPointData = bindingData->entryPoints[computePipeline->m_entryPointIndex];
 
+    // The argument data for the entry-point parameters is stored in host memory, normally passed
+    // to cuLaunchKernel as the launch parameter buffer.
+    const void* launchParamData = entryPointData.data;
+    size_t launchParamSize = entryPointData.size;
+
     // Copy global parameter data to the `SLANG_globalParams` symbol.
     if (computePipeline->m_globalParams)
     {
+        // A late CUDA IR pass can hoist a compute kernel's entry-point uniform parameters into the
+        // `SLANG_globalParams` __constant__ block. In that case reflection still reports them as
+        // entry-point uniforms (so their data lands in `entryPointData` and `globalParams` is
+        // empty), but the emitted kernel reads `__constant__` and takes no launch arguments. Detect
+        // that and route the entry-point uniform blob (host memory) into the symbol, then launch
+        // with no argument buffer.
+        const bool hoistedEntryPointUniforms = (bindingData->globalParamsSize == 0 && launchParamSize > 0);
+
         // TODO: Slang sometimes computes the size of the global parameters layout incorrectly.
         // Instead of the assert, we currently warn about this mismatch once.
         // SLANG_RHI_ASSERT(computePipeline->m_globalParamsSize == bindingData->globalParamsSize);
-        if (computePipeline->m_globalParamsSize != bindingData->globalParamsSize &&
-            !computePipeline->m_warnedAboutGlobalParamsSizeMismatch)
+        const size_t srcSize = hoistedEntryPointUniforms ? launchParamSize : bindingData->globalParamsSize;
+        if (computePipeline->m_globalParamsSize != srcSize && !computePipeline->m_warnedAboutGlobalParamsSizeMismatch)
         {
             m_device->printWarning(
                 "Warning: Incorrect global parameter size (expected %llu, got %llu) for pipeline %s",
                 computePipeline->m_globalParamsSize,
-                bindingData->globalParamsSize,
+                srcSize,
                 computePipeline->m_entryPointName.c_str()
             );
             computePipeline->m_warnedAboutGlobalParamsSizeMismatch = true;
         }
-        SLANG_CUDA_ASSERT_ON_FAIL(cuMemcpyAsync(
-            computePipeline->m_globalParams,
-            bindingData->globalParams,
-            min(bindingData->globalParamsSize, computePipeline->m_globalParamsSize),
-            m_stream
-        ));
+
+        if (hoistedEntryPointUniforms)
+        {
+            SLANG_CUDA_ASSERT_ON_FAIL(cuMemcpyHtoDAsync(
+                computePipeline->m_globalParams,
+                launchParamData,
+                min(launchParamSize, computePipeline->m_globalParamsSize),
+                m_stream
+            ));
+            launchParamData = nullptr;
+            launchParamSize = 0;
+        }
+        else
+        {
+            SLANG_CUDA_ASSERT_ON_FAIL(cuMemcpyAsync(
+                computePipeline->m_globalParams,
+                bindingData->globalParams,
+                min(bindingData->globalParamsSize, computePipeline->m_globalParamsSize),
+                m_stream
+            ));
+        }
     }
 
-    // The argument data for the entry-point parameters are already
-    // stored in host memory, as expected by cuLaunchKernel.
     void* extraOptions[] = {
         CU_LAUNCH_PARAM_BUFFER_POINTER,
-        (void*)entryPointData.data,
+        (void*)launchParamData,
         CU_LAUNCH_PARAM_BUFFER_SIZE,
-        (void*)&entryPointData.size,
+        (void*)&launchParamSize,
         CU_LAUNCH_PARAM_END,
     };
 


### PR DESCRIPTION
## Summary (DRAFT — host half of shader-slang/slang#11747)

Companion to the Slang compiler pass in **shader-slang/slang#11747**, which hoists a CUDA compute kernel's runtime-indexed resource-array entry-point uniforms into a `__constant__ SLANG_globalParams` block (to avoid the slow serial `.param` `ld.param` chain). Because that hoist is a **late emit pass**, it is invisible to reflection — so slang-rhi otherwise binds the uniforms into the `cuLaunchKernel` argument buffer while the emitted kernel reads `__constant__` → `CUDA_ERROR_LAUNCH_OUT_OF_RESOURCES`.

This adds the dispatch-time routing in `CommandExecutor::cmdDispatchCompute`: when a compute kernel's reflection reports entry-point uniforms (`entryPointData.size > 0`) **and** the module exposes a `SLANG_globalParams` `__constant__` symbol (`m_globalParams` valid) **and** there is no separate global-param data (`globalParamsSize == 0`) — i.e. the compiler hoisted the entry-point uniforms — copy the entry-point uniform blob into `SLANG_globalParams` (`cuMemcpyHtoDAsync`) and launch with an empty parameter buffer. Non-hoisted kernels are unaffected.

**Validated** with slang#11747 on an L40S (SlangPy `test_tensor_sum_indirect`): 0.103 / 0.744 / 2.585 ms → 0.026 / 0.031 / 0.208 ms (4× / 24× / 12×), results correct, no `globalParamsSize` mismatch (byte layouts match).

⚠️ Inert without shader-slang/slang#11747 (the routing condition only arises when that pass hoists). Draft until the pair is co-reviewed.

<sub>🤖 Generated by an automated coworker — may be inaccurate. A human maintainer should verify.</sub>