### PR TITLE
Prepare shared state for concurrent pipeline compilation

### DIFF
--- a/examples/base/utils.h
+++ b/examples/base/utils.h
@@ -6,6 +6,7 @@
 
 #include <execution>
 #include <limits>
+#include <mutex>
 #include <vector>
 
 // ---------------------------------------------------------------------------------------
@@ -61,6 +62,7 @@ public:
         const char* message
     ) override
     {
+        std::lock_guard<std::mutex> lock(m_mutex);
         printf("[%s] (%s) %s\n", enumToString(type), enumToString(source), message);
         fflush(stdout);
     }
@@ -70,6 +72,9 @@ public:
         static DebugPrinter instance;
         return &instance;
     }
+
+private:
+    std::mutex m_mutex;
 };
 
 // ---------------------------------------------------------------------------------------

--- a/include/slang-rhi.h
+++ b/include/slang-rhi.h
@@ -3198,6 +3198,8 @@ enum class DebugMessageSource
 class IDebugCallback
 {
 public:
+    /// May be called concurrently from multiple threads. Implementations must provide any required synchronization.
+    /// `message` is valid only for the duration of the call.
     virtual SLANG_NO_THROW void SLANG_MCALL handleMessage(
         DebugMessageType type,
         DebugMessageSource source,
@@ -3946,7 +3948,15 @@ class IPersistentCache : public ISlangUnknown
     SLANG_COM_INTERFACE(0x68981742, 0x7fd6, 0x4700, {0x8a, 0x71, 0xe8, 0xea, 0x42, 0x91, 0x3b, 0x28});
 
 public:
+    /// Writes an entry to the cache.
+    /// Implementations must support concurrent calls to writeCache() and queryCache(), including when the cache is
+    /// shared by multiple devices or used for both shaders and pipelines.
     virtual SLANG_NO_THROW Result SLANG_MCALL writeCache(ISlangBlob* key, ISlangBlob* data) = 0;
+
+    /// Queries an entry from the cache.
+    /// Implementations must support concurrent calls to writeCache() and queryCache(), including when the cache is
+    /// shared by multiple devices or used for both shaders and pipelines.
+    /// A returned blob must remain valid independently of subsequent cache calls.
     virtual SLANG_NO_THROW Result SLANG_MCALL queryCache(ISlangBlob* key, ISlangBlob** outData) = 0;
 };
 

--- a/src/device.cpp
+++ b/src/device.cpp
@@ -82,6 +82,7 @@ ShaderComponentID ShaderCache::getComponentId(std::string_view name)
 
 ShaderComponentID ShaderCache::getComponentId(ComponentKey key)
 {
+    std::lock_guard<std::mutex> lock(m_mutex);
     auto it = componentIds.find(key);
     if (it != componentIds.end())
         return it->second;
@@ -92,6 +93,7 @@ ShaderComponentID ShaderCache::getComponentId(ComponentKey key)
 
 RefPtr<Pipeline> ShaderCache::getSpecializedPipeline(PipelineKey programKey)
 {
+    std::lock_guard<std::mutex> lock(m_mutex);
     auto it = specializedPipelines.find(programKey);
     if (it != specializedPipelines.end())
         return it->second;
@@ -100,11 +102,13 @@ RefPtr<Pipeline> ShaderCache::getSpecializedPipeline(PipelineKey programKey)
 
 void ShaderCache::addSpecializedPipeline(PipelineKey key, RefPtr<Pipeline> specializedPipeline)
 {
+    std::lock_guard<std::mutex> lock(m_mutex);
     specializedPipelines[key] = specializedPipeline;
 }
 
 void ShaderCache::free()
 {
+    std::lock_guard<std::mutex> lock(m_mutex);
     componentIds = decltype(componentIds)();
     specializedPipelines = decltype(specializedPipelines)();
 }
@@ -169,7 +173,7 @@ Result Device::getSpecializedProgram(
     ShaderProgram** outSpecializedProgram
 )
 {
-    // TODO make thread-safe
+    std::lock_guard<std::mutex> lock(program->m_specializedProgramsMutex);
     SpecializationKey key(specializationArgs);
     auto it = program->m_specializedPrograms.find(key);
     if (it != program->m_specializedPrograms.end())
@@ -297,7 +301,7 @@ Result Device::getConcretePipeline(
     if (isSpecializable)
     {
         RefPtr<ShaderProgram> specializedProgram;
-        SLANG_RETURN_ON_FAIL(specializeProgram(program, *specializationArgs, specializedProgram.writeRef()));
+        SLANG_RETURN_ON_FAIL(getSpecializedProgram(program, *specializationArgs, specializedProgram.writeRef()));
         program = specializedProgram;
     }
 

--- a/src/device.h
+++ b/src/device.h
@@ -14,6 +14,7 @@
 
 #include <atomic>
 #include <map>
+#include <mutex>
 #include <unordered_map>
 
 namespace rhi {
@@ -126,6 +127,7 @@ protected:
         std::size_t operator()(const PipelineKey& k) const { return k.hash; }
     };
 
+    std::mutex m_mutex;
     std::unordered_map<ComponentKey, ShaderComponentID, ComponentKeyHasher> componentIds;
     std::unordered_map<PipelineKey, RefPtr<Pipeline>, PipelineKeyHasher> specializedPipelines;
 };

--- a/src/shader.h
+++ b/src/shader.h
@@ -10,6 +10,7 @@
 #include "device-child.h"
 
 #include <unordered_map>
+#include <mutex>
 
 namespace rhi {
 
@@ -60,6 +61,7 @@ public:
 
     bool m_compiledShaders = false;
 
+    std::mutex m_specializedProgramsMutex;
     std::unordered_map<SpecializationKey, RefPtr<ShaderProgram>, SpecializationKey::Hasher> m_specializedPrograms;
 
     ShaderProgram(Device* device, const ShaderProgramDesc& desc);

--- a/tests/shader-cache.h
+++ b/tests/shader-cache.h
@@ -7,6 +7,7 @@
 #include <vector>
 #include <map>
 #include <cstdint>
+#include <mutex>
 
 namespace rhi::testing {
 
@@ -15,8 +16,6 @@ class ShaderCache : public IPersistentCache
 public:
     using Key = std::vector<uint8_t>;
     using Data = std::vector<uint8_t>;
-
-    std::map<Key, Data> entries;
 
     virtual SLANG_NO_THROW Result SLANG_MCALL writeCache(ISlangBlob* key_, ISlangBlob* data_) override
     {
@@ -28,7 +27,8 @@ public:
             static_cast<const uint8_t*>(data_->getBufferPointer()),
             static_cast<const uint8_t*>(data_->getBufferPointer()) + data_->getBufferSize()
         );
-        entries[key] = data;
+        std::lock_guard<std::mutex> lock(m_mutex);
+        m_entries[key] = data;
         return SLANG_OK;
     }
 
@@ -38,13 +38,14 @@ public:
             static_cast<const uint8_t*>(key_->getBufferPointer()),
             static_cast<const uint8_t*>(key_->getBufferPointer()) + key_->getBufferSize()
         );
-        auto it = entries.find(key);
-        if (it == entries.end())
+        std::lock_guard<std::mutex> lock(m_mutex);
+        auto it = m_entries.find(key);
+        if (it == m_entries.end())
         {
             *outData = nullptr;
             return SLANG_E_NOT_FOUND;
         }
-        *outData = UnownedBlob::create(it->second.data(), it->second.size()).detach();
+        *outData = OwnedBlob::create(it->second.data(), it->second.size()).detach();
         return SLANG_OK;
     }
 
@@ -71,6 +72,10 @@ public:
         // if the ref count **was 1 before releasing** in order to free the object.
         return 2;
     }
+
+private:
+    std::mutex m_mutex;
+    std::map<Key, Data> m_entries;
 };
 
 } // namespace rhi::testing

