### PR TITLE
Do not cache shader object layouts keyed on a caller-supplied type layout

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1067,6 +1067,7 @@ if(SLANG_RHI_BUILD_TESTS AND NOT SLANG_RHI_BUILD_SHARED AND NOT EMSCRIPTEN)
         tests/test-sampler.cpp
         tests/test-sha1.cpp
         tests/test-shader-cache.cpp
+        tests/test-shader-object-from-type-layout.cpp
         tests/test-shader-object-large.cpp
         tests/test-shader-object-resource-tracking.cpp
         tests/test-ring-queue.cpp

--- a/src/device.cpp
+++ b/src/device.cpp
@@ -12,6 +12,11 @@ namespace rhi {
 namespace testing {
 bool gDebugDisableStateTracking = false;
 std::atomic<uint64_t> gResourceCount{0};
+
+size_t getShaderObjectLayoutCacheSize(IDevice* device)
+{
+    return checked_cast<Device*>(device)->m_shaderObjectLayoutCache.size();
+}
 } // namespace testing
 
 // ----------------------------------------------------------------------------
@@ -784,8 +789,25 @@ Result Device::createShaderObject(
 
 Result Device::createShaderObjectFromTypeLayout(slang::TypeLayoutReflection* typeLayout, IShaderObject** outObject)
 {
+    // Build the layout directly rather than going through m_shaderObjectLayoutCache.
+    //
+    // That cache is keyed on a raw `slang::TypeLayoutReflection*` and lives as
+    // long as the `Device`. Every other way in supplies a key obtained from
+    // `ISession::getTypeLayout`, which the `Linkage` owns, so the entry's
+    // `ComPtr<slang::ISession>` genuinely covers the key's lifetime. Here the key
+    // comes from the caller, and in practice it is a layout owned by a
+    // `TargetProgram` -- an object slang-rhi holds no reference to and knows
+    // nothing about. Caching it leaves an entry that outlives the layout as soon
+    // as the caller releases its program, and a later allocation landing on the
+    // recycled address turns the next lookup into a use-after-free
+    // (shader-slang/slang#10893).
+    //
+    // slang-rhi cannot vouch for the lifetime of a pointer it was handed, so it
+    // must not retain one past the call. Skipping the cache here keeps every
+    // cached key session-owned, which makes the existing session reference
+    // load-bearing rather than incidental.
     RefPtr<ShaderObjectLayout> shaderObjectLayout;
-    SLANG_RETURN_ON_FAIL(getShaderObjectLayout(m_slangContext.session, typeLayout, shaderObjectLayout.writeRef()));
+    SLANG_RETURN_ON_FAIL(createShaderObjectLayout(m_slangContext.session, typeLayout, shaderObjectLayout.writeRef()));
     RefPtr<ShaderObject> shaderObject;
     SLANG_RETURN_ON_FAIL(createShaderObject(shaderObjectLayout, shaderObject.writeRef()));
     returnComPtr(outObject, shaderObject);

--- a/src/device.cpp
+++ b/src/device.cpp
@@ -3,6 +3,7 @@
 #include "rhi-shared.h"
 #include "shader.h"
 #include "heap.h"
+#include "debug-layer/debug-device.h"
 
 #include <algorithm>
 #include <cstdarg>
@@ -15,6 +16,13 @@ std::atomic<uint64_t> gResourceCount{0};
 
 size_t getShaderObjectLayoutCacheSize(IDevice* device)
 {
+    // Unwrap the debug layer here rather than requiring callers to do it. Tests hold
+    // whatever createDevice returned, which is the wrapper whenever validation is
+    // enabled, and the cost of forgetting is uneven: checked_cast only verifies the
+    // downcast under SLANG_RHI_DEBUG, so a wrapper reaching it aborts in debug builds
+    // but silently reads a bogus pointer in release ones.
+    if (auto debugDevice = dynamic_cast<debug::DebugDevice*>(device))
+        device = debugDevice->baseObject.get();
     return checked_cast<Device*>(device)->m_shaderObjectLayoutCache.size();
 }
 } // namespace testing
@@ -789,23 +797,13 @@ Result Device::createShaderObject(
 
 Result Device::createShaderObjectFromTypeLayout(slang::TypeLayoutReflection* typeLayout, IShaderObject** outObject)
 {
-    // Build the layout directly rather than going through m_shaderObjectLayoutCache.
+    // Build the layout directly rather than caching it.
     //
-    // That cache is keyed on a raw `slang::TypeLayoutReflection*` and lives as
-    // long as the `Device`. Every other way in supplies a key obtained from
-    // `ISession::getTypeLayout`, which the `Linkage` owns, so the entry's
-    // `ComPtr<slang::ISession>` genuinely covers the key's lifetime. Here the key
-    // comes from the caller, and in practice it is a layout owned by a
-    // `TargetProgram` -- an object slang-rhi holds no reference to and knows
-    // nothing about. Caching it leaves an entry that outlives the layout as soon
-    // as the caller releases its program, and a later allocation landing on the
-    // recycled address turns the next lookup into a use-after-free
-    // (shader-slang/slang#10893).
-    //
-    // slang-rhi cannot vouch for the lifetime of a pointer it was handed, so it
-    // must not retain one past the call. Skipping the cache here keeps every
-    // cached key session-owned, which makes the existing session reference
-    // load-bearing rather than incidental.
+    // m_shaderObjectLayoutCache requires session-owned keys (see the invariant on its
+    // declaration). `typeLayout` comes from the caller instead, and in practice belongs
+    // to a `TargetProgram` that slang-rhi holds no reference to, so it does not qualify.
+    // More generally, slang-rhi cannot vouch for the lifetime of a pointer it was handed
+    // and so must not retain one past this call.
     RefPtr<ShaderObjectLayout> shaderObjectLayout;
     SLANG_RETURN_ON_FAIL(createShaderObjectLayout(m_slangContext.session, typeLayout, shaderObjectLayout.writeRef()));
     RefPtr<ShaderObject> shaderObject;
@@ -1112,18 +1110,12 @@ Result Device::getShaderObjectLayout(
         break;
     }
 
+    // Deriving the key here, rather than accepting one, is what keeps the cache
+    // safe: `getTypeLayout` returns a layout owned by the `Linkage`, and the entry
+    // records a strong reference to that same session below, so the key cannot
+    // outlive the entry. See the invariant on m_shaderObjectLayoutCache.
     auto typeLayout = session->getTypeLayout(type);
-    SLANG_RETURN_ON_FAIL(getShaderObjectLayout(session, typeLayout, outLayout));
-    (*outLayout)->m_slangSession = session;
-    return SLANG_OK;
-}
 
-Result Device::getShaderObjectLayout(
-    slang::ISession* session,
-    slang::TypeLayoutReflection* typeLayout,
-    ShaderObjectLayout** outLayout
-)
-{
     RefPtr<ShaderObjectLayout> shaderObjectLayout;
     auto it = m_shaderObjectLayoutCache.find(typeLayout);
     if (it != m_shaderObjectLayoutCache.end())
@@ -1136,6 +1128,7 @@ Result Device::getShaderObjectLayout(
         m_shaderObjectLayoutCache.emplace(typeLayout, shaderObjectLayout);
     }
     *outLayout = shaderObjectLayout.detach();
+    (*outLayout)->m_slangSession = session;
     return SLANG_OK;
 }
 

--- a/src/device.h
+++ b/src/device.h
@@ -26,6 +26,10 @@ namespace testing {
 extern bool gDebugDisableStateTracking;
 // Counter for tracking active Resource instances (for testing deferred delete)
 extern std::atomic<uint64_t> gResourceCount;
+// Number of entries in the device's shader object layout cache. Exposed so tests
+// can assert that createShaderObjectFromTypeLayout does not retain the caller's
+// TypeLayoutReflection pointer (shader-slang/slang#10893).
+size_t getShaderObjectLayoutCacheSize(IDevice* device);
 } // namespace testing
 
 // Base class for adapters.

--- a/src/device.h
+++ b/src/device.h
@@ -26,9 +26,8 @@ namespace testing {
 extern bool gDebugDisableStateTracking;
 // Counter for tracking active Resource instances (for testing deferred delete)
 extern std::atomic<uint64_t> gResourceCount;
-// Number of entries in the device's shader object layout cache. Exposed so tests
-// can assert that createShaderObjectFromTypeLayout does not retain the caller's
-// TypeLayoutReflection pointer (shader-slang/slang#10893).
+// Returns the number of entries in the device's shader object layout cache.
+// Accepts either a device or its debug-layer wrapper.
 size_t getShaderObjectLayoutCacheSize(IDevice* device);
 } // namespace testing
 
@@ -381,16 +380,16 @@ public:
         slang::IBlob** outDiagnostics = nullptr
     );
 
+    /// Returns the cached shader object layout for `type` in `session`, creating it
+    /// on first use.
+    ///
+    /// Takes a type rather than a type layout deliberately: the cache key must be a
+    /// session-owned layout, so this derives it internally instead of accepting one
+    /// from the caller. See the invariant on m_shaderObjectLayoutCache.
     Result getShaderObjectLayout(
         slang::ISession* session,
         slang::TypeReflection* type,
         ShaderObjectContainerType container,
-        ShaderObjectLayout** outLayout
-    );
-
-    Result getShaderObjectLayout(
-        slang::ISession* session,
-        slang::TypeLayoutReflection* typeLayout,
         ShaderObjectLayout** outLayout
     );
 
@@ -474,6 +473,25 @@ public:
     ComPtr<IPersistentCache> m_persistentShaderCache;
     ComPtr<IPersistentCache> m_persistentPipelineCache;
 
+    /// Shader object layouts, keyed by the type layout they were built from.
+    ///
+    /// The key is a raw pointer this cache does not own, and entries live as long as
+    /// the device, so an entry is only sound while the object owning its key is still
+    /// alive. What guarantees that is the strong `ISession` reference each entry holds
+    /// via ShaderObjectLayout::m_slangSession: a layout obtained from
+    /// `ISession::getTypeLayout` belongs to the `Linkage` and so lives at least as long
+    /// as that reference.
+    ///
+    /// The invariant is therefore that every key is a session-owned layout, and it is
+    /// enforced structurally: getShaderObjectLayout is the only path that inserts here,
+    /// and it derives the key from the session itself rather than accepting one.
+    ///
+    /// A layout reached through `IComponentType::getLayout()` belongs to the
+    /// `TargetProgram`, not the session, and must never become a key: releasing the
+    /// program would leave the entry dangling, and a later allocation reusing that
+    /// address turns the next lookup into a use-after-free. That is
+    /// shader-slang/slang#10893, which is why createShaderObjectFromTypeLayout builds
+    /// its layout directly instead of caching one.
     std::map<slang::TypeLayoutReflection*, RefPtr<ShaderObjectLayout>> m_shaderObjectLayoutCache;
 
     // List of heaps managed by this device. DeviceImpl is expected

--- a/tests/test-shader-object-from-type-layout.cpp
+++ b/tests/test-shader-object-from-type-layout.cpp
@@ -19,7 +19,7 @@ using namespace rhi::testing;
 //
 // The failure that follows from that is a use-after-free whose visibility
 // depends on the allocator handing the freed address back out, so testing for
-// it directly means testing for "ASan happened to stay quiet" — which is exactly
+// it directly means testing for "ASan happened to stay quiet" - which is exactly
 // how these findings were previously written off as fixed. This asserts the
 // invariant instead: slang-rhi must not retain a `TypeLayoutReflection*` it was
 // handed. That fails deterministically, on every platform, sanitizer or not.

--- a/tests/test-shader-object-from-type-layout.cpp
+++ b/tests/test-shader-object-from-type-layout.cpp
@@ -54,6 +54,7 @@ GPU_TEST_CASE("shader-object-from-type-layout-not-cached", ALL)
     // repeated calls, not just an insert on the first one.
     ComPtr<IShaderObject> secondShaderObject;
     REQUIRE_CALL(device->createShaderObjectFromTypeLayout(typeLayout, secondShaderObject.writeRef()));
+    REQUIRE(secondShaderObject != nullptr);
 
     // The device must not have retained the caller's type layout.
     CHECK_EQ(getShaderObjectLayoutCacheSize(device), cacheSizeBefore);

--- a/tests/test-shader-object-from-type-layout.cpp
+++ b/tests/test-shader-object-from-type-layout.cpp
@@ -1,9 +1,20 @@
 #include "testing.h"
 
 #include "device.h"
+#include "debug-layer/debug-device.h"
 
 using namespace rhi;
 using namespace rhi::testing;
+
+// When validation is enabled the test receives the debug-layer wrapper rather
+// than the device that owns the cache, so unwrap it first. Same idiom as
+// test-cmd-upload-buffer.cpp.
+static IDevice* getInnerDevice(IDevice* device)
+{
+    if (auto debugDevice = dynamic_cast<debug::DebugDevice*>(device))
+        return debugDevice->baseObject.get();
+    return device;
+}
 
 // Regression test for shader-slang/slang#10893.
 //
@@ -49,7 +60,8 @@ GPU_TEST_CASE("shader-object-from-type-layout-not-cached", ALL)
     }
     REQUIRE(typeLayout != nullptr);
 
-    const size_t cacheSizeBefore = getShaderObjectLayoutCacheSize(device);
+    IDevice* innerDevice = getInnerDevice(device);
+    const size_t cacheSizeBefore = getShaderObjectLayoutCacheSize(innerDevice);
 
     ComPtr<IShaderObject> shaderObject;
     REQUIRE_CALL(device->createShaderObjectFromTypeLayout(typeLayout, shaderObject.writeRef()));
@@ -61,5 +73,5 @@ GPU_TEST_CASE("shader-object-from-type-layout-not-cached", ALL)
     ComPtr<IShaderObject> secondShaderObject;
     REQUIRE_CALL(device->createShaderObjectFromTypeLayout(typeLayout, secondShaderObject.writeRef()));
 
-    CHECK_EQ(getShaderObjectLayoutCacheSize(device), cacheSizeBefore);
+    CHECK_EQ(getShaderObjectLayoutCacheSize(innerDevice), cacheSizeBefore);
 }

