### PR TITLE
Apply fixupBufferDesc when importing buffers from native handles (vulkan/d3d)

### DIFF
--- a/src/d3d12/d3d12-device.cpp
+++ b/src/d3d12/d3d12-device.cpp
@@ -1587,7 +1587,7 @@ Result DeviceImpl::createBuffer(const BufferDesc& desc_, const void* initData, I
 
 Result DeviceImpl::createBufferFromNativeHandle(NativeHandle handle, const BufferDesc& desc, IBuffer** outBuffer)
 {
-    RefPtr<BufferImpl> buffer(new BufferImpl(this, desc));
+    RefPtr<BufferImpl> buffer(new BufferImpl(this, fixupBufferDesc(desc)));
 
     if (handle.type == NativeHandleType::D3D12Resource)
     {

--- a/src/vulkan/vk-buffer.cpp
+++ b/src/vulkan/vk-buffer.cpp
@@ -440,7 +440,7 @@ Result DeviceImpl::createBuffer(const BufferDesc& desc_, const void* initData, I
 
 Result DeviceImpl::createBufferFromNativeHandle(NativeHandle handle, const BufferDesc& desc, IBuffer** outBuffer)
 {
-    RefPtr<BufferImpl> buffer(new BufferImpl(this, desc));
+    RefPtr<BufferImpl> buffer(new BufferImpl(this, fixupBufferDesc(desc)));
 
     if (handle.type == NativeHandleType::VkBuffer)
     {


### PR DESCRIPTION
createBufferFromNativeHandle skipped fixupBufferDesc on the Vulkan and D3D12 backends, so an imported buffer kept defaultState == Undefined while every other buffer got a real state from determineDefaultResourceState(usage). Metal and WGPU already fix up the desc on import.