### PR TITLE
Improve D3D12 testing

### DIFF
--- a/src/d3d12/d3d12-device.cpp
+++ b/src/d3d12/d3d12-device.cpp
@@ -1224,7 +1224,7 @@ Result DeviceImpl::initialize(const DeviceDesc& desc, BackendImpl* backend)
     // Shader model 6.9 requires HitObject and MaybeReorderThread support on ray tracing devices.
     // MaybeReorderThread is allowed to be a no-op, so this feature indicates API availability rather than
     // guaranteeing that the implementation actually reorders threads.
-    if (shaderModelData.HighestShaderModel >= (D3D_SHADER_MODEL)0x69 && hasFeature(Feature::RayTracing))
+    if (hasFeature(Feature::SM_6_9) && hasFeature(Feature::RayTracing))
     {
         addFeature(Feature::ShaderExecutionReordering);
     }

--- a/src/d3d12/d3d12-device.cpp
+++ b/src/d3d12/d3d12-device.cpp
@@ -1221,6 +1221,14 @@ Result DeviceImpl::initialize(const DeviceDesc& desc, BackendImpl* backend)
         }
     }
 
+    // Shader model 6.9 requires HitObject and MaybeReorderThread support on ray tracing devices.
+    // MaybeReorderThread is allowed to be a no-op, so this feature indicates API availability rather than
+    // guaranteeing that the implementation actually reorders threads.
+    if (shaderModelData.HighestShaderModel >= (D3D_SHADER_MODEL)0x69 && hasFeature(Feature::RayTracing))
+    {
+        addFeature(Feature::ShaderExecutionReordering);
+    }
+
     // Initialize slang context.
     SLANG_RETURN_ON_FAIL(m_slangContext.initialize(
         desc.slang,

--- a/tests/doctest-reporter.h
+++ b/tests/doctest-reporter.h
@@ -45,6 +45,7 @@ struct CustomReporter : public IReporter
             stream << "                                       <device> can be d3d11, d3d12, vulkan, metal, cpu, cuda, wgpu\n";
             stream << "                                       to select a specific adapter, the adapter index can be appended after a colon (i.e. d3d12:1)\n";
             stream << "                                       use * to select all available devices\n";
+            stream << " -d3d12-shader-model=<major.minor>     require and cap D3D12 tests to a shader model, e.g. 6.8\n";
             stream << " -d3d12-disable-nvapi                  disable the NVAPI shader extension for native D3D12 testing\n";
             stream << " -optix-version=<version>              select a specific OptiX version to use, e.g. 80100 for version 8.1\n";
             stream << " -memory-report                        print process memory summary at the end of the run\n";

--- a/tests/doctest-reporter.h
+++ b/tests/doctest-reporter.h
@@ -45,6 +45,7 @@ struct CustomReporter : public IReporter
             stream << "                                       <device> can be d3d11, d3d12, vulkan, metal, cpu, cuda, wgpu\n";
             stream << "                                       to select a specific adapter, the adapter index can be appended after a colon (i.e. d3d12:1)\n";
             stream << "                                       use * to select all available devices\n";
+            stream << " -d3d12-disable-nvapi                  disable the NVAPI shader extension for native D3D12 testing\n";
             stream << " -optix-version=<version>              select a specific OptiX version to use, e.g. 80100 for version 8.1\n";
             stream << " -memory-report                        print process memory summary at the end of the run\n";
             stream << " -memory-report-file=<path>            write process memory summary JSON to a file\n";

--- a/tests/main.cpp
+++ b/tests/main.cpp
@@ -7,6 +7,10 @@
 
 #include "doctest-reporter.h"
 
+#include <charconv>
+#include <cstdio>
+#include <string_view>
+
 // Due to current issues in slang we don't enable Agility SDK yet
 SLANG_RHI_EXPORT_AGILITY_SDK
 
@@ -84,6 +88,34 @@ int main(int argc, const char** argv)
                     }
                 }
             }
+        }
+
+        doctest::String d3d12ShaderModel;
+        if (doctest::parseOption(argc, argv, "d3d12-shader-model=", &d3d12ShaderModel))
+        {
+            std::string_view value = d3d12ShaderModel.c_str();
+            size_t separator = value.find('.');
+            unsigned int major = 0;
+            unsigned int minor = 0;
+            auto parseComponent = [](std::string_view component, unsigned int& result)
+            {
+                auto [end, error] = std::from_chars(component.data(), component.data() + component.size(), result);
+                return !component.empty() && error == std::errc() && end == component.data() + component.size();
+            };
+            bool validFormat = separator != std::string_view::npos &&
+                               parseComponent(value.substr(0, separator), major) &&
+                               parseComponent(value.substr(separator + 1), minor);
+            bool validVersion = (major == 5 && minor == 1) || (major == 6 && minor <= 9);
+            if (!validFormat || !validVersion)
+            {
+                std::fprintf(
+                    stderr,
+                    "Invalid D3D12 shader model '%s'; expected 5.1 or 6.0 through 6.9 in major.minor format.\n",
+                    d3d12ShaderModel.c_str()
+                );
+                return 1;
+            }
+            options.d3d12ShaderModel = (major << 4) | minor;
         }
 
         if (doctest::parseFlag(argc, argv, "d3d12-disable-nvapi"))

