### PR TITLE
Simplify and harden the task pool API

### DIFF
--- a/include/slang-rhi.h
+++ b/include/slang-rhi.h
@@ -3907,7 +3907,9 @@ public:
 
     /// \brief Wait for all tasks in a group to complete and release the group.
     ///
-    /// While waiting, the calling thread may execute pending tasks from the group (work-stealing).
+    /// While waiting, the calling thread may execute pending tasks (work-stealing).
+    /// When called outside a task callback, the calling thread may execute any ready task in
+    /// the pool. When called from a task callback, it executes only ready tasks from `group`.
     /// Subject to the restrictions below, this makes it safe to call from a task callback.
     /// A task must not wait on a group that contains the task itself. When called
     /// from a task callback, tasks in the group must not depend on work outside

--- a/include/slang-rhi.h
+++ b/include/slang-rhi.h
@@ -3849,8 +3849,19 @@ private:
 ///
 /// **Dependency rules:**
 /// - Dependencies must not form cycles, doing so might result in a deadlock.
+/// - Dependencies must have been created by the same task pool.
 /// - A dependency task handle must still be valid (not yet released) when passed to `submitTask()`.
 /// - Once a task is submitted, its dependencies may be released immediately by the caller.
+///
+/// **Thread safety:**
+/// - Methods may be called concurrently unless documented otherwise.
+/// - Task and task-group handles are specific to the pool that created them.
+/// - A handle must remain valid while any thread is using it. The caller must synchronize
+///   `releaseTask()` and `releaseTaskGroup()` with other operations on the same handle.
+/// - The task pool must remain alive until all task and task-group handles it created are released.
+/// - Task functions may run on a pool worker, a thread waiting on the pool, or the submitting
+///   thread. Payload deleters may additionally run on any thread that releases the final task
+///   handle. Task functions and payload deleters must be thread-safe and must not throw exceptions.
 ///
 class ITaskPool : public ISlangUnknown
 {
@@ -3908,8 +3919,9 @@ public:
 
     /// \brief Block the calling thread until a task has finished executing.
     ///
-    /// While waiting, the calling thread may execute pending tasks (work-stealing).
-    /// This makes it safe to call from a task callback without deadlock risk.
+    /// When called outside a task callback, the calling thread may execute pending tasks
+    /// (work-stealing). Calling this method from a task callback is only safe when the waited-on
+    /// task can make progress without the calling thread executing additional work.
     ///
     /// \param task Task handle to wait on. Must not be null.
     virtual SLANG_NO_THROW void SLANG_MCALL waitTask(TaskHandle task) = 0;
@@ -3925,31 +3937,40 @@ public:
     /// Waits for every task that has been submitted to this pool (and not yet completed)
     /// to finish executing. Does not release any task handles.
     /// While waiting, the calling thread may execute pending tasks (work-stealing).
+    /// Must not be called from a task callback executing on this pool because the current task
+    /// is included in the wait. Must not race with task submissions from outside task callbacks.
+    /// Tasks that were already pending may submit additional tasks while the wait is in progress.
     virtual SLANG_NO_THROW void SLANG_MCALL waitAll() = 0;
 
     /// \brief Create a new task group for tracking a set of tasks.
     ///
     /// A task group tracks a dynamically growing set of tasks. Tasks are associated with a
     /// group by passing the group handle to `submitTask()`.
+    /// The group may only be used with the task pool that created it.
     ///
     /// \return An opaque handle to the task group.
     virtual SLANG_NO_THROW TaskGroupHandle SLANG_MCALL createTaskGroup() = 0;
 
     /// \brief Block the calling thread until all tasks in the group have completed.
     ///
-    /// While waiting, the calling thread may execute pending tasks (work-stealing).
-    /// This makes it safe to call from a task callback without deadlock risk.
+    /// While waiting, the calling thread may execute pending tasks from the group (work-stealing).
+    /// Subject to the restrictions below, this makes it safe to call from a task callback.
+    /// A task must not wait on a group that contains the task itself. When called
+    /// from a task callback, tasks in the group must not depend on work outside
+    /// the group that cannot otherwise make progress.
     /// Must not be called while other threads are still submitting tasks to the group
     /// outside of task callbacks.
     /// A group must not be reused after `waitTaskGroup` returns.
+    /// Multiple threads may wait on the same group concurrently, but the group must remain valid
+    /// until every waiter has returned.
     ///
     /// \param group Task group handle. Must not be null.
     virtual SLANG_NO_THROW void SLANG_MCALL waitTaskGroup(TaskGroupHandle group) = 0;
 
     /// \brief Release a task group.
     ///
-    /// Must be called exactly once after `waitTaskGroup` returns. Calling with tasks
-    /// still pending is undefined behavior.
+    /// Must be called exactly once after `waitTaskGroup` returns, or after every concurrent
+    /// `waitTaskGroup` call has returned. Calling with tasks still pending is undefined behavior.
     ///
     /// \param group Task group handle. Must not be null.
     virtual SLANG_NO_THROW void SLANG_MCALL releaseTaskGroup(TaskGroupHandle group) = 0;

--- a/include/slang-rhi.h
+++ b/include/slang-rhi.h
@@ -3829,39 +3829,28 @@ private:
 /// Deprecated alias for SLANG_RHI_DEVICE_SCOPE
 #define SLANG_DEVICE_SCOPE(device) SLANG_RHI_DEVICE_SCOPE(device)
 
-/// \brief Interface for a task pool that supports dependency-based scheduling.
+/// \brief Interface for asynchronous task execution.
 ///
 /// Tasks are submitted with `submitTask()`, which returns an opaque `TaskHandle`.
 /// Each task executes a user-provided function with an associated payload.
-/// Tasks may declare dependencies on other tasks, forming a directed acyclic graph (DAG).
-/// A task will not execute until all of its dependencies have completed.
 ///
 /// **Ownership model:**
 /// `submitTask()` returns a `TaskHandle` that the caller owns. The caller must eventually
-/// call `releaseTask()` to release this handle. The task pool also holds an internal
-/// reference while the task is pending or executing, so the task remains alive until
-/// both the pool and the caller have released their references.
+/// release it by calling either `releaseTask()` or `waitAndReleaseTask()`. Releasing a
+/// handle does not cancel or otherwise affect task execution.
 ///
 /// **Payload lifetime:**
-/// If a `payloadDeleter` is provided, it is called when the last reference to the task
-/// is released (i.e. after both the pool and the caller have released). The payload
-/// remains valid and accessible via `getTaskPayload()` until that point.
-///
-/// **Dependency rules:**
-/// - Dependencies must not form cycles, doing so might result in a deadlock.
-/// - Dependencies must have been created by the same task pool.
-/// - A dependency task handle must still be valid (not yet released) when passed to `submitTask()`.
-/// - Once a task is submitted, its dependencies may be released immediately by the caller.
+/// If a `payloadDeleter` is provided, it is called after the task function returns and
+/// before the task is considered complete. The payload must remain valid until then.
 ///
 /// **Thread safety:**
 /// - Methods may be called concurrently unless documented otherwise.
 /// - Task and task-group handles are specific to the pool that created them.
 /// - A handle must remain valid while any thread is using it. The caller must synchronize
-///   `releaseTask()` and `releaseTaskGroup()` with other operations on the same handle.
+///   operations that consume the same handle.
 /// - The task pool must remain alive until all task and task-group handles it created are released.
 /// - Task functions may run on a pool worker, a thread waiting on the pool, or the submitting
-///   thread. Payload deleters may additionally run on any thread that releases the final task
-///   handle. Task functions and payload deleters must be thread-safe and must not throw exceptions.
+///   thread. Task functions and payload deleters must be thread-safe and must not throw exceptions.
 ///
 class ITaskPool : public ISlangUnknown
 {
@@ -3873,74 +3862,39 @@ public:
 
     /// \brief Submit a new task for execution.
     ///
-    /// Submits a task that will call `func(payload)` once all dependencies in `deps` have
-    /// completed. The returned `TaskHandle` must eventually be released with `releaseTask()`.
-    ///
-    /// If `depsCount` is 0, the task is immediately eligible for execution.
-    /// If any dependency is already complete at the time of submission, it is handled correctly.
+    /// Submits a task that will call `func(payload)`. The returned `TaskHandle` must eventually
+    /// be released with either `releaseTask()` or `waitAndReleaseTask()`.
     ///
     /// \param func Function to execute. Must not be null.
     /// \param payload Opaque data passed to `func`. May be null.
-    /// \param payloadDeleter Optional deleter called with `payload` when the task is destroyed. May be null if no cleanup is needed.
-    /// \param deps Array of `TaskHandle`s that must complete before this task runs. May be null if `depsCount` is 0.
-    /// \param depsCount Number of entries in `deps`.
+    /// \param payloadDeleter Optional deleter called with `payload` after `func` returns. May be null if no cleanup is needed.
     /// \param group Optional task group handle. If non-null, the task is associated with the group.
-    /// \return A handle to the submitted task. The caller must release this with `releaseTask()`.
+    /// \return A handle to the submitted task.
     virtual SLANG_NO_THROW TaskHandle SLANG_MCALL submitTask(
         void (*func)(void*),
         void* payload,
         void (*payloadDeleter)(void*),
-        TaskHandle* deps,
-        size_t depsCount,
         TaskGroupHandle group = nullptr
     ) = 0;
 
-    /// \brief Get the payload associated with a task.
-    ///
-    /// Returns the `payload` pointer that was passed to `submitTask()`. The payload remains
-    /// valid until the task is fully released (i.e. after the caller calls `releaseTask()`
-    /// and the pool has finished executing the task).
-    ///
-    /// \param task Task handle. Must not be null.
-    /// \return The payload pointer.
-    virtual SLANG_NO_THROW void* SLANG_MCALL getTaskPayload(TaskHandle task) = 0;
-
     /// \brief Release the caller's reference to a task.
     ///
-    /// Releases the caller's ownership of the task handle. If this is the last reference
-    /// (i.e. the task has already completed and the pool has released its internal reference),
-    /// the task is destroyed.
-    ///
-    /// A task may be released before it has finished executing, the pool's internal reference
-    /// keeps it alive until completion.
+    /// Releases the caller's ownership of the task handle without waiting. The task may still
+    /// be pending or executing and will continue to completion.
     ///
     /// \param task Task handle to release. Must not be null. Must not be used after this call.
     virtual SLANG_NO_THROW void SLANG_MCALL releaseTask(TaskHandle task) = 0;
 
-    /// \brief Block the calling thread until a task has finished executing.
+    /// \brief Wait for a task to finish and release its handle.
     ///
     /// When called outside a task callback, the calling thread may execute pending tasks
     /// (work-stealing). Calling this method from a task callback is only safe when the waited-on
     /// task can make progress without the calling thread executing additional work.
     ///
-    /// \param task Task handle to wait on. Must not be null.
-    virtual SLANG_NO_THROW void SLANG_MCALL waitTask(TaskHandle task) = 0;
-
-    /// \brief Check whether a task has finished executing (non-blocking).
+    /// This call consumes `task`; the handle must not be used afterward.
     ///
-    /// \param task Task handle to check. Must not be null.
-    /// \return True if the task has completed, false if it is still pending or executing.
-    virtual SLANG_NO_THROW bool SLANG_MCALL isTaskDone(TaskHandle task) = 0;
-
-    /// \brief Block the calling thread until all submitted tasks have finished.
-    ///
-    /// Waits for every task that has been submitted to this pool (and not yet completed)
-    /// to finish executing. Does not release any task handles.
-    /// While waiting, the calling thread may execute pending tasks (work-stealing).
-    /// Must not be called from a task callback executing on this pool because the current task
-    /// is included in the wait. Must not race with task submissions from outside task callbacks.
-    /// Tasks that were already pending may submit additional tasks while the wait is in progress.
-    virtual SLANG_NO_THROW void SLANG_MCALL waitAll() = 0;
+    /// \param task Task handle to wait on and release. Must not be null.
+    virtual SLANG_NO_THROW void SLANG_MCALL waitAndReleaseTask(TaskHandle task) = 0;
 
     /// \brief Create a new task group for tracking a set of tasks.
     ///
@@ -3951,7 +3905,7 @@ public:
     /// \return An opaque handle to the task group.
     virtual SLANG_NO_THROW TaskGroupHandle SLANG_MCALL createTaskGroup() = 0;
 
-    /// \brief Block the calling thread until all tasks in the group have completed.
+    /// \brief Wait for all tasks in a group to complete and release the group.
     ///
     /// While waiting, the calling thread may execute pending tasks from the group (work-stealing).
     /// Subject to the restrictions below, this makes it safe to call from a task callback.
@@ -3960,20 +3914,11 @@ public:
     /// the group that cannot otherwise make progress.
     /// Must not be called while other threads are still submitting tasks to the group
     /// outside of task callbacks.
-    /// A group must not be reused after `waitTaskGroup` returns.
-    /// Multiple threads may wait on the same group concurrently, but the group must remain valid
-    /// until every waiter has returned.
+    /// This call consumes `group`; the handle must not be used afterward. Only one thread may
+    /// wait on a group.
     ///
-    /// \param group Task group handle. Must not be null.
-    virtual SLANG_NO_THROW void SLANG_MCALL waitTaskGroup(TaskGroupHandle group) = 0;
-
-    /// \brief Release a task group.
-    ///
-    /// Must be called exactly once after `waitTaskGroup` returns, or after every concurrent
-    /// `waitTaskGroup` call has returned. Calling with tasks still pending is undefined behavior.
-    ///
-    /// \param group Task group handle. Must not be null.
-    virtual SLANG_NO_THROW void SLANG_MCALL releaseTaskGroup(TaskGroupHandle group) = 0;
+    /// \param group Task group handle to wait on and release. Must not be null.
+    virtual SLANG_NO_THROW void SLANG_MCALL waitAndReleaseTaskGroup(TaskGroupHandle group) = 0;
 };
 
 class IPersistentCache : public ISlangUnknown

--- a/src/core/task-pool.cpp
+++ b/src/core/task-pool.cpp
@@ -1,20 +1,31 @@
 #include "task-pool.h"
 
+#include <algorithm>
 #include <condition_variable>
+#include <deque>
 #include <exception>
 #include <memory>
 #include <mutex>
-#include <queue>
 #include <thread>
 
 namespace rhi {
 
-// Track work-stealing nesting depth per thread.
-// Only the outermost wait call (depth 0) is allowed to steal and execute tasks.
-// At depth > 0 (inside a stolen task's callback), stealing is forbidden to
-// prevent same-thread circular dependencies: a stolen task's callback might
-// wait on a task that is already mid-execution higher up the same call stack.
+// Track work-stealing nesting depth per thread. Outermost waits may steal any
+// ready task. A nested task-group wait may steal only ready tasks from that
+// group, which lets dynamically spawned work make progress without executing
+// an unrelated task that could wait on the current callback.
 static thread_local int tls_stealDepth = 0;
+
+struct TaskGroup
+{
+    explicit TaskGroup(const void* owner_)
+        : owner(owner_)
+    {
+    }
+
+    const void* owner;
+    std::atomic<size_t> pending{0};
+};
 
 // ----------------------------------------------------------------------------
 // BlockingTaskPool
@@ -22,6 +33,7 @@ static thread_local int tls_stealDepth = 0;
 
 struct BlockingTaskPool::Task
 {
+    const BlockingTaskPool* owner;
     void* payload;
     void (*payloadDeleter)(void*);
 };
@@ -44,13 +56,16 @@ ITaskPool::TaskHandle BlockingTaskPool::submitTask(
 {
     SLANG_RHI_ASSERT(func);
     SLANG_RHI_ASSERT(depsCount == 0 || deps);
+    SLANG_RHI_ASSERT(!group || static_cast<TaskGroup*>(group)->owner == this);
     for (size_t i = 0; i < depsCount; i++)
     {
         SLANG_RHI_ASSERT(deps[i]);
+        SLANG_RHI_ASSERT(static_cast<Task*>(deps[i])->owner == this);
     }
 
     // Create task just to defer the payload deletion.
     Task* task = new Task();
+    task->owner = this;
     task->payload = payload;
     task->payloadDeleter = payloadDeleter;
 
@@ -65,6 +80,7 @@ void* BlockingTaskPool::getTaskPayload(TaskHandle task)
     SLANG_RHI_ASSERT(task);
 
     Task* taskImpl = static_cast<Task*>(task);
+    SLANG_RHI_ASSERT(taskImpl->owner == this);
     return taskImpl->payload;
 }
 
@@ -73,6 +89,7 @@ void BlockingTaskPool::releaseTask(TaskHandle task)
     SLANG_RHI_ASSERT(task);
 
     Task* taskImpl = static_cast<Task*>(task);
+    SLANG_RHI_ASSERT(taskImpl->owner == this);
     if (taskImpl->payloadDeleter)
     {
         taskImpl->payloadDeleter(taskImpl->payload);
@@ -82,11 +99,14 @@ void BlockingTaskPool::releaseTask(TaskHandle task)
 
 void BlockingTaskPool::waitTask(TaskHandle task)
 {
-    SLANG_UNUSED(task);
+    SLANG_RHI_ASSERT(task);
+    SLANG_RHI_ASSERT(static_cast<Task*>(task)->owner == this);
 }
 
 bool BlockingTaskPool::isTaskDone(TaskHandle task)
 {
+    SLANG_RHI_ASSERT(task);
+    SLANG_RHI_ASSERT(static_cast<Task*>(task)->owner == this);
     return true;
 }
 
@@ -94,19 +114,21 @@ void BlockingTaskPool::waitAll() {}
 
 ITaskPool::TaskGroupHandle BlockingTaskPool::createTaskGroup()
 {
-    return new char;
+    return new TaskGroup(this);
 }
 
 void BlockingTaskPool::waitTaskGroup(TaskGroupHandle group)
 {
     SLANG_RHI_ASSERT(group);
-    SLANG_UNUSED(group);
+    SLANG_RHI_ASSERT(static_cast<TaskGroup*>(group)->owner == this);
 }
 
 void BlockingTaskPool::releaseTaskGroup(TaskGroupHandle group)
 {
     SLANG_RHI_ASSERT(group);
-    delete static_cast<char*>(group);
+    TaskGroup* g = static_cast<TaskGroup*>(group);
+    SLANG_RHI_ASSERT(g->owner == this);
+    delete g;
 }
 
 // ----------------------------------------------------------------------------
@@ -142,15 +164,10 @@ struct ThreadedTaskPool::Task
     struct TaskGroup* group = nullptr;
 };
 
-struct TaskGroup
-{
-    std::atomic<size_t> pending{0};
-};
-
 struct ThreadedTaskPool::Pool
 {
     // Queue of tasks ready for execution.
-    std::queue<ThreadedTaskPool::Task*> m_queue;
+    std::deque<ThreadedTaskPool::Task*> m_queue;
     std::mutex m_queueMutex;
     // Condition variable for worker threads (notified when queue gets items or stop).
     std::condition_variable m_queueCV;
@@ -170,8 +187,24 @@ struct ThreadedTaskPool::Pool
 
     void workerThread();
 
-    // Try to dequeue a ready task from the queue. Returns nullptr if the queue is empty.
-    Task* tryDequeue();
+    // Try to dequeue a ready task. When group is non-null, only tasks from that
+    // group are eligible. Returns nullptr if no matching task is ready.
+    Task* tryDequeue(TaskGroup* group = nullptr);
+
+    // Must be called with m_queueMutex held.
+    bool hasQueuedTask(TaskGroup* group) const
+    {
+        if (!group)
+            return !m_queue.empty();
+        return std::any_of(
+            m_queue.begin(),
+            m_queue.end(),
+            [group](const Task* task)
+            {
+                return task->group == group;
+            }
+        );
+    }
 
     // Execute a task and perform all completion bookkeeping (done flag, children,
     // group counter, tasksRemaining counter, reference release). Used by both
@@ -216,7 +249,7 @@ struct ThreadedTaskPool::Pool
         while (!m_queue.empty())
         {
             Task* task = m_queue.front();
-            m_queue.pop();
+            m_queue.pop_front();
             // Null check to silence GCC -Wstringop-overflow (it inlines releaseTask
             // and cannot prove queue elements are non-null).
             if (task)
@@ -254,12 +287,11 @@ struct ThreadedTaskPool::Pool
 
         {
             std::lock_guard<std::mutex> lock(m_queueMutex);
-            m_queue.push(task);
+            m_queue.push_back(task);
             m_queueCV.notify_one();
-            // Only wake one work-stealing waiter per enqueue to avoid thundering herd.
-            // The completion path in executeTask() uses notify_all() to wake all waiters
-            // so they can recheck their specific conditions (done, pending==0, etc.).
-            m_stealCV.notify_one();
+            // Nested work-stealing waiters filter by task group. Wake all waiters
+            // because notify_one() could select a waiter for a different group.
+            m_stealCV.notify_all();
         }
     }
 
@@ -275,6 +307,7 @@ struct ThreadedTaskPool::Pool
         SLANG_RHI_ASSERT(func);
         SLANG_RHI_ASSERT(depsCount == 0 || deps);
         SLANG_RHI_ASSERT(!m_stop.load(std::memory_order_relaxed));
+        SLANG_RHI_ASSERT(!group || group->owner == this);
 
         Task* task = new Task();
 
@@ -331,9 +364,9 @@ struct ThreadedTaskPool::Pool
                     else
                     {
                         // Dependency is already done, decrement the counter.
-                        // Relaxed ordering is safe here because dep->childrenMutex provides
-                        // the necessary acquire/release synchronization.
-                        if (task->depsRemaining.fetch_sub(1, std::memory_order_relaxed) == 1)
+                        // Each decrement publishes the dependency's results. The final decrement
+                        // acquires all preceding decrements before the task is enqueued.
+                        if (task->depsRemaining.fetch_sub(1, std::memory_order_acq_rel) == 1)
                         {
                             readyToEnqueue = true;
                         }
@@ -360,39 +393,31 @@ struct ThreadedTaskPool::Pool
         return task->done.load(std::memory_order_acquire);
     }
 
-    // Work-stealing wait loop. Spins until `isDone` returns true, stealing and
-    // executing queued tasks when possible (only at steal-depth 0 to prevent
-    // circular chains). Falls back to blocking on m_stealCV when no work is
-    // available. At depth > 0 the predicate excludes !m_queue.empty() to avoid
-    // a spin-loop that would starve worker threads.
+    // Work-stealing wait loop. Outermost waits may steal any task. Nested waits
+    // normally block to avoid circular execution chains, but a nested group
+    // wait may steal tasks from that group only.
     template<typename Pred>
-    void waitWithStealing(Pred isDone)
+    void waitWithStealing(Pred isDone, TaskGroup* nestedGroup = nullptr)
     {
         while (!isDone())
         {
-            if (tls_stealDepth == 0)
+            TaskGroup* groupFilter = tls_stealDepth == 0 ? nullptr : nestedGroup;
+            if (tls_stealDepth == 0 || groupFilter)
             {
-                if (Task* stolen = tryDequeue())
+                if (Task* stolen = tryDequeue(groupFilter))
                 {
                     executeTask(stolen);
                     continue;
                 }
             }
             std::unique_lock<std::mutex> lock(m_queueMutex);
-            if (tls_stealDepth == 0)
-            {
-                m_stealCV.wait(
-                    lock,
-                    [&]
-                    {
-                        return isDone() || !m_queue.empty();
-                    }
-                );
-            }
-            else
-            {
-                m_stealCV.wait(lock, isDone);
-            }
+            m_stealCV.wait(
+                lock,
+                [&]
+                {
+                    return isDone() || ((tls_stealDepth == 0 || groupFilter) && hasQueuedTask(groupFilter));
+                }
+            );
         }
     }
 
@@ -420,13 +445,22 @@ struct ThreadedTaskPool::Pool
     }
 };
 
-ThreadedTaskPool::Task* ThreadedTaskPool::Pool::tryDequeue()
+ThreadedTaskPool::Task* ThreadedTaskPool::Pool::tryDequeue(TaskGroup* group)
 {
     std::lock_guard<std::mutex> lock(m_queueMutex);
-    if (m_queue.empty())
+    auto it = group ? std::find_if(
+                          m_queue.begin(),
+                          m_queue.end(),
+                          [group](const Task* task)
+                          {
+                              return task->group == group;
+                          }
+                      )
+                    : m_queue.begin();
+    if (it == m_queue.end())
         return nullptr;
-    Task* task = m_queue.front();
-    m_queue.pop();
+    Task* task = *it;
+    m_queue.erase(it);
     return task;
 }
 
@@ -438,10 +472,8 @@ void ThreadedTaskPool::Pool::executeTask(Task* task)
     // always runs. Without this, an exception would deadlock waiters.
     // NOTE: If a task throws, it is still marked as done and its children
     // will execute. There is currently no failure propagation mechanism.
-    // Increment steal depth so that any waitTask/waitAll/waitTaskGroup called
-    // from the task callback cannot steal tasks. This prevents same-thread
-    // circular dependencies where a stolen task's callback waits on a task
-    // already mid-execution higher up the same call stack.
+    // Increment steal depth so nested waits do not steal unrelated tasks. A
+    // nested task-group wait may still execute work from its own group.
     tls_stealDepth++;
     try
     {
@@ -465,7 +497,9 @@ void ThreadedTaskPool::Pool::executeTask(Task* task)
         for (Task* child : task->children)
         {
             // Decrement the child's dependency counter.
-            if (child->depsRemaining.fetch_sub(1, std::memory_order_relaxed) == 1)
+            // Each decrement publishes the dependency's results. The final decrement
+            // acquires all preceding decrements before the task is enqueued.
+            if (child->depsRemaining.fetch_sub(1, std::memory_order_acq_rel) == 1)
             {
                 // All dependencies satisfied; enqueue the child.
                 enqueue(child);
@@ -475,9 +509,9 @@ void ThreadedTaskPool::Pool::executeTask(Task* task)
         }
         task->children.clear();
     }
-    // Release the pool's reference.
-    // This must happen before decrementing m_tasksRemaining so that
-    // waitAll() only returns after all payload deleters have been called.
+    // Release the pool's reference before decrementing m_tasksRemaining. If the
+    // caller has already released its reference, this also runs the payload deleter
+    // before waitAll() returns.
     releaseTask(task);
     // Decrement the group pending counter.
     // Safety: group is user-managed, but this is safe because waitTaskGroup()
@@ -517,7 +551,7 @@ void ThreadedTaskPool::Pool::workerThread()
             if (m_stop.load() && m_queue.empty())
                 return;
             task = m_queue.front();
-            m_queue.pop();
+            m_queue.pop_front();
         }
         executeTask(task);
     }
@@ -526,12 +560,14 @@ void ThreadedTaskPool::Pool::workerThread()
 void ThreadedTaskPool::Pool::waitTaskGroup(TaskGroup* group)
 {
     SLANG_RHI_ASSERT(group);
+    SLANG_RHI_ASSERT(group->owner == this);
 
     waitWithStealing(
         [group]
         {
             return group->pending.load(std::memory_order_acquire) == 0;
-        }
+        },
+        group
     );
 }
 
