### PR TITLE
Adopt slang nvapi_hit_objects capability; remove SM 6.9 + NVAPI HitObject workaround

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,10 +87,22 @@ jobs:
         with:
           version: '5.0.6'
 
+      # TEMPORARY (revert once a slang release contains shader-slang/slang#12089):
+      # Build slang from the PR branch so CI exercises the `nvapi_hit_objects` capability,
+      # which is not in any slang release yet. Applied to all jobs except Emscripten
+      # (whose wasm libs cannot be built from source with this preset).
+      - name: Build slang from source (PR shader-slang/slang#12089)
+        if: matrix.compiler != 'emscripten'
+        run: |
+          git clone --recursive --branch ser-abi-single-source https://github.com/shader-slang/slang slang-src
+          cd slang-src
+          cmake --preset default
+          cmake --build --preset release
+
       - name: Configure
         env:
           SLANG_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: cmake --preset ${{matrix.preset}} ${{ contains(matrix.flags, 'coverage') && '-DSLANG_RHI_ENABLE_COVERAGE=ON' || '' }}
+        run: cmake --preset ${{matrix.preset}} ${{ contains(matrix.flags, 'coverage') && '-DSLANG_RHI_ENABLE_COVERAGE=ON' || '' }} ${{ matrix.compiler != 'emscripten' && format('-DSLANG_RHI_FETCH_SLANG=OFF -DSLANG_RHI_SLANG_INCLUDE_DIR={0}/slang-src/include -DSLANG_RHI_SLANG_BINARY_DIR={0}/slang-src/build/Release', github.workspace) || '' }}
 
       - name: Build
         run: cmake --build build --config ${{matrix.config}}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,15 +99,23 @@ jobs:
           cmake --preset default
           cmake --build --preset release
 
-      # github.workspace is a backslash path on Windows (e.g. W:\ghbridge-runner\...), and
-      # CMake's if(EXISTS ...) rejects backslash escapes when the path flows into slang-rhi's
-      # copy_file(). Export a forward-slash copy of the slang-src dir for the -D paths below.
-      - name: Normalize slang-src path (forward slashes)
-        if: matrix.compiler != 'emscripten'
+      # github.workspace is a backslash path on Windows self-hosted runners
+      # (e.g. W:\ghbridge-runner\...); CMake's if(EXISTS ...) then rejects \g and
+      # similar as invalid escapes once the path reaches slang-rhi's copy_file().
+      # Export a forward-slash slang-src dir for the -D paths in Configure. The
+      # Windows runner has no bash, so normalize with cmd there and pass the
+      # already-forward-slash workspace through with bash elsewhere.
+      - name: Normalize slang-src path (non-Windows)
+        if: matrix.compiler != 'emscripten' && runner.os != 'Windows'
         shell: bash
+        run: echo "SLANG_SRC_DIR=${{ github.workspace }}/slang-src" >> "$GITHUB_ENV"
+
+      - name: Normalize slang-src path (Windows)
+        if: matrix.compiler != 'emscripten' && runner.os == 'Windows'
+        shell: cmd
         run: |
-          WS='${{ github.workspace }}'
-          echo "SLANG_SRC_DIR=${WS//\\//}/slang-src" >> "$GITHUB_ENV"
+          set "WS=${{ github.workspace }}"
+          echo SLANG_SRC_DIR=%WS:\=/%/slang-src>>%GITHUB_ENV%
 
       - name: Configure
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,10 +99,20 @@ jobs:
           cmake --preset default
           cmake --build --preset release
 
+      # github.workspace is a backslash path on Windows (e.g. W:\ghbridge-runner\...), and
+      # CMake's if(EXISTS ...) rejects backslash escapes when the path flows into slang-rhi's
+      # copy_file(). Export a forward-slash copy of the slang-src dir for the -D paths below.
+      - name: Normalize slang-src path (forward slashes)
+        if: matrix.compiler != 'emscripten'
+        shell: bash
+        run: |
+          WS='${{ github.workspace }}'
+          echo "SLANG_SRC_DIR=${WS//\\//}/slang-src" >> "$GITHUB_ENV"
+
       - name: Configure
         env:
           SLANG_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: cmake --preset ${{matrix.preset}} ${{ contains(matrix.flags, 'coverage') && '-DSLANG_RHI_ENABLE_COVERAGE=ON' || '' }} ${{ matrix.compiler != 'emscripten' && format('-DSLANG_RHI_FETCH_SLANG=OFF -DSLANG_RHI_SLANG_INCLUDE_DIR={0}/slang-src/include -DSLANG_RHI_SLANG_BINARY_DIR={0}/slang-src/build/Release', github.workspace) || '' }}
+        run: cmake --preset ${{matrix.preset}} ${{ contains(matrix.flags, 'coverage') && '-DSLANG_RHI_ENABLE_COVERAGE=ON' || '' }} ${{ matrix.compiler != 'emscripten' && format('-DSLANG_RHI_FETCH_SLANG=OFF -DSLANG_RHI_SLANG_INCLUDE_DIR={0}/include -DSLANG_RHI_SLANG_BINARY_DIR={0}/build/Release', env.SLANG_SRC_DIR) || '' }}
 
       - name: Build
         run: cmake --build build --config ${{matrix.config}}

--- a/include/slang-rhi/capabilities.h
+++ b/include/slang-rhi/capabilities.h
@@ -241,7 +241,8 @@
     x(_GL_NV_shader_subgroup_partitioned) \
     x(_GL_NV_shader_texture_footprint) \
     x(_GL_NV_cluster_acceleration_structure) \
-    x(_GL_NV_cooperative_vector)
+    x(_GL_NV_cooperative_vector) \
+    x(nvapi_hit_objects)
 // clang-format on
 
 namespace rhi {

--- a/src/d3d12/d3d12-device.cpp
+++ b/src/d3d12/d3d12-device.cpp
@@ -1076,6 +1076,10 @@ Result DeviceImpl::initialize(const DeviceDesc& desc, BackendImpl* backend)
                     reorderingCaps == NVAPI_D3D12_RAYTRACING_THREAD_REORDERING_CAP_STANDARD)
                 {
                     addFeature(Feature::ShaderExecutionReordering);
+                    // Opt into the NVAPI HitObject / SER ABI (slang `nvapi_hit_objects`, shader-slang/slang#12089).
+                    // Under that design native DXR is the default and the NVAPI HitObject ABI must be requested
+                    // explicitly. Slang releases that predate the atom silently ignore this capability.
+                    addCapability(Capability::nvapi_hit_objects);
                 }
                 NVAPI_D3D12_RAYTRACING_CLUSTER_OPERATIONS_CAPS clusterOpsCaps;
                 if (NvAPI_D3D12_GetRaytracingCaps(

--- a/tests/test-ray-tracing-clusters.cpp
+++ b/tests/test-ray-tracing-clusters.cpp
@@ -796,8 +796,6 @@ GPU_TEST_CASE("ray-tracing-cluster-tracing", D3D12 | Vulkan | CUDA)
 
 GPU_TEST_CASE("ray-tracing-cluster-tracing-hit-object", D3D12 | Vulkan | CUDA)
 {
-    SKIP_D3D12_NVAPI_WITH_SM_6_9(device);
-
     if (!device->hasFeature(Feature::RayTracing))
         SKIP("ray tracing not supported");
     if (!device->hasFeature(Feature::ClusterAccelerationStructure))

--- a/tests/test-ray-tracing-hitobject-intrinsics.cpp
+++ b/tests/test-ray-tracing-hitobject-intrinsics.cpp
@@ -166,8 +166,6 @@ void checkQueryAndInvokeResult(ISlangBlob* resultBlob)
 
 GPU_TEST_CASE("ray-tracing-hitobject-query-invoke-nop-rg", ALL)
 {
-    SKIP_D3D12_NVAPI_WITH_SM_6_9(device);
-
     if (!device->hasFeature(Feature::RayTracing))
         SKIP("ray tracing not supported");
     if (!device->hasFeature(Feature::ShaderExecutionReordering))
@@ -184,8 +182,6 @@ GPU_TEST_CASE("ray-tracing-hitobject-query-invoke-nop-rg", ALL)
 
 GPU_TEST_CASE("ray-tracing-hitobject-query-invoke-nop-ch", ALL)
 {
-    SKIP_D3D12_NVAPI_WITH_SM_6_9(device);
-
     if (!device->hasFeature(Feature::RayTracing))
         SKIP("ray tracing not supported");
     if (!device->hasFeature(Feature::ShaderExecutionReordering))
@@ -207,8 +203,6 @@ GPU_TEST_CASE("ray-tracing-hitobject-query-invoke-nop-ch", ALL)
 
 GPU_TEST_CASE("ray-tracing-hitobject-query-invoke-nop-ms", ALL)
 {
-    SKIP_D3D12_NVAPI_WITH_SM_6_9(device);
-
     if (!device->hasFeature(Feature::RayTracing))
         SKIP("ray tracing not supported");
     if (!device->hasFeature(Feature::ShaderExecutionReordering))
@@ -230,8 +224,6 @@ GPU_TEST_CASE("ray-tracing-hitobject-query-invoke-nop-ms", ALL)
 
 GPU_TEST_CASE("ray-tracing-hitobject-query-invoke-miss-rg", ALL)
 {
-    SKIP_D3D12_NVAPI_WITH_SM_6_9(device);
-
     if (!device->hasFeature(Feature::RayTracing))
         SKIP("ray tracing not supported");
     if (!device->hasFeature(Feature::ShaderExecutionReordering))
@@ -253,8 +245,6 @@ GPU_TEST_CASE("ray-tracing-hitobject-query-invoke-miss-rg", ALL)
 
 GPU_TEST_CASE("ray-tracing-hitobject-query-invoke-miss-ch", ALL)
 {
-    SKIP_D3D12_NVAPI_WITH_SM_6_9(device);
-
     if (!device->hasFeature(Feature::RayTracing))
         SKIP("ray tracing not supported");
     if (!device->hasFeature(Feature::ShaderExecutionReordering))
@@ -276,8 +266,6 @@ GPU_TEST_CASE("ray-tracing-hitobject-query-invoke-miss-ch", ALL)
 
 GPU_TEST_CASE("ray-tracing-hitobject-query-invoke-miss-ms", ALL)
 {
-    SKIP_D3D12_NVAPI_WITH_SM_6_9(device);
-
     if (!device->hasFeature(Feature::RayTracing))
         SKIP("ray tracing not supported");
     if (!device->hasFeature(Feature::ShaderExecutionReordering))
@@ -299,8 +287,6 @@ GPU_TEST_CASE("ray-tracing-hitobject-query-invoke-miss-ms", ALL)
 
 GPU_TEST_CASE("ray-tracing-hitobject-query-invoke-hit-rg", ALL)
 {
-    SKIP_D3D12_NVAPI_WITH_SM_6_9(device);
-
     if (!device->hasFeature(Feature::RayTracing))
         SKIP("ray tracing not supported");
     if (!device->hasFeature(Feature::ShaderExecutionReordering))
@@ -322,8 +308,6 @@ GPU_TEST_CASE("ray-tracing-hitobject-query-invoke-hit-rg", ALL)
 
 GPU_TEST_CASE("ray-tracing-hitobject-query-invoke-hit-ch", ALL)
 {
-    SKIP_D3D12_NVAPI_WITH_SM_6_9(device);
-
     if (!device->hasFeature(Feature::RayTracing))
         SKIP("ray tracing not supported");
     if (!device->hasFeature(Feature::ShaderExecutionReordering))
@@ -345,8 +329,6 @@ GPU_TEST_CASE("ray-tracing-hitobject-query-invoke-hit-ch", ALL)
 
 GPU_TEST_CASE("ray-tracing-hitobject-query-invoke-hit-ms", ALL)
 {
-    SKIP_D3D12_NVAPI_WITH_SM_6_9(device);
-
     if (!device->hasFeature(Feature::RayTracing))
         SKIP("ray tracing not supported");
     if (!device->hasFeature(Feature::ShaderExecutionReordering))
@@ -368,8 +350,6 @@ GPU_TEST_CASE("ray-tracing-hitobject-query-invoke-hit-ms", ALL)
 
 GPU_TEST_CASE("ray-tracing-hitobject-query-hit-kind-front-face", ALL)
 {
-    SKIP_D3D12_NVAPI_WITH_SM_6_9(device);
-
     if (!device->hasFeature(Feature::RayTracing))
         SKIP("ray tracing not supported");
     if (!device->hasFeature(Feature::ShaderExecutionReordering))
@@ -391,8 +371,6 @@ GPU_TEST_CASE("ray-tracing-hitobject-query-hit-kind-front-face", ALL)
 
 GPU_TEST_CASE("ray-tracing-hitobject-query-hit-kind-back-face", ALL)
 {
-    SKIP_D3D12_NVAPI_WITH_SM_6_9(device);
-
     if (!device->hasFeature(Feature::RayTracing))
         SKIP("ray tracing not supported");
     if (!device->hasFeature(Feature::ShaderExecutionReordering))
@@ -414,8 +392,6 @@ GPU_TEST_CASE("ray-tracing-hitobject-query-hit-kind-back-face", ALL)
 
 GPU_TEST_CASE("ray-tracing-hitobject-query-hit-kind-custom", ALL)
 {
-    SKIP_D3D12_NVAPI_WITH_SM_6_9(device);
-
     if (!device->hasFeature(Feature::RayTracing))
         SKIP("ray tracing not supported");
     if (!device->hasFeature(Feature::ShaderExecutionReordering))
@@ -518,8 +494,6 @@ GPU_TEST_CASE("ray-tracing-hitobject-make-hit", ALL | DontCreateDevice)
 
 GPU_TEST_CASE("ray-tracing-hitobject-make-miss", ALL)
 {
-    SKIP_D3D12_NVAPI_WITH_SM_6_9(device);
-
     if (!device->hasFeature(Feature::RayTracing))
         SKIP("ray tracing not supported");
     if (!device->hasFeature(Feature::ShaderExecutionReordering))
@@ -536,8 +510,6 @@ GPU_TEST_CASE("ray-tracing-hitobject-make-miss", ALL)
 
 GPU_TEST_CASE("ray-tracing-hitobject-make-motion-miss", ALL)
 {
-    SKIP_D3D12_NVAPI_WITH_SM_6_9(device);
-
     if (!device->hasFeature(Feature::RayTracing))
         SKIP("ray tracing not supported");
     if (!device->hasFeature(Feature::ShaderExecutionReordering))
@@ -593,8 +565,6 @@ GPU_TEST_CASE("ray-tracing-hitobject-make-motion-hit", ALL | DontCreateDevice)
 
 GPU_TEST_CASE("ray-tracing-hitobject-trace-motion-ray", ALL)
 {
-    SKIP_D3D12_NVAPI_WITH_SM_6_9(device);
-
     if (!device->hasFeature(Feature::RayTracing))
         SKIP("ray tracing not supported");
     if (!device->hasFeature(Feature::ShaderExecutionReordering))
@@ -623,7 +593,6 @@ GPU_TEST_CASE("ray-tracing-hitobject-trace-motion-ray", ALL)
 
 GPU_TEST_CASE("ray-tracing-hitobject-query-ray-desc", ALL)
 {
-    SKIP_D3D12_NVAPI_WITH_SM_6_9(device);
     if (device->getDeviceType() == DeviceType::D3D12 && device->hasFeature(Feature::SM_6_9) &&
         !device->hasCapability(Capability::hlsl_nvapi))
         SKIP("Skipping due to slang bug");
@@ -644,8 +613,6 @@ GPU_TEST_CASE("ray-tracing-hitobject-query-ray-desc", ALL)
 
 GPU_TEST_CASE("ray-tracing-hitobject-query-instance-id", ALL)
 {
-    SKIP_D3D12_NVAPI_WITH_SM_6_9(device);
-
     if (!device->hasFeature(Feature::RayTracing))
         SKIP("ray tracing not supported");
     if (!device->hasFeature(Feature::ShaderExecutionReordering))
@@ -688,8 +655,6 @@ GPU_TEST_CASE("ray-tracing-hitobject-set-and-get-shader-table-index", CUDA /*| D
 
 GPU_TEST_CASE("ray-tracing-hitobject-load-local-root-table-constant", D3D12 | CUDA)
 {
-    SKIP_D3D12_NVAPI_WITH_SM_6_9(device);
-
     if (!device->hasFeature(Feature::RayTracing))
         SKIP("ray tracing not supported");
     if (!device->hasFeature(Feature::ShaderExecutionReordering))

--- a/tests/test-ray-tracing-lss.cpp
+++ b/tests/test-ray-tracing-lss.cpp
@@ -238,8 +238,6 @@ GPU_TEST_CASE("ray-tracing-lss-intrinsics", ALL)
 
 GPU_TEST_CASE("ray-tracing-lss-intrinsics-hit-object", ALL)
 {
-    SKIP_D3D12_NVAPI_WITH_SM_6_9(device);
-
     if (!device->hasFeature(Feature::RayTracing))
         SKIP("ray tracing not supported");
     if (!device->hasFeature(Feature::AccelerationStructureLinearSweptSpheres))

--- a/tests/test-ray-tracing-reorder.cpp
+++ b/tests/test-ray-tracing-reorder.cpp
@@ -125,8 +125,6 @@ struct RayTracingTriangleReorderTest
 
 GPU_TEST_CASE("ray-tracing-reorder-hint", ALL)
 {
-    SKIP_D3D12_NVAPI_WITH_SM_6_9(device);
-
     if (!device->hasFeature(Feature::RayTracing))
         SKIP("ray tracing not supported");
     if (!device->hasFeature(Feature::ShaderExecutionReordering))
@@ -139,8 +137,6 @@ GPU_TEST_CASE("ray-tracing-reorder-hint", ALL)
 
 GPU_TEST_CASE("ray-tracing-reorder-hit-obj", ALL)
 {
-    SKIP_D3D12_NVAPI_WITH_SM_6_9(device);
-
     if (!device->hasFeature(Feature::RayTracing))
         SKIP("ray tracing not supported");
     if (!device->hasFeature(Feature::ShaderExecutionReordering))
@@ -153,8 +149,6 @@ GPU_TEST_CASE("ray-tracing-reorder-hit-obj", ALL)
 
 GPU_TEST_CASE("ray-tracing-reorder-hit-obj-and-hint", ALL)
 {
-    SKIP_D3D12_NVAPI_WITH_SM_6_9(device);
-
     if (!device->hasFeature(Feature::RayTracing))
         SKIP("ray tracing not supported");
     if (!device->hasFeature(Feature::ShaderExecutionReordering))

--- a/tests/test-ray-tracing-sphere.cpp
+++ b/tests/test-ray-tracing-sphere.cpp
@@ -238,8 +238,6 @@ GPU_TEST_CASE("ray-tracing-sphere-intrinsics", ALL)
 
 GPU_TEST_CASE("ray-tracing-sphere-intrinsics-hit-object", ALL)
 {
-    SKIP_D3D12_NVAPI_WITH_SM_6_9(device);
-
     if (!device->hasFeature(Feature::RayTracing))
         SKIP("ray tracing not supported");
     if (!device->hasFeature(Feature::AccelerationStructureSpheres))

--- a/tests/testing.cpp
+++ b/tests/testing.cpp
@@ -775,15 +775,6 @@ ComPtr<IDevice> createTestingDevice(
             extDesc.highestShaderModel = options().d3d12ShaderModel;
             requireSpecificD3D12ShaderModel = true;
         }
-        else
-        {
-            // TODO: Slang current emits invalid HitObject code when D3D12 SM 6.9 and NVAPI are enabled.
-            // https://github.com/shader-slang/slang/issues/11903
-            // We currently default testing to cap at SM 6.8 to avoid this issue,
-            // but ideally we should be able to test SM 6.9 with NVAPI enabled.
-            // We can test SM 6.9 with/without NVAPI using -d3d12-shader-model and -d3d12-disable-nvapi cli options.
-            extDesc.highestShaderModel = 0x68;
-        }
         deviceDesc.next = &extDesc;
     }
 

--- a/tests/testing.h
+++ b/tests/testing.h
@@ -524,19 +524,6 @@ bool checkNoSilentGpuSkips();
 #define GPU_TEST_CASE_EX(name, flags, debugLayerOptions)                                                               \
     GPU_TEST_CASE_IMPL(name, DOCTEST_ANONYMOUS(GPU_TEST_ANONYMOUS_), flags, debugLayerOptions)
 
-// TODO: Slang current emits invalid HitObject code when D3D12 SM 6.9 and NVAPI are enabled.
-// https://github.com/shader-slang/slang/issues/11903
-#define SKIP_D3D12_NVAPI_WITH_SM_6_9(device)                                                                           \
-    do                                                                                                                 \
-    {                                                                                                                  \
-        if (device && device->getDeviceType() == ::rhi::DeviceType::D3D12 &&                                           \
-            device->hasFeature(::rhi::Feature::SM_6_9) && device->hasCapability(::rhi::Capability::hlsl_nvapi))        \
-        {                                                                                                              \
-            SKIP("Slang generates invalid HitObject code when D3D12 SM 6.9 and NVAPI are enabled");                    \
-        }                                                                                                              \
-    }                                                                                                                  \
-    while (0)
-
 #define CHECK_CALL(x) CHECK(!SLANG_FAILED(x))
 #define REQUIRE_CALL(x) REQUIRE(!SLANG_FAILED(x))
 


### PR DESCRIPTION
Depends on shader-slang/slang#12089 (the `nvapi_hit_objects` single-source SER-ABI design). **Draft** — includes a temporary CI commit and cannot merge until #12089 is released.

## What

1. **Opt into the NVAPI HitObject ABI via `nvapi_hit_objects`.** slang#12089 makes NVAPI HitObject an explicit opt-in (native DXR 1.3 / SM 6.9 is now the default). D3D12 devices that expose NVAPI thread reordering now request the `nvapi_hit_objects` capability so HitObject keeps lowering to the NVAPI ABI. Slang releases predating the atom silently ignore it (`src/slang-context.h` skips capabilities unknown to the slang session), so this is safe against older slang.

2. **Remove the SM 6.9 + NVAPI HitObject workaround.** With #12089 the HitObject type and every op consult one ABI decision, so D3D12 SM 6.9 + NVAPI no longer emits mixed `dx::HitObject`/NVAPI HLSL. Drops `SKIP_D3D12_NVAPI_WITH_SM_6_9` (macro + all call sites) and the SM 6.8 test cap (testing uses the device's highest supported shader model again). The inline `ray-tracing-hitobject-query-ray-desc` skip is **kept** — its native (non-NVAPI) path still hits a separate, unfixed slang issue.

3. **TEMP: build slang from the #12089 branch for CI.** `nvapi_hit_objects` isn't in any slang release yet, so CI builds slang from `ser-abi-single-source` (`SLANG_RHI_FETCH_SLANG=OFF`) on all jobs except Emscripten (whose wasm libs can't be built from source here). **Revert this commit and pin the slang release once #12089 merges and is cut.**

## Validation

Codegen verified on macOS against a #12089 slang build — this is a shader-emission change, so no D3D12 device is needed to confirm the ABI selection:

| scenario | result |
| --- | --- |
| `nvapi_hit_objects` + SM 6.9 | clean `NvHitObject` (NVAPI ABI) |
| plain `hlsl_nvapi` + SM 6.9 (atomics, no opt-in) | native `dx::HitObject` |
| 2-arg native `Invoke` under `nvapi_hit_objects` | clean `E41400` diagnostic |
| native `query-ray-desc` | still errors → inline skip retained |

Runtime NVAPI SER at SM 6.9 is exercised by this PR's CI on the D3D12 self-hosted runners, **subject to the runner actually exposing SM 6.9** (needs a preview Agility SDK; otherwise these jobs run at SM 6.8).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
