### PR TITLE
test-ray-tracing-clusters.slang: Fix a float4() initialization

### DIFF
--- a/tests/test-ray-tracing-clusters.slang
+++ b/tests/test-ray-tracing-clusters.slang
@@ -71,7 +71,7 @@ void rayGenClustersHitObject()
 
     // Color
     BuiltInTriangleIntersectionAttributes attribs = hit.GetAttributes<BuiltInTriangleIntersectionAttributes>();
-    resultTexture[pixel] = float4(attribs.barycentrics, 1.f);
+    resultTexture[pixel] = float4(attribs.barycentrics, 1.f, 1.f);
 
     // IDs
     uint index = pixel.y * dim.x + pixel.x;


### PR DESCRIPTION
The shader initializes a float4 vector by using float2,float arguments. Pass the float argument twice to avoid relying on the implicit float->float2 conversion.

Fixes #798