@@ -593,12 +629,13 @@ void ThreadedTaskPool::waitAll()
 
 ITaskPool::TaskGroupHandle ThreadedTaskPool::createTaskGroup()
 {
-    return new TaskGroup();
+    return new TaskGroup(m_pool);
 }
 
 void ThreadedTaskPool::waitTaskGroup(TaskGroupHandle group)
 {
     SLANG_RHI_ASSERT(group);
+    SLANG_RHI_ASSERT(static_cast<TaskGroup*>(group)->owner == m_pool);
 
     m_pool->waitTaskGroup(static_cast<TaskGroup*>(group));
 }
@@ -608,6 +645,7 @@ void ThreadedTaskPool::releaseTaskGroup(TaskGroupHandle group)
     SLANG_RHI_ASSERT(group);
 
     TaskGroup* g = static_cast<TaskGroup*>(group);
+    SLANG_RHI_ASSERT(g->owner == m_pool);
     SLANG_RHI_ASSERT(g->pending.load(std::memory_order_acquire) == 0);
     delete g;
 }

--- a/src/core/task-pool.cpp
+++ b/src/core/task-pool.cpp
@@ -4,7 +4,6 @@
 #include <condition_variable>
 #include <deque>
 #include <exception>
-#include <memory>
 #include <mutex>
 #include <thread>
 