--- a/tests/test-pipeline-cache.cpp
+++ b/tests/test-pipeline-cache.cpp
@@ -6,6 +6,7 @@
 #include <fstream>
 #include <map>
 #include <algorithm>
+#include <mutex>
 
 using namespace rhi;
 using namespace rhi::testing;
@@ -25,18 +26,17 @@ public:
     using Key = std::vector<uint8_t>;
     using Data = std::vector<uint8_t>;
 
-    std::map<Key, Data> entries;
-    Stats stats;
-
     void clear()
     {
-        entries.clear();
-        stats = {};
+        std::lock_guard<std::mutex> lock(m_mutex);
+        m_entries.clear();
+        m_stats = {};
     }
 
     void corrupt()
     {
-        for (auto& entry : entries)
+        std::lock_guard<std::mutex> lock(m_mutex);
+        for (auto& entry : m_entries)
         {
             // Corrupt the data.
             if (!entry.second.empty())
@@ -49,9 +49,14 @@ public:
         }
     }
 
+    Stats getStats() const
+    {
+        std::lock_guard<std::mutex> lock(m_mutex);
+        return m_stats;
+    }
+
     virtual SLANG_NO_THROW Result SLANG_MCALL writeCache(ISlangBlob* key_, ISlangBlob* data_) override
     {
-        stats.writeCount++;
         Key key(
             static_cast<const uint8_t*>(key_->getBufferPointer()),
             static_cast<const uint8_t*>(key_->getBufferPointer()) + key_->getBufferSize()
@@ -60,27 +65,30 @@ public:
             static_cast<const uint8_t*>(data_->getBufferPointer()),
             static_cast<const uint8_t*>(data_->getBufferPointer()) + data_->getBufferSize()
         );
-        entries[key] = data;
-        stats.entryCount = entries.size();
+        std::lock_guard<std::mutex> lock(m_mutex);
+        m_stats.writeCount++;
+        m_entries[key] = data;
+        m_stats.entryCount = m_entries.size();
         return SLANG_OK;
     }
 
     virtual SLANG_NO_THROW Result SLANG_MCALL queryCache(ISlangBlob* key_, ISlangBlob** outData) override
     {
-        stats.queryCount++;
         Key key(
             static_cast<const uint8_t*>(key_->getBufferPointer()),
             static_cast<const uint8_t*>(key_->getBufferPointer()) + key_->getBufferSize()
         );
-        auto it = entries.find(key);
-        if (it == entries.end())
+        std::lock_guard<std::mutex> lock(m_mutex);
+        m_stats.queryCount++;
+        auto it = m_entries.find(key);
+        if (it == m_entries.end())
         {
-            stats.missCount++;
+            m_stats.missCount++;
             *outData = nullptr;
             return SLANG_E_NOT_FOUND;
         }
-        stats.hitCount++;
-        *outData = UnownedBlob::create(it->second.data(), it->second.size()).detach();
+        m_stats.hitCount++;
+        *outData = OwnedBlob::create(it->second.data(), it->second.size()).detach();
         return SLANG_OK;
     }
 