--- a/tests/test-shader-object-from-type-layout.cpp
+++ b/tests/test-shader-object-from-type-layout.cpp
@@ -1,0 +1,65 @@
+#include "testing.h"
+
+#include "device.h"
+
+using namespace rhi;
+using namespace rhi::testing;
+
+// Regression test for shader-slang/slang#10893.
+//
+// `Device::m_shaderObjectLayoutCache` is keyed on a raw
+// `slang::TypeLayoutReflection*` and lives as long as the `Device`. Every other
+// way into that cache supplies a key obtained from `ISession::getTypeLayout`,
+// which the `Linkage` owns, so the entry's `ComPtr<slang::ISession>` covers the
+// key. `createShaderObjectFromTypeLayout` is different: the key comes from the
+// caller, and in practice it is a layout owned by a `TargetProgram`. Caching it
+// leaves an entry that outlives the layout as soon as the caller releases its
+// program, and a later allocation landing on the recycled address turns the next
+// lookup into a use-after-free.
+//
+// The failure that follows from that is a use-after-free whose visibility
+// depends on the allocator handing the freed address back out, so testing for
+// it directly means testing for "ASan happened to stay quiet" — which is exactly
+// how these findings were previously written off as fixed. This asserts the
+// invariant instead: slang-rhi must not retain a `TypeLayoutReflection*` it was
+// handed. That fails deterministically, on every platform, sanitizer or not.
+GPU_TEST_CASE("shader-object-from-type-layout-not-cached", ALL)
+{
+    ComPtr<IShaderProgram> shaderProgram;
+    REQUIRE_CALL(loadProgram(device, "test-shader-object-from-type-layout", "computeMain", shaderProgram.writeRef()));
+
+    // Reach the layout through the program's own component, which is what makes
+    // the resulting TypeLayoutReflection owned by the TargetProgram rather than
+    // by the session.
+    slang::IComponentType* globalScope = shaderProgram->getDesc().slangGlobalScope;
+    REQUIRE(globalScope != nullptr);
+    slang::ProgramLayout* programLayout = globalScope->getLayout(0);
+    REQUIRE(programLayout != nullptr);
+
+    // Reach the `Params` element type layout the way a caller would: through the
+    // program's own layout, not through the session.
+    slang::VariableLayoutReflection* paramsVar = programLayout->getParameterByIndex(0);
+    REQUIRE(paramsVar != nullptr);
+    slang::TypeLayoutReflection* typeLayout = paramsVar->getTypeLayout();
+    REQUIRE(typeLayout != nullptr);
+    if (typeLayout->getKind() == slang::TypeReflection::Kind::ConstantBuffer ||
+        typeLayout->getKind() == slang::TypeReflection::Kind::ParameterBlock)
+    {
+        typeLayout = typeLayout->getElementTypeLayout();
+    }
+    REQUIRE(typeLayout != nullptr);
+
+    const size_t cacheSizeBefore = getShaderObjectLayoutCacheSize(device);
+
+    ComPtr<IShaderObject> shaderObject;
+    REQUIRE_CALL(device->createShaderObjectFromTypeLayout(typeLayout, shaderObject.writeRef()));
+    REQUIRE(shaderObject != nullptr);
+
+    // The device must not have taken a reference to the caller's pointer. A
+    // second call is included because a cache would only be observable on the
+    // insert, and this also pins the "no reuse across calls" behaviour.
+    ComPtr<IShaderObject> secondShaderObject;
+    REQUIRE_CALL(device->createShaderObjectFromTypeLayout(typeLayout, secondShaderObject.writeRef()));
+
+    CHECK_EQ(getShaderObjectLayoutCacheSize(device), cacheSizeBefore);
+}

