### PR TITLE
Optimize SHA-1 implementation

### DIFF
--- a/src/core/sha1.cpp
+++ b/src/core/sha1.cpp
@@ -12,7 +12,11 @@
 #endif
 #include <immintrin.h>
 #elif SLANG_PROCESSOR_ARM_64
+#if SLANG_VC && !defined(__clang__)
+#include <arm64_neon.h>
+#else
 #include <arm_neon.h>
+#endif
 #if SLANG_WINDOWS_FAMILY
 #ifndef WIN32_LEAN_AND_MEAN
 #define WIN32_LEAN_AND_MEAN

--- a/src/core/sha1.cpp
+++ b/src/core/sha1.cpp
@@ -1,114 +1,34 @@
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
 #include "sha1.h"
+
+#include <slang.h>
+
+#if SLANG_PROCESSOR_X86_64
+#if SLANG_VC && !defined(__clang__)
+#include <intrin.h>
+#else
+#include <cpuid.h>
+#endif
+#include <immintrin.h>
+#elif SLANG_PROCESSOR_ARM_64
+#include <arm_neon.h>
+#if SLANG_WINDOWS_FAMILY
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+#include <Windows.h>
+#elif SLANG_LINUX_FAMILY
+#include <sys/auxv.h>
+#include <asm/hwcap.h>
+#endif
+#endif
 
 namespace rhi {
 
-SHA1::SHA1()
-    : m_index(0)
-    , m_bits(0)
-{
-    m_state[0] = 0x67452301;
-    m_state[1] = 0xefcdab89;
-    m_state[2] = 0x98badcfe;
-    m_state[3] = 0x10325476;
-    m_state[4] = 0xc3d2e1f0;
-}
+namespace {
 
-SHA1& SHA1::update(uint8_t byte)
-{
-    addByte(byte);
-    m_bits += 8;
-    return *this;
-}
-
-SHA1& SHA1::update(const void* data, size_t len)
-{
-    if (!data || len == 0)
-        return *this;
-
-    const uint8_t* ptr = reinterpret_cast<const uint8_t*>(data);
-
-    // Fill up buffer if not full.
-    while (len > 0 && m_index != 0)
-    {
-        update(*ptr++);
-        len--;
-    }
-
-    // Process full blocks.
-    while (len >= sizeof(m_buf))
-    {
-        processBlock(ptr);
-        ptr += sizeof(m_buf);
-        len -= sizeof(m_buf);
-        m_bits += sizeof(m_buf) * 8;
-    }
-
-    // Process remaining bytes.
-    while (len > 0)
-    {
-        update(*ptr++);
-        len--;
-    }
-
-    return *this;
-}
-
-SHA1::Digest SHA1::getDigest() const
-{
-    SHA1 copy{*this};
-    return copy.finalize();
-}
-
-std::string SHA1::getHexDigest() const
-{
-    static const char* hex_digits = "0123456789abcdef";
-    std::string hex;
-    hex.reserve(40);
-    for (auto b : getDigest())
-    {
-        hex.push_back(hex_digits[b >> 4]);
-        hex.push_back(hex_digits[b & 0xf]);
-    }
-    return hex;
-}
-
-SHA1::Digest SHA1::finalize()
-{
-    // Finalize with 0x80, some zero padding and the length in bits.
-    addByte(0x80);
-    while (m_index % 64 != 56)
-    {
-        addByte(0);
-    }
-    for (int i = 7; i >= 0; --i)
-    {
-        addByte(uint8_t(m_bits >> (i * 8)));
-    }
-
-    Digest digest;
-    for (int i = 0; i < 5; i++)
-    {
-        for (int j = 3; j >= 0; j--)
-        {
-            digest[i * 4 + j] = (m_state[i] >> ((3 - j) * 8)) & 0xff;
-        }
-    }
-
-    return digest;
-}
-
-void SHA1::addByte(uint8_t byte)
-{
-    m_buf[m_index++] = byte;
-
-    if (m_index >= sizeof(m_buf))
-    {
-        m_index = 0;
-        processBlock(m_buf);
-    }
-}
-
-void SHA1::processBlock(const uint8_t* ptr)
+void sha1_process_block_software(const uint8_t* ptr, uint32_t state[5])
 {
     auto rol32 = [](uint32_t x, uint32_t n)
     {
@@ -125,11 +45,11 @@ void SHA1::processBlock(const uint8_t* ptr)
     const uint32_t c2 = 0x8f1bbcdc;
     const uint32_t c3 = 0xca62c1d6;
 
-    uint32_t a = m_state[0];
-    uint32_t b = m_state[1];
-    uint32_t c = m_state[2];
-    uint32_t d = m_state[3];
-    uint32_t e = m_state[4];
+    uint32_t a = state[0];
+    uint32_t b = state[1];
+    uint32_t c = state[2];
+    uint32_t d = state[3];
+    uint32_t e = state[4];
 
     uint32_t w[16];
 
@@ -235,11 +155,493 @@ void SHA1::processBlock(const uint8_t* ptr)
 #undef SHA1_ROUND_3
 #undef SHA1_ROUND_4
 
-    m_state[0] += a;
-    m_state[1] += b;
-    m_state[2] += c;
-    m_state[3] += d;
-    m_state[4] += e;
+    state[0] += a;
+    state[1] += b;
+    state[2] += c;
+    state[3] += d;
+    state[4] += e;
+}
+
+#if SLANG_PROCESSOR_X86_64
+bool cpu_has_sha_ni()
+{
+#if SLANG_VC && !defined(__clang__)
+    int info[4] = {0};
+    __cpuidex(info, 7, 0);
+    return (info[1] & (1 << 29)) != 0; // EBX bit 29 = SHA
+#else
+    unsigned int eax, ebx, ecx, edx;
+    if (__get_cpuid_count(7, 0, &eax, &ebx, &ecx, &edx))
+    {
+        return (ebx & (1 << 29)) != 0;
+    }
+    return false;
+#endif
+}
+
+#if SLANG_VC && !defined(__clang__)
+#define SLANG_RHI_SHA_TARGET
+#else
+#define SLANG_RHI_SHA_TARGET __attribute__((target("sha,sse4.1")))
+#endif
+
+SLANG_RHI_SHA_TARGET
+void sha1_process_block_shani(const uint8_t* data, uint32_t state[5])
+{
+    __m128i abcd, e0, e1;
+    __m128i msg0, msg1, msg2, msg3;
+
+    // Load state: SHA1 state is [A, B, C, D, E]
+    abcd = _mm_loadu_si128(reinterpret_cast<const __m128i*>(state));
+    e0 = _mm_set_epi32(state[4], 0, 0, 0);
+
+    // Byte-swap since SHA1 is big-endian.
+    const __m128i shuf_mask = _mm_set_epi8(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
+
+    // Reverse the order of A,B,C,D for the SHA-NI instructions.
+    abcd = _mm_shuffle_epi32(abcd, 0x1B);
+
+    // Save original state for addition at end.
+    __m128i abcd_save = abcd;
+    __m128i e_save = e0;
+
+    // Load and byte-swap message.
+    msg0 = _mm_shuffle_epi8(_mm_loadu_si128(reinterpret_cast<const __m128i*>(data + 0)), shuf_mask);
+    msg1 = _mm_shuffle_epi8(_mm_loadu_si128(reinterpret_cast<const __m128i*>(data + 16)), shuf_mask);
+    msg2 = _mm_shuffle_epi8(_mm_loadu_si128(reinterpret_cast<const __m128i*>(data + 32)), shuf_mask);
+    msg3 = _mm_shuffle_epi8(_mm_loadu_si128(reinterpret_cast<const __m128i*>(data + 48)), shuf_mask);
+
+    // Rounds 0-3
+    e0 = _mm_add_epi32(e0, msg0);
+    e1 = abcd;
+    abcd = _mm_sha1rnds4_epu32(abcd, e0, 0);
+
+    // Rounds 4-7
+    e1 = _mm_sha1nexte_epu32(e1, msg1);
+    e0 = abcd;
+    abcd = _mm_sha1rnds4_epu32(abcd, e1, 0);
+    msg0 = _mm_sha1msg1_epu32(msg0, msg1);
+
+    // Rounds 8-11
+    e0 = _mm_sha1nexte_epu32(e0, msg2);
+    e1 = abcd;
+    abcd = _mm_sha1rnds4_epu32(abcd, e0, 0);
+    msg1 = _mm_sha1msg1_epu32(msg1, msg2);
+    msg0 = _mm_xor_si128(msg0, msg2);
+
+    // Rounds 12-15
+    e1 = _mm_sha1nexte_epu32(e1, msg3);
+    e0 = abcd;
+    abcd = _mm_sha1rnds4_epu32(abcd, e1, 0);
+    msg2 = _mm_sha1msg1_epu32(msg2, msg3);
+    msg1 = _mm_xor_si128(msg1, msg3);
+    msg0 = _mm_sha1msg2_epu32(msg0, msg3);
+
+    // Rounds 16-19
+    e0 = _mm_sha1nexte_epu32(e0, msg0);
+    e1 = abcd;
+    abcd = _mm_sha1rnds4_epu32(abcd, e0, 0);
+    msg3 = _mm_sha1msg1_epu32(msg3, msg0);
+    msg2 = _mm_xor_si128(msg2, msg0);
+    msg1 = _mm_sha1msg2_epu32(msg1, msg0);
+
+    // Rounds 20-23
+    e1 = _mm_sha1nexte_epu32(e1, msg1);
+    e0 = abcd;
+    abcd = _mm_sha1rnds4_epu32(abcd, e1, 1);
+    msg0 = _mm_sha1msg1_epu32(msg0, msg1);
+    msg3 = _mm_xor_si128(msg3, msg1);
+    msg2 = _mm_sha1msg2_epu32(msg2, msg1);
+
+    // Rounds 24-27
+    e0 = _mm_sha1nexte_epu32(e0, msg2);
+    e1 = abcd;
+    abcd = _mm_sha1rnds4_epu32(abcd, e0, 1);
+    msg1 = _mm_sha1msg1_epu32(msg1, msg2);
+    msg0 = _mm_xor_si128(msg0, msg2);
+    msg3 = _mm_sha1msg2_epu32(msg3, msg2);
+
+    // Rounds 28-31
+    e1 = _mm_sha1nexte_epu32(e1, msg3);
+    e0 = abcd;
+    abcd = _mm_sha1rnds4_epu32(abcd, e1, 1);
+    msg2 = _mm_sha1msg1_epu32(msg2, msg3);
+    msg1 = _mm_xor_si128(msg1, msg3);
+    msg0 = _mm_sha1msg2_epu32(msg0, msg3);
+
+    // Rounds 32-35
+    e0 = _mm_sha1nexte_epu32(e0, msg0);
+    e1 = abcd;
+    abcd = _mm_sha1rnds4_epu32(abcd, e0, 1);
+    msg3 = _mm_sha1msg1_epu32(msg3, msg0);
+    msg2 = _mm_xor_si128(msg2, msg0);
+    msg1 = _mm_sha1msg2_epu32(msg1, msg0);
+
+    // Rounds 36-39
+    e1 = _mm_sha1nexte_epu32(e1, msg1);
+    e0 = abcd;
+    abcd = _mm_sha1rnds4_epu32(abcd, e1, 1);
+    msg0 = _mm_sha1msg1_epu32(msg0, msg1);
+    msg3 = _mm_xor_si128(msg3, msg1);
+    msg2 = _mm_sha1msg2_epu32(msg2, msg1);
+
+    // Rounds 40-43
+    e0 = _mm_sha1nexte_epu32(e0, msg2);
+    e1 = abcd;
+    abcd = _mm_sha1rnds4_epu32(abcd, e0, 2);
+    msg1 = _mm_sha1msg1_epu32(msg1, msg2);
+    msg0 = _mm_xor_si128(msg0, msg2);
+    msg3 = _mm_sha1msg2_epu32(msg3, msg2);
+
+    // Rounds 44-47
+    e1 = _mm_sha1nexte_epu32(e1, msg3);
+    e0 = abcd;
+    abcd = _mm_sha1rnds4_epu32(abcd, e1, 2);
+    msg2 = _mm_sha1msg1_epu32(msg2, msg3);
+    msg1 = _mm_xor_si128(msg1, msg3);
+    msg0 = _mm_sha1msg2_epu32(msg0, msg3);
+
+    // Rounds 48-51
+    e0 = _mm_sha1nexte_epu32(e0, msg0);
+    e1 = abcd;
+    abcd = _mm_sha1rnds4_epu32(abcd, e0, 2);
+    msg3 = _mm_sha1msg1_epu32(msg3, msg0);
+    msg2 = _mm_xor_si128(msg2, msg0);
+    msg1 = _mm_sha1msg2_epu32(msg1, msg0);
+
+    // Rounds 52-55
+    e1 = _mm_sha1nexte_epu32(e1, msg1);
+    e0 = abcd;
+    abcd = _mm_sha1rnds4_epu32(abcd, e1, 2);
+    msg0 = _mm_sha1msg1_epu32(msg0, msg1);
+    msg3 = _mm_xor_si128(msg3, msg1);
+    msg2 = _mm_sha1msg2_epu32(msg2, msg1);
+
+    // Rounds 56-59
+    e0 = _mm_sha1nexte_epu32(e0, msg2);
+    e1 = abcd;
+    abcd = _mm_sha1rnds4_epu32(abcd, e0, 2);
+    msg1 = _mm_sha1msg1_epu32(msg1, msg2);
+    msg0 = _mm_xor_si128(msg0, msg2);
+    msg3 = _mm_sha1msg2_epu32(msg3, msg2);
+
+    // Rounds 60-63
+    e1 = _mm_sha1nexte_epu32(e1, msg3);
+    e0 = abcd;
+    abcd = _mm_sha1rnds4_epu32(abcd, e1, 3);
+    msg2 = _mm_sha1msg1_epu32(msg2, msg3);
+    msg1 = _mm_xor_si128(msg1, msg3);
+    msg0 = _mm_sha1msg2_epu32(msg0, msg3);
+
+    // Rounds 64-67
+    e0 = _mm_sha1nexte_epu32(e0, msg0);
+    e1 = abcd;
+    abcd = _mm_sha1rnds4_epu32(abcd, e0, 3);
+    msg3 = _mm_sha1msg1_epu32(msg3, msg0);
+    msg2 = _mm_xor_si128(msg2, msg0);
+    msg1 = _mm_sha1msg2_epu32(msg1, msg0);
+
+    // Rounds 68-71
+    e1 = _mm_sha1nexte_epu32(e1, msg1);
+    e0 = abcd;
+    abcd = _mm_sha1rnds4_epu32(abcd, e1, 3);
+    msg3 = _mm_xor_si128(msg3, msg1);
+    msg2 = _mm_sha1msg2_epu32(msg2, msg1);
+
+    // Rounds 72-75
+    e0 = _mm_sha1nexte_epu32(e0, msg2);
+    e1 = abcd;
+    abcd = _mm_sha1rnds4_epu32(abcd, e0, 3);
+    msg3 = _mm_sha1msg2_epu32(msg3, msg2);
+
+    // Rounds 76-79
+    e1 = _mm_sha1nexte_epu32(e1, msg3);
+    e0 = abcd;
+    abcd = _mm_sha1rnds4_epu32(abcd, e1, 3);
+
+    // Add saved state.
+    e0 = _mm_sha1nexte_epu32(e0, e_save);
+    abcd = _mm_add_epi32(abcd, abcd_save);
+
+    // Store state (reverse ABCD back to original order).
+    abcd = _mm_shuffle_epi32(abcd, 0x1B);
+    _mm_storeu_si128(reinterpret_cast<__m128i*>(state), abcd);
+    state[4] = static_cast<uint32_t>(_mm_extract_epi32(e0, 3));
+}
+
+#undef SLANG_RHI_SHA_TARGET
+#endif // SLANG_PROCESSOR_X86_64
+
+#if SLANG_PROCESSOR_ARM_64
+bool cpu_has_sha1_ce()
+{
+#if SLANG_APPLE_FAMILY
+    // Apple Silicon always has SHA1 crypto extensions.
+    return true;
+#elif SLANG_LINUX_FAMILY
+    return (getauxval(AT_HWCAP) & HWCAP_SHA1) != 0;
+#elif SLANG_WINDOWS_FAMILY
+    return IsProcessorFeaturePresent(PF_ARM_V8_CRYPTO_INSTRUCTIONS_AVAILABLE) != 0;
+#else
+    return false;
+#endif
+}
+
+#if SLANG_VC && !defined(__clang__)
+#define SLANG_RHI_SHA_CE_TARGET
+#elif defined(__clang__)
+#define SLANG_RHI_SHA_CE_TARGET __attribute__((target("crypto")))
+#else
+#define SLANG_RHI_SHA_CE_TARGET __attribute__((target("+crypto")))
+#endif
+
+SLANG_RHI_SHA_CE_TARGET
+void sha1_process_block_arm_ce(const uint8_t* data, uint32_t state[5])
+{
+    // Load state into NEON registers.
+    uint32x4_t abcd = vld1q_u32(state);
+    uint32_t e0 = state[4];
+
+    // Save for final addition.
+    uint32x4_t abcd_save = abcd;
+    uint32_t e0_save = e0;
+
+    // Load message block (big-endian byte swap).
+    uint32x4_t msg0 = vreinterpretq_u32_u8(vrev32q_u8(vld1q_u8(data + 0)));
+    uint32x4_t msg1 = vreinterpretq_u32_u8(vrev32q_u8(vld1q_u8(data + 16)));
+    uint32x4_t msg2 = vreinterpretq_u32_u8(vrev32q_u8(vld1q_u8(data + 32)));
+    uint32x4_t msg3 = vreinterpretq_u32_u8(vrev32q_u8(vld1q_u8(data + 48)));
+
+    uint32x4_t tmp0, tmp1;
+
+    // Rounds 0-3
+    tmp0 = vaddq_u32(msg0, vdupq_n_u32(0x5a827999));
+    e0 = vsha1h_u32(vgetq_lane_u32(abcd, 0));
+    abcd = vsha1cq_u32(abcd, e0_save, tmp0);
+    msg0 = vsha1su0q_u32(msg0, msg1, msg2);
+
+    // Rounds 4-7
+    tmp1 = vaddq_u32(msg1, vdupq_n_u32(0x5a827999));
+    uint32_t e1 = vsha1h_u32(vgetq_lane_u32(abcd, 0));
+    abcd = vsha1cq_u32(abcd, e0, tmp1);
+    msg0 = vsha1su1q_u32(msg0, msg3);
+    msg1 = vsha1su0q_u32(msg1, msg2, msg3);
+
+    // Rounds 8-11
+    tmp0 = vaddq_u32(msg2, vdupq_n_u32(0x5a827999));
+    e0 = vsha1h_u32(vgetq_lane_u32(abcd, 0));
+    abcd = vsha1cq_u32(abcd, e1, tmp0);
+    msg1 = vsha1su1q_u32(msg1, msg0);
+    msg2 = vsha1su0q_u32(msg2, msg3, msg0);
+
+    // Rounds 12-15
+    tmp1 = vaddq_u32(msg3, vdupq_n_u32(0x5a827999));
+    e1 = vsha1h_u32(vgetq_lane_u32(abcd, 0));
+    abcd = vsha1cq_u32(abcd, e0, tmp1);
+    msg2 = vsha1su1q_u32(msg2, msg1);
+    msg3 = vsha1su0q_u32(msg3, msg0, msg1);
+
+    // Rounds 16-19
+    tmp0 = vaddq_u32(msg0, vdupq_n_u32(0x5a827999));
+    e0 = vsha1h_u32(vgetq_lane_u32(abcd, 0));
+    abcd = vsha1cq_u32(abcd, e1, tmp0);
+    msg3 = vsha1su1q_u32(msg3, msg2);
+    msg0 = vsha1su0q_u32(msg0, msg1, msg2);
+
+    // Rounds 20-23
+    tmp1 = vaddq_u32(msg1, vdupq_n_u32(0x6ed9eba1));
+    e1 = vsha1h_u32(vgetq_lane_u32(abcd, 0));
+    abcd = vsha1pq_u32(abcd, e0, tmp1);
+    msg0 = vsha1su1q_u32(msg0, msg3);
+    msg1 = vsha1su0q_u32(msg1, msg2, msg3);
+
+    // Rounds 24-27
+    tmp0 = vaddq_u32(msg2, vdupq_n_u32(0x6ed9eba1));
+    e0 = vsha1h_u32(vgetq_lane_u32(abcd, 0));
+    abcd = vsha1pq_u32(abcd, e1, tmp0);
+    msg1 = vsha1su1q_u32(msg1, msg0);
+    msg2 = vsha1su0q_u32(msg2, msg3, msg0);
+
+    // Rounds 28-31
+    tmp1 = vaddq_u32(msg3, vdupq_n_u32(0x6ed9eba1));
+    e1 = vsha1h_u32(vgetq_lane_u32(abcd, 0));
+    abcd = vsha1pq_u32(abcd, e0, tmp1);
+    msg2 = vsha1su1q_u32(msg2, msg1);
+    msg3 = vsha1su0q_u32(msg3, msg0, msg1);
+
+    // Rounds 32-35
+    tmp0 = vaddq_u32(msg0, vdupq_n_u32(0x6ed9eba1));
+    e0 = vsha1h_u32(vgetq_lane_u32(abcd, 0));
+    abcd = vsha1pq_u32(abcd, e1, tmp0);
+    msg3 = vsha1su1q_u32(msg3, msg2);
+    msg0 = vsha1su0q_u32(msg0, msg1, msg2);
+
+    // Rounds 36-39
+    tmp1 = vaddq_u32(msg1, vdupq_n_u32(0x6ed9eba1));
+    e1 = vsha1h_u32(vgetq_lane_u32(abcd, 0));
+    abcd = vsha1pq_u32(abcd, e0, tmp1);
+    msg0 = vsha1su1q_u32(msg0, msg3);
+    msg1 = vsha1su0q_u32(msg1, msg2, msg3);
+
+    // Rounds 40-43
+    tmp0 = vaddq_u32(msg2, vdupq_n_u32(0x8f1bbcdc));
+    e0 = vsha1h_u32(vgetq_lane_u32(abcd, 0));
+    abcd = vsha1mq_u32(abcd, e1, tmp0);
+    msg1 = vsha1su1q_u32(msg1, msg0);
+    msg2 = vsha1su0q_u32(msg2, msg3, msg0);
+
+    // Rounds 44-47
+    tmp1 = vaddq_u32(msg3, vdupq_n_u32(0x8f1bbcdc));
+    e1 = vsha1h_u32(vgetq_lane_u32(abcd, 0));
+    abcd = vsha1mq_u32(abcd, e0, tmp1);
+    msg2 = vsha1su1q_u32(msg2, msg1);
+    msg3 = vsha1su0q_u32(msg3, msg0, msg1);
+
+    // Rounds 48-51
+    tmp0 = vaddq_u32(msg0, vdupq_n_u32(0x8f1bbcdc));
+    e0 = vsha1h_u32(vgetq_lane_u32(abcd, 0));
+    abcd = vsha1mq_u32(abcd, e1, tmp0);
+    msg3 = vsha1su1q_u32(msg3, msg2);
+    msg0 = vsha1su0q_u32(msg0, msg1, msg2);
+
+    // Rounds 52-55
+    tmp1 = vaddq_u32(msg1, vdupq_n_u32(0x8f1bbcdc));
+    e1 = vsha1h_u32(vgetq_lane_u32(abcd, 0));
+    abcd = vsha1mq_u32(abcd, e0, tmp1);
+    msg0 = vsha1su1q_u32(msg0, msg3);
+    msg1 = vsha1su0q_u32(msg1, msg2, msg3);
+
+    // Rounds 56-59
+    tmp0 = vaddq_u32(msg2, vdupq_n_u32(0x8f1bbcdc));
+    e0 = vsha1h_u32(vgetq_lane_u32(abcd, 0));
+    abcd = vsha1mq_u32(abcd, e1, tmp0);
+    msg1 = vsha1su1q_u32(msg1, msg0);
+    msg2 = vsha1su0q_u32(msg2, msg3, msg0);
+
+    // Rounds 60-63
+    tmp1 = vaddq_u32(msg3, vdupq_n_u32(0xca62c1d6));
+    e1 = vsha1h_u32(vgetq_lane_u32(abcd, 0));
+    abcd = vsha1pq_u32(abcd, e0, tmp1);
+    msg2 = vsha1su1q_u32(msg2, msg1);
+    msg3 = vsha1su0q_u32(msg3, msg0, msg1);
+
+    // Rounds 64-67
+    tmp0 = vaddq_u32(msg0, vdupq_n_u32(0xca62c1d6));
+    e0 = vsha1h_u32(vgetq_lane_u32(abcd, 0));
+    abcd = vsha1pq_u32(abcd, e1, tmp0);
+    msg3 = vsha1su1q_u32(msg3, msg2);
+
+    // Rounds 68-71
+    tmp1 = vaddq_u32(msg1, vdupq_n_u32(0xca62c1d6));
+    e1 = vsha1h_u32(vgetq_lane_u32(abcd, 0));
+    abcd = vsha1pq_u32(abcd, e0, tmp1);
+
+    // Rounds 72-75
+    tmp0 = vaddq_u32(msg2, vdupq_n_u32(0xca62c1d6));
+    e0 = vsha1h_u32(vgetq_lane_u32(abcd, 0));
+    abcd = vsha1pq_u32(abcd, e1, tmp0);
+
+    // Rounds 76-79
+    tmp1 = vaddq_u32(msg3, vdupq_n_u32(0xca62c1d6));
+    e1 = vsha1h_u32(vgetq_lane_u32(abcd, 0));
+    abcd = vsha1pq_u32(abcd, e0, tmp1);
+
+    // Add saved state.
+    e0 = e1 + e0_save;
+    abcd = vaddq_u32(abcd, abcd_save);
+
+    // Store state.
+    vst1q_u32(state, abcd);
+    state[4] = e0;
+}
+
+#undef SLANG_RHI_SHA_CE_TARGET
+#endif // SLANG_PROCESSOR_ARM_64
+
+using ProcessBlockFn = void (*)(const uint8_t*, uint32_t[5]);
+
+ProcessBlockFn get_process_block_fn()
+{
+    static ProcessBlockFn fn = []() -> ProcessBlockFn
+    {
+#if SLANG_PROCESSOR_X86_64
+        if (cpu_has_sha_ni())
+            return sha1_process_block_shani;
+#elif SLANG_PROCESSOR_ARM_64
+        if (cpu_has_sha1_ce())
+            return sha1_process_block_arm_ce;
+#endif
+        return sha1_process_block_software;
+    }();
+    return fn;
+}
+
+} // anonymous namespace
+
+SHA1::SHA1()
+    : m_processBlock(get_process_block_fn())
+    , m_index(0)
+    , m_bits(0)
+{
+    m_state[0] = 0x67452301;
+    m_state[1] = 0xefcdab89;
+    m_state[2] = 0x98badcfe;
+    m_state[3] = 0x10325476;
+    m_state[4] = 0xc3d2e1f0;
+}
+
+SHA1::Digest SHA1::getDigest() const
+{
+    SHA1 copy{*this};
+    return copy.finalize();
+}
+
+std::string SHA1::getHexDigest() const
+{
+    static const char* hex_digits = "0123456789abcdef";
+    std::string hex;
+    hex.reserve(40);
+    for (auto b : getDigest())
+    {
+        hex.push_back(hex_digits[b >> 4]);
+        hex.push_back(hex_digits[b & 0xf]);
+    }
+    return hex;
+}
+
+SHA1::Digest SHA1::finalize()
+{
+    auto add_byte = [this](uint8_t x)
+    {
+        m_buf[m_index++] = x;
+        if (m_index >= sizeof(m_buf))
+        {
+            m_index = 0;
+            processBlock(m_buf);
+        }
+    };
+
+    // Finalize with 0x80, some zero padding and the length in bits.
+    add_byte(0x80);
+    while (m_index % 64 != 56)
+    {
+        add_byte(0);
+    }
+    for (int i = 7; i >= 0; --i)
+    {
+        add_byte(uint8_t(m_bits >> (i * 8)));
+    }
+
+    Digest digest;
+    for (int i = 0; i < 5; i++)
+    {
+        for (int j = 3; j >= 0; j--)
+        {
+            digest[i * 4 + j] = (m_state[i] >> ((3 - j) * 8)) & 0xff;
+        }
+    }
+
+    return digest;
 }
 
 } // namespace rhi

--- a/src/core/sha1.h
+++ b/src/core/sha1.h
@@ -5,6 +5,7 @@
 #include <string_view>
 #include <cstdint>
 #include <cstdlib>
+#include <cstring>
 
 namespace rhi {
 
@@ -39,14 +40,55 @@ public:
      * Update hash by adding one byte.
      * \param byte Byte to hash.
      */
-    SHA1& update(uint8_t byte);
+    SHA1& update(uint8_t byte) { return update(&byte, 1); }
 
     /**
      * Update hash by adding the given data.
      * \param data Data to hash.
      * \param len Length of data in bytes.
      */
-    SHA1& update(const void* data, size_t len);
+    SHA1& update(const void* data, size_t len)
+    {
+        if (!data || len == 0)
+            return *this;
+
+        const uint8_t* ptr = reinterpret_cast<const uint8_t*>(data);
+        m_bits += static_cast<uint64_t>(len) * 8;
+
+        // If there's existing data in the buffer, try to fill it.
+        if (m_index != 0)
+        {
+            const uint32_t space = 64 - m_index;
+            if (len < space)
+            {
+                std::memcpy(m_buf + m_index, ptr, len);
+                m_index += static_cast<uint32_t>(len);
+                return *this;
+            }
+            std::memcpy(m_buf + m_index, ptr, space);
+            processBlock(m_buf);
+            m_index = 0;
+            ptr += space;
+            len -= space;
+        }
+
+        // Process full 64-byte blocks directly from input.
+        while (len >= 64)
+        {
+            processBlock(ptr);
+            ptr += 64;
+            len -= 64;
+        }
+
+        // Copy remaining bytes into buffer.
+        if (len > 0)
+        {
+            std::memcpy(m_buf, ptr, len);
+            m_index = static_cast<uint32_t>(len);
+        }
+
+        return *this;
+    }
 
     /**
      * Update hash by adding the given string.
@@ -61,10 +103,12 @@ public:
     std::string getHexDigest() const;
 
 private:
-    void addByte(uint8_t x);
-    void processBlock(const uint8_t* ptr);
+    using ProcessBlockFn = void (*)(const uint8_t*, uint32_t[5]);
+
+    void processBlock(const uint8_t* ptr) { m_processBlock(ptr, m_state); }
     Digest finalize();
 
+    ProcessBlockFn m_processBlock;
     uint32_t m_index;
     uint64_t m_bits;
     uint32_t m_state[5];

--- a/src/core/sha1.h
+++ b/src/core/sha1.h
@@ -56,7 +56,7 @@ public:
         m_bits += static_cast<uint64_t>(len) * 8;
 
         // If there's existing data in the buffer, try to fill it.
-        if (m_index != 0)
+        if (m_index != 0 && m_index < sizeof(m_buf))
         {
             const uint32_t space = 64 - m_index;
             if (len < space)

--- a/tests/test-sha1.cpp
+++ b/tests/test-sha1.cpp
@@ -96,4 +96,21 @@ TEST_CASE("sha1")
                                 }
         );
     }
+
+    SUBCASE("block boundaries")
+    {
+        std::array<uint8_t, 256> data;
+        for (size_t i = 0; i < data.size(); ++i)
+            data[i] = static_cast<uint8_t>(i);
+
+        SHA1 contiguous(data.data(), data.size());
+        CHECK(contiguous.getHexDigest() == "4916d6bdb7f78e6803698cab32d1586ea457dfc8");
+
+        SHA1 chunked;
+        chunked.update(data.data(), 1);
+        chunked.update(data.data() + 1, 63);
+        chunked.update(data.data() + 64, 64);
+        chunked.update(data.data() + 128, 128);
+        CHECK(chunked.getHexDigest() == contiguous.getHexDigest());
+    }
 }


### PR DESCRIPTION
Optimize SHA-1 hashing by porting the implementation from slangpy:

- Use SHA-NI on supported x86-64 CPUs and crypto extensions on supported Arm64 CPUs.
- Retain the existing software implementation as a runtime fallback.
- Improve streaming updates with block-based buffering and expose the update path in the header for call-site inlining.
- Use Slang’s existing platform and architecture macros.
- Add coverage for contiguous and chunked block-boundary updates.