### PR TITLE
Refactor shader compilation and pipeline resolution into explicit stages

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -747,6 +747,7 @@ target_sources(slang-rhi PRIVATE
     src/format-conversion.cpp
     src/heap.cpp
     src/pipeline.cpp
+    src/pipeline-resolver.cpp
     src/resource-desc-utils.cpp
     src/rhi-shared.cpp
     src/rhi.cpp

--- a/src/command-buffer.cpp
+++ b/src/command-buffer.cpp
@@ -3,6 +3,7 @@
 #include "rhi-shared.h"
 #include "device.h"
 #include "format-conversion.h"
+#include "pipeline-resolver.h"
 
 namespace rhi {
 
@@ -938,43 +939,7 @@ Result CommandEncoder::getPipelineSpecializationArgs(
 
 Result CommandEncoder::resolvePipelines(Device* device)
 {
-    CommandList* commandList = m_commandList;
-    auto command = commandList->getCommands();
-    while (command)
-    {
-        if (command->id == CommandID::SetRenderState)
-        {
-            auto& cmd = commandList->getCommand<commands::SetRenderState>(command);
-            RenderPipeline* pipeline = checked_cast<RenderPipeline*>(cmd.pipeline);
-            auto specializationArgs = static_cast<ExtendedShaderObjectTypeListObject*>(cmd.specializationArgs);
-            Pipeline* concretePipeline = nullptr;
-            SLANG_RETURN_ON_FAIL(device->getConcretePipeline(pipeline, specializationArgs, concretePipeline));
-            cmd.pipeline = static_cast<RenderPipeline*>(concretePipeline);
-            cmd.specializationArgs = nullptr;
-        }
-        else if (command->id == CommandID::SetComputeState)
-        {
-            auto& cmd = commandList->getCommand<commands::SetComputeState>(command);
-            ComputePipeline* pipeline = checked_cast<ComputePipeline*>(cmd.pipeline);
-            auto specializationArgs = static_cast<ExtendedShaderObjectTypeListObject*>(cmd.specializationArgs);
-            Pipeline* concretePipeline = nullptr;
-            SLANG_RETURN_ON_FAIL(device->getConcretePipeline(pipeline, specializationArgs, concretePipeline));
-            cmd.pipeline = static_cast<ComputePipeline*>(concretePipeline);
-            cmd.specializationArgs = nullptr;
-        }
-        else if (command->id == CommandID::SetRayTracingState)
-        {
-            auto& cmd = commandList->getCommand<commands::SetRayTracingState>(command);
-            RayTracingPipeline* pipeline = checked_cast<RayTracingPipeline*>(cmd.pipeline);
-            auto specializationArgs = static_cast<ExtendedShaderObjectTypeListObject*>(cmd.specializationArgs);
-            Pipeline* concretePipeline = nullptr;
-            SLANG_RETURN_ON_FAIL(device->getConcretePipeline(pipeline, specializationArgs, concretePipeline));
-            cmd.pipeline = static_cast<RayTracingPipeline*>(concretePipeline);
-            cmd.specializationArgs = nullptr;
-        }
-        command = command->next;
-    }
-    return SLANG_OK;
+    return rhi::resolvePipelines(device, m_commandList);
 }
 
 // ----------------------------------------------------------------------------

--- a/src/cuda/cuda-shader-program.cpp
+++ b/src/cuda/cuda-shader-program.cpp
@@ -10,11 +10,11 @@ ShaderProgramImpl::ShaderProgramImpl(Device* device, const ShaderProgramDesc& de
 
 ShaderProgramImpl::~ShaderProgramImpl() {}
 
-Result ShaderProgramImpl::createShaderModule(slang::EntryPointReflection* entryPointInfo, ComPtr<ISlangBlob> kernelCode)
+Result ShaderProgramImpl::createShaderModule(const ShaderModuleDesc& desc, ComPtr<ISlangBlob> kernelCode)
 {
     Module module;
-    module.stage = entryPointInfo->getStage();
-    module.entryPointName = entryPointInfo->getNameOverride();
+    module.stage = desc.stage;
+    module.entryPointName = desc.entryPointName;
     module.code = kernelCode;
     m_modules.push_back(module);
     return SLANG_OK;

--- a/src/cuda/cuda-shader-program.h
+++ b/src/cuda/cuda-shader-program.h
@@ -21,10 +21,7 @@ public:
     ShaderProgramImpl(Device* device, const ShaderProgramDesc& desc);
     ~ShaderProgramImpl();
 
-    virtual Result createShaderModule(
-        slang::EntryPointReflection* entryPointInfo,
-        ComPtr<ISlangBlob> kernelCode
-    ) override;
+    virtual Result createShaderModule(const ShaderModuleDesc& desc, ComPtr<ISlangBlob> kernelCode) override;
 
     virtual ShaderObjectLayout* getRootShaderObjectLayout() override;
 };

--- a/src/d3d11/d3d11-shader-program.cpp
+++ b/src/d3d11/d3d11-shader-program.cpp
@@ -23,7 +23,7 @@ ShaderProgramImpl::~ShaderProgramImpl()
 #endif
 }
 
-Result ShaderProgramImpl::createShaderModule(slang::EntryPointReflection* entryPointInfo, ComPtr<ISlangBlob> kernelCode)
+Result ShaderProgramImpl::createShaderModule(const ShaderModuleDesc& desc, ComPtr<ISlangBlob> kernelCode)
 {
 #if SLANG_RHI_ENABLE_AFTERMATH
     DeviceImpl* device = getDevice<DeviceImpl>();
@@ -37,7 +37,7 @@ Result ShaderProgramImpl::createShaderModule(slang::EntryPointReflection* entryP
         );
     }
 #endif
-    m_modules.push_back({entryPointInfo->getStage(), kernelCode});
+    m_modules.push_back({desc.stage, kernelCode});
     return SLANG_OK;
 }
 

--- a/src/d3d11/d3d11-shader-program.h
+++ b/src/d3d11/d3d11-shader-program.h
@@ -20,10 +20,7 @@ public:
     ShaderProgramImpl(Device* device, const ShaderProgramDesc& desc);
     ~ShaderProgramImpl();
 
-    virtual Result createShaderModule(
-        slang::EntryPointReflection* entryPointInfo,
-        ComPtr<ISlangBlob> kernelCode
-    ) override;
+    virtual Result createShaderModule(const ShaderModuleDesc& desc, ComPtr<ISlangBlob> kernelCode) override;
 
     virtual ShaderObjectLayout* getRootShaderObjectLayout() override;
 

--- a/src/d3d12/d3d12-pipeline.cpp
+++ b/src/d3d12/d3d12-pipeline.cpp
@@ -616,7 +616,7 @@ Result DeviceImpl::createRayTracingPipeline2(const RayTracingPipelineDesc& desc,
         library.DXILLibrary.pShaderBytecode = shader.code.data();
         library.NumExports = 1;
         D3D12_EXPORT_DESC exportDesc = {};
-        exportDesc.Name = getWStr(shader.entryPointInfo->getNameOverride());
+        exportDesc.Name = getWStr(shader.entryPointName.c_str());
         exportDesc.ExportToRename = nullptr;
         exportDesc.Flags = D3D12_EXPORT_FLAG_NONE;
         exports.push_back(exportDesc);
@@ -748,7 +748,7 @@ Result DeviceImpl::createRayTracingPipeline2(const RayTracingPipelineDesc& desc,
                 if (shader.stage != SLANG_STAGE_RAY_GENERATION && shader.stage != SLANG_STAGE_MISS &&
                     shader.stage != SLANG_STAGE_CALLABLE)
                     continue;
-                std::string name = shader.entryPointInfo->getNameOverride();
+                std::string name = shader.entryPointName;
                 void* id = stateObjectProperties->GetShaderIdentifier(string::to_wstring(name).data());
                 if (id)
                 {

--- a/src/d3d12/d3d12-shader-program.cpp
+++ b/src/d3d12/d3d12-shader-program.cpp
@@ -23,11 +23,11 @@ ShaderProgramImpl::~ShaderProgramImpl()
 #endif
 }
 
-Result ShaderProgramImpl::createShaderModule(slang::EntryPointReflection* entryPointInfo, ComPtr<ISlangBlob> kernelCode)
+Result ShaderProgramImpl::createShaderModule(const ShaderModuleDesc& desc, ComPtr<ISlangBlob> kernelCode)
 {
     ShaderBinary shaderBin;
-    shaderBin.stage = entryPointInfo->getStage();
-    shaderBin.entryPointInfo = entryPointInfo;
+    shaderBin.stage = desc.stage;
+    shaderBin.entryPointName = desc.entryPointName;
     shaderBin.code.assign(
         reinterpret_cast<const uint8_t*>(kernelCode->getBufferPointer()),
         reinterpret_cast<const uint8_t*>(kernelCode->getBufferPointer()) + (size_t)kernelCode->getBufferSize()

--- a/src/d3d12/d3d12-shader-program.h
+++ b/src/d3d12/d3d12-shader-program.h
@@ -10,8 +10,7 @@ namespace rhi::d3d12 {
 struct ShaderBinary
 {
     SlangStage stage;
-    slang::EntryPointReflection* entryPointInfo;
-    std::string actualEntryPointNameInAPI;
+    std::string entryPointName;
     std::vector<uint8_t> code;
 };
 
@@ -24,10 +23,7 @@ public:
     ShaderProgramImpl(Device* device, const ShaderProgramDesc& desc);
     ~ShaderProgramImpl();
 
-    virtual Result createShaderModule(
-        slang::EntryPointReflection* entryPointInfo,
-        ComPtr<ISlangBlob> kernelCode
-    ) override;
+    virtual Result createShaderModule(const ShaderModuleDesc& desc, ComPtr<ISlangBlob> kernelCode) override;
 
     virtual ShaderObjectLayout* getRootShaderObjectLayout() override;
 };

--- a/src/device.cpp
+++ b/src/device.cpp
@@ -310,6 +310,30 @@ Result Device::getConcretePipeline(
 
     // Create a new concrete pipeline.
     RefPtr<Pipeline> concretePipeline;
+    SLANG_RETURN_ON_FAIL(createConcretePipeline(pipeline, program, concretePipeline));
+
+    if (isSpecializable)
+    {
+        // Cache the specialized pipeline for later use.
+        m_shaderCache.addSpecializedPipeline(pipelineKey, concretePipeline);
+        // Pipeline is owned by the cache.
+        concretePipeline->breakStrongReferenceToDevice();
+        // Program is owned by the specialized pipeline (which is owned by the cache).
+        concretePipeline->m_program->breakStrongReferenceToDevice();
+    }
+    else
+    {
+        // Store the concrete pipeline in the virtual one.
+        pipeline->setConcretePipeline(concretePipeline);
+    }
+
+    outPipeline = concretePipeline;
+    return SLANG_OK;
+}
+
+Result Device::createConcretePipeline(Pipeline* pipeline, ShaderProgram* program, RefPtr<Pipeline>& outPipeline)
+{
+    RefPtr<Pipeline> concretePipeline;
     switch (pipeline->getType())
     {
     case PipelineType::Render:
@@ -339,21 +363,6 @@ Result Device::getConcretePipeline(
         concretePipeline = checked_cast<RayTracingPipeline*>(rayTracingPipeline.get());
         break;
     }
-    }
-
-    if (isSpecializable)
-    {
-        // Cache the specialized pipeline for later use.
-        m_shaderCache.addSpecializedPipeline(pipelineKey, concretePipeline);
-        // Pipeline is owned by the cache.
-        concretePipeline->breakStrongReferenceToDevice();
-        // Program is owned by the specialized pipeline (which is owned by the cache).
-        concretePipeline->m_program->breakStrongReferenceToDevice();
-    }
-    else
-    {
-        // Store the concrete pipeline in the virtual one.
-        pipeline->setConcretePipeline(concretePipeline);
     }
 
     outPipeline = concretePipeline;
@@ -387,35 +396,41 @@ Result Device::getEntryPointCodeFromShaderCache(
     const char* entryPointName,
     uint32_t entryPointIndex,
     uint32_t targetIndex,
+    slang::IBlob* cacheKey,
+    bool measureCompilerTime,
+    EntryPointCompilationStats* outStats,
     slang::IBlob** outCode,
     slang::IBlob** outDiagnostics
 )
 {
     TimePoint startTime = Timer::now();
     ComPtr<ISlangBlob> codeBlob;
-    ComPtr<ISlangBlob> hashBlob;
+    ComPtr<ISlangBlob> hashBlob(cacheKey);
+    SLANG_UNUSED(program);
+    SLANG_UNUSED(entryPointName);
+
+    if (outStats)
+    {
+        *outStats = {};
+        outStats->startTime = startTime;
+    }
 
     if (m_persistentShaderCache)
     {
         // Hash all relevant state for generating the entry point shader code to use as a key
         // for the shader cache.
-        componentType->getEntryPointHash(entryPointIndex, targetIndex, hashBlob.writeRef());
+        if (!hashBlob)
+            componentType->getEntryPointHash(entryPointIndex, targetIndex, hashBlob.writeRef());
 
         // Query the shader cache.
-        if (m_persistentShaderCache->queryCache(hashBlob, codeBlob.writeRef()) == SLANG_OK)
+        Result cacheResult = m_persistentShaderCache->queryCache(hashBlob, codeBlob.writeRef());
+        if (cacheResult == SLANG_OK)
         {
-            if (m_shaderCompilationReporter)
+            if (outStats)
             {
-                m_shaderCompilationReporter->reportCompileEntryPoint(
-                    program,
-                    entryPointName,
-                    startTime,
-                    Timer::now(),
-                    0.0,
-                    0.0,
-                    true,
-                    codeBlob->getBufferSize()
-                );
+                outStats->endTime = Timer::now();
+                outStats->isCached = true;
+                outStats->cacheSize = codeBlob->getBufferSize();
             }
 
             returnComPtr(outCode, codeBlob);
@@ -424,13 +439,15 @@ Result Device::getEntryPointCodeFromShaderCache(
     }
 
     // Cached entry not found, generate the code and measure compilation time.
-    double startTotalTime, endTotalTime;
-    double startDownstreamTime, endDownstreamTime;
-    componentType->getSession()->getGlobalSession()->getCompilerElapsedTime(&startTotalTime, &startDownstreamTime);
+    double startTotalTime = 0.0, endTotalTime = 0.0;
+    double startDownstreamTime = 0.0, endDownstreamTime = 0.0;
+    if (measureCompilerTime)
+        componentType->getSession()->getGlobalSession()->getCompilerElapsedTime(&startTotalTime, &startDownstreamTime);
     SLANG_RETURN_ON_FAIL(
         componentType->getEntryPointCode(entryPointIndex, targetIndex, codeBlob.writeRef(), outDiagnostics)
     );
-    componentType->getSession()->getGlobalSession()->getCompilerElapsedTime(&endTotalTime, &endDownstreamTime);
+    if (measureCompilerTime)
+        componentType->getSession()->getGlobalSession()->getCompilerElapsedTime(&endTotalTime, &endDownstreamTime);
 
     // Write the generated code to the shader cache if available.
     if (m_persistentShaderCache)
@@ -438,19 +455,13 @@ Result Device::getEntryPointCodeFromShaderCache(
         m_persistentShaderCache->writeCache(hashBlob, codeBlob);
     }
 
-    // Report compilation time.
-    if (m_shaderCompilationReporter)
+    if (outStats)
     {
-        m_shaderCompilationReporter->reportCompileEntryPoint(
-            program,
-            entryPointName,
-            startTime,
-            Timer::now(),
-            endTotalTime - startTotalTime,
-            endDownstreamTime - startDownstreamTime,
-            false,
-            codeBlob->getBufferSize()
-        );
+        outStats->endTime = Timer::now();
+        outStats->totalTime = measureCompilerTime ? endTotalTime - startTotalTime : 0.0;
+        outStats->downstreamTime = measureCompilerTime ? endDownstreamTime - startDownstreamTime : 0.0;
+        outStats->isCached = false;
+        outStats->cacheSize = codeBlob->getBufferSize();
     }
 
     returnComPtr(outCode, codeBlob);

--- a/src/device.h
+++ b/src/device.h
@@ -21,6 +21,7 @@ namespace rhi {
 
 // Forward declarations
 class Heap;
+struct EntryPointCompilationStats;
 
 namespace testing {
 // Debug option for tests to turn off state tracking (so we can effectively test explicit barriers)
@@ -378,6 +379,9 @@ public:
         const char* entryPointName,
         uint32_t entryPointIndex,
         uint32_t targetIndex,
+        slang::IBlob* cacheKey,
+        bool measureCompilerTime,
+        EntryPointCompilationStats* outStats,
         slang::IBlob** outCode,
         slang::IBlob** outDiagnostics = nullptr
     );
@@ -426,6 +430,8 @@ public:
         ExtendedShaderObjectTypeList* specializationArgs,
         Pipeline*& outPipeline
     );
+
+    Result createConcretePipeline(Pipeline* pipeline, ShaderProgram* program, RefPtr<Pipeline>& outPipeline);
 
     virtual Result createShaderObjectLayout(
         slang::ISession* session,

--- a/src/metal/metal-shader-program.cpp
+++ b/src/metal/metal-shader-program.cpp
@@ -12,13 +12,13 @@ ShaderProgramImpl::ShaderProgramImpl(Device* device, const ShaderProgramDesc& de
 
 ShaderProgramImpl::~ShaderProgramImpl() {}
 
-Result ShaderProgramImpl::createShaderModule(slang::EntryPointReflection* entryPointInfo, ComPtr<ISlangBlob> kernelCode)
+Result ShaderProgramImpl::createShaderModule(const ShaderModuleDesc& desc, ComPtr<ISlangBlob> kernelCode)
 {
     DeviceImpl* device = getDevice<DeviceImpl>();
 
     Module module;
-    module.stage = entryPointInfo->getStage();
-    module.entryPointName = entryPointInfo->getNameOverride();
+    module.stage = desc.stage;
+    module.entryPointName = desc.entryPointName;
     module.code = kernelCode;
 
     dispatch_data_t data = dispatch_data_create(

--- a/src/metal/metal-shader-program.h
+++ b/src/metal/metal-shader-program.h
@@ -24,10 +24,7 @@ public:
     ShaderProgramImpl(Device* device, const ShaderProgramDesc& desc);
     ~ShaderProgramImpl();
 
-    virtual Result createShaderModule(
-        slang::EntryPointReflection* entryPointInfo,
-        ComPtr<ISlangBlob> kernelCode
-    ) override;
+    virtual Result createShaderModule(const ShaderModuleDesc& desc, ComPtr<ISlangBlob> kernelCode) override;
 
     virtual ShaderObjectLayout* getRootShaderObjectLayout() override;
 };

--- a/src/pipeline-resolver.cpp
+++ b/src/pipeline-resolver.cpp
@@ -1,0 +1,50 @@
+#include "pipeline-resolver.h"
+
+#include "command-list.h"
+#include "device.h"
+#include "pipeline.h"
+#include "shader-object.h"
+
+namespace rhi {
+
+Result resolvePipelines(Device* device, CommandList* commandList)
+{
+    auto command = commandList->getCommands();
+    while (command)
+    {
+        if (command->id == CommandID::SetRenderState)
+        {
+            auto& cmd = commandList->getCommand<commands::SetRenderState>(command);
+            RenderPipeline* pipeline = checked_cast<RenderPipeline*>(cmd.pipeline);
+            auto specializationArgs = static_cast<ExtendedShaderObjectTypeListObject*>(cmd.specializationArgs);
+            Pipeline* concretePipeline = nullptr;
+            SLANG_RETURN_ON_FAIL(device->getConcretePipeline(pipeline, specializationArgs, concretePipeline));
+            cmd.pipeline = static_cast<RenderPipeline*>(concretePipeline);
+            cmd.specializationArgs = nullptr;
+        }
+        else if (command->id == CommandID::SetComputeState)
+        {
+            auto& cmd = commandList->getCommand<commands::SetComputeState>(command);
+            ComputePipeline* pipeline = checked_cast<ComputePipeline*>(cmd.pipeline);
+            auto specializationArgs = static_cast<ExtendedShaderObjectTypeListObject*>(cmd.specializationArgs);
+            Pipeline* concretePipeline = nullptr;
+            SLANG_RETURN_ON_FAIL(device->getConcretePipeline(pipeline, specializationArgs, concretePipeline));
+            cmd.pipeline = static_cast<ComputePipeline*>(concretePipeline);
+            cmd.specializationArgs = nullptr;
+        }
+        else if (command->id == CommandID::SetRayTracingState)
+        {
+            auto& cmd = commandList->getCommand<commands::SetRayTracingState>(command);
+            RayTracingPipeline* pipeline = checked_cast<RayTracingPipeline*>(cmd.pipeline);
+            auto specializationArgs = static_cast<ExtendedShaderObjectTypeListObject*>(cmd.specializationArgs);
+            Pipeline* concretePipeline = nullptr;
+            SLANG_RETURN_ON_FAIL(device->getConcretePipeline(pipeline, specializationArgs, concretePipeline));
+            cmd.pipeline = static_cast<RayTracingPipeline*>(concretePipeline);
+            cmd.specializationArgs = nullptr;
+        }
+        command = command->next;
+    }
+    return SLANG_OK;
+}
+
+} // namespace rhi

--- a/src/pipeline-resolver.h
+++ b/src/pipeline-resolver.h
@@ -1,0 +1,13 @@
+#pragma once
+
+#include <slang-rhi.h>
+
+namespace rhi {
+
+class CommandList;
+class Device;
+
+/// Resolves virtual pipelines referenced by a command list.
+Result resolvePipelines(Device* device, CommandList* commandList);
+
+} // namespace rhi

--- a/src/shader.cpp
+++ b/src/shader.cpp
@@ -109,6 +109,8 @@ Result ShaderProgram::init()
 
 Result ShaderProgram::compileShaders(Device* device)
 {
+    std::lock_guard<std::mutex> lock(m_compileMutex);
+
     if (m_compiledShaders)
         return SLANG_OK;
 
@@ -119,62 +121,126 @@ Result ShaderProgram::compileShaders(Device* device)
         return SLANG_OK;
     }
 
-    // For a fully specialized program, read and store its kernel code in `shaderProgram`.
-    auto compileShader = [&](slang::EntryPointReflection* entryPointInfo,
-                             slang::IComponentType* entryPointComponent,
-                             uint32_t entryPointIndex)
+    std::vector<CompiledEntryPoint> entryPoints;
+    SLANG_RETURN_ON_FAIL(prepareEntryPointCompilation(device, entryPoints));
+    for (auto& entryPoint : entryPoints)
     {
-        ComPtr<ISlangBlob> kernelCode;
-        ComPtr<ISlangBlob> diagnostics;
-        auto compileResult = device->getEntryPointCodeFromShaderCache(
-            this,
-            entryPointComponent,
-            entryPointInfo->getNameOverride(),
-            entryPointIndex,
-            0,
-            kernelCode.writeRef(),
-            diagnostics.writeRef()
-        );
-        if (diagnostics)
+        entryPoint.result = compileEntryPoint(device, entryPoint, true);
+        reportEntryPointCompilation(device, entryPoint);
+        SLANG_RETURN_ON_FAIL(entryPoint.result);
+    }
+
+    SLANG_RETURN_ON_FAIL(installCompiledEntryPoints(entryPoints));
+    return SLANG_OK;
+}
+
+Result ShaderProgram::prepareEntryPointCompilation(Device* device, std::vector<CompiledEntryPoint>& outEntryPoints)
+{
+    outEntryPoints.clear();
+
+    auto appendEntryPoint = [&](slang::IComponentType* componentType, uint32_t entryPointIndex) -> Result
+    {
+        slang::ProgramLayout* layout = componentType->getLayout();
+        if (!layout)
+            return SLANG_FAIL;
+        slang::EntryPointReflection* reflection = layout->getEntryPointByIndex(entryPointIndex);
+        if (!reflection)
+            return SLANG_FAIL;
+
+        CompiledEntryPoint entryPoint;
+        entryPoint.componentType = componentType;
+        entryPoint.entryPointIndex = entryPointIndex;
+        entryPoint.targetIndex = 0;
+        entryPoint.stage = reflection->getStage();
+        entryPoint.name = string::from_cstr(reflection->getNameOverride());
+        if (device->m_persistentShaderCache)
         {
-            DebugMessageType msgType = DebugMessageType::Warning;
-            if (compileResult != SLANG_OK)
-                msgType = DebugMessageType::Error;
-            device->handleMessage(msgType, DebugMessageSource::Slang, (char*)diagnostics->getBufferPointer());
+            componentType->getEntryPointHash(entryPointIndex, 0, entryPoint.cacheKey.writeRef());
         }
-        SLANG_RETURN_ON_FAIL(compileResult);
-        SLANG_RETURN_ON_FAIL(createShaderModule(entryPointInfo, kernelCode));
+        outEntryPoints.push_back(std::move(entryPoint));
         return SLANG_OK;
     };
 
     if (linkedEntryPoints.size() == 0)
     {
-        // If the user does not explicitly specify entry point components, find them from
-        // `linkedEntryPoints`.
         auto programReflection = linkedProgram->getLayout();
+        if (!programReflection)
+            return SLANG_FAIL;
         for (uint32_t i = 0; i < programReflection->getEntryPointCount(); i++)
         {
-            SLANG_RETURN_ON_FAIL(compileShader(programReflection->getEntryPointByIndex(i), linkedProgram, i));
+            SLANG_RETURN_ON_FAIL(appendEntryPoint(linkedProgram, i));
         }
     }
     else
     {
-        // If the user specifies entry point components via the separated entry point array,
-        // compile code from there.
         for (auto& entryPoint : linkedEntryPoints)
         {
-            SLANG_RETURN_ON_FAIL(compileShader(entryPoint->getLayout()->getEntryPointByIndex(0), entryPoint, 0));
+            SLANG_RETURN_ON_FAIL(appendEntryPoint(entryPoint, 0));
         }
     }
-
-    m_compiledShaders = true;
 
     return SLANG_OK;
 }
 
-Result ShaderProgram::createShaderModule(slang::EntryPointReflection* entryPointInfo, ComPtr<ISlangBlob> kernelCode)
+Result ShaderProgram::compileEntryPoint(Device* device, CompiledEntryPoint& entryPoint, bool measureCompilerTime)
 {
-    SLANG_UNUSED(entryPointInfo);
+    return device->getEntryPointCodeFromShaderCache(
+        this,
+        entryPoint.componentType,
+        entryPoint.name.c_str(),
+        entryPoint.entryPointIndex,
+        entryPoint.targetIndex,
+        entryPoint.cacheKey,
+        measureCompilerTime,
+        &entryPoint.stats,
+        entryPoint.code.writeRef(),
+        entryPoint.diagnostics.writeRef()
+    );
+}
+
+void ShaderProgram::reportEntryPointCompilation(Device* device, const CompiledEntryPoint& entryPoint)
+{
+    if (entryPoint.diagnostics)
+    {
+        device->handleMessage(
+            SLANG_SUCCEEDED(entryPoint.result) ? DebugMessageType::Warning : DebugMessageType::Error,
+            DebugMessageSource::Slang,
+            static_cast<const char*>(entryPoint.diagnostics->getBufferPointer())
+        );
+    }
+
+    if (device->m_shaderCompilationReporter && entryPoint.code)
+    {
+        device->m_shaderCompilationReporter->reportCompileEntryPoint(
+            this,
+            entryPoint.name.c_str(),
+            entryPoint.stats.startTime,
+            entryPoint.stats.endTime,
+            entryPoint.stats.totalTime,
+            entryPoint.stats.downstreamTime,
+            entryPoint.stats.isCached,
+            entryPoint.stats.cacheSize
+        );
+    }
+}
+
+Result ShaderProgram::installCompiledEntryPoints(std::span<const CompiledEntryPoint> entryPoints)
+{
+    for (const auto& entryPoint : entryPoints)
+    {
+        ShaderModuleDesc desc;
+        desc.stage = entryPoint.stage;
+        desc.entryPointName = entryPoint.name.c_str();
+        SLANG_RETURN_ON_FAIL(createShaderModule(desc, entryPoint.code));
+    }
+
+    m_compiledShaders = true;
+    return SLANG_OK;
+}
+
+Result ShaderProgram::createShaderModule(const ShaderModuleDesc& desc, ComPtr<ISlangBlob> kernelCode)
+{
+    SLANG_UNUSED(desc);
     SLANG_UNUSED(kernelCode);
     return SLANG_OK;
 }

--- a/src/shader.h
+++ b/src/shader.h
@@ -14,6 +14,36 @@
 
 namespace rhi {
 
+struct ShaderModuleDesc
+{
+    SlangStage stage = SLANG_STAGE_NONE;
+    const char* entryPointName = nullptr;
+};
+
+struct EntryPointCompilationStats
+{
+    TimePoint startTime = {};
+    TimePoint endTime = {};
+    double totalTime = 0.0;
+    double downstreamTime = 0.0;
+    bool isCached = false;
+    size_t cacheSize = 0;
+};
+
+struct CompiledEntryPoint
+{
+    ComPtr<slang::IComponentType> componentType;
+    uint32_t entryPointIndex = 0;
+    uint32_t targetIndex = 0;
+    SlangStage stage = SLANG_STAGE_NONE;
+    std::string name;
+    ComPtr<ISlangBlob> cacheKey;
+    ComPtr<ISlangBlob> code;
+    ComPtr<ISlangBlob> diagnostics;
+    EntryPointCompilationStats stats;
+    Result result = SLANG_OK;
+};
+
 struct SpecializationKey
 {
     short_vector<ShaderComponentID> componentIDs;
@@ -61,6 +91,9 @@ public:
 
     bool m_compiledShaders = false;
 
+    /// Protects compilation state and backend shader modules.
+    std::mutex m_compileMutex;
+
     std::mutex m_specializedProgramsMutex;
     std::unordered_map<SpecializationKey, RefPtr<ShaderProgram>, SpecializationKey::Hasher> m_specializedPrograms;
 
@@ -74,7 +107,19 @@ public:
 
     Result compileShaders(Device* device);
 
-    virtual Result createShaderModule(slang::EntryPointReflection* entryPointInfo, ComPtr<ISlangBlob> kernelCode);
+    /// Must be called while holding m_compileMutex. Performs only front-end/reflection work.
+    Result prepareEntryPointCompilation(Device* device, std::vector<CompiledEntryPoint>& outEntryPoints);
+
+    /// Performs the concurrency-safe backend code generation operation for one prepared entry point.
+    Result compileEntryPoint(Device* device, CompiledEntryPoint& entryPoint, bool measureCompilerTime);
+
+    /// Reports diagnostics and timing on the caller thread.
+    void reportEntryPointCompilation(Device* device, const CompiledEntryPoint& entryPoint);
+
+    /// Must be called while holding m_compileMutex after every entry point compiled successfully.
+    Result installCompiledEntryPoints(std::span<const CompiledEntryPoint> entryPoints);
+
+    virtual Result createShaderModule(const ShaderModuleDesc& desc, ComPtr<ISlangBlob> kernelCode);
 
     // IShaderProgram interface
     virtual SLANG_NO_THROW const ShaderProgramDesc& SLANG_MCALL getDesc() override;

--- a/src/vulkan/vk-shader-program.cpp
+++ b/src/vulkan/vk-shader-program.cpp
@@ -123,7 +123,7 @@ inline Result findBindlessDescriptorSet(const void* codeData, size_t codeSize, u
     return SLANG_OK;
 }
 
-Result ShaderProgramImpl::createShaderModule(slang::EntryPointReflection* entryPointInfo, ComPtr<ISlangBlob> kernelCode)
+Result ShaderProgramImpl::createShaderModule(const ShaderModuleDesc& desc, ComPtr<ISlangBlob> kernelCode)
 {
     DeviceImpl* device = getDevice<DeviceImpl>();
 
@@ -133,7 +133,7 @@ Result ShaderProgramImpl::createShaderModule(slang::EntryPointReflection* entryP
     auto& stageCreateInfo = m_stageCreateInfos.back();
 
     module.code = kernelCode;
-    module.entryPointName = entryPointInfo->getNameOverride();
+    module.entryPointName = desc.entryPointName;
     SLANG_RETURN_ON_FAIL(findBindlessDescriptorSet(
         kernelCode->getBufferPointer(),
         kernelCode->getBufferSize(),
@@ -162,7 +162,7 @@ Result ShaderProgramImpl::createShaderModule(slang::EntryPointReflection* entryP
 #endif
 
     stageCreateInfo = {VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO};
-    stageCreateInfo.stage = (VkShaderStageFlagBits)translateShaderStage(entryPointInfo->getStage());
+    stageCreateInfo.stage = (VkShaderStageFlagBits)translateShaderStage(desc.stage);
     stageCreateInfo.module = module.shaderModule;
     stageCreateInfo.pName = "main";
 

--- a/src/vulkan/vk-shader-program.h
+++ b/src/vulkan/vk-shader-program.h
@@ -26,10 +26,7 @@ public:
     std::vector<Module> m_modules;
     std::vector<VkPipelineShaderStageCreateInfo> m_stageCreateInfos;
 
-    virtual Result createShaderModule(
-        slang::EntryPointReflection* entryPointInfo,
-        ComPtr<ISlangBlob> kernelCode
-    ) override;
+    virtual Result createShaderModule(const ShaderModuleDesc& desc, ComPtr<ISlangBlob> kernelCode) override;
 
     virtual ShaderObjectLayout* getRootShaderObjectLayout() override;
 };

--- a/src/wgpu/wgpu-shader-program.cpp
+++ b/src/wgpu/wgpu-shader-program.cpp
@@ -19,7 +19,7 @@ ShaderProgramImpl::~ShaderProgramImpl()
     }
 }
 
-Result ShaderProgramImpl::createShaderModule(slang::EntryPointReflection* entryPointInfo, ComPtr<ISlangBlob> kernelCode)
+Result ShaderProgramImpl::createShaderModule(const ShaderModuleDesc& desc, ComPtr<ISlangBlob> kernelCode)
 {
     DeviceImpl* device = getDevice<DeviceImpl>();
 
@@ -28,8 +28,8 @@ Result ShaderProgramImpl::createShaderModule(slang::EntryPointReflection* entryP
         device->printWarning("Web GPU device had reported error before shader compilation.");
 
     Module module;
-    module.stage = entryPointInfo->getStage();
-    module.entryPointName = entryPointInfo->getNameOverride();
+    module.stage = desc.stage;
+    module.entryPointName = desc.entryPointName;
     module.code = std::string((char*)kernelCode->getBufferPointer(), kernelCode->getBufferSize());
 
 #if !SLANG_WASM
@@ -42,10 +42,10 @@ Result ShaderProgramImpl::createShaderModule(slang::EntryPointReflection* entryP
     wgslDesc.chain.sType = WGPUSType_ShaderSourceWGSL;
     wgslDesc.code = WGPUStringView{module.code.c_str(), module.code.size()};
 #endif
-    WGPUShaderModuleDescriptor desc = {};
-    desc.nextInChain = (WGPUChainedStruct*)&wgslDesc;
+    WGPUShaderModuleDescriptor moduleDesc = {};
+    moduleDesc.nextInChain = (WGPUChainedStruct*)&wgslDesc;
 
-    module.module = device->m_ctx.api.wgpuDeviceCreateShaderModule(device->m_ctx.device, &desc);
+    module.module = device->m_ctx.api.wgpuDeviceCreateShaderModule(device->m_ctx.device, &moduleDesc);
     if (!module.module)
     {
         return SLANG_FAIL;

--- a/src/wgpu/wgpu-shader-program.h
+++ b/src/wgpu/wgpu-shader-program.h
@@ -22,10 +22,7 @@ public:
     ShaderProgramImpl(Device* device, const ShaderProgramDesc& desc);
     ~ShaderProgramImpl();
 
-    virtual Result createShaderModule(
-        slang::EntryPointReflection* entryPointInfo,
-        ComPtr<ISlangBlob> kernelCode
-    ) override;
+    virtual Result createShaderModule(const ShaderModuleDesc& desc, ComPtr<ISlangBlob> kernelCode) override;
 
     virtual ShaderObjectLayout* getRootShaderObjectLayout() override;
 


### PR DESCRIPTION
## Summary

This is the second change in the parallel pipeline compilation series, following #821.

It restructures shader compilation and deferred pipeline resolution into explicit stages that can be parallelized by a later PR. Execution remains serial in this change.

## Changes

- Split shader compilation into distinct operations:
  1. Prepare entry-point metadata and cache keys.
  2. Generate code for each prepared entry point.
  3. Report diagnostics and compilation statistics.
  4. Install compiled modules into the backend shader program.
- Add a program-level compilation mutex protecting compilation state and backend shader modules.
- Separate backend pipeline creation from specialization-cache publication through `createConcretePipeline()`.
- Move deferred pipeline resolution out of `CommandEncoder` into a dedicated pipeline resolver.
- Preserve the existing serial traversal and command-patching behavior.
- Update all shader-program backends to create modules from prepared stage and entry-point metadata.
- Retain entry-point names in D3D12 shader binaries for ray-tracing pipeline exports.
- Refactor shader-cache lookup to return compilation statistics to the caller.
- Make compiler-time measurement optional in preparation for concurrent code generation, where Slang’s cumulative global timing cannot be attributed reliably to individual entry points.

## Motivation

Parallel compilation requires clear boundaries between operations with different concurrency requirements:

- Slang reflection and preparation work must remain serialized.
- Prepared entry-point code generation can run concurrently.
- Diagnostics, backend module installation, and cache publication should occur in a controlled order.

This PR introduces those boundaries without changing scheduling, making the structural refactor independently reviewable from the concurrency behavior.

## Behavior

`ShaderProgram::compileShaders()` still holds the program compilation lock and executes every stage sequentially. Deferred render, compute, and ray-tracing pipelines are also resolved serially.

No task-pool scheduling or public parallel-compilation option is introduced in this PR.