--- a/tests/test-shader-object-from-type-layout.cpp
+++ b/tests/test-shader-object-from-type-layout.cpp
@@ -1,39 +1,23 @@
 #include "testing.h"
 
 #include "device.h"
-#include "debug-layer/debug-device.h"
 
 using namespace rhi;
 using namespace rhi::testing;
 
-// When validation is enabled the test receives the debug-layer wrapper rather
-// than the device that owns the cache, so unwrap it first. Same idiom as
-// test-cmd-upload-buffer.cpp.
-static IDevice* getInnerDevice(IDevice* device)
-{
-    if (auto debugDevice = dynamic_cast<debug::DebugDevice*>(device))
-        return debugDevice->baseObject.get();
-    return device;
-}
-
 // Regression test for shader-slang/slang#10893.
 //
-// `Device::m_shaderObjectLayoutCache` is keyed on a raw
-// `slang::TypeLayoutReflection*` and lives as long as the `Device`. Every other
-// way into that cache supplies a key obtained from `ISession::getTypeLayout`,
-// which the `Linkage` owns, so the entry's `ComPtr<slang::ISession>` covers the
-// key. `createShaderObjectFromTypeLayout` is different: the key comes from the
-// caller, and in practice it is a layout owned by a `TargetProgram`. Caching it
-// leaves an entry that outlives the layout as soon as the caller releases its
-// program, and a later allocation landing on the recycled address turns the next
-// lookup into a use-after-free.
+// The rule being defended is the m_shaderObjectLayoutCache invariant documented in
+// device.h: every cache key must be a session-owned layout. This test covers the one
+// entry point that takes a layout from the caller, where that rule cannot be met,
+// and so must not cache at all.
 //
