### PR TITLE
Fix shader table base address alignment

### DIFF
--- a/src/d3d12/d3d12-shader-table.cpp
+++ b/src/d3d12/d3d12-shader-table.cpp
@@ -122,6 +122,9 @@ ShaderTableImpl::PipelineData* ShaderTableImpl::getPipelineData(RayTracingPipeli
 
     pipelineData->buffer = checked_cast<BufferImpl*>(buffer.get());
 
+    // D3D12 should always align allocations to the required minimum.
+    SLANG_RHI_ASSERT(buffer->getDeviceAddress() % D3D12_RAYTRACING_SHADER_TABLE_BYTE_ALIGNMENT == 0);
+
     pipelineData->rayGenTableOffset = rayGenTableOffset;
     pipelineData->missTableOffset = missTableOffset;
     pipelineData->hitGroupTableOffset = hitGroupTableOffset;

--- a/src/vulkan/vk-command.cpp
+++ b/src/vulkan/vk-command.cpp
@@ -1100,7 +1100,8 @@ void CommandRecorder::cmdSetRayTracingState(const commands::SetRayTracingState& 
             return;
         }
         requireBufferState(m_shaderTablePipelineData->buffer, ResourceState::ShaderResource);
-        DeviceAddress shaderTableAddr = m_shaderTablePipelineData->buffer->getDeviceAddress();
+        DeviceAddress shaderTableAddr =
+            m_shaderTablePipelineData->buffer->getDeviceAddress() + m_shaderTablePipelineData->tableOffset;
 
         // Raygen address, stride, and size are set at dispatch time since each raygen
         // shader can have a different record size.
@@ -1164,7 +1165,7 @@ void CommandRecorder::cmdDispatchRays(const commands::DispatchRays& cmd)
 
             // Use vkCmdUpdateBuffer to copy entry point data to the SBT.
             // The data is written at the raygen's sbtOffset (after the shader group handle).
-            VkDeviceSize dstOffset = raygenInfo.sbtOffset;
+            VkDeviceSize dstOffset = m_shaderTablePipelineData->tableOffset + raygenInfo.sbtOffset;
             VkDeviceSize copySize = std::min(entryPointData.size, raygenInfo.paramsSize);
             m_api.vkCmdUpdateBuffer(
                 m_cmdBuffer,

--- a/src/vulkan/vk-shader-table.cpp
+++ b/src/vulkan/vk-shader-table.cpp
@@ -168,17 +168,35 @@ ShaderTableImpl::PipelineData* ShaderTableImpl::getPipelineData(RayTracingPipeli
     bufferDesc.memoryType = MemoryType::DeviceLocal;
     bufferDesc.usage = BufferUsage::ShaderTable | BufferUsage::CopyDestination;
     bufferDesc.defaultState = ResourceState::General;
-    bufferDesc.size = tableSize;
-    if (SLANG_FAILED(device->createBuffer(bufferDesc, tableData.get(), buffer.writeRef())))
+
+    // Vulkan does not guarantee that the buffer's base device address satisfies
+    // shaderGroupBaseAlignment, so reserve enough space to align the SBT within it.
+    const uint64_t tableAlignment = max<uint64_t>(1, rtpProps.shaderGroupBaseAlignment);
+    bufferDesc.size = tableSize + tableAlignment - 1;
+    if (SLANG_FAILED(device->createBuffer(bufferDesc, nullptr, buffer.writeRef())))
     {
         SLANG_RHI_ASSERT_FAILURE("Failed to create shader table buffer");
         return nullptr;
     }
 
+    const DeviceAddress bufferAddress = buffer->getDeviceAddress();
+    const DeviceAddress alignedTableAddress =
+        bufferAddress + (tableAlignment - bufferAddress % tableAlignment) % tableAlignment;
+    const uint32_t tableOffset = (uint32_t)(alignedTableAddress - bufferAddress);
+    SLANG_RHI_ASSERT((bufferAddress + tableOffset) % tableAlignment == 0);
+
+    BufferImpl* bufferImpl = checked_cast<BufferImpl*>(buffer.get());
+    if (SLANG_FAILED(device->uploadBufferInitData(bufferImpl, tableOffset, tableSize, tableData.get())))
+    {
+        SLANG_RHI_ASSERT_FAILURE("Failed to upload shader table data");
+        return nullptr;
+    }
+
     RefPtr<PipelineData> pipelineData = new PipelineData();
 
-    pipelineData->buffer = checked_cast<BufferImpl*>(buffer.get());
+    pipelineData->buffer = bufferImpl;
     pipelineData->raygenInfos = std::move(raygenInfos);
+    pipelineData->tableOffset = tableOffset;
 
     pipelineData->missRecordStride = missRecordSize;
     pipelineData->hitGroupRecordStride = hitGroupRecordSize;

--- a/src/vulkan/vk-shader-table.h
+++ b/src/vulkan/vk-shader-table.h
@@ -30,6 +30,9 @@ public:
         RefPtr<BufferImpl> buffer;
         short_vector<RaygenInfo> raygenInfos;
 
+        // Offset from the start of `buffer` to the aligned shader table base address.
+        uint32_t tableOffset = 0;
+
         uint32_t raygenTableSize;
         uint32_t missTableSize;
         uint32_t hitTableSize;


### PR DESCRIPTION
Align Vulkan shader-table addresses to shaderGroupBaseAlignment and upload table data through the internal initialization queue without blocking on the public graphics queue. Add a validation-backed dispatch regression test.