### PR TITLE
Compile deferred pipeline shaders in parallel

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1047,6 +1047,7 @@ if(SLANG_RHI_BUILD_TESTS AND NOT SLANG_RHI_BUILD_SHARED AND NOT EMSCRIPTEN)
         tests/test-nvrtc.cpp
         tests/test-nvapi.cpp
         tests/test-offset-allocator.cpp
+        tests/test-parallel-pipeline-creation.cpp
         tests/test-pipeline-cache.cpp
         # tests/test-precompiled-module-cache.cpp
         tests/test-precompiled-module.cpp

--- a/include/slang-rhi.h
+++ b/include/slang-rhi.h
@@ -3266,6 +3266,15 @@ enum class AftermathFlags
 };
 SLANG_RHI_ENUM_CLASS_OPERATORS(AftermathFlags);
 
+enum class PipelineCompilationMode
+{
+    /// Use sequential pipeline resolution.
+    Serial,
+
+    /// Experimental: allow deferred pipeline resolution to use available task parallelism.
+    Parallel,
+};
+
 struct DeviceDesc
 {
     StructType structType = StructType::DeviceDesc;
@@ -3320,6 +3329,9 @@ struct DeviceDesc
 
     /// Enable reporting of shader compilation timings.
     bool enableCompilationReports = false;
+
+    /// Controls resolution of deferred pipelines encountered while finishing a command encoder.
+    PipelineCompilationMode pipelineCompilationMode = PipelineCompilationMode::Serial;
 
     /// Enable launching CUDA kernels from inside graphics command buffers
     /// (Vulkan only, via VK_NVX_binary_import). On by default. Set to

--- a/src/device.cpp
+++ b/src/device.cpp
@@ -497,6 +497,8 @@ Result Device::initialize(const DeviceDesc& desc)
         m_shaderCompilationReporter = new ShaderCompilationReporter(this);
     }
 
+    m_pipelineCompilationMode = desc.pipelineCompilationMode;
+
     m_persistentShaderCache = desc.persistentShaderCache;
     m_persistentPipelineCache = desc.persistentPipelineCache;
 

--- a/src/device.h
+++ b/src/device.h
@@ -508,6 +508,11 @@ public:
 
     IDebugCallback* m_debugCallback = nullptr;
 
+    PipelineCompilationMode m_pipelineCompilationMode = PipelineCompilationMode::Serial;
+
+    /// Serializes resolution/publication across command encoders. Work within one resolver may still run concurrently.
+    std::mutex m_pipelineResolutionMutex;
+
     LiveDeviceTracker m_liveDeviceTracker;
 };
 

--- a/src/pipeline-resolver.cpp
+++ b/src/pipeline-resolver.cpp
@@ -1,50 +1,423 @@
 #include "pipeline-resolver.h"
 
 #include "command-list.h"
+#include "core/task-pool.h"
 #include "device.h"
 #include "pipeline.h"
+#include "shader.h"
 #include "shader-object.h"