-// The failure that follows from that is a use-after-free whose visibility
-// depends on the allocator handing the freed address back out, so testing for
-// it directly means testing for "ASan happened to stay quiet" - which is exactly
-// how these findings were previously written off as fixed. This asserts the
-// invariant instead: slang-rhi must not retain a `TypeLayoutReflection*` it was
-// handed. That fails deterministically, on every platform, sanitizer or not.
+// It asserts the invariant rather than the symptom on purpose. The symptom is a
+// use-after-free that only becomes visible when the allocator hands the freed address
+// back out, so testing for it amounts to testing that a sanitizer happened to stay
+// quiet - which is how this issue was previously written off as fixed. Checking that
+// the device did not retain the pointer fails deterministically instead, on every
+// platform, with or without a sanitizer.
 GPU_TEST_CASE("shader-object-from-type-layout-not-cached", ALL)
 {
     ComPtr<IShaderProgram> shaderProgram;
@@ -60,18 +44,17 @@ GPU_TEST_CASE("shader-object-from-type-layout-not-cached", ALL)
     }
     REQUIRE(typeLayout != nullptr);
 
-    IDevice* innerDevice = getInnerDevice(device);
-    const size_t cacheSizeBefore = getShaderObjectLayoutCacheSize(innerDevice);
+    const size_t cacheSizeBefore = getShaderObjectLayoutCacheSize(device);
 
     ComPtr<IShaderObject> shaderObject;
     REQUIRE_CALL(device->createShaderObjectFromTypeLayout(typeLayout, shaderObject.writeRef()));
     REQUIRE(shaderObject != nullptr);
 