@@ -34,8 +33,6 @@ struct TaskGroup
 struct BlockingTaskPool::Task
 {
     const BlockingTaskPool* owner;
-    void* payload;
-    void (*payloadDeleter)(void*);
 };
 
 ITaskPool* BlockingTaskPool::getInterface(const Guid& guid)
@@ -49,39 +46,21 @@ ITaskPool::TaskHandle BlockingTaskPool::submitTask(
     void (*func)(void*),
     void* payload,
     void (*payloadDeleter)(void*),
-    TaskHandle* deps,
-    size_t depsCount,
     TaskGroupHandle group
 )
 {
     SLANG_RHI_ASSERT(func);
-    SLANG_RHI_ASSERT(depsCount == 0 || deps);
     SLANG_RHI_ASSERT(!group || static_cast<TaskGroup*>(group)->owner == this);
-    for (size_t i = 0; i < depsCount; i++)
-    {
-        SLANG_RHI_ASSERT(deps[i]);
-        SLANG_RHI_ASSERT(static_cast<Task*>(deps[i])->owner == this);
-    }
 
-    // Create task just to defer the payload deletion.
+    // Create a completion token for the caller.
     Task* task = new Task();
     task->owner = this;
-    task->payload = payload;
-    task->payloadDeleter = payloadDeleter;
 
-    // Execute the task function.
     func(payload);
+    if (payloadDeleter)
+        payloadDeleter(payload);
 
     return task;
-}
-
-void* BlockingTaskPool::getTaskPayload(TaskHandle task)
-{
-    SLANG_RHI_ASSERT(task);
-
-    Task* taskImpl = static_cast<Task*>(task);
-    SLANG_RHI_ASSERT(taskImpl->owner == this);
-    return taskImpl->payload;
 }
 
 void BlockingTaskPool::releaseTask(TaskHandle task)