+
+#include <unordered_map>
 
 namespace rhi {
 
-Result resolvePipelines(Device* device, CommandList* commandList)
+namespace {
+
+class TaskBatch
 {
-    auto command = commandList->getCommands();
-    while (command)
+public:
+    explicit TaskBatch(ITaskPool* taskPool)
+        : m_taskPool(taskPool)
     {
-        if (command->id == CommandID::SetRenderState)
+    }
+
+    ~TaskBatch() { wait(); }
+
+    Result submit(void (*func)(void*), void* payload, void (*payloadDeleter)(void*))
+    {
+        auto handle = m_taskPool->submitTask(func, payload, payloadDeleter, nullptr, 0);
+        SLANG_RHI_ASSERT(handle);
+        if (!handle)
+        {
+            if (payloadDeleter)
+                payloadDeleter(payload);
+            return SLANG_FAIL;
+        }
+        m_handles.push_back(handle);
+        return SLANG_OK;
+    }
+
+    void wait()
+    {
+        for (auto handle : m_handles)
+        {
+            m_taskPool->waitTask(handle);
+            m_taskPool->releaseTask(handle);
+        }
+        m_handles.clear();
+    }
+
+private:
+    ITaskPool* m_taskPool;
+    std::vector<ITaskPool::TaskHandle> m_handles;
+};
+
+struct PipelineKeyHasher
+{
+    size_t operator()(const PipelineKey& key) const { return key.hash; }
+};
+
+struct PipelineRequest
+{
+    PipelineKey key = {};
+    RefPtr<Pipeline> pipeline;
+    ExtendedShaderObjectTypeListObject* specializationArgs = nullptr;
+    std::vector<const CommandList::CommandSlot*> commands;
+
+    RefPtr<ShaderProgram> program;
+    RefPtr<Pipeline> concretePipeline;
+    bool created = false;
+};
+
+struct ProgramWork
+{
+    RefPtr<ShaderProgram> program;
+    std::unique_lock<std::mutex> compileLock;
+    std::vector<CompiledEntryPoint> entryPoints;
+
+    explicit ProgramWork(ShaderProgram* program_)
+        : program(program_)
+        , compileLock(program_->m_compileMutex)
+    {
+    }
+
+    ProgramWork(ProgramWork&&) = default;
+    ProgramWork& operator=(ProgramWork&&) = default;
+    ProgramWork(const ProgramWork&) = delete;
+    ProgramWork& operator=(const ProgramWork&) = delete;
+};
+
+class PipelineResolver
+{
+public:
+    PipelineResolver(Device* device, CommandList* commandList)
+        : m_device(device)
+        , m_commandList(commandList)
+    {
+    }
+
+    Result resolve()
+    {
+        std::lock_guard<std::mutex> resolutionLock(m_device->m_pipelineResolutionMutex);
+
+        if (m_device->m_pipelineCompilationMode == PipelineCompilationMode::Serial ||
+            m_device->getInfo().deviceType == DeviceType::CPU)
+        {
+            return resolveSerial();
+        }
+
+        SLANG_RETURN_ON_FAIL(collectRequests());
+        SLANG_RETURN_ON_FAIL(preparePrograms());
+        SLANG_RETURN_ON_FAIL(compilePrograms());
+        SLANG_RETURN_ON_FAIL(createPipelines());
+        finalize();
+        return SLANG_OK;
+    }
+
+private:
+    static void getCommandPipeline(
+        CommandList* commandList,
+        const CommandList::CommandSlot* command,
+        Pipeline*& outPipeline,
+        ExtendedShaderObjectTypeListObject*& outSpecializationArgs
+    )
+    {
+        outPipeline = nullptr;
+        outSpecializationArgs = nullptr;
+        switch (command->id)
+        {
+        case CommandID::SetRenderState:
         {
             auto& cmd = commandList->getCommand<commands::SetRenderState>(command);
-            RenderPipeline* pipeline = checked_cast<RenderPipeline*>(cmd.pipeline);
-            auto specializationArgs = static_cast<ExtendedShaderObjectTypeListObject*>(cmd.specializationArgs);
-            Pipeline* concretePipeline = nullptr;
-            SLANG_RETURN_ON_FAIL(device->getConcretePipeline(pipeline, specializationArgs, concretePipeline));
-            cmd.pipeline = static_cast<RenderPipeline*>(concretePipeline);
-            cmd.specializationArgs = nullptr;
+            outPipeline = checked_cast<RenderPipeline*>(cmd.pipeline);
+            outSpecializationArgs = static_cast<ExtendedShaderObjectTypeListObject*>(cmd.specializationArgs);
+            break;
         }
-        else if (command->id == CommandID::SetComputeState)
+        case CommandID::SetComputeState:
         {
             auto& cmd = commandList->getCommand<commands::SetComputeState>(command);
-            ComputePipeline* pipeline = checked_cast<ComputePipeline*>(cmd.pipeline);
-            auto specializationArgs = static_cast<ExtendedShaderObjectTypeListObject*>(cmd.specializationArgs);
-            Pipeline* concretePipeline = nullptr;
-            SLANG_RETURN_ON_FAIL(device->getConcretePipeline(pipeline, specializationArgs, concretePipeline));
-            cmd.pipeline = static_cast<ComputePipeline*>(concretePipeline);
-            cmd.specializationArgs = nullptr;
+            outPipeline = checked_cast<ComputePipeline*>(cmd.pipeline);
+            outSpecializationArgs = static_cast<ExtendedShaderObjectTypeListObject*>(cmd.specializationArgs);
+            break;
         }
-        else if (command->id == CommandID::SetRayTracingState)
+        case CommandID::SetRayTracingState:
         {
             auto& cmd = commandList->getCommand<commands::SetRayTracingState>(command);
-            RayTracingPipeline* pipeline = checked_cast<RayTracingPipeline*>(cmd.pipeline);
-            auto specializationArgs = static_cast<ExtendedShaderObjectTypeListObject*>(cmd.specializationArgs);
-            Pipeline* concretePipeline = nullptr;
-            SLANG_RETURN_ON_FAIL(device->getConcretePipeline(pipeline, specializationArgs, concretePipeline));
-            cmd.pipeline = static_cast<RayTracingPipeline*>(concretePipeline);
-            cmd.specializationArgs = nullptr;
+            outPipeline = checked_cast<RayTracingPipeline*>(cmd.pipeline);
+            outSpecializationArgs = static_cast<ExtendedShaderObjectTypeListObject*>(cmd.specializationArgs);
+            break;
         }
-        command = command->next;
+        default:
+            break;
+        }
     }
-    return SLANG_OK;
+
+    static void patchCommand(
+        CommandList* commandList,
+        const CommandList::CommandSlot* command,
+        Pipeline* concretePipeline
+    )
+    {
+        switch (command->id)
+        {
+        case CommandID::SetRenderState:
+        {
+            auto& cmd = commandList->getCommand<commands::SetRenderState>(command);
+            cmd.pipeline = checked_cast<RenderPipeline*>(concretePipeline);
+            cmd.specializationArgs = nullptr;
+            break;
+        }
+        case CommandID::SetComputeState:
+        {
+            auto& cmd = commandList->getCommand<commands::SetComputeState>(command);
+            cmd.pipeline = checked_cast<ComputePipeline*>(concretePipeline);
+            cmd.specializationArgs = nullptr;
+            break;
+        }
+        case CommandID::SetRayTracingState:
+        {
+            auto& cmd = commandList->getCommand<commands::SetRayTracingState>(command);
+            cmd.pipeline = checked_cast<RayTracingPipeline*>(concretePipeline);
+            cmd.specializationArgs = nullptr;
+            break;
+        }
+        default:
+            break;
+        }
+    }
+
+    Result resolveSerial()
+    {
+        for (auto command = m_commandList->getCommands(); command; command = command->next)
+        {
+            Pipeline* pipeline;
+            ExtendedShaderObjectTypeListObject* specializationArgs;
+            getCommandPipeline(m_commandList, command, pipeline, specializationArgs);
+            if (!pipeline)
+                continue;
+
+            Pipeline* concretePipeline = nullptr;
+            SLANG_RETURN_ON_FAIL(m_device->getConcretePipeline(pipeline, specializationArgs, concretePipeline));
+            patchCommand(m_commandList, command, concretePipeline);
+        }
+        return SLANG_OK;
+    }
+
+    Result collectRequests()
+    {
+        std::unordered_map<PipelineKey, size_t, PipelineKeyHasher> requestMap;
+
+        for (auto command = m_commandList->getCommands(); command; command = command->next)
+        {
+            Pipeline* pipeline;
+            ExtendedShaderObjectTypeListObject* specializationArgs;
+            getCommandPipeline(m_commandList, command, pipeline, specializationArgs);
+            if (!pipeline)
+                continue;
+
+            if (!pipeline->isVirtual())
+            {
+                patchCommand(m_commandList, command, pipeline);
+                continue;
+            }
+
+            PipelineKey key = {};
+            key.pipeline = pipeline;
+            if (pipeline->m_program->isSpecializable())
+            {
+                if (!specializationArgs)
+                    return SLANG_FAIL;
+                for (ShaderComponentID componentID : specializationArgs->componentIDs)
+                    key.specializationArgs.push_back(componentID);
+            }
+            key.updateHash();
+
+            auto [it, inserted] = requestMap.emplace(key, m_requests.size());
+            if (inserted)
+            {
+                PipelineRequest request;
+                request.key = key;
+                request.pipeline = pipeline;
+                request.specializationArgs = specializationArgs;
+                request.commands.push_back(command);
+
+                if (pipeline->m_program->isSpecializable())
+                    request.concretePipeline = m_device->m_shaderCache.getSpecializedPipeline(key);
+                else
+                    request.concretePipeline = pipeline->getConcretePipeline();
+
+                m_requests.push_back(std::move(request));
+            }
+            else
+            {
+                m_requests[it->second].commands.push_back(command);
+            }
+        }
+        return SLANG_OK;
+    }
+
+    Result preparePrograms()
+    {
+        std::unordered_map<ShaderProgram*, size_t> programMap;
+
+        for (auto& request : m_requests)
+        {
+            if (request.concretePipeline)
+                continue;
+
+            request.program = request.pipeline->m_program;
+            if (request.program->isSpecializable())
+            {
+                RefPtr<ShaderProgram> specializedProgram;
+                SLANG_RETURN_ON_FAIL(m_device->getSpecializedProgram(
+                    request.program,
+                    *request.specializationArgs,
+                    specializedProgram.writeRef()
+                ));
+                request.program = specializedProgram;
+            }
+
+            if (programMap.find(request.program) == programMap.end())
+            {
+                size_t index = m_programs.size();
+                programMap.emplace(request.program, index);
+                m_programs.emplace_back(request.program);
+                ProgramWork& programWork = m_programs.back();
+                if (!programWork.program->m_compiledShaders)
+                {
+                    SLANG_RETURN_ON_FAIL(
+                        programWork.program->prepareEntryPointCompilation(m_device, programWork.entryPoints)
+                    );
+                }
+            }
+        }
+        return SLANG_OK;
+    }
+
+    Result compilePrograms()
+    {
+        size_t entryPointCount = 0;
+        for (const auto& program : m_programs)
+            entryPointCount += program.entryPoints.size();
+
+        if (entryPointCount > 1)
+        {
+            struct Payload
+            {
+                Device* device;
+                ShaderProgram* program;
+                CompiledEntryPoint* entryPoint;
+            };
+
+            TaskBatch batch(globalTaskPool());
+            for (auto& program : m_programs)
+            {
+                for (auto& entryPoint : program.entryPoints)
+                {
+                    auto* payload = new Payload{m_device, program.program, &entryPoint};
+                    SLANG_RETURN_ON_FAIL(batch.submit(
+                        [](void* data)
+                        {
+                            auto* payload = static_cast<Payload*>(data);
+                            // TODO: Slang exposes only cumulative global compiler timing. Parallel
+                            // entry-point compilation therefore cannot currently attribute compiler
+                            // time accurately to individual compilation reports.
+                            payload->entryPoint->result =
+                                payload->program->compileEntryPoint(payload->device, *payload->entryPoint, false);
+                        },
+                        payload,
+                        [](void* data)
+                        {
+                            delete static_cast<Payload*>(data);
+                        }
+                    ));
+                }
+            }
+            batch.wait();
+        }
+        else
+        {
+            for (auto& program : m_programs)
+            {
+                for (auto& entryPoint : program.entryPoints)
+                {
+                    entryPoint.result = program.program->compileEntryPoint(m_device, entryPoint, true);
+                }
+            }
+        }
+
+        Result firstFailure = SLANG_OK;
+        for (auto& program : m_programs)
+        {
+            for (const auto& entryPoint : program.entryPoints)
+            {
+                program.program->reportEntryPointCompilation(m_device, entryPoint);
+                if (SLANG_FAILED(entryPoint.result) && SLANG_SUCCEEDED(firstFailure))
+                    firstFailure = entryPoint.result;
+            }
+        }
+        SLANG_RETURN_ON_FAIL(firstFailure);
+
+        // Backend module containers are populated serially. Pipeline creation only reads them afterwards.
+        for (auto& program : m_programs)
+        {
+            if (!program.entryPoints.empty())
+                SLANG_RETURN_ON_FAIL(program.program->installCompiledEntryPoints(program.entryPoints));
+            program.compileLock.unlock();
+        }
+        return SLANG_OK;
+    }
+
+    Result createPipelines()
+    {
+        for (auto& request : m_requests)
+        {
+            if (request.concretePipeline)
+                continue;
+
+            request.created = true;
+            SLANG_RETURN_ON_FAIL(
+                m_device->createConcretePipeline(request.pipeline, request.program, request.concretePipeline)
+            );
+        }
+        return SLANG_OK;
+    }
+
+    void finalize()
+    {
+        for (auto& request : m_requests)
+        {
+            if (request.created)
+            {
+                if (request.pipeline->m_program->isSpecializable())
+                {
+                    m_device->m_shaderCache.addSpecializedPipeline(request.key, request.concretePipeline);
+                    request.concretePipeline->breakStrongReferenceToDevice();
+                    request.concretePipeline->m_program->breakStrongReferenceToDevice();
+                }
+                else
+                {
+                    request.pipeline->setConcretePipeline(request.concretePipeline);
+                }
+            }
+
+            for (const auto* command : request.commands)
+                patchCommand(m_commandList, command, request.concretePipeline);
+        }
+    }
+
+    Device* m_device;
+    CommandList* m_commandList;
+    std::vector<PipelineRequest> m_requests;
+    std::vector<ProgramWork> m_programs;
+};
+
+} // namespace
+
+Result resolvePipelines(Device* device, CommandList* commandList)
+{
+    PipelineResolver resolver(device, commandList);
+    return resolver.resolve();
 }
 
 } // namespace rhi