-    // The device must not have taken a reference to the caller's pointer. A
-    // second call is included because a cache would only be observable on the
-    // insert, and this also pins the "no reuse across calls" behaviour.
+    // Called twice so that the check below also rules out entries accumulating across
+    // repeated calls, not just an insert on the first one.
     ComPtr<IShaderObject> secondShaderObject;
     REQUIRE_CALL(device->createShaderObjectFromTypeLayout(typeLayout, secondShaderObject.writeRef()));
 
-    CHECK_EQ(getShaderObjectLayoutCacheSize(innerDevice), cacheSizeBefore);
+    // The device must not have retained the caller's type layout.
+    CHECK_EQ(getShaderObjectLayoutCacheSize(device), cacheSizeBefore);
 }

--- a/tests/test-shader-object-from-type-layout.slang
+++ b/tests/test-shader-object-from-type-layout.slang
@@ -1,0 +1,18 @@
+// Mirrors the shape that surfaced shader-slang/slang#10893: a struct behind a
+// ConstantBuffer, whose element type layout a caller can pull out of the program
+// layout and hand to createShaderObjectFromTypeLayout.
+
+struct Params
+{
+    float a;
+    float b;
+};
+
+ConstantBuffer<Params> gParams;
+
+[shader("compute")]
+[numthreads(1, 1, 1)]
+void computeMain(uint3 tid: SV_DispatchThreadID, RWStructuredBuffer<float> resultBuffer)
+{
+    resultBuffer[0] = gParams.a + gParams.b;
+}