@@ -90,40 +69,20 @@ void BlockingTaskPool::releaseTask(TaskHandle task)
 
     Task* taskImpl = static_cast<Task*>(task);
     SLANG_RHI_ASSERT(taskImpl->owner == this);
-    if (taskImpl->payloadDeleter)
-    {
-        taskImpl->payloadDeleter(taskImpl->payload);
-    }
     delete taskImpl;
 }
 
-void BlockingTaskPool::waitTask(TaskHandle task)
+void BlockingTaskPool::waitAndReleaseTask(TaskHandle task)
 {
-    SLANG_RHI_ASSERT(task);
-    SLANG_RHI_ASSERT(static_cast<Task*>(task)->owner == this);
+    releaseTask(task);
 }
-
-bool BlockingTaskPool::isTaskDone(TaskHandle task)
-{
-    SLANG_RHI_ASSERT(task);
-    SLANG_RHI_ASSERT(static_cast<Task*>(task)->owner == this);
-    return true;
-}
-
-void BlockingTaskPool::waitAll() {}
 
 ITaskPool::TaskGroupHandle BlockingTaskPool::createTaskGroup()
 {
     return new TaskGroup(this);
 }
 
-void BlockingTaskPool::waitTaskGroup(TaskGroupHandle group)
-{
-    SLANG_RHI_ASSERT(group);
-    SLANG_RHI_ASSERT(static_cast<TaskGroup*>(group)->owner == this);
-}
-
-void BlockingTaskPool::releaseTaskGroup(TaskGroupHandle group)
+void BlockingTaskPool::waitAndReleaseTaskGroup(TaskGroupHandle group)
 {
     SLANG_RHI_ASSERT(group);
     TaskGroup* g = static_cast<TaskGroup*>(group);
@@ -150,15 +109,8 @@ struct ThreadedTaskPool::Task
     // Reference counter.
     std::atomic<size_t> refCount{0};
 
-    // Number of dependencies that are not yet finished.
-    std::atomic<size_t> depsRemaining{0};
-
     // Flag indicating the task has finished.
     std::atomic<bool> done{false};
-
-    // List of tasks that depend on this task.
-    std::vector<Task*> children;
-    std::mutex childrenMutex;
 
     // Optional task group this task belongs to.
     struct TaskGroup* group = nullptr;
@@ -206,12 +158,12 @@ struct ThreadedTaskPool::Pool
         );
     }
 
-    // Execute a task and perform all completion bookkeeping (done flag, children,
-    // group counter, tasksRemaining counter, reference release). Used by both
+    // Execute a task and perform all completion bookkeeping (payload cleanup,
+    // done flag, group counter, tasksRemaining counter, reference release). Used by both
     // workerThread() and work-stealing wait loops.
     void executeTask(Task* task);
 
-    void waitTaskGroup(TaskGroup* group);
+    void waitGroup(TaskGroup* group);
 
     Pool(int workerCount)
     {
@@ -271,13 +223,7 @@ struct ThreadedTaskPool::Pool
         SLANG_RHI_ASSERT(task->pool == this);
 
         if (task->refCount.fetch_sub(1, std::memory_order_acq_rel) == 1)
-        {
-            if (task->payloadDeleter)
-            {
-                task->payloadDeleter(task->payload);
-            }
             delete task;
-        }
     }
 
     void enqueue(Task* task)
@@ -295,17 +241,9 @@ struct ThreadedTaskPool::Pool
         }
     }
 
-    Task* submitTask(
-        void (*func)(void*),
-        void* payload,
-        void (*payloadDeleter)(void*),
-        Task** deps,
-        size_t depsCount,
-        TaskGroup* group
-    )
+    Task* submitTask(void (*func)(void*), void* payload, void (*payloadDeleter)(void*), TaskGroup* group)
     {
         SLANG_RHI_ASSERT(func);
-        SLANG_RHI_ASSERT(depsCount == 0 || deps);
         SLANG_RHI_ASSERT(!m_stop.load(std::memory_order_relaxed));
         SLANG_RHI_ASSERT(!group || group->owner == this);
 
@@ -315,7 +253,6 @@ struct ThreadedTaskPool::Pool
         task->payload = payload;
         task->payloadDeleter = payloadDeleter;
         task->pool = this;
-        task->depsRemaining = depsCount;
         task->group = group;
 
         // Increment the group counter before enqueuing (critical for correctness).
@@ -333,64 +270,8 @@ struct ThreadedTaskPool::Pool
 
         m_tasksRemaining.fetch_add(1, std::memory_order_release);
 
-        if (depsCount == 0)
-        {
-            // If there are no dependencies, enqueue the task immediately.
-            enqueue(task);
-        }
-        else
-        {
-            // Process dependencies.
-            bool readyToEnqueue = false;
-            for (size_t i = 0; i < depsCount; i++)
-            {
-                Task* dep = deps[i];
-                SLANG_RHI_ASSERT(dep);
-                SLANG_RHI_ASSERT(dep->refCount.load(std::memory_order_acquire) > 0);
-                SLANG_RHI_ASSERT(dep->pool == this);
-
-                // Keep the dependency object alive while we touch its mutex.
-                // The child task can run before submitTask() returns and may
-                // release dependency handles from its callback.
-                retainTask(dep);
-                {
-                    std::lock_guard<std::mutex> lock(dep->childrenMutex);
-                    if (!dep->done.load(std::memory_order_acquire))
-                    {
-                        // Add an extra reference that will be released when the dependency finishes.
-                        retainTask(task);
-                        dep->children.push_back(task);
-                    }
-                    else
-                    {
-                        // Dependency is already done, decrement the counter.
-                        // Each decrement publishes the dependency's results. The final decrement
-                        // acquires all preceding decrements before the task is enqueued.
-                        if (task->depsRemaining.fetch_sub(1, std::memory_order_acq_rel) == 1)
-                        {
-                            readyToEnqueue = true;
-                        }
-                    }
-                }
-                releaseTask(dep);
-            }
-            // Enqueue outside the dep lock scope to avoid use-after-free.
-            // Enqueueing while holding dep->childrenMutex could allow a worker to
-            // execute the task and release the dep before we unlock.
-            if (readyToEnqueue)
-            {
-                enqueue(task);
-            }
-        }
+        enqueue(task);
         return task;
-    }
-
-    bool isTaskDone(Task* task)
-    {
-        SLANG_RHI_ASSERT(task);
-        SLANG_RHI_ASSERT(task->pool == this);
-
-        return task->done.load(std::memory_order_acquire);
     }
 
     // Work-stealing wait loop. Outermost waits may steal any task. Nested waits
@@ -466,12 +347,9 @@ ThreadedTaskPool::Task* ThreadedTaskPool::Pool::tryDequeue(TaskGroup* group)
 
 void ThreadedTaskPool::Pool::executeTask(Task* task)
 {
-    // Execute the task function.
-    // Wrap in try/catch to ensure the worker thread survives and the
-    // task-completion bookkeeping (done flag, children, group, counters)
-    // always runs. Without this, an exception would deadlock waiters.
-    // NOTE: If a task throws, it is still marked as done and its children
-    // will execute. There is currently no failure propagation mechanism.
+    // Wrap callbacks in try/catch to ensure the worker thread survives and the
+    // task-completion bookkeeping always runs. Without this, an exception would
+    // deadlock waiters. There is currently no failure propagation mechanism.
     // Increment steal depth so nested waits do not steal unrelated tasks. A
     // nested task-group wait may still execute work from its own group.
     tls_stealDepth++;
@@ -485,39 +363,33 @@ void ThreadedTaskPool::Pool::executeTask(Task* task)
     {
         SLANG_RHI_ASSERT_FAILURE("Task threw an unknown exception");
     }
+    try
+    {
+        if (task->payloadDeleter)
+            task->payloadDeleter(task->payload);
+    } catch (const std::exception& e)
+    {
+        SLANG_RHI_ASSERT_FAILURE(e.what());
+    } catch (...)
+    {
+        SLANG_RHI_ASSERT_FAILURE("Task payload deleter threw an unknown exception");
+    }
     tls_stealDepth--;
+
     // Capture the group pointer before we potentially release the task.
     TaskGroup* group = task->group;
-    // Mark the task as done and notify child tasks.
-    // We hold childrenMutex to safely process the children list and to
-    // synchronize with submitTask() which checks done under the same lock.
-    {
-        std::lock_guard<std::mutex> childLock(task->childrenMutex);
-        task->done.store(true, std::memory_order_release);
-        for (Task* child : task->children)
-        {
-            // Decrement the child's dependency counter.
-            // Each decrement publishes the dependency's results. The final decrement
-            // acquires all preceding decrements before the task is enqueued.
-            if (child->depsRemaining.fetch_sub(1, std::memory_order_acq_rel) == 1)
-            {
-                // All dependencies satisfied; enqueue the child.
-                enqueue(child);
-            }
-            // Release the extra reference taken when adding as a dependency.
-            releaseTask(child);
-        }
-        task->children.clear();
-    }
-    // Release the pool's reference before decrementing m_tasksRemaining. If the
-    // caller has already released its reference, this also runs the payload deleter
-    // before waitAll() returns.
+
+    // Payload cleanup is part of task completion, so publish done only after the
+    // task function and payload deleter have both returned.
+    task->done.store(true, std::memory_order_release);
+
+    // Release the pool's reference before decrementing the completion counters.
     releaseTask(task);
     // Decrement the group pending counter.
-    // Safety: group is user-managed, but this is safe because waitTaskGroup()
+    // Safety: group is user-managed, but this is safe because waitGroup()
     // only returns when pending==0, which requires ALL tasks in the group to
     // have completed this fetch_sub. Therefore no task can still be accessing
-    // the group when the user calls releaseTaskGroup() after waitTaskGroup().
+    // the group when waitAndReleaseTaskGroup() deletes it.
     if (group)
     {
         group->pending.fetch_sub(1, std::memory_order_acq_rel);
@@ -557,7 +429,7 @@ void ThreadedTaskPool::Pool::workerThread()
     }
 }
 