--- a/src/pipeline-resolver.h
+++ b/src/pipeline-resolver.h
@@ -8,6 +8,9 @@ class CommandList;
 class Device;
 
 /// Resolves virtual pipelines referenced by a command list.
+///
+/// Slang front-end work, backend module installation, pipeline creation, and cache publication are
+/// serialized. Fully prepared entry-point code generation may run concurrently.
 Result resolvePipelines(Device* device, CommandList* commandList);
 
 } // namespace rhi

--- a/tests/test-parallel-pipeline-creation-render.slang
+++ b/tests/test-parallel-pipeline-creation-render.slang
@@ -1,0 +1,23 @@
+struct VertexOutput
+{
+    float4 position : SV_Position;
+};
+
+[shader("vertex")]
+VertexOutput vertexMain(uint vertexID : SV_VertexID)
+{
+    static const float2 positions[] = {
+        float2(-1.0f, -1.0f),
+        float2(3.0f, -1.0f),
+        float2(-1.0f, 3.0f),
+    };
+    VertexOutput output;
+    output.position = float4(positions[vertexID], 0.0f, 1.0f);
+    return output;
+}
+
+[shader("fragment")]
+float4 fragmentMain() : SV_Target
+{
+    return float4(1.0f, 0.0f, 0.0f, 1.0f);
+}