--- a/tests/main.cpp
+++ b/tests/main.cpp
@@ -86,6 +86,11 @@ int main(int argc, const char** argv)
             }
         }
 
+        if (doctest::parseFlag(argc, argv, "d3d12-disable-nvapi"))
+        {
+            options.d3d12DisableNVAPI = true;
+        }
+
         doctest::parseIntOption(argc, argv, "optix-version=", doctest::option_int, options.optixVersion);
 
         if (doctest::parseFlag(argc, argv, "memory-report"))

--- a/tests/test-ray-tracing-clusters.cpp
+++ b/tests/test-ray-tracing-clusters.cpp
@@ -796,6 +796,8 @@ GPU_TEST_CASE("ray-tracing-cluster-tracing", D3D12 | Vulkan | CUDA)
 
 GPU_TEST_CASE("ray-tracing-cluster-tracing-hit-object", D3D12 | Vulkan | CUDA)
 {
+    SKIP_D3D12_NVAPI_WITH_SM_6_9(device);
+
     if (!device->hasFeature(Feature::RayTracing))
         SKIP("ray tracing not supported");
     if (!device->hasFeature(Feature::ClusterAccelerationStructure))

--- a/tests/test-ray-tracing-hitobject-intrinsics.cpp
+++ b/tests/test-ray-tracing-hitobject-intrinsics.cpp
@@ -624,6 +624,9 @@ GPU_TEST_CASE("ray-tracing-hitobject-trace-motion-ray", ALL)
 GPU_TEST_CASE("ray-tracing-hitobject-query-ray-desc", ALL)
 {
     SKIP_D3D12_NVAPI_WITH_SM_6_9(device);
+    if (device->getDeviceType() == DeviceType::D3D12 && device->hasFeature(Feature::SM_6_9) &&
+        !device->hasCapability(Capability::hlsl_nvapi))
+        SKIP("Skipping due to slang bug");
 
     if (!device->hasFeature(Feature::RayTracing))
         SKIP("ray tracing not supported");

--- a/tests/test-ray-tracing-hitobject-intrinsics.cpp
+++ b/tests/test-ray-tracing-hitobject-intrinsics.cpp
@@ -166,6 +166,8 @@ void checkQueryAndInvokeResult(ISlangBlob* resultBlob)
 
 GPU_TEST_CASE("ray-tracing-hitobject-query-invoke-nop-rg", ALL)
 {
+    SKIP_D3D12_NVAPI_WITH_SM_6_9(device);
+
     if (!device->hasFeature(Feature::RayTracing))
         SKIP("ray tracing not supported");
     if (!device->hasFeature(Feature::ShaderExecutionReordering))
@@ -182,6 +184,8 @@ GPU_TEST_CASE("ray-tracing-hitobject-query-invoke-nop-rg", ALL)
 
 GPU_TEST_CASE("ray-tracing-hitobject-query-invoke-nop-ch", ALL)
 {
+    SKIP_D3D12_NVAPI_WITH_SM_6_9(device);
+
     if (!device->hasFeature(Feature::RayTracing))
         SKIP("ray tracing not supported");
     if (!device->hasFeature(Feature::ShaderExecutionReordering))
@@ -203,6 +207,8 @@ GPU_TEST_CASE("ray-tracing-hitobject-query-invoke-nop-ch", ALL)
 
 GPU_TEST_CASE("ray-tracing-hitobject-query-invoke-nop-ms", ALL)
 {
+    SKIP_D3D12_NVAPI_WITH_SM_6_9(device);
+
     if (!device->hasFeature(Feature::RayTracing))
         SKIP("ray tracing not supported");
     if (!device->hasFeature(Feature::ShaderExecutionReordering))
@@ -224,6 +230,8 @@ GPU_TEST_CASE("ray-tracing-hitobject-query-invoke-nop-ms", ALL)
 
 GPU_TEST_CASE("ray-tracing-hitobject-query-invoke-miss-rg", ALL)
 {
+    SKIP_D3D12_NVAPI_WITH_SM_6_9(device);
+
     if (!device->hasFeature(Feature::RayTracing))
         SKIP("ray tracing not supported");
     if (!device->hasFeature(Feature::ShaderExecutionReordering))
@@ -245,6 +253,8 @@ GPU_TEST_CASE("ray-tracing-hitobject-query-invoke-miss-rg", ALL)
 
 GPU_TEST_CASE("ray-tracing-hitobject-query-invoke-miss-ch", ALL)
 {
+    SKIP_D3D12_NVAPI_WITH_SM_6_9(device);
+
     if (!device->hasFeature(Feature::RayTracing))
         SKIP("ray tracing not supported");
     if (!device->hasFeature(Feature::ShaderExecutionReordering))
@@ -266,6 +276,8 @@ GPU_TEST_CASE("ray-tracing-hitobject-query-invoke-miss-ch", ALL)
 
 GPU_TEST_CASE("ray-tracing-hitobject-query-invoke-miss-ms", ALL)
 {
+    SKIP_D3D12_NVAPI_WITH_SM_6_9(device);
+
     if (!device->hasFeature(Feature::RayTracing))
         SKIP("ray tracing not supported");
     if (!device->hasFeature(Feature::ShaderExecutionReordering))
@@ -287,6 +299,8 @@ GPU_TEST_CASE("ray-tracing-hitobject-query-invoke-miss-ms", ALL)
 
 GPU_TEST_CASE("ray-tracing-hitobject-query-invoke-hit-rg", ALL)
 {
+    SKIP_D3D12_NVAPI_WITH_SM_6_9(device);
+
     if (!device->hasFeature(Feature::RayTracing))
         SKIP("ray tracing not supported");
     if (!device->hasFeature(Feature::ShaderExecutionReordering))
@@ -308,6 +322,8 @@ GPU_TEST_CASE("ray-tracing-hitobject-query-invoke-hit-rg", ALL)
 
 GPU_TEST_CASE("ray-tracing-hitobject-query-invoke-hit-ch", ALL)
 {
+    SKIP_D3D12_NVAPI_WITH_SM_6_9(device);
+
     if (!device->hasFeature(Feature::RayTracing))
         SKIP("ray tracing not supported");
     if (!device->hasFeature(Feature::ShaderExecutionReordering))
@@ -329,6 +345,8 @@ GPU_TEST_CASE("ray-tracing-hitobject-query-invoke-hit-ch", ALL)
 
 GPU_TEST_CASE("ray-tracing-hitobject-query-invoke-hit-ms", ALL)
 {
+    SKIP_D3D12_NVAPI_WITH_SM_6_9(device);
+
     if (!device->hasFeature(Feature::RayTracing))
         SKIP("ray tracing not supported");
     if (!device->hasFeature(Feature::ShaderExecutionReordering))
@@ -350,6 +368,8 @@ GPU_TEST_CASE("ray-tracing-hitobject-query-invoke-hit-ms", ALL)
 
 GPU_TEST_CASE("ray-tracing-hitobject-query-hit-kind-front-face", ALL)
 {
+    SKIP_D3D12_NVAPI_WITH_SM_6_9(device);
+
     if (!device->hasFeature(Feature::RayTracing))
         SKIP("ray tracing not supported");
     if (!device->hasFeature(Feature::ShaderExecutionReordering))
@@ -371,6 +391,8 @@ GPU_TEST_CASE("ray-tracing-hitobject-query-hit-kind-front-face", ALL)
 
 GPU_TEST_CASE("ray-tracing-hitobject-query-hit-kind-back-face", ALL)
 {
+    SKIP_D3D12_NVAPI_WITH_SM_6_9(device);
+
     if (!device->hasFeature(Feature::RayTracing))
         SKIP("ray tracing not supported");
     if (!device->hasFeature(Feature::ShaderExecutionReordering))
@@ -392,6 +414,8 @@ GPU_TEST_CASE("ray-tracing-hitobject-query-hit-kind-back-face", ALL)
 
 GPU_TEST_CASE("ray-tracing-hitobject-query-hit-kind-custom", ALL)
 {
+    SKIP_D3D12_NVAPI_WITH_SM_6_9(device);
+
     if (!device->hasFeature(Feature::RayTracing))
         SKIP("ray tracing not supported");
     if (!device->hasFeature(Feature::ShaderExecutionReordering))
@@ -494,6 +518,8 @@ GPU_TEST_CASE("ray-tracing-hitobject-make-hit", ALL | DontCreateDevice)
 
 GPU_TEST_CASE("ray-tracing-hitobject-make-miss", ALL)
 {
+    SKIP_D3D12_NVAPI_WITH_SM_6_9(device);
+
     if (!device->hasFeature(Feature::RayTracing))
         SKIP("ray tracing not supported");
     if (!device->hasFeature(Feature::ShaderExecutionReordering))
@@ -510,6 +536,8 @@ GPU_TEST_CASE("ray-tracing-hitobject-make-miss", ALL)
 
 GPU_TEST_CASE("ray-tracing-hitobject-make-motion-miss", ALL)
 {
+    SKIP_D3D12_NVAPI_WITH_SM_6_9(device);
+
     if (!device->hasFeature(Feature::RayTracing))
         SKIP("ray tracing not supported");
     if (!device->hasFeature(Feature::ShaderExecutionReordering))
@@ -565,6 +593,8 @@ GPU_TEST_CASE("ray-tracing-hitobject-make-motion-hit", ALL | DontCreateDevice)
 
 GPU_TEST_CASE("ray-tracing-hitobject-trace-motion-ray", ALL)
 {
+    SKIP_D3D12_NVAPI_WITH_SM_6_9(device);
+
     if (!device->hasFeature(Feature::RayTracing))
         SKIP("ray tracing not supported");
     if (!device->hasFeature(Feature::ShaderExecutionReordering))
@@ -593,6 +623,8 @@ GPU_TEST_CASE("ray-tracing-hitobject-trace-motion-ray", ALL)
 
 GPU_TEST_CASE("ray-tracing-hitobject-query-ray-desc", ALL)
 {
+    SKIP_D3D12_NVAPI_WITH_SM_6_9(device);
+
     if (!device->hasFeature(Feature::RayTracing))
         SKIP("ray tracing not supported");
     if (!device->hasFeature(Feature::ShaderExecutionReordering))
@@ -609,6 +641,8 @@ GPU_TEST_CASE("ray-tracing-hitobject-query-ray-desc", ALL)
 
 GPU_TEST_CASE("ray-tracing-hitobject-query-instance-id", ALL)
 {
+    SKIP_D3D12_NVAPI_WITH_SM_6_9(device);
+
     if (!device->hasFeature(Feature::RayTracing))
         SKIP("ray tracing not supported");
     if (!device->hasFeature(Feature::ShaderExecutionReordering))
@@ -651,6 +685,8 @@ GPU_TEST_CASE("ray-tracing-hitobject-set-and-get-shader-table-index", CUDA /*| D
 
 GPU_TEST_CASE("ray-tracing-hitobject-load-local-root-table-constant", D3D12 | CUDA)
 {
+    SKIP_D3D12_NVAPI_WITH_SM_6_9(device);
+
     if (!device->hasFeature(Feature::RayTracing))
         SKIP("ray tracing not supported");
     if (!device->hasFeature(Feature::ShaderExecutionReordering))

--- a/tests/test-ray-tracing-hitobject-intrinsics.slang
+++ b/tests/test-ray-tracing-hitobject-intrinsics.slang
@@ -43,7 +43,11 @@ void rayGenShaderMakeQueryInvokeNOP()
 
     // Invoking a NOP shouldn't have an effect, but we do it anyway to make sure it doesn't crash.
     RayPayload payload = {};
+#ifdef SLANG_RHI_TEST_D3D12_NATIVE_HIT_OBJECT
+    HitObject.Invoke(hitObjectNOP, payload);
+#else
     HitObject.Invoke(sceneBVH, hitObjectNOP, payload);
+#endif
     resultBuffer[0].invokeWasSuccess = 1;
 }
 
@@ -76,7 +80,11 @@ void closestHitMakeQueryInvokeNOP(inout RayPayload payload, in BuiltInTriangleIn
 
     // Invoking a NOP shouldn't have an effect, but we do it anyway to make sure it doesn't crash.
     RayPayload hitObjPayload = {};
+#ifdef SLANG_RHI_TEST_D3D12_NATIVE_HIT_OBJECT
+    HitObject.Invoke(hitObjectNOP, hitObjPayload);
+#else
     HitObject.Invoke(sceneBVH, hitObjectNOP, hitObjPayload);
+#endif
 
     payload.invokeWasSuccess = 1;
 }
@@ -110,7 +118,11 @@ void missMakeQueryInvokeNOP(inout RayPayload payload)
 
     // Invoking a NOP shouldn't have an effect, but we do it anyway to make sure it doesn't crash.
     RayPayload hitObjPayload = {};
+#ifdef SLANG_RHI_TEST_D3D12_NATIVE_HIT_OBJECT
+    HitObject.Invoke(hitObjectNOP, hitObjPayload);
+#else
     HitObject.Invoke(sceneBVH, hitObjectNOP, hitObjPayload);
+#endif
 
     payload.invokeWasSuccess = 1;
 }
@@ -134,7 +146,11 @@ void rayGenShaderMakeQueryInvokeMiss()
     resultBuffer[0].queryWasSuccess = hitObjectMiss.IsMiss();
 
     RayPayload payloadMiss = {};
+#ifdef SLANG_RHI_TEST_D3D12_NATIVE_HIT_OBJECT
+    HitObject.Invoke(hitObjectMiss, payloadMiss);
+#else
     HitObject.Invoke(sceneBVH, hitObjectMiss, payloadMiss);
+#endif
     resultBuffer[0].invokeWasSuccess = payloadMiss.invokeWasSuccess;
 }
 
@@ -163,7 +179,11 @@ void closestHitMakeQueryInvokeMiss(inout RayPayload payload, in BuiltInTriangleI
     payload.queryWasSuccess = hitObjectMiss.IsMiss();
 
     RayPayload payloadMiss = {};
+#ifdef SLANG_RHI_TEST_D3D12_NATIVE_HIT_OBJECT
+    HitObject.Invoke(hitObjectMiss, payloadMiss);
+#else
     HitObject.Invoke(sceneBVH, hitObjectMiss, payloadMiss);
+#endif
     payload.invokeWasSuccess = payloadMiss.invokeWasSuccess;
 }
 
@@ -188,7 +208,11 @@ void missMakeQueryInvokeMiss(inout RayPayload payload)
     payload.queryWasSuccess = hitObjectMiss.IsMiss();
 
     RayPayload payloadMiss = {};
+#ifdef SLANG_RHI_TEST_D3D12_NATIVE_HIT_OBJECT
+    HitObject.Invoke(hitObjectMiss, payloadMiss);
+#else
     HitObject.Invoke(sceneBVH, hitObjectMiss, payloadMiss);
+#endif
     payload.invokeWasSuccess = payloadMiss.invokeWasSuccess;
 }
 
@@ -210,7 +234,11 @@ void rayGenShaderTraceQueryInvokeHit()
     resultBuffer[0].queryWasSuccess = hitObjectHit.IsHit();
 
     RayPayload payloadHit = {};
+#ifdef SLANG_RHI_TEST_D3D12_NATIVE_HIT_OBJECT
+    HitObject.Invoke(hitObjectHit, payloadHit);
+#else
     HitObject.Invoke(sceneBVH, hitObjectHit, payloadHit);
+#endif
     resultBuffer[0].invokeWasSuccess = payloadHit.invokeWasSuccess;
 }
 
@@ -239,7 +267,11 @@ void closestHitMakeQueryInvokeHit(inout RayPayload payload, in BuiltInTriangleIn
     payload.queryWasSuccess = hitObjectHit.IsHit();
 
     RayPayload payloadHit = {};
+#ifdef SLANG_RHI_TEST_D3D12_NATIVE_HIT_OBJECT
+    HitObject.Invoke(hitObjectHit, payloadHit);
+#else
     HitObject.Invoke(sceneBVH, hitObjectHit, payloadHit);
+#endif
     payload.invokeWasSuccess = payloadHit.invokeWasSuccess;
 }
 
@@ -262,7 +294,11 @@ void missMakeQueryInvokeHit(inout RayPayload payload)
     payload.queryWasSuccess = hitObjectHit.IsHit();
 
     RayPayload payloadHit = {};
+#ifdef SLANG_RHI_TEST_D3D12_NATIVE_HIT_OBJECT
+    HitObject.Invoke(hitObjectHit, payloadHit);
+#else
     HitObject.Invoke(sceneBVH, hitObjectHit, payloadHit);
+#endif
     payload.invokeWasSuccess = payloadHit.invokeWasSuccess;
 }
 
@@ -395,12 +431,20 @@ void rayGenShaderMakeMiss()
     ray.TMin = 0.001;
     ray.TMax = 10000.0;
 
+#ifdef SLANG_RHI_TEST_D3D12_NATIVE_HIT_OBJECT
+    HitObject hitObjectMiss = HitObject.MakeMiss(0, 0, ray);
+#else
     HitObject hitObjectMiss = HitObject.MakeMiss(0, ray);
+#endif
 
     resultBuffer[0].queryWasSuccess = hitObjectMiss.IsMiss();
 
     RayPayload payload = {};
+#ifdef SLANG_RHI_TEST_D3D12_NATIVE_HIT_OBJECT
+    HitObject.Invoke(hitObjectMiss, payload);
+#else
     HitObject.Invoke(sceneBVH, hitObjectMiss, payload);
+#endif
     resultBuffer[0].invokeWasSuccess = payload.invokeWasSuccess;
 }
 
@@ -451,7 +495,11 @@ void rayGenShaderTraceMotionRay()
 
     // Invoke the hit
     RayPayload payloadInvoke = {};
+#ifdef SLANG_RHI_TEST_D3D12_NATIVE_HIT_OBJECT
+    HitObject.Invoke(hitobj, payloadInvoke);
+#else
     HitObject.Invoke(sceneBVH, hitobj, payloadInvoke);
+#endif
     resultBuffer[0].invokeWasSuccess = payloadInvoke.invokeWasSuccess;
 }
 

--- a/tests/test-ray-tracing-lss.cpp
+++ b/tests/test-ray-tracing-lss.cpp
@@ -238,6 +238,8 @@ GPU_TEST_CASE("ray-tracing-lss-intrinsics", ALL)
 
 GPU_TEST_CASE("ray-tracing-lss-intrinsics-hit-object", ALL)
 {
+    SKIP_D3D12_NVAPI_WITH_SM_6_9(device);
+
     if (!device->hasFeature(Feature::RayTracing))
         SKIP("ray tracing not supported");
     if (!device->hasFeature(Feature::AccelerationStructureLinearSweptSpheres))

--- a/tests/test-ray-tracing-reorder.cpp
+++ b/tests/test-ray-tracing-reorder.cpp
@@ -125,6 +125,8 @@ struct RayTracingTriangleReorderTest
 
 GPU_TEST_CASE("ray-tracing-reorder-hint", ALL)
 {
+    SKIP_D3D12_NVAPI_WITH_SM_6_9(device);
+
     if (!device->hasFeature(Feature::RayTracing))
         SKIP("ray tracing not supported");
     if (!device->hasFeature(Feature::ShaderExecutionReordering))
@@ -137,6 +139,8 @@ GPU_TEST_CASE("ray-tracing-reorder-hint", ALL)
 
 GPU_TEST_CASE("ray-tracing-reorder-hit-obj", ALL)
 {
+    SKIP_D3D12_NVAPI_WITH_SM_6_9(device);
+
     if (!device->hasFeature(Feature::RayTracing))
         SKIP("ray tracing not supported");
     if (!device->hasFeature(Feature::ShaderExecutionReordering))
@@ -149,6 +153,8 @@ GPU_TEST_CASE("ray-tracing-reorder-hit-obj", ALL)
 
 GPU_TEST_CASE("ray-tracing-reorder-hit-obj-and-hint", ALL)
 {
+    SKIP_D3D12_NVAPI_WITH_SM_6_9(device);
+
     if (!device->hasFeature(Feature::RayTracing))
         SKIP("ray tracing not supported");
     if (!device->hasFeature(Feature::ShaderExecutionReordering))

--- a/tests/test-ray-tracing-reorder.slang
+++ b/tests/test-ray-tracing-reorder.slang
@@ -32,7 +32,11 @@ void rayGenShaderReorderHint()
     uint numHintBits = 1;
     ReorderThread(hint, numHintBits);
 
+#ifdef SLANG_RHI_TEST_D3D12_NATIVE_HIT_OBJECT
+    HitObject.Invoke(hit, payload);
+#else
     HitObject.Invoke(sceneBVH, hit, payload);
+#endif
     resultTexture[pixel] = payload.color;
 }
 
@@ -56,7 +60,11 @@ void rayGenShaderReorderHitObj()
 
     ReorderThread(hit);
 
+#ifdef SLANG_RHI_TEST_D3D12_NATIVE_HIT_OBJECT
+    HitObject.Invoke(hit, payload);
+#else
     HitObject.Invoke(sceneBVH, hit, payload);
+#endif
     resultTexture[pixel] = payload.color;
 }
 
@@ -82,7 +90,11 @@ void rayGenShaderReorderHitObjAndHint()
     uint numHintBits = 1;
     ReorderThread(hit, hint, numHintBits);
 
+#ifdef SLANG_RHI_TEST_D3D12_NATIVE_HIT_OBJECT
+    HitObject.Invoke(hit, payload);
+#else
     HitObject.Invoke(sceneBVH, hit, payload);
+#endif
     resultTexture[pixel] = payload.color;
 }
 

--- a/tests/test-ray-tracing-sphere.cpp
+++ b/tests/test-ray-tracing-sphere.cpp
@@ -238,6 +238,8 @@ GPU_TEST_CASE("ray-tracing-sphere-intrinsics", ALL)
 
 GPU_TEST_CASE("ray-tracing-sphere-intrinsics-hit-object", ALL)
 {
+    SKIP_D3D12_NVAPI_WITH_SM_6_9(device);
+
     if (!device->hasFeature(Feature::RayTracing))
         SKIP("ray tracing not supported");
     if (!device->hasFeature(Feature::AccelerationStructureSpheres))

--- a/tests/testing.cpp
+++ b/tests/testing.cpp
@@ -36,6 +36,38 @@ static ShaderCache gShaderCache;
 // Temp directory to create files for teting in.
 static std::filesystem::path gTestTempDirectory;
 
+static Feature getShaderModelFeature(uint32_t shaderModel)
+{
+    switch (shaderModel)
+    {
+    case 0x51:
+        return Feature::SM_5_1;
+    case 0x60:
+        return Feature::SM_6_0;
+    case 0x61:
+        return Feature::SM_6_1;
+    case 0x62:
+        return Feature::SM_6_2;
+    case 0x63:
+        return Feature::SM_6_3;
+    case 0x64:
+        return Feature::SM_6_4;
+    case 0x65:
+        return Feature::SM_6_5;
+    case 0x66:
+        return Feature::SM_6_6;
+    case 0x67:
+        return Feature::SM_6_7;
+    case 0x68:
+        return Feature::SM_6_8;
+    case 0x69:
+        return Feature::SM_6_9;
+    default:
+        SLANG_RHI_ASSERT_FAILURE("Unhandled D3D12 shader model");
+        return Feature::_Count;
+    }
+}
+
 // Calculates a files sytem compatible date string formatted YYYY-MM-DD-hh-mm-ss.
 static std::string buildCurrentDateString()
 {
@@ -723,12 +755,18 @@ ComPtr<IDevice> createTestingDevice(
     deviceDesc.slang.compilerOptionEntryCount = compilerOptions.size();
 
     D3D12DeviceExtendedDesc extDesc = {};
+    bool requireSpecificD3D12ShaderModel = false;
     if (deviceType == DeviceType::D3D12)
     {
         extDesc.rootParameterShaderAttributeName = "root";
         if (extraOptions && extraOptions->d3d12HighestShaderModel != 0)
         {
             extDesc.highestShaderModel = extraOptions->d3d12HighestShaderModel;
+        }
+        else if (options().d3d12ShaderModel != 0)
+        {
+            extDesc.highestShaderModel = options().d3d12ShaderModel;
+            requireSpecificD3D12ShaderModel = true;
         }
         deviceDesc.next = &extDesc;
     }
@@ -741,6 +779,12 @@ ComPtr<IDevice> createTestingDevice(
 #endif
 
     REQUIRE_CALL(getRHI()->createDevice(deviceDesc, device.writeRef()));
+
+    if (requireSpecificD3D12ShaderModel)
+    {
+        Feature feature = getShaderModelFeature(extDesc.highestShaderModel);
+        REQUIRE(device->hasFeature(feature));
+    }
 
     if (useCachedDevice)
     {
@@ -850,6 +894,12 @@ DeviceAvailabilityResult checkDeviceTypeAvailable(DeviceType deviceType)
 #if SLANG_RHI_DEBUG
     desc.debugCallback = &sCaptureDebugCallback;
 #endif
+    D3D12DeviceExtendedDesc d3d12ExtDesc = {};
+    if (deviceType == DeviceType::D3D12 && options().d3d12ShaderModel != 0)
+    {
+        d3d12ExtDesc.highestShaderModel = options().d3d12ShaderModel;
+        desc.next = &d3d12ExtDesc;
+    }
 #if SLANG_RHI_ENABLE_NVAPI
     if (deviceType == DeviceType::D3D12 && !options().d3d12DisableNVAPI)
     {

--- a/tests/testing.cpp
+++ b/tests/testing.cpp
@@ -626,7 +626,7 @@ ComPtr<IDevice> createTestingDevice(
         compilerOptions.push_back(nvapiSearchPath);
     }
 #endif
-    if (deviceType == DeviceType::D3D12)
+    if (deviceType == DeviceType::D3D12 && !options().d3d12DisableNVAPI)
     {
         deviceDesc.nvapiExtUavSlot = 999;
         preprocessorMacros.push_back({"NV_SHADER_EXTN_SLOT", "u999"});
@@ -638,6 +638,12 @@ ComPtr<IDevice> createTestingDevice(
         compilerOptions.push_back(nvapiSearchPath);
     }
 #endif
+
+    // Set SLANG_RHI_TEST_D3D12_NATIVE_HIT_OBJECT if NVAPI is disabled.
+    if (deviceType == DeviceType::D3D12 && options().d3d12DisableNVAPI)
+    {
+        preprocessorMacros.push_back({"SLANG_RHI_TEST_D3D12_NATIVE_HIT_OBJECT", "1"});
+    }
 
 #if SLANG_RHI_ENABLE_OPTIX
     // Setup OptiX headers
@@ -845,7 +851,7 @@ DeviceAvailabilityResult checkDeviceTypeAvailable(DeviceType deviceType)
     desc.debugCallback = &sCaptureDebugCallback;
 #endif
 #if SLANG_RHI_ENABLE_NVAPI
-    if (deviceType == DeviceType::D3D12)
+    if (deviceType == DeviceType::D3D12 && !options().d3d12DisableNVAPI)
     {
         desc.nvapiExtUavSlot = 999;
     }

--- a/tests/testing.cpp
+++ b/tests/testing.cpp
@@ -671,8 +671,13 @@ ComPtr<IDevice> createTestingDevice(
     }
 #endif
 
-    // Set SLANG_RHI_TEST_D3D12_NATIVE_HIT_OBJECT if NVAPI is disabled.
-    if (deviceType == DeviceType::D3D12 && options().d3d12DisableNVAPI)
+    // Set SLANG_RHI_TEST_D3D12_NATIVE_HIT_OBJECT if NVAPI is disabled explicitly or unavailable in this build.
+#if SLANG_RHI_ENABLE_NVAPI
+    const bool useNativeD3D12HitObject = options().d3d12DisableNVAPI;
+#else
+    const bool useNativeD3D12HitObject = true;
+#endif
+    if (deviceType == DeviceType::D3D12 && useNativeD3D12HitObject)
     {
         preprocessorMacros.push_back({"SLANG_RHI_TEST_D3D12_NATIVE_HIT_OBJECT", "1"});
     }

--- a/tests/testing.cpp
+++ b/tests/testing.cpp
@@ -768,6 +768,15 @@ ComPtr<IDevice> createTestingDevice(
             extDesc.highestShaderModel = options().d3d12ShaderModel;
             requireSpecificD3D12ShaderModel = true;
         }
+        else
+        {
+            // TODO: Slang current emits invalid HitObject code when D3D12 SM 6.9 and NVAPI are enabled.
+            // https://github.com/shader-slang/slang/issues/11903
+            // We currently default testing to cap at SM 6.8 to avoid this issue,
+            // but ideally we should be able to test SM 6.9 with NVAPI enabled.
+            // We can test SM 6.9 with/without NVAPI using -d3d12-shader-model and -d3d12-disable-nvapi cli options.
+            extDesc.highestShaderModel = 0x68;
+        }
         deviceDesc.next = &extDesc;
     }
 

--- a/tests/testing.h
+++ b/tests/testing.h
@@ -29,6 +29,7 @@ struct Options
     std::string memoryReportFile;
     std::array<bool, kDeviceTypeCount + 1> deviceSelected;
     std::array<int, kDeviceTypeCount + 1> deviceAdapterIndex;
+    uint32_t d3d12ShaderModel = 0;
     bool d3d12DisableNVAPI = false;
     int optixVersion = 0;
 

--- a/tests/testing.h
+++ b/tests/testing.h
@@ -29,6 +29,7 @@ struct Options
     std::string memoryReportFile;
     std::array<bool, kDeviceTypeCount + 1> deviceSelected;
     std::array<int, kDeviceTypeCount + 1> deviceAdapterIndex;
+    bool d3d12DisableNVAPI = false;
     int optixVersion = 0;
 
     Options()

--- a/tests/testing.h
+++ b/tests/testing.h
@@ -524,6 +524,19 @@ bool checkNoSilentGpuSkips();
 #define GPU_TEST_CASE_EX(name, flags, debugLayerOptions)                                                               \
     GPU_TEST_CASE_IMPL(name, DOCTEST_ANONYMOUS(GPU_TEST_ANONYMOUS_), flags, debugLayerOptions)
 
+// TODO: Slang current emits invalid HitObject code when D3D12 SM 6.9 and NVAPI are enabled.
+// https://github.com/shader-slang/slang/issues/11903
+#define SKIP_D3D12_NVAPI_WITH_SM_6_9(device)                                                                           \
+    do                                                                                                                 \
+    {                                                                                                                  \
+        if (device && device->getDeviceType() == ::rhi::DeviceType::D3D12 &&                                           \
+            device->hasFeature(::rhi::Feature::SM_6_9) && device->hasCapability(::rhi::Capability::hlsl_nvapi))        \
+        {                                                                                                              \
+            SKIP("Slang generates invalid HitObject code when D3D12 SM 6.9 and NVAPI are enabled");                    \
+        }                                                                                                              \
+    }                                                                                                                  \
+    while (0)
+
 #define CHECK_CALL(x) CHECK(!SLANG_FAILED(x))
 #define REQUIRE_CALL(x) REQUIRE(!SLANG_FAILED(x))
 


### PR DESCRIPTION
- Fix tests when running with SM 6.9.
- Add `-d3d12-shader-model` and `-d3d12-disable-nvapi` switches to `slang-rhi-tests`.
- Default to running with SM 6.8 for now due to the various issues with SM 6.9 code generation in slang.