### PR DESCRIPTION
## Motivation

`Device::m_shaderObjectLayoutCache` (`src/device.h`) is keyed on a raw `slang::TypeLayoutReflection*` and lives as long as the `Device`. Two entry points reach it:

| entry point | key origin | actual owner | reference held by the entry | safe |
| --- | --- | --- | --- | --- |
| `createShaderObject(session, type, container)` | `session->getTypeLayout(type)` | `Linkage` / `ISession` | `ComPtr<ISession>` | yes |
| `createShaderObjectFromTypeLayout(typeLayout)` | caller-supplied | `TargetProgram` / `ComponentType` | `ComPtr<ISession>` of the *device's* session — the wrong object | **no** |

On the second path the key belongs to an object slang-rhi holds no reference to and knows nothing about. The entry outlives the layout as soon as the caller releases its program, and once an unrelated allocation lands on the recycled address the next lookup returns a `ShaderObjectLayout` whose `m_elementTypeLayout` dangles. `ShaderObject::init` then dereferences it.

That is shader-slang/slang#10893, which the Slang nightly sanitizer job hits intermittently:

```
SUMMARY: AddressSanitizer: heap-buffer-overflow source/core/slang-list.h:95:25 in Slang::List<Slang::TypeLayout::ResourceInfo, Slang::StandardAllocator>::begin()
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior source/slang/slang-reflection-api.cpp:1401:29
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior source/slang/slang-type-layout.h:772:25
```

Concretely, `tools/render-test/render-test-main.cpp` takes this path whenever a test input gives no explicit type name, e.g. `//TEST_INPUT:set gParams = new{ values: [ new ImplA{ v: 3 }, new ImplB{ v: 5 } ] }` in `tests/language-feature/dynamic-dispatch/constantbuffer-struct-interface-array.slang`. Devices persist across tests via a process-lifetime cache, so entries accumulate for the life of the process, and the CPU backend never clears `m_shaderObjectLayoutCache` at all (only the d3d12, vulkan and wgpu destructors do).

## Proposed solution

Build the layout directly on that path instead of going through the cache.

This is correct by construction rather than by argument: slang-rhi cannot vouch for the lifetime of a pointer a caller handed it, so it must not retain one past the call. It also keeps every remaining cached key session-owned, which promotes the existing `ComPtr<ISession>` from incidental to load-bearing.

The alternative — extending the public API so the caller passes the owning `IComponentType*` and holding a reference to *that* — would preserve caching, but it is an ABI break, and the measurements below show the cache was providing no reuse on this path to preserve.

Two options were considered and rejected:

- **Keying on a stable identity such as `ShaderComponentID`.** `ShaderCache::getComponentId` builds its key from `type->getName()` plus specialization argument names, so distinct types sharing a name across modules, and anonymous types, collide. A collision returns the *wrong* layout rather than crashing — worse than the present bug.
- **Validating or evicting entries on lookup.** There is no way to test a raw pointer for staleness, and Slang exposes no program- or session-destruction hook to subscribe to.

## Change summary

