### PR TITLE
Enable parallel CUDA ray-tracing pipeline creation

### DIFF
--- a/src/cuda/cuda-device.h
+++ b/src/cuda/cuda-device.h
@@ -23,12 +23,8 @@ class DeviceImpl : public Device
 public:
     virtual bool canCreatePipelineOnTaskPool(const Pipeline* pipeline) const override
     {
-        // OptiX ray-tracing pipeline creation submits nested work to the global task pool.
-        // Run it on the caller thread until that work can be integrated without blocking workers.
-        // TODO: Flatten this work by staging CUDA ray-tracing pipeline creation: enqueue the
-        // OptiX module tasks directly into the resolver's task group, then enqueue pipeline
-        // finalization after all dynamically spawned OptiX tasks have completed.
-        return pipeline->getType() != PipelineType::RayTracing;
+        SLANG_UNUSED(pipeline);
+        return true;
     }
 
     Context m_ctx;

--- a/src/vulkan/vk-backend.cpp
+++ b/src/vulkan/vk-backend.cpp
@@ -8,6 +8,21 @@
 
 namespace rhi::vk {
 
+BackendImpl::~BackendImpl()
+{
+    releaseAdapterEnumerationContext();
+}
+
+void BackendImpl::releaseAdapterEnumerationContext()
+{
+    if (m_adapterEnumerationInstance != VK_NULL_HANDLE)
+    {
+        m_adapterEnumerationApi.vkDestroyInstance(m_adapterEnumerationInstance, nullptr);
+        m_adapterEnumerationInstance = VK_NULL_HANDLE;
+    }
+    m_adapterEnumerationModule.destroy();
+}
+
 std::span<const AdapterImpl> BackendImpl::getAdapters()
 {
     ensureAdapters();
@@ -30,12 +45,14 @@ Result BackendImpl::createDevice(const DeviceDesc& desc, IDevice** outDevice)
 
 Result BackendImpl::enumerateAdapters()
 {
-    VulkanModule module;
-    SLANG_RETURN_ON_FAIL(module.init());
-    SLANG_RHI_DEFERRED({ module.destroy(); });
+    bool retainEnumerationContext = false;
+    SLANG_RHI_DEFERRED({
+        if (!retainEnumerationContext)
+            releaseAdapterEnumerationContext();
+    });
 
-    VulkanApi api;
-    SLANG_RETURN_ON_FAIL(api.initGlobalProcs(module));
+    SLANG_RETURN_ON_FAIL(m_adapterEnumerationModule.init());
+    SLANG_RETURN_ON_FAIL(m_adapterEnumerationApi.initGlobalProcs(m_adapterEnumerationModule));
 
     VkInstanceCreateInfo instanceCreateInfo = {VK_STRUCTURE_TYPE_INSTANCE_CREATE_INFO};
     const char* instanceExtensions[] = {
@@ -49,28 +66,34 @@ Result BackendImpl::enumerateAdapters()
 #if SLANG_APPLE_FAMILY
     instanceCreateInfo.flags = VK_INSTANCE_CREATE_ENUMERATE_PORTABILITY_BIT_KHR;
 #endif
-    VkInstance instance;
-    SLANG_VK_RETURN_ON_FAIL(api.vkCreateInstance(&instanceCreateInfo, nullptr, &instance));
-    SLANG_RHI_DEFERRED({ api.vkDestroyInstance(instance, nullptr); });
+    SLANG_VK_RETURN_ON_FAIL(
+        m_adapterEnumerationApi.vkCreateInstance(&instanceCreateInfo, nullptr, &m_adapterEnumerationInstance)
+    );
 
-    SLANG_RETURN_ON_FAIL(api.initInstanceProcs(instance));
-    if (!(api.vkEnumeratePhysicalDevices && api.vkGetPhysicalDeviceProperties2))
+    SLANG_RETURN_ON_FAIL(m_adapterEnumerationApi.initInstanceProcs(m_adapterEnumerationInstance));
+    if (!(m_adapterEnumerationApi.vkEnumeratePhysicalDevices && m_adapterEnumerationApi.vkGetPhysicalDeviceProperties2))
     {
         return SLANG_FAIL;
     }
 
     uint32_t physicalDeviceCount = 0;
-    SLANG_VK_RETURN_ON_FAIL(api.vkEnumeratePhysicalDevices(instance, &physicalDeviceCount, nullptr));
+    SLANG_VK_RETURN_ON_FAIL(
+        m_adapterEnumerationApi.vkEnumeratePhysicalDevices(m_adapterEnumerationInstance, &physicalDeviceCount, nullptr)
+    );
     std::vector<VkPhysicalDevice> physicalDevices(physicalDeviceCount);
-    SLANG_VK_RETURN_ON_FAIL(api.vkEnumeratePhysicalDevices(instance, &physicalDeviceCount, physicalDevices.data()));
+    SLANG_VK_RETURN_ON_FAIL(m_adapterEnumerationApi.vkEnumeratePhysicalDevices(
+        m_adapterEnumerationInstance,
+        &physicalDeviceCount,
+        physicalDevices.data()
+    ));
 
     for (const auto& physicalDevice : physicalDevices)
     {
         VkPhysicalDeviceIDProperties idProps = {VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_ID_PROPERTIES};
         VkPhysicalDeviceProperties2 props = {VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PROPERTIES_2};
         props.pNext = &idProps;
-        SLANG_RHI_ASSERT(api.vkGetPhysicalDeviceProperties2);
-        api.vkGetPhysicalDeviceProperties2(physicalDevice, &props);
+        SLANG_RHI_ASSERT(m_adapterEnumerationApi.vkGetPhysicalDeviceProperties2);
+        m_adapterEnumerationApi.vkGetPhysicalDeviceProperties2(physicalDevice, &props);
 
         AdapterInfo info = {};
         info.deviceType = DeviceType::Vulkan;
@@ -103,6 +126,12 @@ Result BackendImpl::enumerateAdapters()
 
     // Mark default adapter (prefer discrete if available).
     markDefaultAdapter(m_adapters);
+
+    // Keep the enumeration instance alive for the backend lifetime. Besides matching
+    // the lifetime of the cached adapter list, this prevents Vulkan ICDs from being
+    // unloaded and reloaded between devices. Some Linux drivers cannot reliably be
+    // reloaded after other GPU libraries have consumed the static TLS surplus.
+    retainEnumerationContext = true;
 
     return SLANG_OK;
 }

--- a/src/vulkan/vk-backend.h
+++ b/src/vulkan/vk-backend.h
@@ -8,6 +8,8 @@ namespace rhi::vk {
 class BackendImpl : public Backend
 {
 public:
+    ~BackendImpl() override;
+
     std::span<const AdapterImpl> getAdapters();
 
     // Backend implementation
@@ -19,7 +21,12 @@ protected:
     Result enumerateAdapters() override;
 
 private:
+    void releaseAdapterEnumerationContext();
+
     std::vector<AdapterImpl> m_adapters;
+    VulkanModule m_adapterEnumerationModule;
+    VulkanApi m_adapterEnumerationApi;
+    VkInstance m_adapterEnumerationInstance = VK_NULL_HANDLE;
 };
 
 } // namespace rhi::vk

--- a/tests/test-parallel-pipeline-creation.cpp
+++ b/tests/test-parallel-pipeline-creation.cpp
@@ -147,6 +147,70 @@ void runDeferredPipelineBatch(IDevice* device)
     }
 }
 
+void runDeferredCudaRayTracingPipelineBatch(IDevice* device)
+{
+    ComPtr<IShaderProgram> program;
+    REQUIRE_CALL(loadProgram(device, "test-ray-tracing-raygen-entrypoint", {"rayGenA", "rayGenB"}, program.writeRef()));
+
+    ComPtr<IRayTracingPipeline> pipelines[2];
+    for (auto& pipeline : pipelines)
+    {
+        RayTracingPipelineDesc pipelineDesc = {};
+        pipelineDesc.program = program;
+        pipelineDesc.deferTargetCompilation = true;
+        REQUIRE_CALL(device->createRayTracingPipeline(pipelineDesc, pipeline.writeRef()));
+    }
+
+    ComPtr<IShaderTable> shaderTable;
+    ShaderTableDesc shaderTableDesc = {};
+    shaderTableDesc.program = program;
+    const char* rayGenNames[] = {"rayGenA", "rayGenB"};
+    shaderTableDesc.rayGenShaderCount = SLANG_COUNT_OF(rayGenNames);
+    shaderTableDesc.rayGenShaderEntryPointNames = rayGenNames;
+    REQUIRE_CALL(device->createShaderTable(shaderTableDesc, shaderTable.writeRef()));
+
+    ComPtr<IBuffer> outputBuffers[2];
+    for (auto& outputBuffer : outputBuffers)
+    {
+        BufferDesc bufferDesc = {};
+        bufferDesc.size = 4 * sizeof(uint32_t);
+        bufferDesc.usage = BufferUsage::UnorderedAccess | BufferUsage::CopySource;
+        REQUIRE_CALL(device->createBuffer(bufferDesc, nullptr, outputBuffer.writeRef()));
+    }
+
+    auto queue = device->getQueue(QueueType::Graphics);
+    auto encoder = queue->createCommandEncoder();
+    for (uint32_t i = 0; i < std::size(pipelines); ++i)
+    {
+        auto pass = encoder->beginRayTracingPass();
+        auto rootObject = pass->bindPipeline(pipelines[i], shaderTable);
+        auto entryPoint = ShaderCursor(rootObject->getEntryPoint(i));
+        entryPoint["output"].setBinding(outputBuffers[i]);
+        entryPoint["value"].setData<uint32_t>(i == 0 ? 1 : 10);
+        pass->dispatchRays(i, 2, 2, 1);
+        pass->end();
+    }
+
+    ComPtr<ICommandBuffer> commandBuffer;
+    REQUIRE_CALL(encoder->finish(commandBuffer.writeRef()));
+    REQUIRE_CALL(queue->submit(commandBuffer));
+    REQUIRE_CALL(queue->waitOnHost());
+
+    compareComputeResult(device, outputBuffers[0], std::array<uint32_t, 4>{1, 2, 3, 4});
+    compareComputeResult(device, outputBuffers[1], std::array<uint32_t, 4>{10, 12, 14, 16});
+}
+
+struct TaskPoolReset
+{
+    ComPtr<IDevice>& device;
+
+    ~TaskPoolReset()
+    {
+        device.setNull();
+        CHECK(SLANG_SUCCEEDED(getRHI()->initTaskPool(-1)));
+    }
+};
+
 } // namespace
 
 GPU_TEST_CASE("parallel-pipeline-creation", ALL | DontCreateDevice)
@@ -181,4 +245,22 @@ GPU_TEST_CASE("serial-pipeline-creation", ALL | DontCreateDevice)
     device = createTestingDevice(ctx, ctx->deviceType, false, &options);
     REQUIRE(device);
     runDeferredPipelineBatch(device);
+}
+
+GPU_TEST_CASE("parallel-pipeline-creation-cuda-ray-tracing", CUDA | DontCreateDevice)
+{
+    // Two pipeline tasks saturate the single worker plus the waiting caller.
+    // Both then wait on dynamically spawned OptiX task-group work.
+    releaseCachedDevices();
+    REQUIRE_CALL(getRHI()->initTaskPool(1));
+    TaskPoolReset taskPoolReset{device};
+
+    DeviceExtraOptions options;
+    options.pipelineCompilationMode = PipelineCompilationMode::Parallel;
+    device = createTestingDevice(ctx, ctx->deviceType, false, &options);
+    REQUIRE(device);
+    if (!device->hasFeature(Feature::RayTracing))
+        SKIP("ray tracing not supported");
+
+    runDeferredCudaRayTracingPipelineBatch(device);
 }


### PR DESCRIPTION
Allow CUDA ray-tracing pipelines to be created on the task pool now that nested OptiX task-group work can make progress under worker saturation.

Add a single-worker regression test that builds two deferred ray-tracing pipelines in parallel, dispatches both ray-generation entry points, and verifies their output.