--- a/tests/test-parallel-pipeline-creation.cpp
+++ b/tests/test-parallel-pipeline-creation.cpp
@@ -1,0 +1,167 @@
+#include "testing.h"
+
+using namespace rhi;
+using namespace rhi::testing;
+
+namespace {
+
+void runDeferredPipelineBatch(IDevice* device)
+{
+    const char* entryPointNames[] = {"computeAdd", "computeMul", "computeSub", "computeNeg"};
+    ComPtr<IShaderProgram> programs[4];
+    ComPtr<IComputePipeline> pipelines[5];
+
+    for (size_t i = 0; i < std::size(programs); ++i)
+    {
+        REQUIRE_CALL(
+            loadProgram(device, "test-parallel-pipeline-creation", entryPointNames[i], programs[i].writeRef())
+        );
+
+        ComputePipelineDesc desc = {};
+        desc.program = programs[i];
+        desc.deferTargetCompilation = true;
+        REQUIRE_CALL(device->createComputePipeline(desc, pipelines[i].writeRef()));
+    }
+
+    // A second virtual pipeline sharing the add program exercises program-level deduplication.
+    ComputePipelineDesc secondAddDesc = {};
+    secondAddDesc.program = programs[0];
+    secondAddDesc.deferTargetCompilation = true;
+    REQUIRE_CALL(device->createComputePipeline(secondAddDesc, pipelines[4].writeRef()));
+
+    // A two-entry-point graphics program exercises concurrent getEntryPointCode calls on one linked component.
+    ComPtr<IShaderProgram> renderProgram;
+    ComPtr<IRenderPipeline> renderPipeline;
+    ComPtr<ITexture> colorTexture;
+    ComPtr<ITextureView> colorView;
+    if (device->hasFeature(Feature::Rasterization))
+    {
+        REQUIRE_CALL(loadProgram(
+            device,
+            "test-parallel-pipeline-creation-render",
+            {"vertexMain", "fragmentMain"},
+            renderProgram.writeRef()
+        ));
+        ColorTargetDesc colorTarget = {};
+        colorTarget.format = Format::RGBA8Unorm;
+        RenderPipelineDesc renderPipelineDesc = {};
+        renderPipelineDesc.program = renderProgram;
+        renderPipelineDesc.targets = &colorTarget;
+        renderPipelineDesc.targetCount = 1;
+        renderPipelineDesc.deferTargetCompilation = true;
+
+        // WGPU currently requires an input layout even when the vertex shader has no vertex inputs.
+        ComPtr<IInputLayout> inputLayout;
+        if (device->getDeviceType() == DeviceType::WGPU)
+        {
+            InputLayoutDesc inputLayoutDesc = {};
+            REQUIRE_CALL(device->createInputLayout(inputLayoutDesc, inputLayout.writeRef()));
+            renderPipelineDesc.inputLayout = inputLayout;
+        }
+        REQUIRE_CALL(device->createRenderPipeline(renderPipelineDesc, renderPipeline.writeRef()));
+
+        TextureDesc colorTextureDesc = {};
+        colorTextureDesc.type = TextureType::Texture2D;
+        colorTextureDesc.size = {4, 4, 1};
+        colorTextureDesc.format = Format::RGBA8Unorm;
+        colorTextureDesc.usage = TextureUsage::RenderTarget | TextureUsage::CopySource;
+        colorTextureDesc.defaultState = ResourceState::RenderTarget;
+        colorTexture = device->createTexture(colorTextureDesc, nullptr);
+        REQUIRE(colorTexture);
+        TextureViewDesc colorViewDesc = {};
+        colorViewDesc.format = Format::RGBA8Unorm;
+        REQUIRE_CALL(device->createTextureView(colorTexture, colorViewDesc, colorView.writeRef()));
+    }
+
+    float initialData[] = {1.0f, 2.0f, 3.0f, 4.0f};
+    BufferDesc bufferDesc = {};
+    bufferDesc.size = sizeof(initialData);
+    bufferDesc.elementSize = sizeof(float);
+    bufferDesc.usage = BufferUsage::ShaderResource | BufferUsage::UnorderedAccess | BufferUsage::CopySource;
+    bufferDesc.defaultState = ResourceState::UnorderedAccess;
+    bufferDesc.memoryType = MemoryType::DeviceLocal;
+    ComPtr<IBuffer> buffer;
+    REQUIRE_CALL(device->createBuffer(bufferDesc, initialData, buffer.writeRef()));
+
+    auto queue = device->getQueue(QueueType::Graphics);
+    auto encoder = queue->createCommandEncoder();
+
+    // Reusing pipelines[0] exercises pipeline-level deduplication in the resolver.
+    IComputePipeline* dispatchPipelines[] = {
+        pipelines[0],
+        pipelines[4],
+        pipelines[0],
+        pipelines[1],
+        pipelines[2],
+        pipelines[3],
+    };
+    for (IComputePipeline* pipeline : dispatchPipelines)
+    {
+        auto pass = encoder->beginComputePass();
+        auto rootObject = pass->bindPipeline(pipeline);
+        ShaderCursor(rootObject)["buffer"].setBinding(buffer);
+        pass->dispatchCompute(1, 1, 1);
+        pass->end();
+    }
+
+    if (renderPipeline)
+    {
+        RenderPassColorAttachment colorAttachment = {};
+        colorAttachment.view = colorView;
+        colorAttachment.loadOp = LoadOp::Clear;
+        colorAttachment.storeOp = StoreOp::Store;
+        RenderPassDesc renderPassDesc = {};
+        renderPassDesc.colorAttachments = &colorAttachment;
+        renderPassDesc.colorAttachmentCount = 1;
+        auto renderPass = encoder->beginRenderPass(renderPassDesc);
+        renderPass->bindPipeline(renderPipeline);
+        RenderState renderState = {};
+        renderState.viewports[0] = Viewport::fromSize(4, 4);
+        renderState.viewportCount = 1;
+        renderState.scissorRects[0] = ScissorRect::fromSize(4, 4);
+        renderState.scissorRectCount = 1;
+        renderPass->setRenderState(renderState);
+        DrawArguments drawArgs = {};
+        drawArgs.vertexCount = 3;
+        renderPass->draw(drawArgs);
+        renderPass->end();
+    }
+
+    ComPtr<ICommandBuffer> commandBuffer;
+    REQUIRE_CALL(encoder->finish(commandBuffer.writeRef()));
+    REQUIRE_CALL(queue->submit(commandBuffer));
+    REQUIRE_CALL(queue->waitOnHost());
+
+    compareComputeResult(device, buffer, makeArray<float>(-7.5f, -9.5f, -11.5f, -13.5f));
+
+    if (colorTexture)
+    {
+        std::array<uint8_t, 4 * 4 * 4> expectedPixels = {};
+        for (size_t i = 0; i < expectedPixels.size(); i += 4)
+        {
+            expectedPixels[i + 0] = 255;
+            expectedPixels[i + 3] = 255;
+        }
+        compareComputeResult(device, colorTexture, 0, 0, expectedPixels);
+    }
+}
+
+} // namespace
+
+GPU_TEST_CASE("parallel-pipeline-compilation", ALL | DontCreateDevice)
+{
+    DeviceExtraOptions options;
+    options.pipelineCompilationMode = PipelineCompilationMode::Parallel;
+    device = createTestingDevice(ctx, ctx->deviceType, false, &options);
+    REQUIRE(device);
+    runDeferredPipelineBatch(device);
+}
+
+GPU_TEST_CASE("serial-pipeline-creation", ALL | DontCreateDevice)
+{
+    DeviceExtraOptions options;
+    options.pipelineCompilationMode = PipelineCompilationMode::Serial;
+    device = createTestingDevice(ctx, ctx->deviceType, false, &options);
+    REQUIRE(device);
+    runDeferredPipelineBatch(device);
+}