| file | change |
| --- | --- |
| `src/device.cpp` | `createShaderObjectFromTypeLayout` calls `createShaderObjectLayout` directly; adds the `testing::getShaderObjectLayoutCacheSize` implementation |
| `src/device.h` | declares `testing::getShaderObjectLayoutCacheSize`, alongside the existing `gDebugDisableStateTracking` test hook |
| `tests/test-shader-object-from-type-layout.cpp` | regression test asserting the invariant |
| `tests/test-shader-object-from-type-layout.slang` | minimal shader with a `ConstantBuffer<Params>` global |
| `CMakeLists.txt` | registers the new test |

## Concepts and vocabulary

- **`TargetProgram` vs `Linkage` ownership.** `Linkage` owns `List<RefPtr<TargetRequest>> targets`, and each `TargetRequest` owns `Dictionary<TypeLayoutKey, RefPtr<TypeLayout>> typeLayouts`. So a layout obtained via `ISession::getTypeLayout` lives exactly as long as the session. A layout reached through `IComponentType::getLayout()` instead belongs to the `TargetProgram`, which is tied to a `ComponentType` — releasing the program frees those `TypeLayout` objects however long the session lives. This distinction is the whole of the bug.
- **Dangling entry vs stale lookup.** A cache entry whose key has been freed is *dangling*; that alone is harmless until an unrelated allocation reuses the address and a lookup returns the entry — the *stale lookup*, which is the crash. The former happens deterministically, the latter only when the allocator cooperates. The measurements below rely on that separation.

## Process report

**Why this layer.** The defect is that a cache entry outlives the object owning its key. slang-rhi is where the entry is created, and it is the only place that can know it has no claim on the key's lifetime, so the fix belongs here rather than in Slang. Nothing in Slang is malformed: `TypeLayoutReflection` is a valid pointer that its owner is entitled to free.

**Is the input shape correct?** Yes — a caller passing a program-owned type layout to `createShaderObjectFromTypeLayout` is using the API exactly as documented. The API takes a `slang::TypeLayoutReflection*` and says nothing about ownership, so a program-owned layout is legitimate input. What was wrong was the callee's assumption that it could retain the pointer. That is why the fix changes the retention, not the caller and not the accepted shape.

**Why not fix the caller instead.** `tools/render-test/render-test-main.cpp` in Slang could be changed to keep its program alive, but that only patches the one in-tree caller; `createShaderObjectFromTypeLayout` is public API, and any downstream caller doing the same legitimate thing would still corrupt the device's cache.

**Evidence that the split above is real, not just argued.** Instrumenting `Device::getShaderObjectLayout` to record every insert with its entry point, then testing recorded keys with `__asan_region_is_poisoned` while the cache is in use, over the full Slang test suite at `ff45b15ed3`:

```
createShaderObject                 inserts=49 dangling=0
createShaderObjectFromTypeLayout   inserts=38 dangling=36
```

Zero of 49 on the session-keyed path; 36 of 38 on the caller-supplied path. The remaining 2 are the final inserts of the run, freed after the last sweep. After this change the caller-supplied path no longer appears in the cache at all, and the Slang suite is unchanged at 6374 passed / 0 failed.

**Cost of losing the cache on this path.** Counting calls and distinct keys over the same suite:

```
createShaderObjectFromTypeLayout: calls=38 distinct-keys=38
 -> 0 lookup(s) would have hit the cache.
```

Every call presented a distinct key, so the cache never served a hit here. This measures render-test's usage only; a downstream caller could exercise the entry point far more heavily, in which case `createShaderObjectLayout` cost would be worth revisiting.

**Why the test asserts the invariant rather than the crash.** The use-after-free is only observable when the allocator recycles a freed address, so a test for the symptom is really a test for "the sanitizer happened to stay quiet" — which is how these findings were previously written off as fixed, and why the issue then resurfaced. The test instead checks that `createShaderObjectFromTypeLayout` leaves the cache size unchanged, which fails deterministically on any platform, with or without a sanitizer. Verified both ways on the CPU backend: `PASSED` with the fix, `CHECK_EQ( 1, 0 )` / `FAILED` with it reverted.

**Why a test hook.** The invariant is about internal state with no public accessor. `src/device.h` already exposes `gDebugDisableStateTracking` and `gResourceCount` in `namespace testing` for the same reason, so `getShaderObjectLayoutCacheSize` follows the established pattern rather than widening the public API.

**Note for reviewers.** `tests/testing.cpp:902` blanket-skips the CPU backend on Linux ("Known issues with CPU backend on linux"), so this test only runs there on the other backends. The pass/fail verification above was done by lifting that gate locally; that change is deliberately not included here.
