### PR TITLE
Add native handle invalid-input coverage

### DIFF
--- a/src/d3d12/d3d12-device.cpp
+++ b/src/d3d12/d3d12-device.cpp
@@ -1508,7 +1508,8 @@ Result DeviceImpl::createTextureFromNativeHandle(NativeHandle handle, const Text
 {
     if (handle.type != NativeHandleType::D3D12Resource || handle.value == 0)
     {
-        return SLANG_E_INVALID_ARG;
+        *outTexture = nullptr;
+        return SLANG_E_INVALID_HANDLE;
     }
 
     TextureDesc desc = fixupTextureDesc(desc_);
@@ -1587,16 +1588,14 @@ Result DeviceImpl::createBuffer(const BufferDesc& desc_, const void* initData, I
 
 Result DeviceImpl::createBufferFromNativeHandle(NativeHandle handle, const BufferDesc& desc, IBuffer** outBuffer)
 {
-    RefPtr<BufferImpl> buffer(new BufferImpl(this, fixupBufferDesc(desc)));
+    if (handle.type != NativeHandleType::D3D12Resource || handle.value == 0)
+    {
+        *outBuffer = nullptr;
+        return SLANG_E_INVALID_HANDLE;
+    }
 
-    if (handle.type == NativeHandleType::D3D12Resource)
-    {
-        buffer->m_resource.setResource((ID3D12Resource*)handle.value);
-    }
-    else
-    {
-        return SLANG_FAIL;
-    }
+    RefPtr<BufferImpl> buffer(new BufferImpl(this, fixupBufferDesc(desc)));
+    buffer->m_resource.setResource((ID3D12Resource*)handle.value);
 
     returnComPtr(outBuffer, buffer);
     return SLANG_OK;

--- a/src/metal/metal-buffer.cpp
+++ b/src/metal/metal-buffer.cpp
@@ -129,7 +129,8 @@ Result DeviceImpl::createBufferFromNativeHandle(NativeHandle handle, const Buffe
 
     if (handle.type != NativeHandleType::MTLBuffer || handle.value == 0)
     {
-        return SLANG_E_INVALID_ARG;
+        *outBuffer = nullptr;
+        return SLANG_E_INVALID_HANDLE;
     }
 
     MTL::Buffer* nativeBuffer = reinterpret_cast<MTL::Buffer*>(handle.value);

--- a/src/metal/metal-texture.cpp
+++ b/src/metal/metal-texture.cpp
@@ -227,7 +227,8 @@ Result DeviceImpl::createTextureFromNativeHandle(NativeHandle handle, const Text
 
     if (handle.type != NativeHandleType::MTLTexture || handle.value == 0)
     {
-        return SLANG_E_INVALID_ARG;
+        *outTexture = nullptr;
+        return SLANG_E_INVALID_HANDLE;
     }
 
     MTL::Texture* nativeTexture = reinterpret_cast<MTL::Texture*>(handle.value);

--- a/src/vulkan/vk-buffer.cpp
+++ b/src/vulkan/vk-buffer.cpp
@@ -440,16 +440,14 @@ Result DeviceImpl::createBuffer(const BufferDesc& desc_, const void* initData, I
 
 Result DeviceImpl::createBufferFromNativeHandle(NativeHandle handle, const BufferDesc& desc, IBuffer** outBuffer)
 {
-    RefPtr<BufferImpl> buffer(new BufferImpl(this, fixupBufferDesc(desc)));
+    if (handle.type != NativeHandleType::VkBuffer || handle.value == 0)
+    {
+        *outBuffer = nullptr;
+        return SLANG_E_INVALID_HANDLE;
+    }
 
-    if (handle.type == NativeHandleType::VkBuffer)
-    {
-        buffer->m_buffer.m_buffer = (VkBuffer)handle.value;
-    }
-    else
-    {
-        return SLANG_FAIL;
-    }
+    RefPtr<BufferImpl> buffer(new BufferImpl(this, fixupBufferDesc(desc)));
+    buffer->m_buffer.m_buffer = (VkBuffer)handle.value;
 
     returnComPtr(outBuffer, buffer);
     return SLANG_OK;

--- a/src/vulkan/vk-texture.cpp
+++ b/src/vulkan/vk-texture.cpp
@@ -462,7 +462,8 @@ Result DeviceImpl::createTextureFromNativeHandle(NativeHandle handle, const Text
 {
     if (handle.type != NativeHandleType::VkImage || handle.value == 0)
     {
-        return SLANG_E_INVALID_ARG;
+        *outTexture = nullptr;
+        return SLANG_E_INVALID_HANDLE;
     }
 
     TextureDesc desc = fixupTextureDesc(desc_);

--- a/tests/test-buffer-from-handle.cpp
+++ b/tests/test-buffer-from-handle.cpp
@@ -3,6 +3,21 @@
 using namespace rhi;
 using namespace rhi::testing;
 
+static void dispatchIncrement(IDevice* device, IComputePipeline* pipeline, IBuffer* buffer)
+{
+    auto queue = device->getQueue(QueueType::Graphics);
+    auto commandEncoder = queue->createCommandEncoder();
+
+    auto passEncoder = commandEncoder->beginComputePass();
+    auto rootObject = passEncoder->bindPipeline(pipeline);
+    ShaderCursor(rootObject)["buffer"].setBinding(buffer);
+    passEncoder->dispatchCompute(1, 1, 1);
+    passEncoder->end();
+
+    queue->submit(commandEncoder->finish());
+    queue->waitOnHost();
+}
+
 GPU_TEST_CASE("buffer-from-handle", D3D12 | Vulkan | Metal | CUDA | WGPU)
 {
     ComPtr<IShaderProgram> shaderProgram;
@@ -28,26 +43,53 @@ GPU_TEST_CASE("buffer-from-handle", D3D12 | Vulkan | Metal | CUDA | WGPU)
     REQUIRE_CALL(device->createBuffer(bufferDesc, (void*)initialData, originalNumbersBuffer.writeRef()));
 
     NativeHandle handle;
-    originalNumbersBuffer->getNativeHandle(&handle);
+    REQUIRE_CALL(originalNumbersBuffer->getNativeHandle(&handle));
+
     ComPtr<IBuffer> buffer;
     REQUIRE_CALL(device->createBufferFromNativeHandle(handle, bufferDesc, buffer.writeRef()));
     compareComputeResult(device, buffer, makeArray<float>(0.0f, 1.0f, 2.0f, 3.0f));
 
-    // We have done all the set up work, now it is time to start recording a command buffer for
-    // GPU execution.
+    dispatchIncrement(device, pipeline, buffer);
+    compareComputeResult(device, buffer, makeArray<float>(1.0f, 2.0f, 3.0f, 4.0f));
+
+    compareComputeResult(device, originalNumbersBuffer, makeArray<float>(1.0f, 2.0f, 3.0f, 4.0f));
+
+    // Destroy a wrapper created from the native handle, then keep using the original buffer.
     {
-        auto queue = device->getQueue(QueueType::Graphics);
-        auto commandEncoder = queue->createCommandEncoder();
+        buffer.setNull();
 
-        auto passEncoder = commandEncoder->beginComputePass();
-        auto rootObject = passEncoder->bindPipeline(pipeline);
-        ShaderCursor(rootObject)["buffer"].setBinding(buffer);
-        passEncoder->dispatchCompute(1, 1, 1);
-        passEncoder->end();
+        {
+            ComPtr<IBuffer> scopedWrapper;
+            REQUIRE_CALL(device->createBufferFromNativeHandle(handle, bufferDesc, scopedWrapper.writeRef()));
+            dispatchIncrement(device, pipeline, scopedWrapper);
+            compareComputeResult(device, scopedWrapper, makeArray<float>(2.0f, 3.0f, 4.0f, 5.0f));
+        }
 
-        queue->submit(commandEncoder->finish());
-        queue->waitOnHost();
+        compareComputeResult(device, originalNumbersBuffer, makeArray<float>(2.0f, 3.0f, 4.0f, 5.0f));
+
+        dispatchIncrement(device, pipeline, originalNumbersBuffer);
+        compareComputeResult(device, originalNumbersBuffer, makeArray<float>(3.0f, 4.0f, 5.0f, 6.0f));
     }
 
-    compareComputeResult(device, buffer, makeArray<float>(1.0f, 2.0f, 3.0f, 4.0f));
+    // Invalid native handles should fail without producing a wrapper object.
+    {
+        NativeHandle wrongTypeHandle = handle;
+        wrongTypeHandle.type = NativeHandleType::Undefined;
+
+        ComPtr<IBuffer> invalidBuffer;
+        CHECK_EQ(
+            device->createBufferFromNativeHandle(wrongTypeHandle, bufferDesc, invalidBuffer.writeRef()),
+            SLANG_E_INVALID_HANDLE
+        );
+        CHECK_EQ(invalidBuffer.get(), nullptr);
+
+        NativeHandle zeroValueHandle = handle;
+        zeroValueHandle.value = 0;
+
+        CHECK_EQ(
+            device->createBufferFromNativeHandle(zeroValueHandle, bufferDesc, invalidBuffer.writeRef()),
+            SLANG_E_INVALID_HANDLE
+        );
+        CHECK_EQ(invalidBuffer.get(), nullptr);
+    }
 }

--- a/tests/test-texture-from-handle.cpp
+++ b/tests/test-texture-from-handle.cpp
@@ -28,6 +28,28 @@ GPU_TEST_CASE("texture-from-native-handle", D3D12 | Vulkan | Metal)
     NativeHandle handle = {};
     REQUIRE_CALL(originalTexture->getNativeHandle(&handle));
 
+    // Invalid native handles should fail without producing a wrapper object.
+    {
+        NativeHandle wrongTypeHandle = handle;
+        wrongTypeHandle.type = NativeHandleType::Undefined;
+
+        ComPtr<ITexture> invalidTexture;
+        CHECK_EQ(
+            device->createTextureFromNativeHandle(wrongTypeHandle, desc, invalidTexture.writeRef()),
+            SLANG_E_INVALID_HANDLE
+        );
+        CHECK_EQ(invalidTexture.get(), nullptr);
+
+        NativeHandle zeroValueHandle = handle;
+        zeroValueHandle.value = 0;
+
+        CHECK_EQ(
+            device->createTextureFromNativeHandle(zeroValueHandle, desc, invalidTexture.writeRef()),
+            SLANG_E_INVALID_HANDLE
+        );
+        CHECK_EQ(invalidTexture.get(), nullptr);
+    }
+
     // D3D12 and Metal can check the texture descriptor from the native handle.
     // Vulkan cannot, so we skip this check.
     if (device->getDeviceType() == DeviceType::D3D12 || device->getDeviceType() == DeviceType::Metal)


### PR DESCRIPTION
Normalize buffer and texture native-handle creation so wrong-type or zero-value handles return SLANG_E_INVALID_HANDLE and clear the output object. Extend buffer and texture tests to cover invalid handles, and add buffer wrapper lifetime coverage for native-handle wrappers.