@@ -107,6 +115,11 @@ public:
         // if the ref count **was 1 before releasing** in order to free the object.
         return 2;
     }
+
+private:
+    mutable std::mutex m_mutex;
+    std::map<Key, Data> m_entries;
+    Stats m_stats;
 };
 
 
@@ -125,7 +138,7 @@ struct PipelineCacheTest
         device = createTestingDevice(ctx, ctx->deviceType, false, &extraOptions);
     }
 
-    VirtualCache::Stats getStats() { return pipelineCache.stats; }
+    VirtualCache::Stats getStats() { return pipelineCache.getStats(); }
 
     void run(GpuTestContext* ctx_, std::string tempDirectory_)
     {

--- a/tests/test-shader-cache.cpp
+++ b/tests/test-shader-cache.cpp
@@ -4,6 +4,7 @@
 #include <fstream>
 #include <map>
 #include <algorithm>
+#include <mutex>
 
 using namespace rhi;
 using namespace rhi::testing;
@@ -27,34 +28,29 @@ public:
         std::vector<uint8_t> data;
     };
 
-    std::map<Key, Entry> entries;
-    Stats stats;
-    uint32_t maxEntryCount = 1024;
-    uint32_t ticketCounter = 0;
-
     void clear()
     {
-        entries.clear();
-        stats = {};
-        maxEntryCount = 1024;
-        ticketCounter = 0;
+        std::lock_guard<std::mutex> lock(m_mutex);
+        m_entries.clear();
+        m_stats = {};
+        m_maxEntryCount = 1024;
+        m_ticketCounter = 0;
+    }
+
+    Stats getStats() const
+    {
+        std::lock_guard<std::mutex> lock(m_mutex);
+        return m_stats;
+    }
+
+    void setMaxEntryCount(uint32_t maxEntryCount)
+    {
+        std::lock_guard<std::mutex> lock(m_mutex);
+        m_maxEntryCount = maxEntryCount;
     }
 
     virtual SLANG_NO_THROW Result SLANG_MCALL writeCache(ISlangBlob* key_, ISlangBlob* data_) override
     {
-        while (entries.size() >= maxEntryCount)
-        {
-            auto it = std::min_element(
-                entries.begin(),
-                entries.end(),
-                [](const auto& a, const auto& b)
-                {
-                    return a.second.ticket < b.second.ticket;
-                }
-            );
-            entries.erase(it);
-        }
-
         Key key(
             static_cast<const uint8_t*>(key_->getBufferPointer()),
             static_cast<const uint8_t*>(key_->getBufferPointer()) + key_->getBufferSize()
@@ -63,8 +59,21 @@ public:
             static_cast<const uint8_t*>(data_->getBufferPointer()),
             static_cast<const uint8_t*>(data_->getBufferPointer()) + data_->getBufferSize()
         );
-        entries[key] = {ticketCounter++, data};
-        stats.entryCount = entries.size();
+        std::lock_guard<std::mutex> lock(m_mutex);
+        while (m_entries.size() >= m_maxEntryCount)
+        {
+            auto it = std::min_element(
+                m_entries.begin(),
+                m_entries.end(),
+                [](const auto& a, const auto& b)
+                {
+                    return a.second.ticket < b.second.ticket;
+                }
+            );
+            m_entries.erase(it);
+        }
+        m_entries[key] = {m_ticketCounter++, data};
+        m_stats.entryCount = m_entries.size();
         return SLANG_OK;
     }
 
