### PR TITLE
Fix Vulkan pipeline cache for RT pipelines

### DIFF
--- a/src/core/sha1.h
+++ b/src/core/sha1.h
@@ -6,6 +6,7 @@
 #include <cstdint>
 #include <cstdlib>
 #include <cstring>
+#include <type_traits>
 
 namespace rhi {
 
@@ -88,6 +89,17 @@ public:
         }
 
         return *this;
+    }
+
+    /**
+     * Update hash by adding the given basic value.
+     * \param data Data to hash.
+     */
+    template<typename T>
+    SHA1& update(const T& value)
+        requires std::is_fundamental_v<T> || std::is_enum_v<T>
+    {
+        return update(&value, sizeof(value));
     }
 
     /**

--- a/src/vulkan/vk-pipeline.cpp
+++ b/src/vulkan/vk-pipeline.cpp
@@ -47,22 +47,6 @@ struct PipelineCacheBinaryHeader
     uint32_t dataOffset;
 };
 
-template<typename T>
-void hashValue(SHA1& sha1, const T& value)
-{
-    sha1.update(&value, sizeof(value));
-}
-
-inline void hashString(SHA1& sha1, const char* value)
-{
-    const uint64_t size = value ? strlen(value) : UINT64_MAX;
-    hashValue(sha1, size);
-    if (value)
-    {
-        sha1.update(value, size);
-    }
-}
-
 // Generate a stable ray tracing pipeline key from the inputs owned by slang-rhi. This is used only when
 // vkGetPipelineKeyKHR returns an unusable all-zero key. Keep the version and hashed fields in sync with
 // RayTracingPipelineDesc and the Vulkan ray tracing pipeline creation code.
@@ -80,12 +64,22 @@ static Result getRayTracingPipelineFallbackKey(
     static constexpr char kKeyTag[] = "slang-rhi-vulkan-ray-tracing-pipeline";
     static constexpr uint32_t kKeyVersion = 1;
     sha1.update(kKeyTag, sizeof(kKeyTag));
-    hashValue(sha1, kKeyVersion);
+    sha1.update(kKeyVersion);
+
+    auto updateNullableString = [&](const char* value)
+    {
+        const uint64_t size = value ? strlen(value) : UINT64_MAX;
+        sha1.update(size);
+        if (value)
+        {
+            sha1.update(value, size);
+        }
+    };
 
     const uint32_t moduleCount = (uint32_t)program->m_modules.size();
     if (moduleCount != program->m_stageCreateInfos.size())
         return SLANG_FAIL;
-    hashValue(sha1, moduleCount);
+    sha1.update(moduleCount);
     for (uint32_t i = 0; i < moduleCount; ++i)
     {
         const ShaderProgramImpl::Module& module = program->m_modules[i];
@@ -93,48 +87,48 @@ static Result getRayTracingPipelineFallbackKey(
         if (!module.code || stage.pNext)
             return SLANG_E_NOT_AVAILABLE;
 
-        hashValue(sha1, stage.flags);
-        hashValue(sha1, stage.stage);
-        hashString(sha1, module.entryPointName.c_str());
+        sha1.update(stage.flags);
+        sha1.update(stage.stage);
+        updateNullableString(module.entryPointName.c_str());
 
         const uint64_t codeSize = module.code->getBufferSize();
-        hashValue(sha1, codeSize);
+        sha1.update(codeSize);
         sha1.update(module.code->getBufferPointer(), codeSize);
 
         const VkSpecializationInfo* specialization = stage.pSpecializationInfo;
         const uint8_t hasSpecialization = specialization != nullptr;
-        hashValue(sha1, hasSpecialization);
+        sha1.update(hasSpecialization);
         if (specialization)
         {
-            hashValue(sha1, specialization->mapEntryCount);
+            sha1.update(specialization->mapEntryCount);
             for (uint32_t j = 0; j < specialization->mapEntryCount; ++j)
             {
                 const VkSpecializationMapEntry& entry = specialization->pMapEntries[j];
-                hashValue(sha1, entry.constantID);
+                sha1.update(entry.constantID);
                 const uint64_t offset = entry.offset;
                 const uint64_t size = entry.size;
-                hashValue(sha1, offset);
-                hashValue(sha1, size);
+                sha1.update(offset);
+                sha1.update(size);
             }
             const uint64_t dataSize = specialization->dataSize;
-            hashValue(sha1, dataSize);
+            sha1.update(dataSize);
             sha1.update(specialization->pData, dataSize);
         }
     }
 
-    hashValue(sha1, desc.hitGroupCount);
+    sha1.update(desc.hitGroupCount);
     for (uint32_t i = 0; i < desc.hitGroupCount; ++i)
     {
         const HitGroupDesc& hitGroup = desc.hitGroups[i];
-        hashString(sha1, hitGroup.hitGroupName);
-        hashString(sha1, hitGroup.closestHitEntryPoint);
-        hashString(sha1, hitGroup.anyHitEntryPoint);
-        hashString(sha1, hitGroup.intersectionEntryPoint);
+        updateNullableString(hitGroup.hitGroupName);
+        updateNullableString(hitGroup.closestHitEntryPoint);
+        updateNullableString(hitGroup.anyHitEntryPoint);
+        updateNullableString(hitGroup.intersectionEntryPoint);
     }
-    hashValue(sha1, desc.maxRecursion);
-    hashValue(sha1, desc.maxRayPayloadSize);
-    hashValue(sha1, desc.maxAttributeSizeInBytes);
-    hashValue(sha1, desc.flags);
+    sha1.update(desc.maxRecursion);
+    sha1.update(desc.maxRayPayloadSize);
+    sha1.update(desc.maxAttributeSizeInBytes);
+    sha1.update(desc.flags);
 
     outDigest = sha1.getDigest();
     return SLANG_OK;
@@ -154,10 +148,11 @@ static bool isAllZeroPipelineKey(const VkPipelineBinaryKeyKHR& key)
 
 // Create a pipeline cache key based on the device and pipeline create info.
 // The key is a SHA1 hash that includes the adapter LUID, global pipeline key, and the pipeline create info key.
+template<typename GetFallbackPipelineKey>
 Result getPipelineCacheKey(
     DeviceImpl* device,
     void* createInfo,
-    const SHA1::Digest* fallbackPipelineKey,
+    GetFallbackPipelineKey getFallbackPipelineKey,
     ISlangBlob** outBlob
 )
 {
@@ -186,15 +181,16 @@ Result getPipelineCacheKey(
         );
         if (isAllZeroPipelineKey(pipelineKey))
         {
-            if (!fallbackPipelineKey)
+            SHA1::Digest fallbackPipelineKey;
+            if (SLANG_FAILED(getFallbackPipelineKey(fallbackPipelineKey)))
             {
                 device->printWarning(
-                    "vkGetPipelineKeyKHR returned an all-zero pipeline key and application didn't provide a fallback "
-                    "key, disabling caching for this pipeline."
+                    "vkGetPipelineKeyKHR returned an all-zero pipeline key and no usable application fallback key is "
+                    "available, disabling caching for this pipeline."
                 );
                 return SLANG_E_NOT_AVAILABLE;
             }
-            sha1.update(fallbackPipelineKey->data(), fallbackPipelineKey->size());
+            sha1.update(fallbackPipelineKey.data(), fallbackPipelineKey.size());
         }
         else
         {
@@ -359,7 +355,12 @@ Result deserializePipelineBinaries(DeviceImpl* device, ISlangBlob* blob, short_v
     return SLANG_OK;
 }
 
-template<typename VkPipelineCreateInfo>
+struct NoFallbackPipelineKey
+{
+    Result operator()(SHA1::Digest&) const { return SLANG_E_NOT_AVAILABLE; }
+};
+
+template<typename VkPipelineCreateInfo, typename GetFallbackPipelineKey = NoFallbackPipelineKey>
 Result createPipelineWithCache(
     DeviceImpl* device,
     VkPipelineCreateInfo* createInfo,
@@ -367,7 +368,7 @@ Result createPipelineWithCache(
     VkPipeline* outPipeline,
     bool& outCached,
     size_t& outCacheSize,
-    const SHA1::Digest* fallbackPipelineKey = nullptr
+    GetFallbackPipelineKey getFallbackPipelineKey = {}
 )
 {
     auto& api = device->m_api;
@@ -387,7 +388,7 @@ Result createPipelineWithCache(
     VkPipeline pipeline = VK_NULL_HANDLE;
 
     // Create pipeline cache key.
-    if (SLANG_FAILED(getPipelineCacheKey(device, createInfo, fallbackPipelineKey, pipelineCacheKey.writeRef())))
+    if (SLANG_FAILED(getPipelineCacheKey(device, createInfo, getFallbackPipelineKey, pipelineCacheKey.writeRef())))
     {
         device->printWarning("Failed to get pipeline cache key, disabling pipeline cache.");
         return createPipelineFunc(device, createInfo, outPipeline);
@@ -971,16 +972,6 @@ Result DeviceImpl::createRayTracingPipeline2(const RayTracingPipelineDesc& desc,
     createInfo.basePipelineHandle = VK_NULL_HANDLE;
     createInfo.basePipelineIndex = 0;
 
-    SHA1::Digest fallbackPipelineKey;
-    const SHA1::Digest* fallbackPipelineKeyPtr = nullptr;
-    if (m_persistentPipelineCache)
-    {
-        // NVIDIA drivers have returned the same all-zero pipeline key for distinct ray tracing pipelines.
-        // Prepare a stable application key so caching remains safe and useful if that happens.
-        if (SLANG_SUCCEEDED(getRayTracingPipelineFallbackKey(program, desc, fallbackPipelineKey)))
-            fallbackPipelineKeyPtr = &fallbackPipelineKey;
-    }
-
     VkPipeline vkPipeline = VK_NULL_HANDLE;
     bool cached = false;
     size_t cacheSize = 0;
@@ -1003,7 +994,10 @@ Result DeviceImpl::createRayTracingPipeline2(const RayTracingPipelineDesc& desc,
             &vkPipeline,
             cached,
             cacheSize,
-            fallbackPipelineKeyPtr
+            [program, &desc](SHA1::Digest& outDigest)
+            {
+                return getRayTracingPipelineFallbackKey(program, desc, outDigest);
+            }
         )
     );
 

--- a/src/vulkan/vk-pipeline.cpp
+++ b/src/vulkan/vk-pipeline.cpp
@@ -47,9 +47,119 @@ struct PipelineCacheBinaryHeader
     uint32_t dataOffset;
 };
 
+template<typename T>
+void hashValue(SHA1& sha1, const T& value)
+{
+    sha1.update(&value, sizeof(value));
+}
+
+inline void hashString(SHA1& sha1, const char* value)
+{
+    const uint64_t size = value ? strlen(value) : UINT64_MAX;
+    hashValue(sha1, size);
+    if (value)
+    {
+        sha1.update(value, size);
+    }
+}
+
+// Generate a stable ray tracing pipeline key from the inputs owned by slang-rhi. This is used only when
+// vkGetPipelineKeyKHR returns an unusable all-zero key. Keep the version and hashed fields in sync with
+// RayTracingPipelineDesc and the Vulkan ray tracing pipeline creation code.
+static Result getRayTracingPipelineFallbackKey(
+    ShaderProgramImpl* program,
+    const RayTracingPipelineDesc& desc,
+    SHA1::Digest& outDigest
+)
+{
+    // Unknown extension structures cannot be hashed safely.
+    if (desc.next)
+        return SLANG_E_NOT_AVAILABLE;
+
+    SHA1 sha1;
+    static constexpr char kKeyTag[] = "slang-rhi-vulkan-ray-tracing-pipeline";
+    static constexpr uint32_t kKeyVersion = 1;
+    sha1.update(kKeyTag, sizeof(kKeyTag));
+    hashValue(sha1, kKeyVersion);
+
+    const uint32_t moduleCount = (uint32_t)program->m_modules.size();
+    if (moduleCount != program->m_stageCreateInfos.size())
+        return SLANG_FAIL;
+    hashValue(sha1, moduleCount);
+    for (uint32_t i = 0; i < moduleCount; ++i)
+    {
+        const ShaderProgramImpl::Module& module = program->m_modules[i];
+        const VkPipelineShaderStageCreateInfo& stage = program->m_stageCreateInfos[i];
+        if (!module.code || stage.pNext)
+            return SLANG_E_NOT_AVAILABLE;
+
+        hashValue(sha1, stage.flags);
+        hashValue(sha1, stage.stage);
+        hashString(sha1, module.entryPointName.c_str());
+
+        const uint64_t codeSize = module.code->getBufferSize();
+        hashValue(sha1, codeSize);
+        sha1.update(module.code->getBufferPointer(), codeSize);
+
+        const VkSpecializationInfo* specialization = stage.pSpecializationInfo;
+        const uint8_t hasSpecialization = specialization != nullptr;
+        hashValue(sha1, hasSpecialization);
+        if (specialization)
+        {
+            hashValue(sha1, specialization->mapEntryCount);
+            for (uint32_t j = 0; j < specialization->mapEntryCount; ++j)
+            {
+                const VkSpecializationMapEntry& entry = specialization->pMapEntries[j];
+                hashValue(sha1, entry.constantID);
+                const uint64_t offset = entry.offset;
+                const uint64_t size = entry.size;
+                hashValue(sha1, offset);
+                hashValue(sha1, size);
+            }
+            const uint64_t dataSize = specialization->dataSize;
+            hashValue(sha1, dataSize);
+            sha1.update(specialization->pData, dataSize);
+        }
+    }
+
+    hashValue(sha1, desc.hitGroupCount);
+    for (uint32_t i = 0; i < desc.hitGroupCount; ++i)
+    {
+        const HitGroupDesc& hitGroup = desc.hitGroups[i];
+        hashString(sha1, hitGroup.hitGroupName);
+        hashString(sha1, hitGroup.closestHitEntryPoint);
+        hashString(sha1, hitGroup.anyHitEntryPoint);
+        hashString(sha1, hitGroup.intersectionEntryPoint);
+    }
+    hashValue(sha1, desc.maxRecursion);
+    hashValue(sha1, desc.maxRayPayloadSize);
+    hashValue(sha1, desc.maxAttributeSizeInBytes);
+    hashValue(sha1, desc.flags);
+
+    outDigest = sha1.getDigest();
+    return SLANG_OK;
+}
+
+static bool isAllZeroPipelineKey(const VkPipelineBinaryKeyKHR& key)
+{
+    if (key.keySize == 0)
+        return true;
+    for (uint32_t i = 0; i < key.keySize; ++i)
+    {
+        if (key.key[i] != 0)
+            return false;
+    }
+    return true;
+}
+
 // Create a pipeline cache key based on the device and pipeline create info.
 // The key is a SHA1 hash that includes the adapter LUID, global pipeline key, and the pipeline create info key.
-Result getPipelineCacheKey(DeviceImpl* device, void* createInfo, ISlangBlob** outBlob)
+Result getPipelineCacheKey(
+    DeviceImpl* device,
+    void* createInfo,
+    const SHA1::Digest* fallbackPipelineKey,
+    ISlangBlob** outBlob
+)
 {
     auto& api = device->m_api;
 
@@ -74,7 +184,22 @@ Result getPipelineCacheKey(DeviceImpl* device, void* createInfo, ISlangBlob** ou
             api.vkGetPipelineKeyKHR(device->m_device, &pipelineCreateInfo, &pipelineKey),
             device
         );
-        sha1.update(pipelineKey.key, pipelineKey.keySize);
+        if (isAllZeroPipelineKey(pipelineKey))
+        {
+            if (!fallbackPipelineKey)
+            {
+                device->printWarning(
+                    "vkGetPipelineKeyKHR returned an all-zero pipeline key and application didn't provide a fallback "
+                    "key, disabling caching for this pipeline."
+                );
+                return SLANG_E_NOT_AVAILABLE;
+            }
+            sha1.update(fallbackPipelineKey->data(), fallbackPipelineKey->size());
+        }
+        else
+        {
+            sha1.update(pipelineKey.key, pipelineKey.keySize);
+        }
     }
     SHA1::Digest digest = sha1.getDigest();
     ComPtr<ISlangBlob> blob = OwnedBlob::create(digest.data(), digest.size());
@@ -241,7 +366,8 @@ Result createPipelineWithCache(
     VkResult (*createPipelineFunc)(DeviceImpl* device, VkPipelineCreateInfo* createInfo, VkPipeline* outPipeline),
     VkPipeline* outPipeline,
     bool& outCached,
-    size_t& outCacheSize
+    size_t& outCacheSize,
+    const SHA1::Digest* fallbackPipelineKey = nullptr
 )
 {
     auto& api = device->m_api;
@@ -261,7 +387,7 @@ Result createPipelineWithCache(
     VkPipeline pipeline = VK_NULL_HANDLE;
 
     // Create pipeline cache key.
-    if (SLANG_FAILED(getPipelineCacheKey(device, createInfo, pipelineCacheKey.writeRef())))
+    if (SLANG_FAILED(getPipelineCacheKey(device, createInfo, fallbackPipelineKey, pipelineCacheKey.writeRef())))
     {
         device->printWarning("Failed to get pipeline cache key, disabling pipeline cache.");
         return createPipelineFunc(device, createInfo, outPipeline);
@@ -294,6 +420,7 @@ Result createPipelineWithCache(
             {
                 createInfo->pNext = binaryInfo.pNext;
                 pipeline = VK_NULL_HANDLE;
+                device->printWarning("Failed to create pipeline from cache, creating new pipeline.");
             }
             for (auto& binary : pipelineBinaries)
             {
@@ -844,6 +971,16 @@ Result DeviceImpl::createRayTracingPipeline2(const RayTracingPipelineDesc& desc,
     createInfo.basePipelineHandle = VK_NULL_HANDLE;
     createInfo.basePipelineIndex = 0;
 
+    SHA1::Digest fallbackPipelineKey;
+    const SHA1::Digest* fallbackPipelineKeyPtr = nullptr;
+    if (m_persistentPipelineCache)
+    {
+        // NVIDIA drivers have returned the same all-zero pipeline key for distinct ray tracing pipelines.
+        // Prepare a stable application key so caching remains safe and useful if that happens.
+        if (SLANG_SUCCEEDED(getRayTracingPipelineFallbackKey(program, desc, fallbackPipelineKey)))
+            fallbackPipelineKeyPtr = &fallbackPipelineKey;
+    }
+
     VkPipeline vkPipeline = VK_NULL_HANDLE;
     bool cached = false;
     size_t cacheSize = 0;
@@ -865,7 +1002,8 @@ Result DeviceImpl::createRayTracingPipeline2(const RayTracingPipelineDesc& desc,
             },
             &vkPipeline,
             cached,
-            cacheSize
+            cacheSize,
+            fallbackPipelineKeyPtr
         )
     );
 

--- a/tests/test-pipeline-cache.cpp
+++ b/tests/test-pipeline-cache.cpp
@@ -542,6 +542,11 @@ GPU_TEST_CASE("pipeline-cache-ray-tracing", Vulkan | DontCreateDevice)
     runTest<PipelineCacheTestRayTracing<false>>(ctx);
 }
 
+GPU_TEST_CASE("pipeline-cache-ray-tracing-corrupt", Vulkan | DontCreateDevice)
+{
+    runTest<PipelineCacheTestRayTracing<true>>(ctx);
+}
+
 #if 0
 // TODO: D3D12 does fail in debug layers and not return an error correctly.
 GPU_TEST_CASE("pipeline-cache-render-corrupt", Vulkan | DontCreateDevice)

--- a/tests/test-pipeline-cache.cpp
+++ b/tests/test-pipeline-cache.cpp
@@ -1,5 +1,6 @@
 #include "testing.h"
 
+#include <array>
 #include <filesystem>
 #include <fstream>
 #include <map>
@@ -148,7 +149,7 @@ struct PipelineCacheTestCompute : PipelineCacheTest
     ComPtr<IComputePipeline> computePipeline;
     ComPtr<IBuffer> buffer;
 
-    std::string computeShader = std::string(
+    std::string computeShaderAdd = std::string(
         R"(
         [shader("compute")]
         [numthreads(4, 1, 1)]
@@ -158,6 +159,20 @@ struct PipelineCacheTestCompute : PipelineCacheTest
         {
             var input = buffer[sv_dispatchThreadID.x];
             buffer[sv_dispatchThreadID.x] = input + 1.0f;
+        }
+        )"
+    );
+
+    std::string computeShaderMultiply = std::string(
+        R"(
+        [shader("compute")]
+        [numthreads(4, 1, 1)]
+        void main(
+            uint3 sv_dispatchThreadID : SV_DispatchThreadID,
+            uniform RWStructuredBuffer<float> buffer)
+        {
+            var input = buffer[sv_dispatchThreadID.x];
+            buffer[sv_dispatchThreadID.x] = input * 2.0f;
         }
         )"
     );
@@ -223,16 +238,17 @@ struct PipelineCacheTestCompute : PipelineCacheTest
 
     void runTests()
     {
-        // Cache is cold and we expect 1 miss.
+        // Cache is cold and we expect 2 misses for 2 different programs.
         createDevice();
         if (!device->hasFeature(Feature::PipelineCache))
             SKIP("Pipeline cache is not supported on this device type.");
-        runComputePipeline(computeShader, {1.f, 2.f, 3.f, 4.f});
-        CHECK_EQ(getStats().writeCount, 1);
-        CHECK_EQ(getStats().queryCount, 1);
-        CHECK_EQ(getStats().missCount, 1);
+        runComputePipeline(computeShaderAdd, {1.f, 2.f, 3.f, 4.f});
+        runComputePipeline(computeShaderMultiply, {0.f, 2.f, 4.f, 6.f});
+        CHECK_EQ(getStats().writeCount, 2);
+        CHECK_EQ(getStats().queryCount, 2);
+        CHECK_EQ(getStats().missCount, 2);
         CHECK_EQ(getStats().hitCount, 0);
-        CHECK_EQ(getStats().entryCount, 1);
+        CHECK_EQ(getStats().entryCount, 2);
 
         // Corrupt the cache.
         if constexpr (Corrupt)
@@ -240,14 +256,15 @@ struct PipelineCacheTestCompute : PipelineCacheTest
             pipelineCache.corrupt();
         }
 
-        // Cache is hot and we expect 1 hit.
+        // Cache is hot and we expect 2 hits.
         createDevice();
-        runComputePipeline(computeShader, {1.f, 2.f, 3.f, 4.f});
-        CHECK_EQ(getStats().writeCount, Corrupt ? 2 : 1);
-        CHECK_EQ(getStats().queryCount, 2);
-        CHECK_EQ(getStats().missCount, 1);
-        CHECK_EQ(getStats().hitCount, 1);
-        CHECK_EQ(getStats().entryCount, 1);
+        runComputePipeline(computeShaderAdd, {1.f, 2.f, 3.f, 4.f});
+        runComputePipeline(computeShaderMultiply, {0.f, 2.f, 4.f, 6.f});
+        CHECK_EQ(getStats().writeCount, Corrupt ? 4 : 2);
+        CHECK_EQ(getStats().queryCount, 4);
+        CHECK_EQ(getStats().missCount, 2);
+        CHECK_EQ(getStats().hitCount, 2);
+        CHECK_EQ(getStats().entryCount, 2);
     }
 };
 
@@ -257,7 +274,7 @@ struct PipelineCacheTestRender : PipelineCacheTest
     ComPtr<IRenderPipeline> renderPipeline;
     ComPtr<ITexture> texture;
 
-    std::string renderShader = std::string(
+    std::string renderShaderMagenta = std::string(
         R"(
         [shader("vertex")]
         float4 vertexMain(uint vid: SV_VertexID) : SV_Position
@@ -277,6 +294,24 @@ struct PipelineCacheTestRender : PipelineCacheTest
         )"
     );
 
+    std::string renderShaderCyan = std::string(
+        R"(
+        [shader("vertex")]
+        float4 vertexMain(uint vid: SV_VertexID) : SV_Position
+        {
+            float2 uv = float2((vid << 1) & 2, vid & 2);
+            return float4(uv * float2(2, -2) + float2(-1, 1), 0, 1);
+        }
+
+        [shader("fragment")]
+        float4 fragmentMain()
+            : SV_Target
+        {
+            return float4(0.0, 1.0, 1.0, 1.0);
+        }
+        )"
+    );
+
     void createResources()
     {
         TextureDesc textureDesc = {};
@@ -292,7 +327,7 @@ struct PipelineCacheTestRender : PipelineCacheTest
         renderPipeline = nullptr;
     }
 
-    void createRenderPipeline(std::string_view shaderSource)
+    void createRenderPipeline(std::string_view shaderSource, bool enableBlend)
     {
         ComPtr<IShaderProgram> shaderProgram;
         REQUIRE_CALL(
@@ -303,6 +338,7 @@ struct PipelineCacheTestRender : PipelineCacheTest
         pipelineDesc.program = shaderProgram.get();
         ColorTargetDesc colorTargetDesc = {};
         colorTargetDesc.format = Format::RGBA32Float;
+        colorTargetDesc.enableBlend = enableBlend;
         pipelineDesc.targetCount = 1;
         pipelineDesc.targets = &colorTargetDesc;
         REQUIRE_CALL(device->createRenderPipeline(pipelineDesc, renderPipeline.writeRef()));
@@ -345,10 +381,10 @@ struct PipelineCacheTestRender : PipelineCacheTest
                ) == 0;
     }
 
-    void runRenderPipeline(std::string_view shaderSource, const std::vector<float>& expectedOutput)
+    void runRenderPipeline(std::string_view shaderSource, bool enableBlend, const std::vector<float>& expectedOutput)
     {
         createResources();
-        createRenderPipeline(shaderSource);
+        createRenderPipeline(shaderSource, enableBlend);
         dispatchRenderPipeline();
         CHECK(checkOutput(expectedOutput));
         freeResources();
@@ -356,16 +392,17 @@ struct PipelineCacheTestRender : PipelineCacheTest
 
     void runTests()
     {
-        // Cache is cold and we expect 1 miss.
+        // Cache is cold and we expect 2 misses for different programs and blend configurations.
         createDevice();
         if (!device->hasFeature(Feature::PipelineCache))
             SKIP("Pipeline cache is not supported on this device type.");
-        runRenderPipeline(renderShader, {1.f, 0.f, 1.f, 1.f});
-        CHECK_EQ(getStats().writeCount, 1);
-        CHECK_EQ(getStats().queryCount, 1);
-        CHECK_EQ(getStats().missCount, 1);
+        runRenderPipeline(renderShaderMagenta, false, {1.f, 0.f, 1.f, 1.f});
+        runRenderPipeline(renderShaderCyan, true, {0.f, 1.f, 1.f, 1.f});
+        CHECK_EQ(getStats().writeCount, 2);
+        CHECK_EQ(getStats().queryCount, 2);
+        CHECK_EQ(getStats().missCount, 2);
         CHECK_EQ(getStats().hitCount, 0);
-        CHECK_EQ(getStats().entryCount, 1);
+        CHECK_EQ(getStats().entryCount, 2);
 
         // Corrupt the cache.
         if constexpr (Corrupt)
@@ -373,14 +410,104 @@ struct PipelineCacheTestRender : PipelineCacheTest
             pipelineCache.corrupt();
         }
 
-        // Cache is hot and we expect 1 hit.
+        // Cache is hot and we expect 2 hits.
         createDevice();
-        runRenderPipeline(renderShader, {1.f, 0.f, 1.f, 1.f});
-        CHECK_EQ(getStats().writeCount, Corrupt ? 2 : 1);
-        CHECK_EQ(getStats().queryCount, 2);
-        CHECK_EQ(getStats().missCount, 1);
-        CHECK_EQ(getStats().hitCount, 1);
-        CHECK_EQ(getStats().entryCount, 1);
+        runRenderPipeline(renderShaderMagenta, false, {1.f, 0.f, 1.f, 1.f});
+        runRenderPipeline(renderShaderCyan, true, {0.f, 1.f, 1.f, 1.f});
+        CHECK_EQ(getStats().writeCount, Corrupt ? 4 : 2);
+        CHECK_EQ(getStats().queryCount, 4);
+        CHECK_EQ(getStats().missCount, 2);
+        CHECK_EQ(getStats().hitCount, 2);
+        CHECK_EQ(getStats().entryCount, 2);
+    }
+};
+
+template<bool Corrupt>
+struct PipelineCacheTestRayTracing : PipelineCacheTest
+{
+    ComPtr<IRayTracingPipeline> rayTracingPipeline;
+
+    void runRayTracingPipeline(
+        const char* entryPointName,
+        uint32_t value,
+        uint32_t maxRecursion,
+        RayTracingPipelineFlags flags,
+        const std::array<uint32_t, 4>& expectedOutput
+    )
+    {
+        ComPtr<IShaderProgram> shaderProgram;
+        REQUIRE_CALL(
+            loadProgram(device, "test-ray-tracing-raygen-entrypoint", entryPointName, shaderProgram.writeRef())
+        );
+
+        RayTracingPipelineDesc pipelineDesc = {};
+        pipelineDesc.program = shaderProgram;
+        pipelineDesc.maxRecursion = maxRecursion;
+        pipelineDesc.flags = flags;
+        REQUIRE_CALL(device->createRayTracingPipeline(pipelineDesc, rayTracingPipeline.writeRef()));
+
+        ComPtr<IShaderTable> shaderTable;
+        ShaderTableDesc shaderTableDesc = {};
+        shaderTableDesc.program = shaderProgram;
+        shaderTableDesc.rayGenShaderCount = 1;
+        shaderTableDesc.rayGenShaderEntryPointNames = &entryPointName;
+        REQUIRE_CALL(device->createShaderTable(shaderTableDesc, shaderTable.writeRef()));
+
+        BufferDesc bufferDesc = {};
+        bufferDesc.size = expectedOutput.size() * sizeof(uint32_t);
+        bufferDesc.usage = BufferUsage::UnorderedAccess | BufferUsage::CopySource;
+        ComPtr<IBuffer> outputBuffer;
+        REQUIRE_CALL(device->createBuffer(bufferDesc, nullptr, outputBuffer.writeRef()));
+
+        auto queue = device->getQueue(QueueType::Graphics);
+        auto commandEncoder = queue->createCommandEncoder();
+        auto passEncoder = commandEncoder->beginRayTracingPass();
+        auto rootObject = passEncoder->bindPipeline(rayTracingPipeline, shaderTable);
+        auto cursor = ShaderCursor(rootObject->getEntryPoint(0));
+        cursor["output"].setBinding(outputBuffer);
+        cursor["value"].setData(value);
+        passEncoder->dispatchRays(0, 2, 2, 1);
+        passEncoder->end();
+        REQUIRE_CALL(queue->submit(commandEncoder->finish()));
+        REQUIRE_CALL(queue->waitOnHost());
+        compareComputeResult(device, outputBuffer, expectedOutput);
+
+        rayTracingPipeline = nullptr;
+    }
+
+    void runTests()
+    {
+        // Cache is cold and we expect 3 misses for different programs and pipeline configurations.
+        createDevice();
+        if (!device->hasFeature(Feature::PipelineCache))
+            SKIP("Pipeline cache is not supported on this device type.");
+        if (!device->hasFeature(Feature::RayTracing))
+            SKIP("Ray tracing is not supported on this device type.");
+        runRayTracingPipeline("rayGenA", 1, 1, RayTracingPipelineFlags::None, {1, 2, 3, 4});
+        runRayTracingPipeline("rayGenB", 10, 1, RayTracingPipelineFlags::None, {10, 12, 14, 16});
+        runRayTracingPipeline("rayGenA", 100, 2, RayTracingPipelineFlags::None, {100, 101, 102, 103});
+        CHECK_EQ(getStats().writeCount, 3);
+        CHECK_EQ(getStats().queryCount, 3);
+        CHECK_EQ(getStats().missCount, 3);
+        CHECK_EQ(getStats().hitCount, 0);
+        CHECK_EQ(getStats().entryCount, 3);
+
+        // Corrupt the cache.
+        if constexpr (Corrupt)
+        {
+            pipelineCache.corrupt();
+        }
+
+        // Cache is hot and we expect 3 hits.
+        createDevice();
+        runRayTracingPipeline("rayGenA", 1, 1, RayTracingPipelineFlags::None, {1, 2, 3, 4});
+        runRayTracingPipeline("rayGenB", 10, 1, RayTracingPipelineFlags::None, {10, 12, 14, 16});
+        runRayTracingPipeline("rayGenA", 100, 2, RayTracingPipelineFlags::None, {100, 101, 102, 103});
+        CHECK_EQ(getStats().writeCount, Corrupt ? 6 : 3);
+        CHECK_EQ(getStats().queryCount, 6);
+        CHECK_EQ(getStats().missCount, 3);
+        CHECK_EQ(getStats().hitCount, 3);
+        CHECK_EQ(getStats().entryCount, 3);
     }
 };
 
@@ -408,6 +535,11 @@ GPU_TEST_CASE("pipeline-cache-compute-corrupt", Vulkan | DontCreateDevice)
 GPU_TEST_CASE("pipeline-cache-render", D3D12 | Vulkan | DontCreateDevice)
 {
     runTest<PipelineCacheTestRender<false>>(ctx);
+}
+
+GPU_TEST_CASE("pipeline-cache-ray-tracing", Vulkan | DontCreateDevice)
+{
+    runTest<PipelineCacheTestRayTracing<false>>(ctx);
 }
 
 #if 0


### PR DESCRIPTION
- Add persistent pipeline-cache coverage for Vulkan ray-tracing pipelines.
- Work around drivers returning unusable all-zero RT pipeline keys by generating a stable fallback hash from:
  - emitted SPIR-V and shader-stage metadata;
  - specialization data;
  - hit-group configuration;
  - relevant RT pipeline settings.
- Disable caching with a warning when an all-zero key is returned and no safe fallback is available.
- Log when pipeline creation from cached binaries fails and compilation is retried.
- Expand compute, render, and RT cache tests to cover distinct programs and pipeline configurations, including cold misses, hot hits, and output validation.