### PR TITLE
Make surface usage handling consistent across backends

### DIFF
--- a/include/slang-rhi.h
+++ b/include/slang-rhi.h
@@ -2896,8 +2896,8 @@ struct SurfaceInfo
 {
     /// The preferred format for the surface.
     Format preferredFormat;
-    /// The supported texture usage for the surface.
-    /// The actual support may be more limited depending on the format.
+    /// The surface-level upper bound for supported texture usage.
+    /// The actual support may be more limited depending on the selected format.
     TextureUsage supportedUsage;
     /// The list of supported formats for the surface.
     const Format* formats;
@@ -2909,7 +2909,8 @@ struct SurfaceConfig
 {
     /// Surface format. If left undefined, the preferred format is used.
     Format format = Format::Undefined;
-    /// Usage of the surface. If left undefined, the supported usage is used.
+    /// Usage of the surface. If left undefined, the backend selects a safe,
+    /// format-compatible subset of the supported usage.
     TextureUsage usage = TextureUsage::None;
     // size_t viewFormatCount;
     // const Format* viewFormats;

--- a/src/cuda/cuda-surface.cpp
+++ b/src/cuda/cuda-surface.cpp
@@ -180,6 +180,14 @@ Result SurfaceImpl::init(DeviceImpl* device, WindowHandle windowHandle)
 
     SLANG_RETURN_ON_FAIL(createVulkanDevice());
 
+    VkSurfaceCapabilitiesKHR surfaceCaps = {};
+    SLANG_VK_RETURN_ON_FAIL(m_api.vkGetPhysicalDeviceSurfaceCapabilitiesKHR(m_physicalDevice, m_surface, &surfaceCaps));
+    if (!(surfaceCaps.supportedUsageFlags & VK_IMAGE_USAGE_TRANSFER_DST_BIT))
+    {
+        m_deviceImpl->printError("CUDA surface requires transfer-destination swapchain images.");
+        return SLANG_E_NOT_AVAILABLE;
+    }
+
     uint32_t formatCount = 0;
     m_api.vkGetPhysicalDeviceSurfaceFormatsKHR(m_physicalDevice, m_surface, &formatCount, nullptr);
     std::vector<VkSurfaceFormatKHR> surfaceFormats(formatCount);

--- a/src/cuda/cuda-surface.cpp
+++ b/src/cuda/cuda-surface.cpp
@@ -400,6 +400,11 @@ Result SurfaceImpl::createSwapchain()
     // issue an error
     VkSurfaceCapabilitiesKHR surfaceCaps = {};
     SLANG_VK_RETURN_ON_FAIL(m_api.vkGetPhysicalDeviceSurfaceCapabilitiesKHR(m_physicalDevice, m_surface, &surfaceCaps));
+    if (!(surfaceCaps.supportedUsageFlags & VK_IMAGE_USAGE_TRANSFER_DST_BIT))
+    {
+        m_deviceImpl->printError("CUDA surface requires transfer-destination swapchain images.");
+        return SLANG_E_NOT_AVAILABLE;
+    }
 
     VkExtent2D imageExtent = {};
     if (surfaceCaps.currentExtent.width != UINT32_MAX)
@@ -497,7 +502,8 @@ Result SurfaceImpl::createSwapchain()
     swapchainDesc.imageColorSpace = VK_COLOR_SPACE_SRGB_NONLINEAR_KHR;
     swapchainDesc.imageExtent = imageExtent;
     swapchainDesc.imageArrayLayers = 1;
-    swapchainDesc.imageUsage = VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT;
+    // CUDA presents by copying its shared image into the Vulkan swapchain image.
+    swapchainDesc.imageUsage = VK_IMAGE_USAGE_TRANSFER_DST_BIT;
     swapchainDesc.imageSharingMode = VK_SHARING_MODE_EXCLUSIVE;
     swapchainDesc.preTransform = preTransform;
     swapchainDesc.compositeAlpha = compositeAlpha;
@@ -878,12 +884,8 @@ Result SurfaceImpl::configure(const SurfaceConfig& config)
     // Push/pop CUDA context to restore caller's context (e.g., PyTorch) after configuration.
     SLANG_CUDA_CTX_SCOPE(m_deviceImpl);
 
+    SLANG_RETURN_ON_FAIL(validateConfig(config));
     setConfig(config);
-
-    if (m_config.width == 0 || m_config.height == 0)
-    {
-        return SLANG_FAIL;
-    }
     if (m_config.format == Format::Undefined)
     {
         m_config.format = m_info.preferredFormat;

--- a/src/d3d/d3d-surface.h
+++ b/src/d3d/d3d-surface.h
@@ -49,8 +49,10 @@ public:
         swapChainDesc.BufferDesc.Width = m_config.width;
         swapChainDesc.BufferDesc.Height = m_config.height;
         swapChainDesc.BufferDesc.Format = getMapFormat(srgbToLinearFormat(m_config.format));
+        // Render-target output is the internal presentation path. Optional native usages are
+        // enabled only when the resolved public configuration requests them.
         swapChainDesc.BufferUsage = DXGI_USAGE_RENDER_TARGET_OUTPUT;
-        if (is_set(m_info.supportedUsage, TextureUsage::UnorderedAccess))
+        if (is_set(m_config.usage, TextureUsage::UnorderedAccess))
             swapChainDesc.BufferUsage |= DXGI_USAGE_UNORDERED_ACCESS;
         swapChainDesc.SwapEffect = m_swapEffect;
         swapChainDesc.OutputWindow = m_windowHandle;
@@ -108,6 +110,7 @@ public:
 
     virtual SLANG_NO_THROW Result SLANG_MCALL configure(const SurfaceConfig& config) override
     {
+        SLANG_RETURN_ON_FAIL(validateConfig(config));
         setConfig(config);
         if (m_config.format == Format::Undefined)
         {

--- a/src/debug-layer/debug-surface.cpp
+++ b/src/debug-layer/debug-surface.cpp
@@ -23,8 +23,6 @@ Result DebugSurface::configure(const SurfaceConfig& config)
 
     const SurfaceInfo& info = baseObject->getInfo();
 
-    m_configured = false;
-
     // format must be Format::Undefined (selecting preferred format) or any of the supported formats.
     if (config.format != Format::Undefined && !contains(info.formats, info.formatCount, config.format))
     {

--- a/src/metal/metal-surface.cpp
+++ b/src/metal/metal-surface.cpp
@@ -25,25 +25,22 @@ SurfaceImpl::~SurfaceImpl() {}
 
 Result SurfaceImpl::configure(const SurfaceConfig& config)
 {
+    SLANG_RETURN_ON_FAIL(validateConfig(config));
     setConfig(config);
-
-    if (m_config.width == 0 || m_config.height == 0)
-    {
-        return SLANG_FAIL;
-    }
     if (m_config.format == Format::Undefined)
     {
         m_config.format = m_info.preferredFormat;
     }
     if (m_config.usage == TextureUsage::None)
     {
-        // TODO: Once we have propert support for format support, we can add additional usages depending on the format.
-        m_config.usage = TextureUsage::Present | TextureUsage::RenderTarget | TextureUsage::CopyDestination;
+        m_config.usage = (TextureUsage::Present | TextureUsage::RenderTarget | TextureUsage::CopyDestination) &
+                         m_info.supportedUsage;
     }
 
     m_metalLayer->setPixelFormat(translatePixelFormat(m_config.format));
     m_metalLayer->setDrawableSize(CGSize{(float)m_config.width, (float)m_config.height});
-    m_metalLayer->setFramebufferOnly(m_config.usage == TextureUsage::RenderTarget);
+    const TextureUsage framebufferOnlyUsage = TextureUsage::Present | TextureUsage::RenderTarget;
+    m_metalLayer->setFramebufferOnly((m_config.usage & ~framebufferOnlyUsage) == TextureUsage::None);
     // m_metalLayer->setDisplaySyncEnabled(config.vsync);
     m_configured = true;
 

--- a/src/rhi-shared.cpp
+++ b/src/rhi-shared.cpp
@@ -560,6 +560,19 @@ void Surface::setConfig(const SurfaceConfig& config)
     m_config = config;
 }
 
+Result Surface::validateConfig(const SurfaceConfig& config) const
+{
+    if (config.format != Format::Undefined && !contains(m_info.formats, m_info.formatCount, config.format))
+        return SLANG_E_INVALID_ARG;
+    if (config.usage != (config.usage & m_info.supportedUsage))
+        return SLANG_E_INVALID_ARG;
+    if (config.width == 0 || config.height == 0)
+        return SLANG_E_INVALID_ARG;
+    if (config.desiredImageCount == 0)
+        return SLANG_E_INVALID_ARG;
+    return SLANG_OK;
+}
+
 // ----------------------------------------------------------------------------
 // Helpers
 // ----------------------------------------------------------------------------

--- a/src/rhi-shared.h
+++ b/src/rhi-shared.h
@@ -345,6 +345,7 @@ public:
 public:
     void setInfo(const SurfaceInfo& info);
     void setConfig(const SurfaceConfig& config);
+    Result validateConfig(const SurfaceConfig& config) const;
 
     SurfaceInfo m_info;
     StructHolder m_infoHolder;

--- a/src/vulkan/vk-api.cpp
+++ b/src/vulkan/vk-api.cpp
@@ -143,6 +143,16 @@ Result VulkanApi::initInstanceProcs(VkInstance instance)
         vkGetPhysicalDeviceProperties2 =
             (PFN_vkGetPhysicalDeviceProperties2)vkGetInstanceProcAddr(instance, "vkGetPhysicalDeviceProperties2KHR");
     }
+    if (!vkGetPhysicalDeviceFormatProperties2)
+    {
+        vkGetPhysicalDeviceFormatProperties2 = (PFN_vkGetPhysicalDeviceFormatProperties2)
+            vkGetInstanceProcAddr(instance, "vkGetPhysicalDeviceFormatProperties2KHR");
+    }
+    if (!vkGetPhysicalDeviceImageFormatProperties2)
+    {
+        vkGetPhysicalDeviceImageFormatProperties2 = (PFN_vkGetPhysicalDeviceImageFormatProperties2)
+            vkGetInstanceProcAddr(instance, "vkGetPhysicalDeviceImageFormatProperties2KHR");
+    }
     if (!vkGetPhysicalDeviceCalibrateableTimeDomainsKHR && vkGetPhysicalDeviceCalibrateableTimeDomainsEXT)
         vkGetPhysicalDeviceCalibrateableTimeDomainsKHR = vkGetPhysicalDeviceCalibrateableTimeDomainsEXT;
     if (!vkGetPhysicalDeviceCalibrateableTimeDomainsEXT && vkGetPhysicalDeviceCalibrateableTimeDomainsKHR)

--- a/src/vulkan/vk-surface.cpp
+++ b/src/vulkan/vk-surface.cpp
@@ -29,10 +29,16 @@ static VkImageUsageFlags getSwapchainImageUsage(TextureUsage usage)
     return result;
 }
 
-static bool isSwapchainImageUsageSupported(DeviceImpl* device, Format format, VkImageUsageFlags imageUsage)
+static Result querySwapchainImageUsageSupport(
+    DeviceImpl* device,
+    Format format,
+    VkImageUsageFlags imageUsage,
+    bool* outSupported
+)
 {
+    *outSupported = false;
     if (imageUsage == 0)
-        return false;
+        return SLANG_OK;
 
     VkPhysicalDeviceImageFormatInfo2 imageInfo = {VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_IMAGE_FORMAT_INFO_2};
     imageInfo.format = getVkFormat(format);
@@ -41,11 +47,17 @@ static bool isSwapchainImageUsageSupported(DeviceImpl* device, Format format, Vk
     imageInfo.usage = imageUsage;
 
     VkImageFormatProperties2 imageProperties = {VK_STRUCTURE_TYPE_IMAGE_FORMAT_PROPERTIES_2};
-    return device->m_api.vkGetPhysicalDeviceImageFormatProperties2(
-               device->m_api.m_physicalDevice,
-               &imageInfo,
-               &imageProperties
-           ) == VK_SUCCESS;
+    VkResult result = device->m_api.vkGetPhysicalDeviceImageFormatProperties2(
+        device->m_api.m_physicalDevice,
+        &imageInfo,
+        &imageProperties
+    );
+    if (result == VK_ERROR_FORMAT_NOT_SUPPORTED)
+        return SLANG_OK;
+    SLANG_VK_RETURN_ON_FAIL_REPORT(result, device);
+
+    *outSupported = true;
+    return SLANG_OK;
 }
 
 SurfaceImpl::~SurfaceImpl()
@@ -424,11 +436,14 @@ Result SurfaceImpl::configure(const SurfaceConfig& config)
         // CopyDestination is useful for the compute fallback, but it is not required for a
         // presentable surface. Drop it when the selected format does not support the complete
         // optimal-tiling usage combination.
-        if (!isSwapchainImageUsageSupported(
-                m_device,
-                resolvedConfig.format,
-                getSwapchainImageUsage(resolvedConfig.usage)
-            ))
+        bool usageSupported = false;
+        SLANG_RETURN_ON_FAIL(querySwapchainImageUsageSupport(
+            m_device,
+            resolvedConfig.format,
+            getSwapchainImageUsage(resolvedConfig.usage),
+            &usageSupported
+        ));
+        if (!usageSupported)
         {
             resolvedConfig.usage &= ~TextureUsage::CopyDestination;
         }
@@ -442,7 +457,14 @@ Result SurfaceImpl::configure(const SurfaceConfig& config)
         }
     }
 
-    if (!isSwapchainImageUsageSupported(m_device, resolvedConfig.format, getSwapchainImageUsage(resolvedConfig.usage)))
+    bool usageSupported = false;
+    SLANG_RETURN_ON_FAIL(querySwapchainImageUsageSupport(
+        m_device,
+        resolvedConfig.format,
+        getSwapchainImageUsage(resolvedConfig.usage),
+        &usageSupported
+    ));
+    if (!usageSupported)
     {
         m_device->printError("Surface format does not support the requested usage.");
         return SLANG_E_INVALID_ARG;

--- a/src/vulkan/vk-surface.cpp
+++ b/src/vulkan/vk-surface.cpp
@@ -406,44 +406,49 @@ void SurfaceImpl::destroySwapchain()
 Result SurfaceImpl::configure(const SurfaceConfig& config)
 {
     SLANG_RETURN_ON_FAIL(validateConfig(config));
-    setConfig(config);
-    if (m_config.format == Format::Undefined)
+    SurfaceConfig resolvedConfig = config;
+    if (resolvedConfig.format == Format::Undefined)
     {
-        m_config.format = m_info.preferredFormat;
+        resolvedConfig.format = m_info.preferredFormat;
     }
-    if (m_config.usage == TextureUsage::None)
+    if (resolvedConfig.usage == TextureUsage::None)
     {
         // Do not auto-add UnorderedAccess here: a format's optimal-tiling features may report
         // storage support while the swapchain still rejects VK_IMAGE_USAGE_STORAGE_BIT for that
         // format (e.g. *_SRGB), tripping VUID-VkSwapchainCreateInfoKHR-imageFormat-01778. Apps
         // that need storage on the swapchain must request it explicitly; configure() then
         // validates it against the format below.
-        m_config.usage = (TextureUsage::Present | TextureUsage::RenderTarget | TextureUsage::CopyDestination) &
-                         m_info.supportedUsage;
+        resolvedConfig.usage = (TextureUsage::Present | TextureUsage::RenderTarget | TextureUsage::CopyDestination) &
+                               m_info.supportedUsage;
 
         // CopyDestination is useful for the compute fallback, but it is not required for a
         // presentable surface. Drop it when the selected format does not support the complete
         // optimal-tiling usage combination.
-        if (!isSwapchainImageUsageSupported(m_device, m_config.format, getSwapchainImageUsage(m_config.usage)))
+        if (!isSwapchainImageUsageSupported(
+                m_device,
+                resolvedConfig.format,
+                getSwapchainImageUsage(resolvedConfig.usage)
+            ))
         {
-            m_config.usage &= ~TextureUsage::CopyDestination;
+            resolvedConfig.usage &= ~TextureUsage::CopyDestination;
         }
     }
     else
     {
-        if (m_config.usage != (m_config.usage & m_info.supportedUsage))
+        if (resolvedConfig.usage != (resolvedConfig.usage & m_info.supportedUsage))
         {
             m_device->printError("Surface does not support the requested usage.");
             return SLANG_E_INVALID_ARG;
         }
     }
 
-    if (!isSwapchainImageUsageSupported(m_device, m_config.format, getSwapchainImageUsage(m_config.usage)))
+    if (!isSwapchainImageUsageSupported(m_device, resolvedConfig.format, getSwapchainImageUsage(resolvedConfig.usage)))
     {
         m_device->printError("Surface format does not support the requested usage.");
         return SLANG_E_INVALID_ARG;
     }
 
+    setConfig(resolvedConfig);
     m_configured = false;
     destroySwapchain();
     SLANG_RETURN_ON_FAIL(createSwapchain());

--- a/src/vulkan/vk-surface.cpp
+++ b/src/vulkan/vk-surface.cpp
@@ -18,6 +18,36 @@ static Format translateVkFormat(VkFormat format)
     return reverseMapLookup<Format, VkFormat, Format::Undefined, Format::_Count>(getVkFormat, format);
 }
 
+static VkImageUsageFlags getSwapchainImageUsage(TextureUsage usage)
+{
+    // Present is a surface semantic, not a VkImageUsageFlagBits value. The generic Vulkan
+    // texture-usage translation maps it to TRANSFER_SRC, which is not appropriate here unless
+    // CopySource was explicitly requested.
+    VkImageUsageFlags result = _calcImageUsageFlags(usage & ~TextureUsage::Present);
+    if (result == 0 && is_set(usage, TextureUsage::Present))
+        result = VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT;
+    return result;
+}
+
+static bool isSwapchainImageUsageSupported(DeviceImpl* device, Format format, VkImageUsageFlags imageUsage)
+{
+    if (imageUsage == 0)
+        return false;
+
+    VkPhysicalDeviceImageFormatInfo2 imageInfo = {VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_IMAGE_FORMAT_INFO_2};
+    imageInfo.format = getVkFormat(format);
+    imageInfo.type = VK_IMAGE_TYPE_2D;
+    imageInfo.tiling = VK_IMAGE_TILING_OPTIMAL;
+    imageInfo.usage = imageUsage;
+
+    VkImageFormatProperties2 imageProperties = {VK_STRUCTURE_TYPE_IMAGE_FORMAT_PROPERTIES_2};
+    return device->m_api.vkGetPhysicalDeviceImageFormatProperties2(
+               device->m_api.m_physicalDevice,
+               &imageInfo,
+               &imageProperties
+           ) == VK_SUCCESS;
+}
+
 SurfaceImpl::~SurfaceImpl()
 {
     auto& api = m_device->m_api;
@@ -137,7 +167,9 @@ Result SurfaceImpl::init(DeviceImpl* device, WindowHandle windowHandle)
         api.vkGetPhysicalDeviceSurfaceCapabilitiesKHR(api.m_physicalDevice, m_surface, &surfaceCaps),
         m_device
     );
-    m_info.supportedUsage = TextureUsage::Present | TextureUsage::RenderTarget;
+    m_info.supportedUsage = TextureUsage::Present;
+    if (surfaceCaps.supportedUsageFlags & VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT)
+        m_info.supportedUsage |= TextureUsage::RenderTarget;
     if (surfaceCaps.supportedUsageFlags & VK_IMAGE_USAGE_STORAGE_BIT)
         m_info.supportedUsage |= TextureUsage::UnorderedAccess;
     if (surfaceCaps.supportedUsageFlags & VK_IMAGE_USAGE_SAMPLED_BIT)
@@ -157,7 +189,7 @@ Result SurfaceImpl::createSwapchain()
     auto& api = m_device->m_api;
 
     // It is necessary to query the caps -> otherwise the LunarG verification layer will
-    // issue an error. The reported supportedUsageFlags are also used below to clamp the
+    // issue an error. The reported supportedUsageFlags are also used below to validate the
     // requested image usage.
     VkSurfaceCapabilitiesKHR surfaceCaps = {};
     SLANG_VK_RETURN_ON_FAIL_REPORT(
@@ -265,10 +297,12 @@ Result SurfaceImpl::createSwapchain()
     swapchainDesc.imageColorSpace = VK_COLOR_SPACE_SRGB_NONLINEAR_KHR;
     swapchainDesc.imageExtent = imageExtent;
     swapchainDesc.imageArrayLayers = 1;
-    // Clamp the requested usage to what the surface actually supports. supportedUsageFlags is
-    // format-independent, so this is a defense-in-depth backstop; the primary guard against
-    // requesting storage on a format that can't support it is the usage derivation in configure().
-    swapchainDesc.imageUsage = _calcImageUsageFlags(m_config.usage) & surfaceCaps.supportedUsageFlags;
+    swapchainDesc.imageUsage = getSwapchainImageUsage(m_config.usage);
+    if (swapchainDesc.imageUsage != (swapchainDesc.imageUsage & surfaceCaps.supportedUsageFlags))
+    {
+        m_device->printError("Surface does not support the requested usage.");
+        return SLANG_E_INVALID_ARG;
+    }
     swapchainDesc.imageSharingMode = VK_SHARING_MODE_EXCLUSIVE;
     swapchainDesc.preTransform = preTransform;
     swapchainDesc.compositeAlpha = compositeAlpha;
@@ -371,18 +405,12 @@ void SurfaceImpl::destroySwapchain()
 
 Result SurfaceImpl::configure(const SurfaceConfig& config)
 {
+    SLANG_RETURN_ON_FAIL(validateConfig(config));
     setConfig(config);
-
-    if (m_config.width == 0 || m_config.height == 0)
-    {
-        return SLANG_FAIL;
-    }
     if (m_config.format == Format::Undefined)
     {
         m_config.format = m_info.preferredFormat;
     }
-    FormatSupport formatSupport = {};
-    m_device->getFormatSupport(m_config.format, &formatSupport);
     if (m_config.usage == TextureUsage::None)
     {
         // Do not auto-add UnorderedAccess here: a format's optimal-tiling features may report
@@ -392,41 +420,28 @@ Result SurfaceImpl::configure(const SurfaceConfig& config)
         // validates it against the format below.
         m_config.usage = (TextureUsage::Present | TextureUsage::RenderTarget | TextureUsage::CopyDestination) &
                          m_info.supportedUsage;
-        // The default degrades to what the selected format supports; explicit requests error below.
-        if (!is_set(formatSupport, FormatSupport::RenderTarget))
-            m_config.usage &= ~TextureUsage::RenderTarget;
-        if (!is_set(formatSupport, FormatSupport::CopyDestination))
+
+        // CopyDestination is useful for the compute fallback, but it is not required for a
+        // presentable surface. Drop it when the selected format does not support the complete
+        // optimal-tiling usage combination.
+        if (!isSwapchainImageUsageSupported(m_device, m_config.format, getSwapchainImageUsage(m_config.usage)))
+        {
             m_config.usage &= ~TextureUsage::CopyDestination;
+        }
     }
     else
     {
-        if (!is_set(formatSupport, FormatSupport::RenderTarget) && is_set(m_config.usage, TextureUsage::RenderTarget))
+        if (m_config.usage != (m_config.usage & m_info.supportedUsage))
         {
-            m_device->printError("Surface format does not support render target usage.");
+            m_device->printError("Surface does not support the requested usage.");
             return SLANG_E_INVALID_ARG;
         }
-        if (!is_set(formatSupport, FormatSupport::CopyDestination) &&
-            is_set(m_config.usage, TextureUsage::CopyDestination))
-        {
-            m_device->printError("Surface format does not support copy destination usage.");
-            return SLANG_E_INVALID_ARG;
-        }
-        if (!is_set(formatSupport, FormatSupport::ShaderUavStore) &&
-            is_set(m_config.usage, TextureUsage::UnorderedAccess))
-        {
-            m_device->printError("Surface format does not support unordered access usage.");
-            return SLANG_E_INVALID_ARG;
-        }
-        if (!is_set(formatSupport, FormatSupport::ShaderLoad) && is_set(m_config.usage, TextureUsage::ShaderResource))
-        {
-            m_device->printError("Surface format does not support shader resource usage.");
-            return SLANG_E_INVALID_ARG;
-        }
-        if (!is_set(formatSupport, FormatSupport::CopySource) && is_set(m_config.usage, TextureUsage::CopySource))
-        {
-            m_device->printError("Surface format does not support copy source usage.");
-            return SLANG_E_INVALID_ARG;
-        }
+    }
+
+    if (!isSwapchainImageUsageSupported(m_device, m_config.format, getSwapchainImageUsage(m_config.usage)))
+    {
+        m_device->printError("Surface format does not support the requested usage.");
+        return SLANG_E_INVALID_ARG;
     }
 
     m_configured = false;

--- a/src/wgpu/wgpu-device.cpp
+++ b/src/wgpu/wgpu-device.cpp
@@ -325,7 +325,7 @@ void DeviceImpl::initializeFormatSupport()
         }
 
         // Add flags depending on feature support.
-        if (format == Format::BGRA8UnormSrgb)
+        if (format == Format::BGRA8Unorm)
         {
             flags |= supportBGRA8UnormStorage ? STORAGE_WO : 0;
         }

--- a/src/wgpu/wgpu-surface.cpp
+++ b/src/wgpu/wgpu-surface.cpp
@@ -168,38 +168,39 @@ Result SurfaceImpl::init(DeviceImpl* device, WindowHandle windowHandle)
 Result SurfaceImpl::configure(const SurfaceConfig& config)
 {
     SLANG_RETURN_ON_FAIL(validateConfig(config));
-    setConfig(config);
-    if (m_config.format == Format::Undefined)
+    SurfaceConfig resolvedConfig = config;
+    if (resolvedConfig.format == Format::Undefined)
     {
-        m_config.format = m_info.preferredFormat;
+        resolvedConfig.format = m_info.preferredFormat;
     }
-    if (m_config.usage == TextureUsage::None)
+    if (resolvedConfig.usage == TextureUsage::None)
     {
-        m_config.usage = (TextureUsage::Present | TextureUsage::RenderTarget | TextureUsage::CopyDestination) &
-                         m_info.supportedUsage;
+        resolvedConfig.usage = (TextureUsage::Present | TextureUsage::RenderTarget | TextureUsage::CopyDestination) &
+                               m_info.supportedUsage;
     }
 
     // sRGB formats cannot be used as storage textures.
-    if (getFormatInfo(m_config.format).isSrgb && is_set(m_config.usage, TextureUsage::UnorderedAccess))
+    if (getFormatInfo(resolvedConfig.format).isSrgb && is_set(resolvedConfig.usage, TextureUsage::UnorderedAccess))
     {
         return SLANG_E_INVALID_ARG;
     }
 
-    WGPUTextureUsage usage = translateTextureUsage(m_config.usage);
+    WGPUTextureUsage usage = translateTextureUsage(resolvedConfig.usage);
     if (usage == WGPUTextureUsage_None)
         usage = WGPUTextureUsage_RenderAttachment;
 
     WGPUSurfaceConfiguration wgpuConfig = {};
     wgpuConfig.device = m_device->m_ctx.device;
-    wgpuConfig.format = translateTextureFormat(m_config.format);
+    wgpuConfig.format = translateTextureFormat(resolvedConfig.format);
     wgpuConfig.usage = usage;
     // TODO: support more view formats
     wgpuConfig.viewFormatCount = 1;
     wgpuConfig.viewFormats = &wgpuConfig.format;
     wgpuConfig.alphaMode = WGPUCompositeAlphaMode_Opaque;
-    wgpuConfig.width = m_config.width;
-    wgpuConfig.height = m_config.height;
-    wgpuConfig.presentMode = m_config.vsync ? m_vsyncOnMode : m_vsyncOffMode;
+    wgpuConfig.width = resolvedConfig.width;
+    wgpuConfig.height = resolvedConfig.height;
+    wgpuConfig.presentMode = resolvedConfig.vsync ? m_vsyncOnMode : m_vsyncOffMode;
+    setConfig(resolvedConfig);
     m_device->m_ctx.api.wgpuSurfaceConfigure(m_surface, &wgpuConfig);
     m_configured = true;
 

--- a/src/wgpu/wgpu-surface.cpp
+++ b/src/wgpu/wgpu-surface.cpp
@@ -130,7 +130,7 @@ Result SurfaceImpl::init(DeviceImpl* device, WindowHandle windowHandle)
     m_info.preferredFormat = preferredFormat;
     m_info.formats = m_supportedFormats.data();
     m_info.formatCount = (uint32_t)m_supportedFormats.size();
-    m_info.supportedUsage = usage;
+    m_info.supportedUsage = TextureUsage::Present | usage;
 
     auto findPresentMode = [&](const WGPUPresentMode* modes, size_t modeCount) -> WGPUPresentMode
     {
@@ -167,32 +167,32 @@ Result SurfaceImpl::init(DeviceImpl* device, WindowHandle windowHandle)
 
 Result SurfaceImpl::configure(const SurfaceConfig& config)
 {
+    SLANG_RETURN_ON_FAIL(validateConfig(config));
     setConfig(config);
-
-    if (m_config.width == 0 || m_config.height == 0)
-    {
-        return SLANG_FAIL;
-    }
     if (m_config.format == Format::Undefined)
     {
         m_config.format = m_info.preferredFormat;
     }
     if (m_config.usage == TextureUsage::None)
     {
-        m_config.usage = m_info.supportedUsage;
+        m_config.usage = (TextureUsage::Present | TextureUsage::RenderTarget | TextureUsage::CopyDestination) &
+                         m_info.supportedUsage;
     }
 
     // sRGB formats cannot be used as storage textures.
-    TextureUsage usage = m_config.usage;
-    if (getFormatInfo(m_config.format).isSrgb)
+    if (getFormatInfo(m_config.format).isSrgb && is_set(m_config.usage, TextureUsage::UnorderedAccess))
     {
-        usage &= ~TextureUsage::UnorderedAccess;
+        return SLANG_E_INVALID_ARG;
     }
+
+    WGPUTextureUsage usage = translateTextureUsage(m_config.usage);
+    if (usage == WGPUTextureUsage_None)
+        usage = WGPUTextureUsage_RenderAttachment;
 
     WGPUSurfaceConfiguration wgpuConfig = {};
     wgpuConfig.device = m_device->m_ctx.device;
     wgpuConfig.format = translateTextureFormat(m_config.format);
-    wgpuConfig.usage = translateTextureUsage(usage);
+    wgpuConfig.usage = usage;
     // TODO: support more view formats
     wgpuConfig.viewFormatCount = 1;
     wgpuConfig.viewFormats = &wgpuConfig.format;

--- a/src/wgpu/wgpu-surface.cpp
+++ b/src/wgpu/wgpu-surface.cpp
@@ -179,13 +179,17 @@ Result SurfaceImpl::configure(const SurfaceConfig& config)
                                m_info.supportedUsage;
     }
 
-    // sRGB formats cannot be used as storage textures.
-    if (getFormatInfo(resolvedConfig.format).isSrgb && is_set(resolvedConfig.usage, TextureUsage::UnorderedAccess))
+    if (is_set(resolvedConfig.usage, TextureUsage::UnorderedAccess))
     {
-        return SLANG_E_INVALID_ARG;
+        FormatSupport formatSupport = FormatSupport::None;
+        SLANG_RETURN_ON_FAIL(m_device->getFormatSupport(resolvedConfig.format, &formatSupport));
+        if (!is_set(formatSupport, FormatSupport::ShaderUavStore))
+            return SLANG_E_INVALID_ARG;
     }
 
     WGPUTextureUsage usage = translateTextureUsage(resolvedConfig.usage);
+    // Present is an RHI surface semantic, while WebGPU requires a concrete native usage.
+    // Keep RenderAttachment as an internal implementation detail for Present-only configs.
     if (usage == WGPUTextureUsage_None)
         usage = WGPUTextureUsage_RenderAttachment;
 
@@ -200,8 +204,14 @@ Result SurfaceImpl::configure(const SurfaceConfig& config)
     wgpuConfig.width = resolvedConfig.width;
     wgpuConfig.height = resolvedConfig.height;
     wgpuConfig.presentMode = resolvedConfig.vsync ? m_vsyncOnMode : m_vsyncOffMode;
-    setConfig(resolvedConfig);
+    if (m_device->getAndClearLastUncapturedError() != WGPUErrorType_NoError)
+        m_device->printWarning("WebGPU device had reported an error before surface configuration.");
+
     m_device->m_ctx.api.wgpuSurfaceConfigure(m_surface, &wgpuConfig);
+    if (m_device->getAndClearLastUncapturedError() != WGPUErrorType_NoError)
+        return SLANG_FAIL;
+
+    setConfig(resolvedConfig);
     m_configured = true;
 
     return SLANG_OK;

--- a/tests/test-surface.cpp
+++ b/tests/test-surface.cpp
@@ -48,6 +48,7 @@ struct SurfaceTest
 
     GLFWwindow* window;
     ComPtr<ISurface> surface;
+    uint32_t configurationCount = 0;
 
     virtual Format getSurfaceFormat() { return surface->getInfo().preferredFormat; }
     virtual TextureUsage getSurfaceUsage() { return TextureUsage::None; }
@@ -67,16 +68,6 @@ struct SurfaceTest
         REQUIRE(this->surface);
         CHECK(is_set(this->surface->getInfo().supportedUsage, TextureUsage::Present));
 
-#if !SLANG_RHI_DEBUG
-        SurfaceConfig invalidConfig = {};
-        invalidConfig.format = this->surface->getInfo().preferredFormat;
-        invalidConfig.usage = TextureUsage::DepthStencil;
-        invalidConfig.width = 1;
-        invalidConfig.height = 1;
-        CHECK(this->surface->configure(invalidConfig) == SLANG_E_INVALID_ARG);
-        CHECK(this->surface->getConfig() == nullptr);
-#endif
-
         initResources();
     }
 
@@ -93,7 +84,9 @@ struct SurfaceTest
 
         SurfaceConfig config = {};
         config.format = getSurfaceFormat();
-        config.usage = getSurfaceUsage();
+        // Exercise default usage resolution on the first configuration and explicit usage
+        // validation on subsequent configurations.
+        config.usage = configurationCount++ == 0 ? TextureUsage::None : getSurfaceUsage();
         config.width = width;
         config.height = height;
         config.vsync = false;
@@ -104,6 +97,8 @@ struct SurfaceTest
         CHECK(surface->getConfig()->height == height);
         CHECK(surface->getConfig()->usage != TextureUsage::None);
         CHECK(surface->getConfig()->usage == (surface->getConfig()->usage & surface->getInfo().supportedUsage));
+        if (config.usage != TextureUsage::None)
+            CHECK(surface->getConfig()->usage == config.usage);
     }
 
     void run()
@@ -178,6 +173,8 @@ struct RenderSurfaceTest : SurfaceTest
 {
     ComPtr<IBuffer> vertexBuffer;
     ComPtr<IRenderPipeline> pipeline;
+
+    TextureUsage getSurfaceUsage() override { return TextureUsage::Present | TextureUsage::RenderTarget; }
 
     void initResources() override
     {
@@ -283,11 +280,9 @@ struct ComputeSurfaceTest : SurfaceTest
 
     TextureUsage getSurfaceUsage() override
     {
-        // Exercise explicit storage usage on Vulkan when both the surface and selected format
-        // support it. This verifies that surface-level usage reporting is not restricted by the
-        // preferred (typically sRGB) format.
-        if (device->getDeviceType() == DeviceType::Vulkan &&
-            is_set(surface->getInfo().supportedUsage, TextureUsage::UnorderedAccess))
+        // Exercise explicit storage usage on every backend where both the surface and selected
+        // format support it.
+        if (is_set(surface->getInfo().supportedUsage, TextureUsage::UnorderedAccess))
         {
             FormatSupport formatSupport = {};
             REQUIRE_CALL(device->getFormatSupport(getSurfaceFormat(), &formatSupport));

--- a/tests/test-surface.cpp
+++ b/tests/test-surface.cpp
@@ -45,6 +45,7 @@ struct SurfaceTest
     ComPtr<ISurface> surface;
 
     virtual Format getSurfaceFormat() { return surface->getInfo().preferredFormat; }
+    virtual TextureUsage getSurfaceUsage() { return TextureUsage::None; }
     virtual void initResources() = 0;
     virtual void renderFrame(ITexture* texture, uint32_t width, uint32_t height, uint32_t frameIndex) = 0;
 
@@ -59,6 +60,17 @@ struct SurfaceTest
         REQUIRE(this->queue);
         this->surface = device->createSurface(getWindowHandleFromGLFW(window));
         REQUIRE(this->surface);
+        CHECK(is_set(this->surface->getInfo().supportedUsage, TextureUsage::Present));
+
+#if !SLANG_RHI_DEBUG
+        SurfaceConfig invalidConfig = {};
+        invalidConfig.format = this->surface->getInfo().preferredFormat;
+        invalidConfig.usage = TextureUsage::DepthStencil;
+        invalidConfig.width = 1;
+        invalidConfig.height = 1;
+        CHECK(this->surface->configure(invalidConfig) == SLANG_E_INVALID_ARG);
+        CHECK(this->surface->getConfig() == nullptr);
+#endif
 
         initResources();
     }
@@ -76,6 +88,7 @@ struct SurfaceTest
 
         SurfaceConfig config = {};
         config.format = getSurfaceFormat();
+        config.usage = getSurfaceUsage();
         config.width = width;
         config.height = height;
         config.vsync = false;
@@ -84,6 +97,8 @@ struct SurfaceTest
         CHECK(surface->getConfig());
         CHECK(surface->getConfig()->width == width);
         CHECK(surface->getConfig()->height == height);
+        CHECK(surface->getConfig()->usage != TextureUsage::None);
+        CHECK(surface->getConfig()->usage == (surface->getConfig()->usage & surface->getInfo().supportedUsage));
     }
 
     void run()
@@ -102,6 +117,7 @@ struct SurfaceTest
             ComPtr<ITexture> texture = surface->acquireNextImage();
             CHECK(texture->getDesc().size.width == width);
             CHECK(texture->getDesc().size.height == height);
+            CHECK(texture->getDesc().usage == surface->getConfig()->usage);
             renderFrame(texture, width, height, i);
             surface->present();
         }
@@ -118,6 +134,7 @@ struct SurfaceTest
             ComPtr<ITexture> texture = surface->acquireNextImage();
             CHECK(texture->getDesc().size.width == width);
             CHECK(texture->getDesc().size.height == height);
+            CHECK(texture->getDesc().usage == surface->getConfig()->usage);
             renderFrame(texture, width, height, i);
             surface->present();
         }
@@ -143,6 +160,7 @@ struct SurfaceTest
             ComPtr<ITexture> texture = surface->acquireNextImage();
             CHECK(texture->getDesc().size.width == width);
             CHECK(texture->getDesc().size.height == height);
+            CHECK(texture->getDesc().usage == surface->getConfig()->usage);
             renderFrame(texture, width, height, i);
             surface->present();
         }
@@ -256,6 +274,22 @@ struct ComputeSurfaceTest : SurfaceTest
             }
         }
         return info.preferredFormat;
+    }
+
+    TextureUsage getSurfaceUsage() override
+    {
+        // Exercise explicit storage usage on Vulkan when both the surface and selected format
+        // support it. This verifies that surface-level usage reporting is not restricted by the
+        // preferred (typically sRGB) format.
+        if (device->getDeviceType() == DeviceType::Vulkan &&
+            is_set(surface->getInfo().supportedUsage, TextureUsage::UnorderedAccess))
+        {
+            FormatSupport formatSupport = {};
+            REQUIRE_CALL(device->getFormatSupport(getSurfaceFormat(), &formatSupport));
+            if (is_set(formatSupport, FormatSupport::ShaderUavStore))
+                return TextureUsage::Present | TextureUsage::UnorderedAccess;
+        }
+        return TextureUsage::None;
     }
 
     void initResources() override

--- a/tests/test-surface.cpp
+++ b/tests/test-surface.cpp
@@ -12,6 +12,11 @@
 #include <GLFW/glfw3native.h>
 #include <slang-rhi/glfw.h>
 
+// X11 defines None as a macro after slang-rhi.h has already removed it.
+#ifdef None
+#undef None
+#endif
+
 using namespace rhi;
 using namespace rhi::testing;
 


### PR DESCRIPTION
Define SurfaceInfo::supportedUsage as the surface-level upper bound, while allowing the selected format to impose additional restrictions. Treat an empty SurfaceConfig::usage as a request for a safe, format-compatible default, and reject unsupported explicit configurations consistently in backend code rather than relying on the debug layer.

Update the backends to ensure that the resolved surface configuration matches both the native swapchain resource and acquired texture descriptors:

- validate formats, usage flags, dimensions, and image counts centrally
- validate Vulkan usage combinations for optimal tiling and avoid silently clamping requested swapchain usage
- keep Present as a surface semantic rather than mapping it to an unrelated Vulkan image usage
- require transfer-destination support for CUDA's Vulkan presentation swapchain
- request D3D unordered-access support only when configured
- derive Metal framebufferOnly from the resolved usage
- advertise Present in WebGPU and reject unsupported sRGB storage usage

Extend the surface tests to verify Present support, resolved usage, acquired texture descriptors, and backend-side rejection of invalid configurations.