-void ThreadedTaskPool::Pool::waitTaskGroup(TaskGroup* group)
+void ThreadedTaskPool::Pool::waitGroup(TaskGroup* group)
 {
     SLANG_RHI_ASSERT(group);
     SLANG_RHI_ASSERT(group->owner == this);
@@ -592,19 +464,10 @@ ITaskPool::TaskHandle ThreadedTaskPool::submitTask(
     void (*func)(void*),
     void* payload,
     void (*payloadDeleter)(void*),
-    TaskHandle* deps,
-    size_t depsCount,
     TaskGroupHandle group
 )
 {
-    return m_pool->submitTask(func, payload, payloadDeleter, (Task**)deps, depsCount, static_cast<TaskGroup*>(group));
-}
-
-void* ThreadedTaskPool::getTaskPayload(TaskHandle task)
-{
-    SLANG_RHI_ASSERT(task);
-
-    return static_cast<Task*>(task)->payload;
+    return m_pool->submitTask(func, payload, payloadDeleter, static_cast<TaskGroup*>(group));
 }
 
 void ThreadedTaskPool::releaseTask(TaskHandle task)
@@ -612,19 +475,11 @@ void ThreadedTaskPool::releaseTask(TaskHandle task)
     m_pool->releaseTask(static_cast<Task*>(task));
 }
 
-void ThreadedTaskPool::waitTask(TaskHandle task)
+void ThreadedTaskPool::waitAndReleaseTask(TaskHandle task)
 {
-    m_pool->waitTask(static_cast<Task*>(task));
-}
-
-bool ThreadedTaskPool::isTaskDone(TaskHandle task)
-{
-    return m_pool->isTaskDone(static_cast<Task*>(task));
-}
-
-void ThreadedTaskPool::waitAll()
-{
-    m_pool->waitAll();
+    Task* taskImpl = static_cast<Task*>(task);
+    m_pool->waitTask(taskImpl);
+    m_pool->releaseTask(taskImpl);
 }
 
 ITaskPool::TaskGroupHandle ThreadedTaskPool::createTaskGroup()
@@ -632,20 +487,13 @@ ITaskPool::TaskGroupHandle ThreadedTaskPool::createTaskGroup()
     return new TaskGroup(m_pool);
 }
 
-void ThreadedTaskPool::waitTaskGroup(TaskGroupHandle group)
+void ThreadedTaskPool::waitAndReleaseTaskGroup(TaskGroupHandle group)
 {
     SLANG_RHI_ASSERT(group);
     SLANG_RHI_ASSERT(static_cast<TaskGroup*>(group)->owner == m_pool);
 
-    m_pool->waitTaskGroup(static_cast<TaskGroup*>(group));
-}
-
-void ThreadedTaskPool::releaseTaskGroup(TaskGroupHandle group)
-{
-    SLANG_RHI_ASSERT(group);
-
     TaskGroup* g = static_cast<TaskGroup*>(group);
-    SLANG_RHI_ASSERT(g->owner == m_pool);
+    m_pool->waitGroup(g);
     SLANG_RHI_ASSERT(g->pending.load(std::memory_order_acquire) == 0);
     delete g;
 }

--- a/src/core/task-pool.h
+++ b/src/core/task-pool.h
@@ -16,26 +16,16 @@ public:
         void (*func)(void*),
         void* payload,
         void (*payloadDeleter)(void*),
-        TaskHandle* deps,
-        size_t depsCount,
         TaskGroupHandle group = nullptr
     ) override;
 
-    virtual SLANG_NO_THROW void* SLANG_MCALL getTaskPayload(TaskHandle task) override;
-
     virtual SLANG_NO_THROW void SLANG_MCALL releaseTask(TaskHandle task) override;
 
-    virtual SLANG_NO_THROW void SLANG_MCALL waitTask(TaskHandle task) override;
-
-    virtual SLANG_NO_THROW bool SLANG_MCALL isTaskDone(TaskHandle task) override;
-
-    virtual SLANG_NO_THROW void SLANG_MCALL waitAll() override;
+    virtual SLANG_NO_THROW void SLANG_MCALL waitAndReleaseTask(TaskHandle task) override;
 
     virtual SLANG_NO_THROW TaskGroupHandle SLANG_MCALL createTaskGroup() override;
 
-    virtual SLANG_NO_THROW void SLANG_MCALL waitTaskGroup(TaskGroupHandle group) override;
-
-    virtual SLANG_NO_THROW void SLANG_MCALL releaseTaskGroup(TaskGroupHandle group) override;
+    virtual SLANG_NO_THROW void SLANG_MCALL waitAndReleaseTaskGroup(TaskGroupHandle group) override;
 
 private:
     struct Task;
@@ -56,26 +46,16 @@ public:
         void (*func)(void*),
         void* payload,
         void (*payloadDeleter)(void*),
-        TaskHandle* deps,
-        size_t depsCount,
         TaskGroupHandle group = nullptr
     ) override;
 
-    virtual SLANG_NO_THROW void* SLANG_MCALL getTaskPayload(TaskHandle task) override;
-
     virtual SLANG_NO_THROW void SLANG_MCALL releaseTask(TaskHandle task) override;
 
-    virtual SLANG_NO_THROW void SLANG_MCALL waitTask(TaskHandle task) override;
-
-    virtual SLANG_NO_THROW bool SLANG_MCALL isTaskDone(TaskHandle task) override;
-
-    virtual SLANG_NO_THROW void SLANG_MCALL waitAll() override;
+    virtual SLANG_NO_THROW void SLANG_MCALL waitAndReleaseTask(TaskHandle task) override;
 
     virtual SLANG_NO_THROW TaskGroupHandle SLANG_MCALL createTaskGroup() override;
 
-    virtual SLANG_NO_THROW void SLANG_MCALL waitTaskGroup(TaskGroupHandle group) override;
-
-    virtual SLANG_NO_THROW void SLANG_MCALL releaseTaskGroup(TaskGroupHandle group) override;
+    virtual SLANG_NO_THROW void SLANG_MCALL waitAndReleaseTaskGroup(TaskGroupHandle group) override;
 
 private:
     struct Task;

--- a/src/cuda/optix-api-impl.cpp
+++ b/src/cuda/optix-api-impl.cpp
@@ -608,8 +608,6 @@ Result executeOptixTasks(ITaskPool* taskPool, std::span<OptixTask> initialTasks)
                 {
                     delete static_cast<OptixTaskPayload*>(p);
                 },
-                nullptr,
-                0,
                 payload->group
             );
             payload->taskPool->releaseTask(handle);
@@ -627,16 +625,13 @@ Result executeOptixTasks(ITaskPool* taskPool, std::span<OptixTask> initialTasks)
             {
                 delete static_cast<OptixTaskPayload*>(p);
             },
-            nullptr,
-            0,
             group
         );
         taskPool->releaseTask(handle);
     }
 
     // Wait for all tasks (including recursively spawned sub-tasks) to complete.
-    taskPool->waitTaskGroup(group);
-    taskPool->releaseTaskGroup(group);
+    taskPool->waitAndReleaseTaskGroup(group);
 
     if (failed.load(std::memory_order_relaxed))
         return SLANG_FAIL;

