### PR TITLE
Temporarily disable metallib_4_0 capability

### DIFF
--- a/src/metal/metal-device.cpp
+++ b/src/metal/metal-device.cpp
@@ -263,8 +263,8 @@ Result DeviceImpl::initialize(const DeviceDesc& desc, BackendImpl* backend)
         addCapability(Capability::metallib_3_1);
     if (osVersion.majorVersion >= 15)
         addCapability(Capability::metallib_3_2);
-    if (osVersion.majorVersion >= 26)
-        addCapability(Capability::metallib_4_0);
+    // TODO: Re-enable once Slang passes -std=metal4.0 to the downstream Metal compiler.
+    // Slang 2026.12.2 emits Metal 4.0-only attributes when this capability is enabled.
 
     auto supportsAnyGPUFamilyInRange = [&](MTL::GPUFamily first, MTL::GPUFamily last)
     {

--- a/src/metal/metal-device.cpp
+++ b/src/metal/metal-device.cpp
@@ -265,6 +265,9 @@ Result DeviceImpl::initialize(const DeviceDesc& desc, BackendImpl* backend)
         addCapability(Capability::metallib_3_2);
     // TODO: Re-enable once Slang passes -std=metal4.0 to the downstream Metal compiler.
     // Slang 2026.12.2 emits Metal 4.0-only attributes when this capability is enabled.
+    // https://github.com/shader-slang/slang/issues/12325
+    // if (osVersion.majorVersion >= 26)
+    //     addCapability(Capability::metallib_4_0);
 
     auto supportsAnyGPUFamilyInRange = [&](MTL::GPUFamily first, MTL::GPUFamily last)
     {

--- a/tests/test-device-features.cpp
+++ b/tests/test-device-features.cpp
@@ -78,6 +78,7 @@ GPU_TEST_CASE("metal-device-capabilities", Metal)
     CHECK(device->hasCapability(Capability::metallib_3_0) == (macOSMajorVersion >= 13));
     CHECK(device->hasCapability(Capability::metallib_3_1) == (macOSMajorVersion >= 14));
     CHECK(device->hasCapability(Capability::metallib_3_2) == (macOSMajorVersion >= 15));
-    CHECK(device->hasCapability(Capability::metallib_4_0) == (macOSMajorVersion >= 26));
+    // Temporarily disabled until Slang's Metal 4.0 output selects the Metal 4.0 downstream language standard.
+    CHECK_FALSE(device->hasCapability(Capability::metallib_4_0));
 }
 #endif

--- a/tests/test-device-features.cpp
+++ b/tests/test-device-features.cpp
@@ -78,7 +78,8 @@ GPU_TEST_CASE("metal-device-capabilities", Metal)
     CHECK(device->hasCapability(Capability::metallib_3_0) == (macOSMajorVersion >= 13));
     CHECK(device->hasCapability(Capability::metallib_3_1) == (macOSMajorVersion >= 14));
     CHECK(device->hasCapability(Capability::metallib_3_2) == (macOSMajorVersion >= 15));
-    // Temporarily disabled until Slang's Metal 4.0 output selects the Metal 4.0 downstream language standard.
-    CHECK_FALSE(device->hasCapability(Capability::metallib_4_0));
+    // TODO: Temporarily disabled until Slang's Metal 4.0 output selects the Metal 4.0 downstream language standard.
+    // https://github.com/shader-slang/slang/issues/12325
+    // CHECK(device->hasCapability(Capability::metallib_4_0) == (macOSMajorVersion >= 26));
 }
 #endif


### PR DESCRIPTION
This is a workaround for a Slang bug.