### PR TITLE
Implement createBufferFromNativeHandle for the CUDA backend

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -17,7 +17,7 @@
 | `createTextureFromNativeHandle`    | :x:     | :x:  | :x:   | yes   | yes    | yes     | :x:  |
 | `createTextureFromSharedHandle`    | :x:     | yes  | :x:   | :x:   | :x:    | :x:     | :x:  |
 | `createBuffer`                     | yes     | yes  | yes   | yes   | yes    | yes     | yes  |
-| `createBufferFromNativeHandle`     | :x:     | :x:  | :x:   | yes   | yes    | :x:     | :x:  |
+| `createBufferFromNativeHandle`     | :x:     | yes  | :x:   | yes   | yes    | yes     | yes  |
 | `createBufferFromSharedHandle`     | :x:     | yes  | :x:   | :x:   | :x:    | :x:     | :x:  |
 | `mapBuffer`                        | yes     | yes  | yes   | yes   | yes    | yes     | yes  |
 | `unmapBuffer`                      | yes     | yes  | yes   | yes   | yes    | yes     | yes  |

--- a/src/cuda/cuda-buffer.cpp
+++ b/src/cuda/cuda-buffer.cpp
@@ -97,6 +97,23 @@ Result DeviceImpl::createBuffer(const BufferDesc& desc_, const void* initData, I
     return SLANG_OK;
 }
 
+Result DeviceImpl::createBufferFromNativeHandle(NativeHandle handle, const BufferDesc& desc, IBuffer** outBuffer)
+{
+    if (handle.type != NativeHandleType::CUdeviceptr || handle.value == 0)
+    {
+        *outBuffer = nullptr;
+        return SLANG_E_INVALID_HANDLE;
+    }
+
+    // The buffer does not own the memory the device pointer refers to. We leave both the heap
+    // allocation and the external memory object unset so the destructor doesn't free anything.
+    RefPtr<BufferImpl> buffer = new BufferImpl(this, fixupBufferDesc(desc));
+    buffer->m_cudaMemory = reinterpret_cast<void*>(handle.value);
+
+    returnComPtr(outBuffer, buffer);
+    return SLANG_OK;
+}
+
 Result DeviceImpl::createBufferFromSharedHandle(NativeHandle handle, const BufferDesc& desc, IBuffer** outBuffer)
 {
     if (!handle)

--- a/src/cuda/cuda-device.h
+++ b/src/cuda/cuda-device.h
@@ -53,6 +53,12 @@ public:
         IBuffer** outBuffer
     ) override;
 
+    virtual SLANG_NO_THROW Result SLANG_MCALL createBufferFromNativeHandle(
+        NativeHandle handle,
+        const BufferDesc& desc,
+        IBuffer** outBuffer
+    ) override;
+
     virtual SLANG_NO_THROW Result SLANG_MCALL createBufferFromSharedHandle(
         NativeHandle handle,
         const BufferDesc& desc,

--- a/tests/test-buffer-from-handle.cpp
+++ b/tests/test-buffer-from-handle.cpp
@@ -3,7 +3,7 @@
 using namespace rhi;
 using namespace rhi::testing;
 
-GPU_TEST_CASE("buffer-from-handle", D3D12 | Vulkan | Metal)
+GPU_TEST_CASE("buffer-from-handle", D3D12 | Vulkan | Metal | CUDA | WGPU)
 {
     ComPtr<IShaderProgram> shaderProgram;
     REQUIRE_CALL(loadProgram(device, "test-compute-trivial", "computeMain", shaderProgram.writeRef()));


### PR DESCRIPTION
Add createBufferFromNativeHandle for the CUDA backend. Add missing edits for metal/wgpu in the api doc. Activate tests for cuda/wgpu.