--- a/src/pipeline-resolver.cpp
+++ b/src/pipeline-resolver.cpp
@@ -25,7 +25,7 @@ public:
 
     Result submit(void (*func)(void*), void* payload, void (*payloadDeleter)(void*))
     {
-        auto handle = m_taskPool->submitTask(func, payload, payloadDeleter, nullptr, 0);
+        auto handle = m_taskPool->submitTask(func, payload, payloadDeleter);
         SLANG_RHI_ASSERT(handle);
         if (!handle)
         {
@@ -40,10 +40,7 @@ public:
     void wait()
     {
         for (auto handle : m_handles)
-        {
-            m_taskPool->waitTask(handle);
-            m_taskPool->releaseTask(handle);
-        }
+            m_taskPool->waitAndReleaseTask(handle);
         m_handles.clear();
     }
 

--- a/tests/test-task-pool.cpp
+++ b/tests/test-task-pool.cpp
@@ -3,8 +3,6 @@
 #include "core/task-pool.h"
 
 #include <thread>
-#include <string>
-#include <functional>
 
 using namespace rhi;
 
@@ -36,246 +34,17 @@ void testSimple(ITaskPool* pool)
                 size_t j = *static_cast<size_t*>(payload);
                 deleted[j] = true;
                 delete static_cast<size_t*>(payload);
-            },
-            nullptr,
-            0
+            }
         );
     }
 
     for (size_t i = 0; i < N; ++i)
     {
         CAPTURE(i);
-        CHECK(!deleted[i]);
-        pool->waitTask(tasks[i]);
-        pool->releaseTask(tasks[i]);
-        CHECK(result[i] == (size_t)i);
-    }
-
-    pool->waitAll();
-
-    for (size_t i = 0; i < N; ++i)
-    {
-        CAPTURE(i);
-        CHECK(deleted[i]);
-    }
-}
-
-// Create a number of tasks and wait for all of them at once.
-void testWaitAll(ITaskPool* pool)
-{
-    REQUIRE(pool != nullptr);
-
-    static constexpr size_t N = 1000;
-    static size_t result[N];
-    static bool deleted[N];
-
-    ::memset(result, 0, sizeof(result));
-    ::memset(deleted, 0, sizeof(deleted));
-
-    for (size_t i = 0; i < N; ++i)
-    {
-        size_t* payload = new size_t{i};
-        ITaskPool::TaskHandle task = pool->submitTask(
-            [](void* payload)
-            {
-                size_t j = *static_cast<size_t*>(payload);
-                result[j] = j;
-            },
-            payload,
-            [](void* payload)
-            {
-                size_t j = *static_cast<size_t*>(payload);
-                deleted[j] = true;
-                delete static_cast<size_t*>(payload);
-            },
-            nullptr,
-            0
-        );
-        CHECK(!deleted[i]);
-        pool->releaseTask(task);
-    }
-
-    pool->waitAll();
-
-    for (size_t i = 0; i < N; ++i)
-    {
-        CAPTURE(i);
+        pool->waitAndReleaseTask(tasks[i]);
         CHECK(result[i] == (size_t)i);
         CHECK(deleted[i]);
     }
-}
-
-// Create a number of tasks and wait for all of them at once.
-void testSimpleDependency(ITaskPool* pool)
-{
-    REQUIRE(pool != nullptr);
-
-    static constexpr size_t N = 1000;
-    static size_t result[N];
-    static ITaskPool::TaskHandle tasks[N];
-    static std::atomic<size_t> finished;
-
-    finished = 0;
-
-    for (size_t i = 0; i < N; ++i)
-    {
-        tasks[i] = pool->submitTask(
-            [](void* payload)
-            {
-                size_t j = (size_t)(uintptr_t)payload;
-                result[j] = j;
-                finished++;
-            },
-            (void*)i,
-            nullptr,
-            nullptr,
-            0
-        );
-    }
-
-    ITaskPool::TaskHandle waitTask = pool->submitTask(
-        [](void*)
-        {
-            CHECK(finished == N);
-        },
-        nullptr,
-        nullptr,
-        tasks,
-        N
-    );
-
-    for (size_t i = 0; i < N; ++i)
-    {
-        pool->releaseTask(tasks[i]);
-    }
-
-    pool->waitTask(waitTask);
-    pool->releaseTask(waitTask);
-
-    for (size_t i = 0; i < N; ++i)
-    {
-        CAPTURE(i);
-        CHECK(result[i] == (size_t)i);
-    }
-}
-
-inline ITaskPool::TaskHandle spawn(ITaskPool* pool, int depth)
-{
-    if (depth > 0)
-    {
-        ITaskPool::TaskHandle a = spawn(pool, depth - 1);
-        ITaskPool::TaskHandle b = spawn(pool, depth - 1);
-        ITaskPool::TaskHandle tasks[] = {a, b};
-        ITaskPool::TaskHandle c = pool->submitTask(
-            [](void*)
-            {
-            },
-            nullptr,
-            nullptr,
-            tasks,
-            2
-        );
-        pool->releaseTask(a);
-        pool->releaseTask(b);
-        return c;
-    }
-    else
-    {
-        return pool->submitTask(
-            [](void*)
-            {
-            },
-            nullptr,
-            nullptr,
-            nullptr,
-            0
-        );
-    }
-}
-
-void testRecursiveDependency(ITaskPool* pool)
-{
-    REQUIRE(pool != nullptr);
-
-    ITaskPool::TaskHandle task = spawn(pool, 10);
-    pool->waitTask(task);
-    pool->releaseTask(task);
-}
-
-struct FibonacciPayload
-{
-    int result;
-    ITaskPool::TaskHandle a;
-    ITaskPool::TaskHandle b;
-};
-
-static ITaskPool* fibonacciPool;
-
-inline ITaskPool::TaskHandle fibonacciTask(int n)
-{
-    FibonacciPayload* payload = new FibonacciPayload{};
-
-    if (n <= 1)
-    {
-        payload->result = n;
-        payload->a = nullptr;
-        payload->b = nullptr;
-        return fibonacciPool->submitTask(
-            [](void* payload)
-            {
-            },
-            payload,
-            [](void* p)
-            {
-                delete static_cast<FibonacciPayload*>(p);
-            },
-            nullptr,
-            0
-        );
-    }
-    else
-    {
-        payload->a = fibonacciTask(n - 1);
-        payload->b = fibonacciTask(n - 2);
-        ITaskPool::TaskHandle tasks[] = {payload->a, payload->b};
-        return fibonacciPool->submitTask(
-            [](void* payload)
-            {
-                FibonacciPayload* p = static_cast<FibonacciPayload*>(payload);
-                FibonacciPayload* pa = static_cast<FibonacciPayload*>(fibonacciPool->getTaskPayload(p->a));
-                FibonacciPayload* pb = static_cast<FibonacciPayload*>(fibonacciPool->getTaskPayload(p->b));
-                p->result = pa->result + pb->result;
-                fibonacciPool->releaseTask(p->a);
-                fibonacciPool->releaseTask(p->b);
-            },
-            payload,
-            [](void* p)
-            {
-                delete static_cast<FibonacciPayload*>(p);
-            },
-            tasks,
-            2
-        );
-    }
-}
-
-inline int fibonacci(int n)
-{
-    return n <= 1 ? n : fibonacci(n - 1) + fibonacci(n - 2);
-}
-
-void testFibonacci(ITaskPool* pool)
-{
-    REQUIRE(pool != nullptr);
-
-    fibonacciPool = pool;
-    int N = 25;
-    int expected = fibonacci(N);
-    ITaskPool::TaskHandle task = fibonacciTask(N);
-    pool->waitTask(task);
-    int result = static_cast<FibonacciPayload*>(pool->getTaskPayload(task))->result;
-    CHECK(result == expected);
-    pool->releaseTask(task);
 }
 
 // Basic group lifecycle: create, submit tasks, wait, release.
@@ -285,7 +54,9 @@ void testGroupBasic(ITaskPool* pool)
 
     static constexpr size_t N = 100;
     static std::atomic<size_t> counter;
+    static std::atomic<size_t> deleted;
     counter = 0;
+    deleted = 0;
 
     auto group = pool->createTaskGroup();
 
@@ -297,17 +68,18 @@ void testGroupBasic(ITaskPool* pool)
                 counter.fetch_add(1, std::memory_order_relaxed);
             },
             nullptr,
-            nullptr,
-            nullptr,
-            0,
+            [](void*)
+            {
+                deleted.fetch_add(1, std::memory_order_relaxed);
+            },
             group
         );
         pool->releaseTask(task);
     }
 
-    pool->waitTaskGroup(group);
+    pool->waitAndReleaseTaskGroup(group);
     CHECK(counter.load() == N);
-    pool->releaseTaskGroup(group);
+    CHECK(deleted.load() == N);
 }
 
 // Sub-tasks spawned from callbacks are tracked by the group.
@@ -359,8 +131,6 @@ void testGroupSubTasks(ITaskPool* pool)
                                     {
                                         delete static_cast<SubTaskPayload*>(p3);
                                     },
-                                    nullptr,
-                                    0,
                                     sp->group
                                 );
                                 sp->pool->releaseTask(t);
@@ -372,8 +142,6 @@ void testGroupSubTasks(ITaskPool* pool)
                     {
                         delete static_cast<SubTaskPayload*>(p2);
                     },
-                    nullptr,
-                    0,
                     payload->group
                 );
                 payload->pool->releaseTask(task);
@@ -389,16 +157,13 @@ void testGroupSubTasks(ITaskPool* pool)
         {
             delete static_cast<SubTaskPayload*>(p);
         },
-        nullptr,
-        0,
         group
     );
     pool->releaseTask(task);
 
-    pool->waitTaskGroup(group);
+    pool->waitAndReleaseTaskGroup(group);
     // 1 root (depth 2) + 2 children (depth 1) + 4 leaves (depth 0) = 7
     CHECK(counter.load() == 7);
-    pool->releaseTaskGroup(group);
 }
 
 // Empty group: wait immediately after create.
@@ -407,55 +172,7 @@ void testGroupEmpty(ITaskPool* pool)
     REQUIRE(pool != nullptr);
 
     auto group = pool->createTaskGroup();
-    pool->waitTaskGroup(group);
-    pool->releaseTaskGroup(group);
-}
-
-// Group with dependencies: tasks have both a group and dependency handles.
-void testGroupWithDependencies(ITaskPool* pool)
-{
-    REQUIRE(pool != nullptr);
-
-    static std::atomic<size_t> order;
-    order = 0;
-
-    auto group = pool->createTaskGroup();
-
-    // First task in the group.
-    static size_t firstOrder;
-    ITaskPool::TaskHandle first = pool->submitTask(
-        [](void*)
-        {
-            firstOrder = order.fetch_add(1, std::memory_order_relaxed);
-        },
-        nullptr,
-        nullptr,
-        nullptr,
-        0,
-        group
-    );
-
-    // Second task depends on first, also in the group.
-    static size_t secondOrder;
-    ITaskPool::TaskHandle second = pool->submitTask(
-        [](void*)
-        {
-            secondOrder = order.fetch_add(1, std::memory_order_relaxed);
-        },
-        nullptr,
-        nullptr,
-        &first,
-        1,
-        group
-    );
-
-    pool->releaseTask(first);
-    pool->releaseTask(second);
-
-    pool->waitTaskGroup(group);
-    CHECK(firstOrder < secondOrder);
-    CHECK(order.load() == 2);
-    pool->releaseTaskGroup(group);
+    pool->waitAndReleaseTaskGroup(group);
 }
 
 void testTaskPool(ITaskPool* pool, int iterations)
@@ -466,31 +183,6 @@ void testTaskPool(ITaskPool* pool, int iterations)
         {
             testSimple(pool);
         }
-    }
-    SUBCASE("wait-all")
-    {
-        for (int i = 0; i < iterations; ++i)
-        {
-            testWaitAll(pool);
-        }
-    }
-    SUBCASE("simple-dependency")
-    {
-        for (int i = 0; i < iterations; ++i)
-        {
-            testSimpleDependency(pool);
-        }
-    }
-    SUBCASE("recursive-dependency")
-    {
-        for (int i = 0; i < iterations; ++i)
-        {
-            testRecursiveDependency(pool);
-        }
-    }
-    SUBCASE("fibonacci")
-    {
-        testFibonacci(pool);
     }
     SUBCASE("group-basic")
     {
@@ -511,13 +203,6 @@ void testTaskPool(ITaskPool* pool, int iterations)
         for (int i = 0; i < iterations; ++i)
         {
             testGroupEmpty(pool);
-        }
-    }
-    SUBCASE("group-with-dependencies")
-    {
-        for (int i = 0; i < iterations; ++i)
-        {
-            testGroupWithDependencies(pool);
         }
     }
 }
@@ -565,9 +250,7 @@ void testExternalWaitStealsReadyTask(ITaskPool* pool)
                 std::this_thread::yield();
         },
         &blockerState,
-        nullptr,
-        nullptr,
-        0
+        nullptr
     );
 
     while (!blockerStarted.load(std::memory_order_acquire))