@@ -74,15 +83,16 @@ public:
             static_cast<const uint8_t*>(key_->getBufferPointer()),
             static_cast<const uint8_t*>(key_->getBufferPointer()) + key_->getBufferSize()
         );
-        auto it = entries.find(key);
-        if (it == entries.end())
+        std::lock_guard<std::mutex> lock(m_mutex);
+        auto it = m_entries.find(key);
+        if (it == m_entries.end())
         {
-            stats.missCount++;
+            m_stats.missCount++;
             *outData = nullptr;
             return SLANG_E_NOT_FOUND;
         }
-        stats.hitCount++;
-        *outData = UnownedBlob::create(it->second.data.data(), it->second.data.size()).detach();
+        m_stats.hitCount++;
+        *outData = OwnedBlob::create(it->second.data.data(), it->second.data.size()).detach();
         return SLANG_OK;
     }
 
@@ -109,6 +119,13 @@ public:
         // if the ref count **was 1 before releasing** in order to free the object.
         return 2;
     }
+
+private:
+    mutable std::mutex m_mutex;
+    std::map<Key, Entry> m_entries;
+    Stats m_stats;
+    uint32_t m_maxEntryCount = 1024;
+    uint32_t m_ticketCounter = 0;
 };
 
 static VirtualShaderCache shaderCache;
@@ -287,7 +304,7 @@ struct ShaderCacheTest
         freeComputeResources();
     }
 