--- a/tests/test-parallel-pipeline-creation.slang
+++ b/tests/test-parallel-pipeline-creation.slang
@@ -1,0 +1,29 @@
+RWStructuredBuffer<float> buffer;
+
+[shader("compute")]
+[numthreads(4, 1, 1)]
+void computeAdd(uint3 tid : SV_DispatchThreadID)
+{
+    buffer[tid.x] += 1.0f;
+}
+
+[shader("compute")]
+[numthreads(4, 1, 1)]
+void computeMul(uint3 tid : SV_DispatchThreadID)
+{
+    buffer[tid.x] *= 2.0f;
+}
+
+[shader("compute")]
+[numthreads(4, 1, 1)]
+void computeSub(uint3 tid : SV_DispatchThreadID)
+{
+    buffer[tid.x] -= 0.5f;
+}
+
+[shader("compute")]
+[numthreads(4, 1, 1)]
+void computeNeg(uint3 tid : SV_DispatchThreadID)
+{
+    buffer[tid.x] = -buffer[tid.x];
+}

--- a/tests/testing.cpp
+++ b/tests/testing.cpp
@@ -626,6 +626,7 @@ ComPtr<IDevice> createTestingDevice(
         if (extraOptions->persistentPipelineCache)
             deviceDesc.persistentPipelineCache = extraOptions->persistentPipelineCache;
         deviceDesc.enableCompilationReports = extraOptions->enableCompilationReports;
+        deviceDesc.pipelineCompilationMode = extraOptions->pipelineCompilationMode;
         deviceDesc.existingDeviceHandles = extraOptions->existingDeviceHandles;
         deviceDesc.enableAftermath = extraOptions->enableAftermath;
         deviceDesc.enableRayTracingValidation = extraOptions->enableRayTracingValidation;

--- a/tests/testing.h
+++ b/tests/testing.h
@@ -328,6 +328,7 @@ struct DeviceExtraOptions
     IPersistentCache* persistentShaderCache = nullptr;
     IPersistentCache* persistentPipelineCache = nullptr;
     bool enableCompilationReports = false;
+    PipelineCompilationMode pipelineCompilationMode = PipelineCompilationMode::Serial;
     DeviceNativeHandles existingDeviceHandles;
 
     // D3D12-specific (no effect for other devices): Limit the maximum shader model. When set to 0


### PR DESCRIPTION
## Summary

This is the third change in the parallel pipeline compilation series, following #822.

It adds task-parallel entry-point code generation when resolving a batch of deferred pipelines. Backend shader-module installation, pipeline object creation, cache publication, and command patching remain serialized.

## Changes

- Add `PipelineCompilationMode`:
  - `Serial` - use sequential pipeline resolution (default)
  - `Parallel`, allow deferred pipeline resolution to use available task parallelism (experimental)
- Replace the single-pass resolver with a phased pipeline resolver:
  1. Collect and deduplicate pipeline requests.
  2. Resolve specialized programs and prepare entry-point compilation.
  3. Generate prepared entry-point code concurrently.
  4. Install backend shader modules serially.
  5. Create backend pipeline objects serially.
  6. Publish caches and patch command-list references serially.
- Deduplicate:
  - repeated uses of the same pipeline;
  - equivalent specialized pipeline requests;
  - multiple pipelines sharing the same shader program.
- Acquire each program’s compilation lock before preparation and hold it through backend module installation.
- Serialize resolution and cache publication across command encoders on the same device.
- Wait for all submitted compilation tasks before reporting diagnostics or returning a compilation failure.
- Keep the CPU backend on the serial path.
- Avoid task-pool overhead when a batch contains only one entry point.
- Add testing support for selecting the pipeline compilation mode.

## Compilation reporting

Slang currently exposes cumulative global compiler timing. Those values cannot be attributed accurately to individual entry points compiled concurrently.

Parallel entry-point compilation therefore continues to report diagnostics, cache status, output size, and wall-clock timestamps, but does not report per-entry-point compiler and downstream times.

## Scope

This PR parallelizes shader code generation only.

Backend pipeline object creation remains serial and will be enabled selectively in a follow-up PR after each backend’s concurrency requirements have been reviewed.

## Tests

The new deferred-pipeline test exercises:

- Multiple independent compute programs.
- Multiple entry points from one linked graphics program.
- Repeated use of the same pipeline.
- Multiple pipelines sharing one shader program.
- The explicit serial compatibility mode.
- Result validation after command submission.