@@ -579,22 +262,18 @@ void testExternalWaitStealsReadyTask(ITaskPool* pool)
             static_cast<std::atomic<bool>*>(data)->store(true, std::memory_order_relaxed);
         },
         &targetExecuted,
-        nullptr,
-        nullptr,
-        0
+        nullptr
     );
 
-    // The only worker is blocked, so waitTask() must execute the target here.
-    pool->waitTask(target);
+    // The only worker is blocked, so the waiting thread must execute the target here.
+    pool->waitAndReleaseTask(target);
     CHECK(targetExecuted.load(std::memory_order_relaxed));
 
     releaseBlocker.store(true, std::memory_order_release);
-    pool->waitTask(blocker);
-    pool->releaseTask(target);
-    pool->releaseTask(blocker);
+    pool->waitAndReleaseTask(blocker);
 }
 
-// A task callback calls waitTask on another task that was submitted first.
+// A task callback waits on another task that was submitted first.
 // The earlier task can therefore make progress on another executor.
 void testWorkStealingWaitTaskFromCallback(ITaskPool* pool)
 {
@@ -609,9 +288,7 @@ void testWorkStealingWaitTaskFromCallback(ITaskPool* pool)
             static_cast<std::atomic<int>*>(p)->store(1, std::memory_order_relaxed);
         },
         &result,
-        nullptr,
-        nullptr,
-        0
+        nullptr
     );
 
     // Task B: waits on A from inside its callback, then sets result to 2.
@@ -627,21 +304,16 @@ void testWorkStealingWaitTaskFromCallback(ITaskPool* pool)
         [](void* p)
         {
             auto* ctx = static_cast<Payload*>(p);
-            ctx->pool->waitTask(ctx->taskA);
+            ctx->pool->waitAndReleaseTask(ctx->taskA);
             CHECK(ctx->result->load(std::memory_order_relaxed) == 1);
             ctx->result->store(2, std::memory_order_relaxed);
         },
         &payload,
-        nullptr,
-        nullptr,
-        0
+        nullptr
     );
 
-    pool->waitTask(taskB);
+    pool->waitAndReleaseTask(taskB);
     CHECK(result.load() == 2);
-
-    pool->releaseTask(taskA);
-    pool->releaseTask(taskB);
 }
 
 // Nested wait chain: task C waits on B, B waits on A. Each waited-on task was
@@ -658,9 +330,7 @@ void testWorkStealingNestedWait(ITaskPool* pool)
             static_cast<std::atomic<int>*>(p)->fetch_add(1, std::memory_order_relaxed);
         },
         &order,
-        nullptr,
-        nullptr,
-        0
+        nullptr
     );
 
     struct WaitPayload
@@ -675,13 +345,11 @@ void testWorkStealingNestedWait(ITaskPool* pool)
         [](void* p)
         {
             auto* ctx = static_cast<WaitPayload*>(p);
-            ctx->pool->waitTask(ctx->dep);
+            ctx->pool->waitAndReleaseTask(ctx->dep);
             ctx->order->fetch_add(1, std::memory_order_relaxed);
         },
         &payloadB,
-        nullptr,
-        nullptr,
-        0
+        nullptr
     );
 
     WaitPayload payloadC{pool, taskB, &order};
@@ -690,24 +358,18 @@ void testWorkStealingNestedWait(ITaskPool* pool)
         [](void* p)
         {
             auto* ctx = static_cast<WaitPayload*>(p);
-            ctx->pool->waitTask(ctx->dep);
+            ctx->pool->waitAndReleaseTask(ctx->dep);
             ctx->order->fetch_add(1, std::memory_order_relaxed);
         },
         &payloadC,
-        nullptr,
-        nullptr,
-        0
+        nullptr
     );
 
-    pool->waitTask(taskC);
+    pool->waitAndReleaseTask(taskC);
     CHECK(order.load() == 3);
-
-    pool->releaseTask(taskA);
-    pool->releaseTask(taskB);
-    pool->releaseTask(taskC);
 }
 
-// A task callback uses waitTaskGroup to wait on sub-tasks it spawns.
+// A task callback waits on a group of sub-tasks it spawns.
 // With 1 worker, the callback's thread must steal sub-tasks to make progress.
 void testWorkStealingWaitGroupFromCallback(ITaskPool* pool)
 {
@@ -739,27 +401,21 @@ void testWorkStealingWaitGroupFromCallback(ITaskPool* pool)
                     },
                     ctx->sum,
                     nullptr,
-                    nullptr,
-                    0,
                     group
                 );
             }
 
-            ctx->pool->waitTaskGroup(group);
-            ctx->pool->releaseTaskGroup(group);
+            ctx->pool->waitAndReleaseTaskGroup(group);
 
             for (int i = 0; i < N; ++i)
                 ctx->pool->releaseTask(subtasks[i]);
         },
         &payload,
-        nullptr,
-        nullptr,
-        0
+        nullptr
     );
 
-    pool->waitTask(task);
+    pool->waitAndReleaseTask(task);
     CHECK(sum.load() == 10);
-    pool->releaseTask(task);
 }
 
 struct NestedGroupTaskPayload
@@ -793,8 +449,6 @@ void runNestedGroupTask(void* data)
             {
                 delete static_cast<NestedGroupTaskPayload*>(childData);
             },
-            nullptr,
-            0,
             payload->group
         );
         payload->pool->releaseTask(task);
@@ -802,7 +456,7 @@ void runNestedGroupTask(void* data)
 }
 
 // Saturate a single-worker pool with two callbacks that each wait on a
-// dynamically growing task group. The thread calling waitTask() becomes the
+// dynamically growing task group. The thread waiting on a task becomes the
 // second executor, so both executors are inside callbacks when the group work
 // is queued. Nested group-specific stealing is required to make progress.
 void testNestedGroupWaitWithSaturatedWorkers()
@@ -842,27 +496,19 @@ void testNestedGroupWaitWithSaturatedWorkers()
                     {
                         delete static_cast<NestedGroupTaskPayload*>(rootData);
                     },
-                    nullptr,
-                    0,
                     group
                 );
                 payload->pool->releaseTask(rootTask);
 
-                payload->pool->waitTaskGroup(group);
-                payload->pool->releaseTaskGroup(group);
+                payload->pool->waitAndReleaseTaskGroup(group);
             },
             &payloads[i],
-            nullptr,
-            nullptr,
-            0
+            nullptr
         );
     }
 
     for (auto parent : parents)
-    {
-        pool->waitTask(parent);
-        pool->releaseTask(parent);
-    }
+        pool->waitAndReleaseTask(parent);
 
     // Two complete binary trees with depth 4: 2 * (2^5 - 1).
     CHECK(sum.load(std::memory_order_relaxed) == 62);

--- a/tests/test-task-pool.cpp
+++ b/tests/test-task-pool.cpp
@@ -540,11 +540,62 @@ TEST_CASE("task-pool-threaded-single-worker")
     testTaskPool(pool, 1);
 }
 
-// Work-stealing tests: use a single worker thread to force scenarios that
-// would deadlock without work-stealing in wait functions.
+// Work-stealing tests use a single worker thread so the waiting caller also
+// participates in task execution.
 
-// A task callback calls waitTask on another task. With 1 worker thread and
-// no work-stealing, the worker blocks and the waited-on task never runs.
+void testExternalWaitStealsReadyTask(ITaskPool* pool)
+{
+    REQUIRE(pool != nullptr);
+
+    std::atomic<bool> blockerStarted{false};
+    std::atomic<bool> releaseBlocker{false};
+    std::atomic<bool> targetExecuted{false};
+    struct BlockerState
+    {
+        std::atomic<bool>* started;
+        std::atomic<bool>* release;
+    } blockerState{&blockerStarted, &releaseBlocker};
+
+    auto blocker = pool->submitTask(
+        [](void* data)
+        {
+            auto* state = static_cast<BlockerState*>(data);
+            state->started->store(true, std::memory_order_release);
+            while (!state->release->load(std::memory_order_acquire))
+                std::this_thread::yield();
+        },
+        &blockerState,
+        nullptr,
+        nullptr,
+        0
+    );
+
+    while (!blockerStarted.load(std::memory_order_acquire))
+        std::this_thread::yield();
+
+    auto target = pool->submitTask(
+        [](void* data)
+        {
+            static_cast<std::atomic<bool>*>(data)->store(true, std::memory_order_relaxed);
+        },
+        &targetExecuted,
+        nullptr,
+        nullptr,
+        0
+    );
+
+    // The only worker is blocked, so waitTask() must execute the target here.
+    pool->waitTask(target);
+    CHECK(targetExecuted.load(std::memory_order_relaxed));
+
+    releaseBlocker.store(true, std::memory_order_release);
+    pool->waitTask(blocker);
+    pool->releaseTask(target);
+    pool->releaseTask(blocker);
+}
+
+// A task callback calls waitTask on another task that was submitted first.
+// The earlier task can therefore make progress on another executor.
 void testWorkStealingWaitTaskFromCallback(ITaskPool* pool)
 {
     REQUIRE(pool != nullptr);
@@ -593,8 +644,8 @@ void testWorkStealingWaitTaskFromCallback(ITaskPool* pool)
     pool->releaseTask(taskB);
 }
 
-// Nested wait chain: task C waits on B, B waits on A. With 1 worker thread,
-// this requires two levels of work-stealing to avoid deadlock.
+// Nested wait chain: task C waits on B, B waits on A. Each waited-on task was
+// submitted first and can therefore make progress on another executor.
 void testWorkStealingNestedWait(ITaskPool* pool)
 {
     REQUIRE(pool != nullptr);
@@ -711,11 +762,121 @@ void testWorkStealingWaitGroupFromCallback(ITaskPool* pool)
     pool->releaseTask(task);
 }
 