-    VirtualShaderCache::Stats getStats() { return shaderCache.stats; }
+    VirtualShaderCache::Stats getStats() { return shaderCache.getStats(); }
 
     void run(GpuTestContext* ctx_, std::string tempDirectory_)
     {
@@ -594,7 +611,7 @@ struct ShaderCacheTestEviction : ShaderCacheTest
 {
     void runTests()
     {
-        shaderCache.maxEntryCount = 2;
+        shaderCache.setMaxEntryCount(2);
 
         // Write shader source files.
         writeShader(computeShaderA, "shader-cache-compute-a.slang");

--- a/tests/testing.cpp
+++ b/tests/testing.cpp
@@ -8,6 +8,7 @@
 #include <cstdlib>
 #include <filesystem>
 #include <map>
+#include <mutex>
 #include <string>
 #include <fstream>
 
@@ -149,9 +150,17 @@ void writeFile(std::string_view path, const void* data, size_t size)
 class CaptureDebugCallback : public IDebugCallback
 {
 public:
-    std::string output;
+    void clear()
+    {
+        std::lock_guard<std::mutex> lock(m_mutex);
+        m_output.clear();
+    }
 
-    void clear() { output.clear(); }
+    std::string getOutput() const
+    {
+        std::lock_guard<std::mutex> lock(m_mutex);
+        return m_output;
+    }
 
     virtual SLANG_NO_THROW void SLANG_MCALL handleMessage(
         DebugMessageType type,
@@ -159,11 +168,16 @@ public:
         const char* message
     ) override
     {
-        output += "[" + std::string(rhi::enumToString(type)) + "] ";
-        output += "[" + std::string(rhi::enumToString(source)) + "] ";
-        output += message;
-        output += "\n";
+        std::lock_guard<std::mutex> lock(m_mutex);
+        m_output += "[" + std::string(rhi::enumToString(type)) + "] ";
+        m_output += "[" + std::string(rhi::enumToString(source)) + "] ";
+        m_output += message;
+        m_output += "\n";
     }
+
+private:
+    mutable std::mutex m_mutex;
+    std::string m_output;
 };
 
 static CaptureDebugCallback sCaptureDebugCallback;
@@ -202,6 +216,8 @@ public:
         if (shouldIgnoreMessage(type, source, message))
             return;
 
+        std::lock_guard<std::mutex> lock(m_mutex);
+
         doctest::String msg = "[" + doctest::String(enumToString(type)) + "] ";
         msg += "[" + doctest::String(enumToString(source)) + "] ";
         msg += message;
@@ -228,6 +244,9 @@ public:
             FAIL(msg);
         }
     }
+
+private:
+    std::mutex m_mutex;
 };
 
 static DebugCallback sDebugCallback;
@@ -881,7 +900,7 @@ DeviceAvailabilityResult checkDeviceTypeAvailable(DeviceType deviceType)
     {                                                                                                                  \
         result.available = false;                                                                                      \
         result.error = msg;                                                                                            \
-        result.debugCallbackOutput = sCaptureDebugCallback.output;                                                     \
+        result.debugCallbackOutput = sCaptureDebugCallback.getOutput();                                                \
         result.diagnostics = diagnostics ? (const char*)diagnostics->getBufferPointer() : "";                          \
         return result;                                                                                                 \
     }


### PR DESCRIPTION
## Summary

This is the first change in the parallel pipeline compilation series. It establishes the thread-safety contracts and protects shared state that later changes will access concurrently.

This PR does not introduce parallel pipeline compilation itself.

## Changes

- Document that `IDebugCallback::handleMessage()` may be called concurrently and that the message string is valid only during the call.
- Document that `IPersistentCache` implementations:
  - must support concurrent `queryCache()` and `writeCache()` calls;
  - may be shared across devices and used for both shader and pipeline caching;
  - must return blobs whose lifetime is independent of subsequent cache operations.
- Protect the internal shader cache and specialized-program map with mutexes.
- Route specialized pipeline resolution through the synchronized program lookup.
- Make example and test debug callbacks thread-safe.
- Make test shader and pipeline caches thread-safe.
- Return owned blobs from test caches so cached data remains valid after releasing the cache lock.
- Provide synchronized accessors for test-cache statistics and configuration.

## Motivation

Later PRs perform shader compilation and supported backend pipeline creation on worker threads. That work can concurrently access shader specialization state, persistent caches, and debug callbacks.

Defining the public concurrency requirements and protecting internally owned state first keeps those prerequisites independently reviewable.