### PR TITLE
Create supported backend pipelines in parallel

### DIFF
--- a/src/cuda/cuda-device.h
+++ b/src/cuda/cuda-device.h
@@ -21,6 +21,16 @@ public:
 class DeviceImpl : public Device
 {
 public:
+    virtual bool canCreatePipelineOnTaskPool(const Pipeline* pipeline) const override
+    {
+        // OptiX ray-tracing pipeline creation submits nested work to the global task pool.
+        // Run it on the caller thread until that work can be integrated without blocking workers.
+        // TODO: Flatten this work by staging CUDA ray-tracing pipeline creation: enqueue the
+        // OptiX module tasks directly into the resolver's task group, then enqueue pipeline
+        // finalization after all dynamically spawned OptiX tasks have completed.
+        return pipeline->getType() != PipelineType::RayTracing;
+    }
+
     Context m_ctx;
     std::string m_adapterName;
     RefPtr<CommandQueueImpl> m_queue;

--- a/src/d3d11/d3d11-device.h
+++ b/src/d3d11/d3d11-device.h
@@ -13,6 +13,12 @@ public:
 class DeviceImpl : public Device
 {
 public:
+    virtual bool canCreatePipelineOnTaskPool(const Pipeline* pipeline) const override
+    {
+        SLANG_UNUSED(pipeline);
+        return true;
+    }
+
     using Device::readBuffer;
 
     DeviceImpl();

--- a/src/d3d12/d3d12-device.h
+++ b/src/d3d12/d3d12-device.h
@@ -31,6 +31,12 @@ public:
 class DeviceImpl : public Device
 {
 public:
+    virtual bool canCreatePipelineOnTaskPool(const Pipeline* pipeline) const override
+    {
+        SLANG_UNUSED(pipeline);
+        return true;
+    }
+
     std::string m_rootParameterShaderAttributeNameBuffer;
     const char* m_rootParameterShaderAttributeName = nullptr;
 

--- a/src/d3d12/d3d12-pipeline.cpp
+++ b/src/d3d12/d3d12-pipeline.cpp
@@ -9,12 +9,22 @@
 #include "core/stable_vector.h"
 #include "core/string.h"
 #include "core/sha1.h"
+#include "core/deferred.h"
 
 #include <climits>
 
 #include <string>
 
 namespace rhi::d3d12 {
+
+#if SLANG_RHI_ENABLE_NVAPI
+// NvAPI_D3D12_SetCreatePipelineStateOptions affects subsequent pipeline creations for
+// a native device. Use a process-wide lock because multiple RHI devices can wrap the
+// same ID3D12Device5.
+SLANG_RHI_STATIC_MUTEX_BEGIN
+static std::mutex s_nvapiRayTracingPipelineCreationMutex;
+SLANG_RHI_STATIC_MUTEX_END
+#endif
 
 void hashShader(SHA1& sha1, const D3D12_SHADER_BYTECODE& shaderBytecode)
 {
@@ -674,59 +684,71 @@ Result DeviceImpl::createRayTracingPipeline2(const RayTracingPipelineDesc& desc,
     globalSignatureSubobject.pDesc = &globalSignatureDesc;
     subObjects.push_back(globalSignatureSubobject);
 
-#if SLANG_RHI_ENABLE_NVAPI
-    bool nvapiResetPipelineStateOptions = false;
-    if (m_nvapiShaderExtension)
-    {
-        SLANG_RHI_NVAPI_RETURN_ON_FAIL(NvAPI_D3D12_SetNvShaderExtnSlotSpaceLocalThread(
-            m_device,
-            m_nvapiShaderExtension.uavSlot,
-            m_nvapiShaderExtension.registerSpace
-        ));
-
-        if (is_set(desc.flags, RayTracingPipelineFlags::EnableLinearSweptSpheres) ||
-            is_set(desc.flags, RayTracingPipelineFlags::EnableSpheres) ||
-            is_set(desc.flags, RayTracingPipelineFlags::EnableClusters))
-        {
-            NVAPI_D3D12_SET_CREATE_PIPELINE_STATE_OPTIONS_PARAMS params = {};
-            params.version = NVAPI_D3D12_SET_CREATE_PIPELINE_STATE_OPTIONS_PARAMS_VER;
-
-            if (is_set(desc.flags, RayTracingPipelineFlags::EnableLinearSweptSpheres))
-                params.flags = NVAPI_D3D12_PIPELINE_CREATION_STATE_FLAGS_ENABLE_LSS_SUPPORT;
-            if (is_set(desc.flags, RayTracingPipelineFlags::EnableSpheres))
-                params.flags = NVAPI_D3D12_PIPELINE_CREATION_STATE_FLAGS_ENABLE_SPHERE_SUPPORT;
-            if (is_set(desc.flags, RayTracingPipelineFlags::EnableClusters))
-                params.flags = NVAPI_D3D12_PIPELINE_CREATION_STATE_FLAGS_ENABLE_CLUSTER_SUPPORT;
-
-            // TODO: This sets global state!
-            // Need to revisit if createRayTracingPipeline2 can get called from multiple threads.
-            SLANG_RHI_NVAPI_RETURN_ON_FAIL(NvAPI_D3D12_SetCreatePipelineStateOptions(m_device5, &params));
-            nvapiResetPipelineStateOptions = true;
-        }
-    }
-#endif // SLANG_RHI_ENABLE_NVAPI
-
     D3D12_STATE_OBJECT_DESC rtpsoDesc = {};
     rtpsoDesc.Type = D3D12_STATE_OBJECT_TYPE_RAYTRACING_PIPELINE;
     rtpsoDesc.NumSubobjects = (UINT)subObjects.size();
     rtpsoDesc.pSubobjects = subObjects.data();
-    SLANG_D3D_RETURN_ON_FAIL_REPORT(
-        m_device5->CreateStateObject(&rtpsoDesc, IID_PPV_ARGS(stateObject.writeRef())),
-        this
-    );
+
+    auto createStateObject = [&]() -> Result
+    {
+        SLANG_D3D_RETURN_ON_FAIL_REPORT(
+            m_device5->CreateStateObject(&rtpsoDesc, IID_PPV_ARGS(stateObject.writeRef())),
+            this
+        );
+        return SLANG_OK;
+    };
 
 #if SLANG_RHI_ENABLE_NVAPI
-    if (m_nvapiShaderExtension)
     {
-        SLANG_RHI_NVAPI_RETURN_ON_FAIL(NvAPI_D3D12_SetNvShaderExtnSlotSpaceLocalThread(m_device, 0xffffffff, 0));
+        std::lock_guard<std::mutex> lock(s_nvapiRayTracingPipelineCreationMutex);
+        bool resetShaderExtensionSlot = false;
+        bool resetPipelineStateOptions = false;
+        SLANG_RHI_DEFERRED({
+            if (resetPipelineStateOptions)
+            {
+                NVAPI_D3D12_SET_CREATE_PIPELINE_STATE_OPTIONS_PARAMS params = {};
+                params.version = NVAPI_D3D12_SET_CREATE_PIPELINE_STATE_OPTIONS_PARAMS_VER;
+                SLANG_RHI_NVAPI_CHECK(NvAPI_D3D12_SetCreatePipelineStateOptions(m_device5, &params));
+            }
+            if (resetShaderExtensionSlot)
+            {
+                SLANG_RHI_NVAPI_CHECK(NvAPI_D3D12_SetNvShaderExtnSlotSpaceLocalThread(m_device, 0xffffffff, 0));
+            }
+        });
 
-        if (nvapiResetPipelineStateOptions)
+        if (m_nvapiShaderExtension)
         {
-            NVAPI_D3D12_SET_CREATE_PIPELINE_STATE_OPTIONS_PARAMS params = {};
-            params.version = NVAPI_D3D12_SET_CREATE_PIPELINE_STATE_OPTIONS_PARAMS_VER;
+            resetShaderExtensionSlot = true;
+            SLANG_RHI_NVAPI_RETURN_ON_FAIL(NvAPI_D3D12_SetNvShaderExtnSlotSpaceLocalThread(
+                m_device,
+                m_nvapiShaderExtension.uavSlot,
+                m_nvapiShaderExtension.registerSpace
+            ));
 
-            SLANG_RHI_NVAPI_RETURN_ON_FAIL(NvAPI_D3D12_SetCreatePipelineStateOptions(m_device5, &params));
+            if (is_set(desc.flags, RayTracingPipelineFlags::EnableLinearSweptSpheres) ||
+                is_set(desc.flags, RayTracingPipelineFlags::EnableSpheres) ||
+                is_set(desc.flags, RayTracingPipelineFlags::EnableClusters))
+            {
+                NVAPI_D3D12_SET_CREATE_PIPELINE_STATE_OPTIONS_PARAMS params = {};
+                params.version = NVAPI_D3D12_SET_CREATE_PIPELINE_STATE_OPTIONS_PARAMS_VER;
+
+                if (is_set(desc.flags, RayTracingPipelineFlags::EnableLinearSweptSpheres))
+                    params.flags = NVAPI_D3D12_PIPELINE_CREATION_STATE_FLAGS_ENABLE_LSS_SUPPORT;
+                if (is_set(desc.flags, RayTracingPipelineFlags::EnableSpheres))
+                    params.flags = NVAPI_D3D12_PIPELINE_CREATION_STATE_FLAGS_ENABLE_SPHERE_SUPPORT;
+                if (is_set(desc.flags, RayTracingPipelineFlags::EnableClusters))
+                    params.flags = NVAPI_D3D12_PIPELINE_CREATION_STATE_FLAGS_ENABLE_CLUSTER_SUPPORT;
+
+                resetPipelineStateOptions = true;
+                SLANG_RHI_NVAPI_RETURN_ON_FAIL(NvAPI_D3D12_SetCreatePipelineStateOptions(m_device5, &params));
+            }
         }
+
+        SLANG_RETURN_ON_FAIL(createStateObject());
+    }
+#else
+    {
+        SLANG_RETURN_ON_FAIL(createStateObject());
     }
 #endif // SLANG_RHI_ENABLE_NVAPI
 

--- a/src/device.h
+++ b/src/device.h
@@ -433,6 +433,14 @@ public:
 
     Result createConcretePipeline(Pipeline* pipeline, ShaderProgram* program, RefPtr<Pipeline>& outPipeline);
 
+    /// Backends opt individual pipelines into creation on the global task pool.
+    /// Pipelines that perform nested work on that pool must return false.
+    virtual bool canCreatePipelineOnTaskPool(const Pipeline* pipeline) const
+    {
+        SLANG_UNUSED(pipeline);
+        return false;
+    }
+
     virtual Result createShaderObjectLayout(
         slang::ISession* session,
         slang::TypeLayoutReflection* typeLayout,

--- a/src/pipeline-resolver.cpp
+++ b/src/pipeline-resolver.cpp
@@ -66,6 +66,7 @@ struct PipelineRequest
 
     RefPtr<ShaderProgram> program;
     RefPtr<Pipeline> concretePipeline;
+    Result result = SLANG_OK;
     bool created = false;
 };
 
@@ -358,7 +359,7 @@ private:
         }
         SLANG_RETURN_ON_FAIL(firstFailure);
 
-        // Backend module containers are populated serially. Pipeline creation only reads them afterwards.
+        // Backend module containers are populated serially. Pipeline workers only read them afterwards.
         for (auto& program : m_programs)
         {
             if (!program.entryPoints.empty())
@@ -368,18 +369,77 @@ private:
         return SLANG_OK;
     }
 
+    static void createPipelineTask(void* data)
+    {
+        auto* payload = static_cast<std::pair<Device*, PipelineRequest*>*>(data);
+        Device* device = payload->first;
+        PipelineRequest* request = payload->second;
+
+        request->result = device->pushCudaContext();
+        if (SLANG_FAILED(request->result))
+            return;
+
+        request->result =
+            device->createConcretePipeline(request->pipeline, request->program, request->concretePipeline);
+        Result popResult = device->popCudaContext();
+        if (SLANG_SUCCEEDED(request->result))
+            request->result = popResult;
+    }
+
     Result createPipelines()
     {
+        std::vector<PipelineRequest*> workerRequests;
+        std::vector<PipelineRequest*> callerRequests;
         for (auto& request : m_requests)
         {
-            if (request.concretePipeline)
-                continue;
-
-            request.created = true;
-            SLANG_RETURN_ON_FAIL(
-                m_device->createConcretePipeline(request.pipeline, request.program, request.concretePipeline)
-            );
+            if (!request.concretePipeline)
+            {
+                if (m_device->canCreatePipelineOnTaskPool(request.pipeline))
+                    workerRequests.push_back(&request);
+                else
+                    callerRequests.push_back(&request);
+            }
         }
+
+        if (workerRequests.size() > 1)
+        {
+            TaskBatch batch(globalTaskPool());
+            for (PipelineRequest* request : workerRequests)
+            {
+                request->created = true;
+                auto* payload = new std::pair<Device*, PipelineRequest*>(m_device, request);
+                SLANG_RETURN_ON_FAIL(batch.submit(
+                    createPipelineTask,
+                    payload,
+                    [](void* data)
+                    {
+                        delete static_cast<std::pair<Device*, PipelineRequest*>*>(data);
+                    }
+                ));
+            }
+            batch.wait();
+        }
+        else
+        {
+            for (PipelineRequest* request : workerRequests)
+            {
+                request->created = true;
+                std::pair<Device*, PipelineRequest*> payload(m_device, request);
+                createPipelineTask(&payload);
+            }
+        }
+
+        // Caller-only requests run after task-pool work completes. In particular, this
+        // prevents CUDA ray-tracing pipeline workers from blocking the same pool used by OptiX.
+        for (PipelineRequest* request : callerRequests)
+        {
+            request->created = true;
+            std::pair<Device*, PipelineRequest*> payload(m_device, request);
+            createPipelineTask(&payload);
+        }
+
+        for (const auto& request : m_requests)
+            SLANG_RETURN_ON_FAIL(request.result);
         return SLANG_OK;
     }
 

--- a/src/pipeline-resolver.h
+++ b/src/pipeline-resolver.h
@@ -9,8 +9,8 @@ class Device;
 
 /// Resolves virtual pipelines referenced by a command list.
 ///
-/// Slang front-end work, backend module installation, pipeline creation, and cache publication are
-/// serialized. Fully prepared entry-point code generation may run concurrently.
+/// Front-end Slang work and cache publication are performed serially. Fully prepared
+/// entry-point code generation and supported backend pipeline creation may run concurrently.
 Result resolvePipelines(Device* device, CommandList* commandList);
 
 } // namespace rhi

--- a/src/vulkan/vk-device.h
+++ b/src/vulkan/vk-device.h
@@ -26,6 +26,12 @@ struct CalibratedTimestampSupport
 class DeviceImpl : public Device
 {
 public:
+    virtual bool canCreatePipelineOnTaskPool(const Pipeline* pipeline) const override
+    {
+        SLANG_UNUSED(pipeline);
+        return true;
+    }
+
     using Device::readBuffer;
 
     Result initVulkanInstance(

--- a/tests/test-parallel-pipeline-creation.cpp
+++ b/tests/test-parallel-pipeline-creation.cpp
@@ -1,4 +1,5 @@
 #include "testing.h"
+#include "shader-cache.h"
 
 using namespace rhi;
 using namespace rhi::testing;
@@ -148,13 +149,29 @@ void runDeferredPipelineBatch(IDevice* device)
 
 } // namespace
 
-GPU_TEST_CASE("parallel-pipeline-compilation", ALL | DontCreateDevice)
+GPU_TEST_CASE("parallel-pipeline-creation", ALL | DontCreateDevice)
 {
     DeviceExtraOptions options;
     options.pipelineCompilationMode = PipelineCompilationMode::Parallel;
     device = createTestingDevice(ctx, ctx->deviceType, false, &options);
     REQUIRE(device);
     runDeferredPipelineBatch(device);
+}
+
+GPU_TEST_CASE("parallel-pipeline-creation-shared-cache", D3D12 | Vulkan | DontCreateDevice)
+{
+    rhi::testing::ShaderCache sharedCache;
+    DeviceExtraOptions options;
+    options.persistentShaderCache = &sharedCache;
+    options.persistentPipelineCache = &sharedCache;
+    options.pipelineCompilationMode = PipelineCompilationMode::Parallel;
+    device = createTestingDevice(ctx, ctx->deviceType, false, &options);
+    REQUIRE(device);
+
+    runDeferredPipelineBatch(device);
+
+    // The cache is test-owned, so release the device's cache reference before the cache goes out of scope.
+    device.setNull();
 }
 
 GPU_TEST_CASE("serial-pipeline-creation", ALL | DontCreateDevice)


### PR DESCRIPTION
## Summary

This is the fourth change in the parallel pipeline compilation series, following #823.

It extends the phased resolver to create independent backend pipeline objects concurrently when the backend explicitly supports it.

## Changes

- Add an internal `canCreatePipelineOnTaskPool()` capability hook.
  - The default is conservative and keeps pipeline creation on the caller thread.
  - D3D11, D3D12, and Vulkan opt in.
  - CUDA opts in for non-ray-tracing pipelines.
- Partition pending pipelines into:
  - worker-safe requests;
  - caller-thread-only requests.
- Submit worker-safe requests to the global task pool when multiple pipelines are available.
- Avoid task-pool overhead when only one worker-safe pipeline needs creation.
- Establish the CUDA context around pipeline creation on worker threads.
- Wait for all worker requests before processing caller-thread-only pipelines and publishing results.
- Preserve serial cache publication and command-list patching.
- Collect worker results and propagate the first pipeline creation failure after all submitted work completes.

## CUDA ray tracing

CUDA ray-tracing pipeline creation remains on the caller thread.

OptiX pipeline creation currently submits nested work to the same global task pool. Running it from a resolver worker could block that pool while waiting for additional work scheduled onto it.

A TODO documents the intended follow-up: flatten OptiX pipeline creation into the resolver’s task graph by scheduling module work directly and adding pipeline finalization after all dynamically produced tasks complete.

## D3D12 NVAPI synchronization

D3D12 ray-tracing pipeline creation can temporarily modify NVAPI state around `CreateStateObject()`.

This PR:

- Protects that sequence with a process-wide mutex, accounting for multiple RHI devices wrapping the same native D3D12 device.
- Keeps NVAPI setup, state-object creation, and reset within the critical section.
- Uses scope-based cleanup so shader-extension slots and pipeline creation options are reset on failure paths as well as success.

## Tests

The parallel pipeline test now covers backend pipeline creation and continues to exercise:

- Multiple independent deferred compute pipelines.
- Multiple entry points from one graphics program.
- Pipeline- and program-level deduplication.
- Explicit parallel and serial modes.
- Result validation after submission.

A shared-cache variant uses one cache for both shaders and pipelines while parallel resolution is active on D3D12 and Vulkan.