### PR TITLE
Use shared staging heap for Vulkan buffer initialization

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1005,6 +1005,7 @@ if(SLANG_RHI_BUILD_TESTS AND NOT SLANG_RHI_BUILD_SHARED AND NOT EMSCRIPTEN)
         tests/test-bindless.cpp
         tests/test-bind-pointers.cpp
         tests/test-blob.cpp
+        tests/test-buffer.cpp
         tests/test-buffer-barrier.cpp
         tests/test-buffer-from-handle.cpp
         tests/test-buffer-shared.cpp

--- a/src/vulkan/vk-buffer.cpp
+++ b/src/vulkan/vk-buffer.cpp
@@ -335,6 +335,58 @@ VkBufferView BufferImpl::getView(Format format, const BufferRange& range)
     return view;
 }
 
+Result DeviceImpl::uploadBufferInitData(IBuffer* buffer, Offset offset, Size size, const void* data)
+{
+    if (!buffer || !data || size == 0)
+        return SLANG_E_INVALID_ARG;
+
+    BufferImpl* dstBuffer = checked_cast<BufferImpl*>(buffer);
+    if (offset > dstBuffer->m_desc.size || size > dstBuffer->m_desc.size - offset)
+        return SLANG_E_INVALID_ARG;
+
+    RefPtr<StagingHeap::Handle> stagingHandle;
+    // Vulkan buffer copy offsets must be aligned to four bytes.
+    SLANG_RETURN_ON_FAIL(m_uploadHeap.stageHandle(data, size, 4, {}, stagingHandle.writeRef()));
+    BufferImpl* srcBuffer = checked_cast<BufferImpl*>(stagingHandle->getBuffer());
+
+    VkCommandBuffer commandBuffer = m_deviceQueue.getCommandBuffer();
+
+    VkBufferCopy copy = {};
+    copy.srcOffset = stagingHandle->getOffset();
+    copy.dstOffset = offset;
+    copy.size = size;
+    m_api.vkCmdCopyBuffer(commandBuffer, srcBuffer->m_buffer.m_buffer, dstBuffer->m_buffer.m_buffer, 1, &copy);
+
+    VkBufferMemoryBarrier dstBarrier = {VK_STRUCTURE_TYPE_BUFFER_MEMORY_BARRIER};
+    dstBarrier.srcAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT;
+    dstBarrier.dstAccessMask = calcAccessFlags(dstBuffer->m_desc.defaultState);
+    dstBarrier.srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+    dstBarrier.dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+    dstBarrier.buffer = dstBuffer->m_buffer.m_buffer;
+    dstBarrier.offset = offset;
+    dstBarrier.size = size;
+    m_api.vkCmdPipelineBarrier(
+        commandBuffer,
+        VK_PIPELINE_STAGE_TRANSFER_BIT,
+        calcPipelineStageFlags(m_api.m_supportedShaderStageFlags, dstBuffer->m_desc.defaultState, false),
+        0,
+        0,
+        nullptr,
+        1,
+        &dstBarrier,
+        0,
+        nullptr
+    );
+
+    // Both buffers must outlive the asynchronous copy. The staging handle also
+    // returns its allocation to the shared heap when this fence slot retires.
+    m_deviceQueue.retainResource(stagingHandle);
+    m_deviceQueue.retainResource(dstBuffer);
+    m_deviceQueue.flush();
+
+    return SLANG_OK;
+}
+
 Result DeviceImpl::createBuffer(const BufferDesc& desc_, const void* initData, IBuffer** outBuffer)
 {
     BufferDesc desc = fixupBufferDesc(desc_);
@@ -392,34 +444,7 @@ Result DeviceImpl::createBuffer(const BufferDesc& desc_, const void* initData, I
     {
         if (desc.memoryType == MemoryType::DeviceLocal)
         {
-            SLANG_RETURN_ON_FAIL(buffer->m_uploadBuffer.init(
-                m_api,
-                bufferSize,
-                VK_BUFFER_USAGE_TRANSFER_SRC_BIT,
-                VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT
-            ));
-            // Copy into staging buffer
-            void* mappedData = nullptr;
-            SLANG_VK_RETURN_ON_FAIL_REPORT(
-                m_api.vkMapMemory(m_device, buffer->m_uploadBuffer.m_memory, 0, bufferSize, 0, &mappedData),
-                this
-            );
-            ::memcpy(mappedData, initData, bufferSize);
-            m_api.vkUnmapMemory(m_device, buffer->m_uploadBuffer.m_memory);
-
-            // Copy from staging buffer to real buffer
-            VkCommandBuffer commandBuffer = m_deviceQueue.getCommandBuffer();
-
-            VkBufferCopy copyInfo = {};
-            copyInfo.size = bufferSize;
-            m_api.vkCmdCopyBuffer(
-                commandBuffer,
-                buffer->m_uploadBuffer.m_buffer,
-                buffer->m_buffer.m_buffer,
-                1,
-                &copyInfo
-            );
-            m_deviceQueue.flush();
+            SLANG_RETURN_ON_FAIL(uploadBufferInitData(buffer, 0, bufferSize, initData));
         }
         else
         {

--- a/src/vulkan/vk-buffer.h
+++ b/src/vulkan/vk-buffer.h
@@ -62,7 +62,6 @@ public:
 
 public:
     VKBufferHandleRAII m_buffer;
-    VKBufferHandleRAII m_uploadBuffer;
     DeviceAddress m_deviceAddress = 0;
 
     struct ViewKey

--- a/src/vulkan/vk-command.cpp
+++ b/src/vulkan/vk-command.cpp
@@ -1937,6 +1937,10 @@ void CommandQueueImpl::retireCommandBuffers()
         }
     }
 
+    // The internal device queue shares this VkQueue. Polling it here releases
+    // initialization staging allocations even if no further internal work occurs.
+    getDevice<DeviceImpl>()->m_deviceQueue.retireCompletedResources();
+
     // Delete deferred resources that are no longer in use by the GPU.
     executeDeferredDeletes();
 

--- a/src/vulkan/vk-device-queue.cpp
+++ b/src/vulkan/vk-device-queue.cpp
@@ -11,6 +11,12 @@ void VulkanDeviceQueue::destroy()
 {
     if (m_api)
     {
+        for (int i = 0; i < m_numCommandBuffers; ++i)
+        {
+            m_fences[i].retainedResources.clear();
+        }
+        m_pendingResourceRetirements = 0;
+
         for (int i = 0; i < int(EventType::CountOf); ++i)
         {
             m_api->vkDestroySemaphore(m_api->m_device, m_semaphores[i], nullptr);
@@ -147,7 +153,43 @@ void VulkanDeviceQueue::_updateFenceAtIndex(int fenceIndex, bool blocking)
             {
                 m_lastFenceCompleted = fence.value;
             }
+
+            if (!fence.retainedResources.empty())
+            {
+                fence.retainedResources.clear();
+                SLANG_RHI_ASSERT(m_pendingResourceRetirements > 0);
+                --m_pendingResourceRetirements;
+            }
         }
+    }
+}
+
+void VulkanDeviceQueue::retainResource(RefObject* resource)
+{
+    SLANG_RHI_ASSERT(resource);
+    auto& retainedResources = m_fences[m_commandBufferIndex].retainedResources;
+    if (retainedResources.empty())
+        ++m_pendingResourceRetirements;
+    retainedResources.push_back(resource);
+}
+
+void VulkanDeviceQueue::retireCompleted()
+{
+    for (int i = 0; i < m_numCommandBuffers; ++i)
+    {
+        _updateFenceAtIndex(i, false);
+    }
+}
+
+void VulkanDeviceQueue::retireCompletedResources()
+{
+    if (m_pendingResourceRetirements == 0)
+        return;
+
+    for (int i = 0; i < m_numCommandBuffers; ++i)
+    {
+        if (!m_fences[i].retainedResources.empty())
+            _updateFenceAtIndex(i, false);
     }
 }
 
@@ -158,10 +200,7 @@ void VulkanDeviceQueue::flushStepB()
     m_commandPool = m_commandPools[m_commandBufferIndex];
 
     // non-blocking update of fence values
-    for (int i = 0; i < m_numCommandBuffers; ++i)
-    {
-        _updateFenceAtIndex(i, false);
-    }
+    retireCompleted();
 
     // blocking update of fence values
     _updateFenceAtIndex(m_commandBufferIndex, true);
@@ -185,6 +224,7 @@ void VulkanDeviceQueue::flushAndWait()
 {
     flush();
     waitForIdle();
+    retireCompleted();
 }
 
 VkSemaphore VulkanDeviceQueue::getSemaphore(EventType eventType)

--- a/src/vulkan/vk-device-queue.h
+++ b/src/vulkan/vk-device-queue.h
@@ -2,6 +2,8 @@
 
 #include "vk-base.h"
 
+#include <vector>
+
 namespace rhi::vk {
 
 struct VulkanDeviceQueue
@@ -25,6 +27,16 @@ struct VulkanDeviceQueue
     void flush();
     /// Performs a full flush, and then waits for idle.
     void flushAndWait();
+
+    /// Retain an object until the commands currently being recorded have completed.
+    void retainResource(RefObject* resource);
+
+    /// Release resources associated with completed submissions without blocking.
+    void retireCompleted();
+
+    /// Release retained resources associated with completed submissions without
+    /// polling fence slots that do not retain resources.
+    void retireCompletedResources();
 
     /// Blocks until all work submitted to GPU has completed
     void waitForIdle() { m_api->vkQueueWaitIdle(m_queue); }
@@ -69,9 +81,10 @@ struct VulkanDeviceQueue
 protected:
     struct FenceInfo
     {
-        VkFence fence;
-        bool active;
-        uint64_t value;
+        VkFence fence = VK_NULL_HANDLE;
+        bool active = false;
+        uint64_t value = 0;
+        std::vector<RefPtr<RefObject>> retainedResources;
     };
 
     void _updateFenceAtIndex(int fenceIndex, bool blocking);
@@ -84,7 +97,7 @@ protected:
     VkCommandPool m_commandPools[kMaxCommandBuffers] = {VK_NULL_HANDLE};
     VkCommandBuffer m_commandBuffers[kMaxCommandBuffers] = {VK_NULL_HANDLE};
 
-    FenceInfo m_fences[kMaxCommandBuffers] = {{VK_NULL_HANDLE, 0, 0u}};
+    FenceInfo m_fences[kMaxCommandBuffers];
 
     VkCommandBuffer m_commandBuffer = VK_NULL_HANDLE;
     VkCommandPool m_commandPool = VK_NULL_HANDLE;
@@ -93,6 +106,7 @@ protected:
 
     uint64_t m_lastFenceCompleted = 1;
     uint64_t m_nextFenceValue = 2;
+    int m_pendingResourceRetirements = 0;
 
     int m_queueIndex = 0;
 

--- a/src/vulkan/vk-device.h
+++ b/src/vulkan/vk-device.h
@@ -65,6 +65,10 @@ public:
         const void* initData,
         IBuffer** outBuffer
     ) override;
+
+    /// Stage and submit initialization data for a newly created buffer.
+    Result uploadBufferInitData(IBuffer* buffer, Offset offset, Size size, const void* data);
+
     virtual SLANG_NO_THROW Result SLANG_MCALL createBufferFromNativeHandle(
         NativeHandle handle,
         const BufferDesc& desc,

--- a/tests/test-buffer.cpp
+++ b/tests/test-buffer.cpp
@@ -1,0 +1,59 @@
+#include "testing.h"
+
+#include "debug-layer/debug-device.h"
+#include "rhi-shared.h"
+
+#include <cstring>
+#include <vector>
+
+using namespace rhi;
+using namespace rhi::testing;
+
+namespace {
+
+Device* getSharedDevice(IDevice* device)
+{
+    if (auto debugDevice = dynamic_cast<debug::DebugDevice*>(device))
+        return (Device*)debugDevice->baseObject.get();
+    return (Device*)device;
+}
+
+} // namespace
+
+GPU_TEST_CASE("buffer-init-data-staging-lifetime", Vulkan)
+{
+    auto queue = device->getQueue(QueueType::Graphics);
+    REQUIRE_CALL(queue->waitOnHost());
+
+    StagingHeap& heap = getSharedDevice(device)->m_uploadHeap;
+    CHECK_EQ(heap.getUsed(), 0);
+
+    std::vector<uint32_t> data(1024);
+    for (size_t i = 0; i < data.size(); ++i)
+        data[i] = uint32_t(i * 1664525u + 1013904223u);
+
+    BufferDesc desc = {};
+    desc.size = data.size() * sizeof(uint32_t);
+    desc.memoryType = MemoryType::DeviceLocal;
+    desc.usage = BufferUsage::CopySource;
+
+    ComPtr<IBuffer> buffer;
+    REQUIRE_CALL(device->createBuffer(desc, data.data(), buffer.writeRef()));
+
+    // Waiting on the public queue also retires work submitted through Vulkan's
+    // internal queue wrapper, which must release the shared staging allocation.
+    REQUIRE_CALL(queue->waitOnHost());
+    CHECK_EQ(heap.getUsed(), 0);
+
+    ComPtr<ISlangBlob> blob;
+    REQUIRE_CALL(device->readBuffer(buffer, 0, desc.size, blob.writeRef()));
+    CHECK_EQ(memcmp(blob->getBufferPointer(), data.data(), desc.size), 0);
+
+    // Releasing the destination immediately must not destroy its native buffer
+    // while the internal initialization copy is still in flight.
+    buffer.setNull();
+    REQUIRE_CALL(device->createBuffer(desc, data.data(), buffer.writeRef()));
+    buffer.setNull();
+    REQUIRE_CALL(queue->waitOnHost());
+    CHECK_EQ(heap.getUsed(), 0);
+}


### PR DESCRIPTION
Replace the dedicated upload buffer retained by every initialized Vulkan buffer with an allocation from the shared staging heap.

Record initialization copies directly on the internal Vulkan device queue instead of submitting a public command buffer. This avoids command-encoding overhead and prevents internal uploads from consuming surface synchronization state.

Retain the staging allocation and destination buffer in the internal fence slot until the copy completes. Add a transfer-to-default-state barrier so the uploaded data is visible to subsequent resource use.

Poll retained-resource fences during public queue retirement so staging memory can be reclaimed even when no more internal work is submitted. Keep the normal submit path inexpensive by skipping polling when no retirements are pending and ignoring internal fences without retained resources.

Add Vulkan coverage for initialization correctness, staging reclamation, and immediate destination release. Document the remaining cross-backend resource initialization work for follow-up PRs.