### PR TITLE
Refactor staging heap alignment for texture transfers

### DIFF
--- a/src/command-buffer.cpp
+++ b/src/command-buffer.cpp
@@ -591,6 +591,10 @@ Result CommandEncoder::uploadTextureData(
     // Get texture
     Texture* textureImpl = checked_cast<Texture*>(dst);
 
+    // Get the buffer offset alignment required for every staged subresource.
+    Size offsetAlignment;
+    SLANG_RETURN_ON_FAIL(getDevice()->getTextureBufferOffsetAlignment(textureImpl->m_desc.format, &offsetAlignment));
+
     // Gather subresource layout for each layer/mip and sum up total required staging buffer size.
     Size totalSize = 0;
     {
@@ -602,6 +606,7 @@ Result CommandEncoder::uploadTextureData(
                 uint32_t mip = subresourceRange.mip + mipOffset;
 
                 textureImpl->getSubresourceRegionLayout(mip, offset, extent, kDefaultAlignment, srLayout);
+                srLayout->sizeInBytes = math::calcAligned(srLayout->sizeInBytes, offsetAlignment);
                 totalSize += srLayout->sizeInBytes;
                 srLayout++;
             }
@@ -610,7 +615,7 @@ Result CommandEncoder::uploadTextureData(
 
     // Allocate and retain a staging buffer for the upload.
     RefPtr<StagingHeap::Handle> handle;
-    SLANG_RETURN_ON_FAIL(getDevice()->m_uploadHeap.allocHandle(totalSize, {}, handle.writeRef()));
+    SLANG_RETURN_ON_FAIL(getDevice()->m_uploadHeap.allocHandle(totalSize, offsetAlignment, {}, handle.writeRef()));
     m_commandList->retainResource(handle);
 
     // Copy subresources a row at a time into the staging buffer.
@@ -680,7 +685,8 @@ Result CommandEncoder::uploadTextureData(
 Result CommandEncoder::uploadBufferData(IBuffer* dst, Offset offset, Size size, const void* data)
 {
     RefPtr<StagingHeap::Handle> handle;
-    SLANG_RETURN_ON_FAIL(getDevice()->m_uploadHeap.stageHandle(data, size, {}, handle.writeRef()));
+    // Buffer copy offsets must be aligned to four bytes.
+    SLANG_RETURN_ON_FAIL(getDevice()->m_uploadHeap.stageHandle(data, size, 4, {}, handle.writeRef()));
 
     m_commandList->retainResource(handle);
 

--- a/src/d3d12/d3d12-device.cpp
+++ b/src/d3d12/d3d12-device.cpp
@@ -1402,6 +1402,13 @@ Result DeviceImpl::getTextureRowAlignment(Format format, Size* outAlignment)
     return SLANG_OK;
 }
 
+Result DeviceImpl::getTextureBufferOffsetAlignment(Format format, Size* outAlignment)
+{
+    SLANG_UNUSED(format);
+    *outAlignment = D3D12_TEXTURE_DATA_PLACEMENT_ALIGNMENT;
+    return SLANG_OK;
+}
+
 Result DeviceImpl::createTexture(const TextureDesc& desc_, const SubresourceData* initData, ITexture** outTexture)
 {
     // Description of uploading on Dx12

--- a/src/d3d12/d3d12-device.h
+++ b/src/d3d12/d3d12-device.h
@@ -101,6 +101,7 @@ public:
         Size* outAlignment
     ) override;
     virtual SLANG_NO_THROW Result SLANG_MCALL getTextureRowAlignment(Format format, Size* outAlignment) override;
+    virtual SLANG_NO_THROW Result getTextureBufferOffsetAlignment(Format format, Size* outAlignment) override;
     virtual SLANG_NO_THROW Result SLANG_MCALL createTexture(
         const TextureDesc& desc,
         const SubresourceData* initData,

--- a/src/device.cpp
+++ b/src/device.cpp
@@ -917,7 +917,9 @@ Result Device::readTexture(
     SLANG_RETURN_ON_FAIL(queue->createCommandEncoder(commandEncoder.writeRef()));
 
     StagingHeap::Allocation stagingAllocation;
-    SLANG_RETURN_ON_FAIL(m_readbackHeap.alloc(layout.sizeInBytes, {}, &stagingAllocation));
+    Size offsetAlignment;
+    SLANG_RETURN_ON_FAIL(getTextureBufferOffsetAlignment(texture->getDesc().format, &offsetAlignment));
+    SLANG_RETURN_ON_FAIL(m_readbackHeap.alloc(layout.sizeInBytes, offsetAlignment, {}, &stagingAllocation));
 
     commandEncoder->copyTextureToBuffer(
         stagingAllocation.getBuffer(),
@@ -988,6 +990,15 @@ Result Device::getTextureRowAlignment(Format format, Size* outAlignment)
 {
     *outAlignment = 0;
     return SLANG_E_NOT_AVAILABLE;
+}
+
+Result Device::getTextureBufferOffsetAlignment(Format format, Size* outAlignment)
+{
+    const Size blockSize = getFormatInfo(format).blockSizeInBytes;
+    if (blockSize == 0)
+        return SLANG_E_INVALID_ARG;
+    *outAlignment = blockSize;
+    return SLANG_OK;
 }
 
 Result Device::createSurface(WindowHandle windowHandle, ISurface** outSurface)

--- a/src/device.h
+++ b/src/device.h
@@ -326,6 +326,9 @@ public:
     // Provides a default implementation that returns SLANG_E_NOT_AVAILABLE.
     virtual SLANG_NO_THROW Result SLANG_MCALL getTextureRowAlignment(Format format, size_t* outAlignment) override;
 
+    // Get the required buffer offset alignment for buffer-texture copies.
+    virtual SLANG_NO_THROW Result getTextureBufferOffsetAlignment(Format format, Size* outAlignment);
+
     // Provides a default implementation that returns SLANG_E_NOT_AVAILABLE.
     virtual SLANG_NO_THROW Result SLANG_MCALL createSurface(WindowHandle windowHandle, ISurface** outSurface) override;
 

--- a/src/staging-heap.cpp
+++ b/src/staging-heap.cpp
@@ -44,31 +44,49 @@ void StagingHeap::release()
 
 Result StagingHeap::allocHandle(size_t size, MetaData metadata, StagingHeap::Handle** outHandle)
 {
+    return allocHandle(size, m_defaultAlignment, metadata, outHandle);
+}
+
+Result StagingHeap::allocHandle(size_t size, Size alignment, MetaData metadata, StagingHeap::Handle** outHandle)
+{
     std::lock_guard<std::mutex> lock(m_mutex);
-    return allocHandleInternal(size, metadata, outHandle);
+    return allocHandleInternal(size, alignment, metadata, outHandle);
 }
 
 Result StagingHeap::alloc(size_t size, MetaData metadata, StagingHeap::Allocation* outAllocation)
 {
-    std::lock_guard<std::mutex> lock(m_mutex);
-    return allocInternal(size, metadata, outAllocation);
+    return alloc(size, m_defaultAlignment, metadata, outAllocation);
 }
 
-Result StagingHeap::allocHandleInternal(size_t size, MetaData metadata, StagingHeap::Handle** outHandle)
+Result StagingHeap::alloc(size_t size, Size alignment, MetaData metadata, StagingHeap::Allocation* outAllocation)
+{
+    std::lock_guard<std::mutex> lock(m_mutex);
+    return allocInternal(size, alignment, metadata, outAllocation);
+}
+
+Result StagingHeap::allocHandleInternal(size_t size, Size alignment, MetaData metadata, StagingHeap::Handle** outHandle)
 {
     *outHandle = nullptr;
     Allocation allocation;
-    SLANG_RETURN_ON_FAIL(allocInternal(size, metadata, &allocation));
+    SLANG_RETURN_ON_FAIL(allocInternal(size, alignment, metadata, &allocation));
 
     RefPtr<Handle> res = new Handle(this, allocation);
     returnRefPtr(outHandle, res);
     return SLANG_OK;
 }
 
-Result StagingHeap::allocInternal(size_t size, MetaData metadata, StagingHeap::Allocation* outAllocation)
+Result StagingHeap::allocInternal(
+    size_t size,
+    Size alignment,
+    MetaData metadata,
+    StagingHeap::Allocation* outAllocation
+)
 {
+    if (alignment == 0)
+        return SLANG_E_INVALID_ARG;
+
     // Get aligned size.
-    size_t alignedSize = alignUp(size);
+    size_t alignedSize = alignAllocationSize(size);
 
     // If pages are kept mapped, then can't have multiple threads allocating from the same page,
     // so record the thread id to lock pages to.
@@ -83,7 +101,7 @@ Result StagingHeap::allocInternal(size_t size, MetaData metadata, StagingHeap::A
             if (page->getLockedToThread() == std::thread::id() || page->getLockedToThread() == thread_id)
             {
                 std::list<Node>::iterator node;
-                if (page->allocNode(alignedSize, metadata, thread_id, node))
+                if (page->allocNode(alignedSize, alignment, metadata, thread_id, node))
                 {
                     Allocation res;
                     res.page = page;
@@ -101,7 +119,7 @@ Result StagingHeap::allocInternal(size_t size, MetaData metadata, StagingHeap::A
     Page* page;
     SLANG_RETURN_ON_FAIL(allocPage(pageSize, &page));
     std::list<Node>::iterator node;
-    page->allocNode(alignedSize, metadata, thread_id, node);
+    page->allocNode(alignedSize, alignment, metadata, thread_id, node);
 
     Allocation res;
     res.page = page;
@@ -114,10 +132,15 @@ Result StagingHeap::allocInternal(size_t size, MetaData metadata, StagingHeap::A
 
 Result StagingHeap::stageHandle(const void* data, size_t size, MetaData metadata, Handle** outHandle)
 {
+    return stageHandle(data, size, m_defaultAlignment, metadata, outHandle);
+}
+
+Result StagingHeap::stageHandle(const void* data, size_t size, Size alignment, MetaData metadata, Handle** outHandle)
+{
     // Perform thread safe allocation.
     {
         std::lock_guard<std::mutex> lock(m_mutex);
-        SLANG_RETURN_ON_FAIL(allocHandleInternal(size, metadata, outHandle));
+        SLANG_RETURN_ON_FAIL(allocHandleInternal(size, alignment, metadata, outHandle));
     }
 
     // Copy data to page.
@@ -130,10 +153,15 @@ Result StagingHeap::stageHandle(const void* data, size_t size, MetaData metadata
 
 Result StagingHeap::stage(const void* data, size_t size, MetaData metadata, Allocation* outAllocation)
 {
+    return stage(data, size, m_defaultAlignment, metadata, outAllocation);
+}
+
+Result StagingHeap::stage(const void* data, size_t size, Size alignment, MetaData metadata, Allocation* outAllocation)
+{
     // Perform thread safe allocation.
     {
         std::lock_guard<std::mutex> lock(m_mutex);
-        SLANG_RETURN_ON_FAIL(allocInternal(size, metadata, outAllocation));
+        SLANG_RETURN_ON_FAIL(allocInternal(size, alignment, metadata, outAllocation));
     }
 
     // Copy data to page.
@@ -257,6 +285,7 @@ StagingHeap::Page::Page(int id, RefPtr<Buffer> buffer)
 
 bool StagingHeap::Page::allocNode(
     Size size,
+    Size alignment,
     StagingHeap::MetaData metadta,
     std::thread::id lock_to_thread,
     std::list<Node>::iterator& res
@@ -265,33 +294,47 @@ bool StagingHeap::Page::allocNode(
     // Check if page is locked to a thread, and if so, that it is the same thread.
     SLANG_RHI_ASSERT(m_locked_to_thread == lock_to_thread || m_locked_to_thread == std::thread::id());
 
-    // Scan nodes for a free slot greater than or equal to size requested
+    // Scan nodes for a free slot that can hold the requested aligned range.
     for (auto node = m_nodes.begin(); node != m_nodes.end(); ++node)
     {
-        if (node->free && node->size >= size)
+        if (!node->free)
+            continue;
+
+        const Size alignedOffset = math::calcAligned(node->offset, alignment);
+        const Size padding = alignedOffset - node->offset;
+        if (padding > node->size || node->size - padding < size)
+            continue;
+
+        // Preserve any free prefix needed to align the allocation.
+        if (padding > 0)
         {
-            // Got one. Increment total used in page.
-            m_totalUsed += size;
-
-            // If node is bigger than necessary, split it.
-            if (node->size > size)
-            {
-                auto next = std::next(node);
-                m_nodes.insert(next, {node->offset + size, node->size - size, true, {}});
-                node->size = size;
-            }
-
-            // Mark node as not free, and store meta data.
-            node->free = false;
-            node->metadata = metadta;
-
-            // Lock to the thread (if specified)
-            m_locked_to_thread = lock_to_thread;
-
-            // Return iterator to node.
-            res = node;
-            return true;
+            const Size remainingSize = node->size - padding;
+            auto next = std::next(node);
+            node = m_nodes.insert(next, {alignedOffset, remainingSize, true, {}});
+            std::prev(node)->size = padding;
         }
+
+        // Got one. Increment total used in page.
+        m_totalUsed += size;
+
+        // If node is bigger than necessary, split it.
+        if (node->size > size)
+        {
+            auto next = std::next(node);
+            m_nodes.insert(next, {node->offset + size, node->size - size, true, {}});
+            node->size = size;
+        }
+
+        // Mark node as not free, and store meta data.
+        node->free = false;
+        node->metadata = metadta;
+
+        // Lock to the thread (if specified)
+        m_locked_to_thread = lock_to_thread;
+
+        // Return iterator to node.
+        res = node;
+        return true;
     }
 
     // No free node found.

--- a/src/staging-heap.h
+++ b/src/staging-heap.h
@@ -42,6 +42,7 @@ public:
         // Allocate a node from the page heap.
         bool allocNode(
             Size size,
+            Size alignment,
             StagingHeap::MetaData metadata,
             std::thread::id lock_to_thread,
             std::list<Node>::iterator& res
@@ -134,19 +135,33 @@ public:
     // Attempt to cleanup and check no allocations remain
     void release();
 
-    // Allocate block of memory and wrap in a ref counted handle that automatically
-    // frees the allocation when handle is freed.
+    /// Allocate a block using the heap's default offset alignment and wrap it in a
+    /// ref-counted handle.
     Result allocHandle(size_t size, MetaData metadata, Handle** outHandle);
 
-    // Allocate a block of memory.
+    /// Allocate a block using the requested offset alignment instead of the heap's
+    /// default, and wrap it in a ref-counted handle.
+    Result allocHandle(size_t size, Size alignment, MetaData metadata, Handle** outHandle);
+
+    /// Allocate a block using the heap's default offset alignment.
     Result alloc(size_t size, MetaData metadata, Allocation* outAllocation);
 
-    // Allocate/store a block of data in the heap and wrap in a ref counted
-    // handle that automatically frees the allocation when handle is freed.
+    /// Allocate a block using the requested offset alignment instead of the heap's default.
+    Result alloc(size_t size, Size alignment, MetaData metadata, Allocation* outAllocation);
+
+    /// Allocate and store data using the heap's default offset alignment, wrapping
+    /// it in a ref-counted handle.
     Result stageHandle(const void* data, size_t size, MetaData metadata, Handle** outHandle);
 
-    // Allocate/store a block of data in the heap.
+    /// Allocate and store data using the requested offset alignment instead of the
+    /// heap's default, wrapping it in a ref-counted handle.
+    Result stageHandle(const void* data, size_t size, Size alignment, MetaData metadata, Handle** outHandle);
+
+    /// Allocate and store data using the heap's default offset alignment.
     Result stage(const void* data, size_t size, MetaData metadata, Allocation* outAllocation);
+
+    /// Allocate and store data using the requested offset alignment instead of the heap's default.
+    Result stage(const void* data, size_t size, Size alignment, MetaData metadata, Allocation* outAllocation);
 
     // Free existing allocation.
     void free(Allocation allocation);
@@ -175,14 +190,20 @@ public:
         return m_totalUsed;
     }
 
-    // Get alignment of heap.
-    Size getAlignment() const { return m_alignment; }
+    // Get the default offset alignment of heap allocations.
+    Size getDefaultAlignment() const { return m_defaultAlignment; }
+
+    // Get the granularity used to round allocation sizes.
+    Size getAllocationGranularity() const { return m_allocationGranularity; }
 
     // Get default page size.
     Size getPageSize() const { return m_pageSize; }
 
-    // Align a size to that of heap allocations.
-    Size alignUp(Size value) { return (value + m_alignment - 1) / m_alignment * m_alignment; }
+    // Round a size up to the heap's allocation granularity.
+    Size alignAllocationSize(Size value)
+    {
+        return (value + m_allocationGranularity - 1) / m_allocationGranularity * m_allocationGranularity;
+    }
 
     // Used by testing system to change whether pages stay mapped
     void testOnlySetKeepPagesMapped(bool keepPagesMapped) { m_keepPagesMapped = keepPagesMapped; }
@@ -198,16 +219,17 @@ private:
     int m_nextPageId = 1;
     Size m_totalCapacity = 0;
     Size m_totalUsed = 0;
-    Size m_alignment = 1024;
+    Size m_defaultAlignment = 1024;
+    Size m_allocationGranularity = 1024;
     Size m_pageSize = 16 * 1024 * 1024;
     bool m_keepPagesMapped = true;
     std::unordered_map<int, RefPtr<Page>> m_pages;
     MemoryType m_memoryType;
     mutable std::mutex m_mutex;
 
-    Result allocHandleInternal(size_t size, MetaData metadata, Handle** outHandle);
+    Result allocHandleInternal(size_t size, Size alignment, MetaData metadata, Handle** outHandle);
 
-    Result allocInternal(size_t size, MetaData metadata, Allocation* outAllocation);
+    Result allocInternal(size_t size, Size alignment, MetaData metadata, Allocation* outAllocation);
 
     Result allocPage(size_t size, StagingHeap::Page** outPage);
 

--- a/src/vulkan/vk-device.cpp
+++ b/src/vulkan/vk-device.cpp
@@ -2140,6 +2140,15 @@ Result DeviceImpl::getTextureRowAlignment(Format format, Size* outAlignment)
     return SLANG_OK;
 }
 
+Result DeviceImpl::getTextureBufferOffsetAlignment(Format format, Size* outAlignment)
+{
+    const FormatInfo& formatInfo = getFormatInfo(format);
+    if (formatInfo.blockSizeInBytes == 0)
+        return SLANG_E_INVALID_ARG;
+    *outAlignment = formatInfo.kind == FormatKind::DepthStencil ? 4 : formatInfo.blockSizeInBytes;
+    return SLANG_OK;
+}
+
 Result DeviceImpl::isCooperativeMatrixSupported(const CooperativeMatrixDesc& desc, bool* outSupported)
 {
     if (!outSupported)

--- a/src/vulkan/vk-device.h
+++ b/src/vulkan/vk-device.h
@@ -154,6 +154,7 @@ public:
     ) override;
 
     virtual SLANG_NO_THROW Result SLANG_MCALL getTextureRowAlignment(Format format, Size* outAlignment) override;
+    virtual SLANG_NO_THROW Result getTextureBufferOffsetAlignment(Format format, Size* outAlignment) override;
 
     virtual SLANG_NO_THROW Result SLANG_MCALL isCooperativeMatrixSupported(
         const CooperativeMatrixDesc& desc,

--- a/tests/test-cmd-upload-buffer.cpp
+++ b/tests/test-cmd-upload-buffer.cpp
@@ -79,7 +79,7 @@ void testUploadToBuffer(IDevice* device, Size size, Offset offset, int tests, bo
             auto encoder = queue->createCommandEncoder();
             for (int i = 0; i < tests; i++)
                 encoder->uploadBufferData(uploads[i].dst, uploads[i].offset, uploads[i].size, uploads[i].data.data());
-            CHECK_EQ(heap.getUsed(), heap.alignUp(uploads[0].size) * tests);
+            CHECK_EQ(heap.getUsed(), heap.alignAllocationSize(uploads[0].size) * tests);
             queue->submit(encoder->finish());
         }
         else
@@ -88,7 +88,7 @@ void testUploadToBuffer(IDevice* device, Size size, Offset offset, int tests, bo
             {
                 auto encoder = queue->createCommandEncoder();
                 encoder->uploadBufferData(uploads[i].dst, uploads[i].offset, uploads[i].size, uploads[i].data.data());
-                CHECK_EQ(heap.getUsed(), heap.alignUp(uploads[0].size) * tests);
+                CHECK_EQ(heap.getUsed(), heap.alignAllocationSize(uploads[0].size) * tests);
                 queue->submit(encoder->finish());
             }
         }

--- a/tests/test-cmd-upload-texture.cpp
+++ b/tests/test-cmd-upload-texture.cpp
@@ -44,6 +44,46 @@ GPU_TEST_CASE("cmd-upload-texture-simple", D3D12 | Vulkan | Metal | CUDA | WGPU)
     );
 }
 
+GPU_TEST_CASE("cmd-upload-texture-subresource-offset-alignment", D3D12 | Vulkan | Metal | CUDA | WGPU)
+{
+    TextureTestOptions options(device);
+    // The generated 33x17 texture has mip sizes that are not all multiples of
+    // D3D12's 512-byte placed-footprint alignment. Uploading all mips together
+    // verifies that each staged subresource starts at a valid backend offset.
+    options.addVariants(
+        TextureType::Texture2D,
+        std::vector<Format>{Format::RGBA8Unorm},
+        TTArray::Off,
+        TTMip::On,
+        TextureInitMode::None,
+        TTFmtDepth::Off,
+        TTPowerOf2::Off
+    );
+
+    runTextureTest(
+        options,
+        [](TextureTestContext* c)
+        {
+            TextureData& data = c->getTextureData();
+            data.initData(TextureInitMode::Random);
+
+            auto queue = c->getDevice()->getQueue(QueueType::Graphics);
+            auto commandEncoder = queue->createCommandEncoder();
+            commandEncoder->uploadTextureData(
+                c->getTexture(),
+                {0, 1, 0, data.desc.mipCount},
+                {0, 0, 0},
+                Extent3D::kWholeTexture,
+                data.subresourceData.data(),
+                data.subresourceData.size()
+            );
+            queue->submit(commandEncoder->finish());
+
+            data.checkEqual(c->getTexture());
+        }
+    );
+}
+
 GPU_TEST_CASE("cmd-upload-texture-compressed-npot-mips", Metal | Vulkan | WGPU)
 {
     TextureTestOptions options(device);

--- a/tests/test-staging-heap.cpp
+++ b/tests/test-staging-heap.cpp
@@ -19,7 +19,7 @@ GPU_TEST_CASE("staging-heap-alloc-free", ALL)
     StagingHeap heap;
     heap.initialize((Device*)device.get(), kPageSize, MemoryType::Upload);
 
-    Size allocSize = heap.alignUp(16);
+    Size allocSize = heap.alignAllocationSize(16);
 
     CHECK_EQ(heap.getUsed(), 0);
     CHECK_EQ(heap.getNumPages(), 0);
@@ -80,7 +80,7 @@ GPU_TEST_CASE("staging-heap-large-page", ALL)
     StagingHeap::Allocation allocation2;
     heap.alloc(16, {2}, &allocation2);
     heap.checkConsistency();
-    CHECK_EQ(allocation2.getOffset(), heap.getAlignment());
+    CHECK_EQ(allocation2.getOffset(), heap.getDefaultAlignment());
     CHECK_EQ(allocation2.getPageId(), 1);
 
     StagingHeap::Allocation bigAllocation2;
@@ -92,7 +92,7 @@ GPU_TEST_CASE("staging-heap-large-page", ALL)
     StagingHeap::Allocation allocation3;
     heap.alloc(16, {2}, &allocation3);
     heap.checkConsistency();
-    CHECK_EQ(allocation3.getOffset(), heap.getAlignment() * 2);
+    CHECK_EQ(allocation3.getOffset(), heap.getDefaultAlignment() * 2);
     CHECK_EQ(allocation3.getPageId(), 1);
 
     heap.free(allocation);
@@ -162,12 +162,38 @@ GPU_TEST_CASE("staging-heap-handles", ALL)
         heap.checkConsistency();
         CHECK_EQ(handle->getOffset(), 0);
         CHECK_EQ(handle->getPageId(), 1);
-        CHECK_EQ(heap.getUsed(), heap.getAlignment());
+        CHECK_EQ(heap.getUsed(), heap.getAllocationGranularity());
     }
 
     // Allocation should be freed when handle goes out of scope.
     CHECK_EQ(heap.getUsed(), 0);
 
+    heap.release();
+}
+
+GPU_TEST_CASE("staging-heap-allocation-alignment", ALL)
+{
+    StagingHeap heap;
+    heap.initialize((Device*)device.get(), kPageSize, MemoryType::Upload);
+
+    StagingHeap::Allocation first;
+    REQUIRE_CALL(heap.alloc(16, {}, &first));
+
+    StagingHeap::Allocation aligned;
+    REQUIRE_CALL(heap.alloc(16, 12, {}, &aligned));
+    CHECK_EQ(aligned.getOffset() % 12, 0);
+    CHECK_EQ(aligned.getOffset(), 1032);
+    CHECK_EQ(aligned.getSize(), heap.getAllocationGranularity());
+
+    StagingHeap::Allocation defaultAligned;
+    REQUIRE_CALL(heap.alloc(16, {}, &defaultAligned));
+    CHECK_EQ(defaultAligned.getOffset() % heap.getDefaultAlignment(), 0);
+    CHECK_EQ(defaultAligned.getOffset(), 3072);
+
+    heap.free(first);
+    heap.free(aligned);
+    heap.free(defaultAligned);
+    heap.checkConsistency();
     heap.release();
 }
 


### PR DESCRIPTION
Separate the staging heap's allocation granularity from its default
offset alignment, and allow callers to override the alignment for
individual allocations. Preserve alignment padding as reusable free
space instead of folding it into the allocation.

Query the required buffer offset alignment for texture transfers from
the device. Use format block alignment by default, D3D12's 512-byte
placed-footprint alignment, and Vulkan's depth/stencil requirements.
Pad every staged mip and array layer so each subresource begins at a
valid backend offset.

Keep buffer uploads at the common 4-byte alignment and use the
format-specific default for Metal texture transfers. This fixes uploads
of formats with non-power-of-two block sizes, including 12-byte texel
formats, without over-aligning every staging allocation.

Add staging heap alignment coverage and a non-power-of-two mip upload
test that exercises alignment between subresources.