+struct NestedGroupTaskPayload
+{
+    ITaskPool* pool;
+    ITaskPool::TaskGroupHandle group;
+    std::atomic<int>* sum;
+    int depth;
+};
+
+void runNestedGroupTask(void* data)
+{
+    auto* payload = static_cast<NestedGroupTaskPayload*>(data);
+    payload->sum->fetch_add(1, std::memory_order_relaxed);
+
+    if (payload->depth == 0)
+        return;
+
+    for (int i = 0; i < 2; ++i)
+    {
+        auto* child = new NestedGroupTaskPayload{
+            payload->pool,
+            payload->group,
+            payload->sum,
+            payload->depth - 1,
+        };
+        auto task = payload->pool->submitTask(
+            runNestedGroupTask,
+            child,
+            [](void* childData)
+            {
+                delete static_cast<NestedGroupTaskPayload*>(childData);
+            },
+            nullptr,
+            0,
+            payload->group
+        );
+        payload->pool->releaseTask(task);
+    }
+}
+
+// Saturate a single-worker pool with two callbacks that each wait on a
+// dynamically growing task group. The thread calling waitTask() becomes the
+// second executor, so both executors are inside callbacks when the group work
+// is queued. Nested group-specific stealing is required to make progress.
+void testNestedGroupWaitWithSaturatedWorkers()
+{
+    ComPtr<ITaskPool> pool(new ThreadedTaskPool(1));
+    std::atomic<int> parentsStarted{0};
+    std::atomic<int> sum{0};
+
+    struct ParentPayload
+    {
+        ITaskPool* pool;
+        std::atomic<int>* parentsStarted;
+        std::atomic<int>* sum;
+    };
+    ParentPayload payloads[] = {
+        {pool, &parentsStarted, &sum},
+        {pool, &parentsStarted, &sum},
+    };
+
+    ITaskPool::TaskHandle parents[2];
+    for (size_t i = 0; i < std::size(parents); ++i)
+    {
+        parents[i] = pool->submitTask(
+            [](void* data)
+            {
+                auto* payload = static_cast<ParentPayload*>(data);
+                payload->parentsStarted->fetch_add(1, std::memory_order_release);
+                while (payload->parentsStarted->load(std::memory_order_acquire) != 2)
+                    std::this_thread::yield();
+
+                auto group = payload->pool->createTaskGroup();
+                auto* root = new NestedGroupTaskPayload{payload->pool, group, payload->sum, 4};
+                auto rootTask = payload->pool->submitTask(
+                    runNestedGroupTask,
+                    root,
+                    [](void* rootData)
+                    {
+                        delete static_cast<NestedGroupTaskPayload*>(rootData);
+                    },
+                    nullptr,
+                    0,
+                    group
+                );
+                payload->pool->releaseTask(rootTask);
+
+                payload->pool->waitTaskGroup(group);
+                payload->pool->releaseTaskGroup(group);
+            },
+            &payloads[i],
+            nullptr,
+            nullptr,
+            0
+        );
+    }
+
+    for (auto parent : parents)
+    {
+        pool->waitTask(parent);
+        pool->releaseTask(parent);
+    }
+
+    // Two complete binary trees with depth 4: 2 * (2^5 - 1).
+    CHECK(sum.load(std::memory_order_relaxed) == 62);
+}
+
 TEST_CASE("task-pool-work-stealing")
 {
-    // Use a single worker thread to force work-stealing in wait functions.
-    // Without work-stealing, these tests would deadlock.
+    // Use a single worker thread so the waiting caller participates in execution.
     ComPtr<ITaskPool> pool(new ThreadedTaskPool(1));
+
+    SUBCASE("external-wait-steals-ready-task")
+    {
+        testExternalWaitStealsReadyTask(pool);
+    }
 
     SUBCASE("wait-task-from-callback")
     {
@@ -738,4 +899,9 @@ TEST_CASE("task-pool-work-stealing")
             testWorkStealingWaitGroupFromCallback(pool);
         }
     }
+}
+
+TEST_CASE("task-pool-nested-group-wait-saturated-workers")
+{
+    testNestedGroupWaitWithSaturatedWorkers();
 }

--- a/tests/test-task-pool.cpp
+++ b/tests/test-task-pool.cpp
@@ -418,18 +418,28 @@ void testWorkStealingWaitGroupFromCallback(ITaskPool* pool)
     CHECK(sum.load() == 10);
 }
 
+struct NestedGroupState
+{
+    std::atomic<int> executed{0};
+};
+
+static thread_local NestedGroupState* tls_expectedNestedGroupState = nullptr;
+
 struct NestedGroupTaskPayload
 {
     ITaskPool* pool;
     ITaskPool::TaskGroupHandle group;
-    std::atomic<int>* sum;
+    NestedGroupState* state;
+    std::atomic<int>* crossGroupExecutions;
     int depth;
 };
 
 void runNestedGroupTask(void* data)
 {
     auto* payload = static_cast<NestedGroupTaskPayload*>(data);
-    payload->sum->fetch_add(1, std::memory_order_relaxed);
+    payload->state->executed.fetch_add(1, std::memory_order_relaxed);
+    if (tls_expectedNestedGroupState && tls_expectedNestedGroupState != payload->state)
+        payload->crossGroupExecutions->fetch_add(1, std::memory_order_relaxed);
 
     if (payload->depth == 0)
         return;
@@ -439,7 +449,8 @@ void runNestedGroupTask(void* data)
         auto* child = new NestedGroupTaskPayload{
             payload->pool,
             payload->group,
-            payload->sum,
+            payload->state,
+            payload->crossGroupExecutions,
             payload->depth - 1,
         };
         auto task = payload->pool->submitTask(
@@ -463,17 +474,23 @@ void testNestedGroupWaitWithSaturatedWorkers()
 {
     ComPtr<ITaskPool> pool(new ThreadedTaskPool(1));
     std::atomic<int> parentsStarted{0};
-    std::atomic<int> sum{0};
+    std::atomic<int> submissionTurn{1};
+    std::atomic<int> crossGroupExecutions{0};
+    NestedGroupState groupStates[2];
 
     struct ParentPayload
     {
         ITaskPool* pool;
         std::atomic<int>* parentsStarted;
-        std::atomic<int>* sum;
+        std::atomic<int>* submissionTurn;
+        int index;
+        NestedGroupState* groupState;
+        NestedGroupState* firstGroupState;
+        std::atomic<int>* crossGroupExecutions;
     };
     ParentPayload payloads[] = {
-        {pool, &parentsStarted, &sum},
-        {pool, &parentsStarted, &sum},
+        {pool, &parentsStarted, &submissionTurn, 0, &groupStates[0], &groupStates[0], &crossGroupExecutions},
+        {pool, &parentsStarted, &submissionTurn, 1, &groupStates[1], &groupStates[0], &crossGroupExecutions},
     };
 
     ITaskPool::TaskHandle parents[2];
@@ -487,8 +504,21 @@ void testNestedGroupWaitWithSaturatedWorkers()
                 while (payload->parentsStarted->load(std::memory_order_acquire) != 2)
                     std::this_thread::yield();
 
+                NestedGroupState* previousExpectedState = tls_expectedNestedGroupState;
+                tls_expectedNestedGroupState = payload->groupState;
+
                 auto group = payload->pool->createTaskGroup();
-                auto* root = new NestedGroupTaskPayload{payload->pool, group, payload->sum, 4};
+                // Queue group 1 first, then let group 0 enter its nested wait first. An
+                // unfiltered nested wait will deterministically execute the wrong root task.
+                while (payload->submissionTurn->load(std::memory_order_acquire) != payload->index)
+                    std::this_thread::yield();
+                auto* root = new NestedGroupTaskPayload{
+                    payload->pool,
+                    group,
+                    payload->groupState,
+                    payload->crossGroupExecutions,
+                    4,
+                };
                 auto rootTask = payload->pool->submitTask(
                     runNestedGroupTask,
                     root,
@@ -500,7 +530,15 @@ void testNestedGroupWaitWithSaturatedWorkers()
                 );
                 payload->pool->releaseTask(rootTask);
 
+                if (payload->index == 1)
+                {
+                    payload->submissionTurn->store(0, std::memory_order_release);
+                    while (payload->firstGroupState->executed.load(std::memory_order_acquire) == 0)
+                        std::this_thread::yield();
+                }
+
                 payload->pool->waitAndReleaseTaskGroup(group);
+                tls_expectedNestedGroupState = previousExpectedState;
             },
             &payloads[i],
             nullptr
@@ -510,8 +548,10 @@ void testNestedGroupWaitWithSaturatedWorkers()
     for (auto parent : parents)
         pool->waitAndReleaseTask(parent);
 
-    // Two complete binary trees with depth 4: 2 * (2^5 - 1).
-    CHECK(sum.load(std::memory_order_relaxed) == 62);
+    // Each group contains a complete binary tree with depth 4: 2^5 - 1 tasks.
+    CHECK(groupStates[0].executed.load(std::memory_order_relaxed) == 31);
+    CHECK(groupStates[1].executed.load(std::memory_order_relaxed) == 31);
+    CHECK(crossGroupExecutions.load(std::memory_order_relaxed) == 0);
 }
 
 TEST_CASE("task-pool-work-stealing")


### PR DESCRIPTION
## Summary

This PR simplifies `ITaskPool` to match the functionality currently required by slang-rhi while retaining support for dynamically growing task groups used by CUDA/OptiX pipeline creation.

It also hardens nested waiting and work-stealing behavior when worker threads are saturated.

## Motivation

The previous interface exposed dependency graphs, payload inspection, polling, whole-pool waits, and separate wait/release operations. These capabilities were not used by production code and made external implementations—such as one backed by nanothread—considerably more complicated.

The remaining API covers the two scheduling patterns slang-rhi needs:

- Submit independent tasks and wait for individual completion.
- Submit dynamically generated tasks into a group and wait for the entire group.

## Changes

- Reduce `ITaskPool` to:
  - `submitTask`
  - `releaseTask`
  - `waitAndReleaseTask`
  - `createTaskGroup`
  - `waitAndReleaseTaskGroup`
- Remove task dependencies, payload access, polling, and public `waitAll`.
- Combine waiting and releasing into consuming operations.
- Make payload cleanup part of task completion.
- Allow outer waits to execute queued work.
- Allow nested group waits to execute only work belonging to that group, avoiding unrelated circular execution chains.
- Add ownership validation for built-in task and group handles.
- Update pipeline resolution and CUDA/OptiX scheduling to use the simplified API.
- Add deterministic coverage for external work stealing, payload cleanup, dynamically growing groups, and saturated worker pools.

The interface GUID remains unchanged.