### PR TITLE
Require expected devices in test runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,17 +40,17 @@ jobs:
           - { os: macos, compiler: gcc }
         include:
           # Builds running on self-hosted runners (build + tests)
-          - { os: windows, platform: "x86_64", compiler: clang, preset: clang, config: "Debug", flags: "unit-test,coverage", runs-on: { labels: [Windows, X64, nvrgfx-kernelvm-bridge] } }
-          - { os: windows, platform: "x86_64", compiler: msvc, preset: default, config: "Release", flags: "unit-test", runs-on: { labels: [Windows, X64, nvrgfx-kernelvm-bridge] } }
-          - { os: linux, platform: "x86_64", compiler: clang, preset: clang, config: "Debug", flags: "unit-test,coverage", runs-on: { labels: [Linux, X64, nvrgfx-kernelvm-bridge] } }
-          - { os: linux, platform: "x86_64", compiler: clang, preset: clang, config: "Release", flags: "unit-test", runs-on: { labels: [Linux, X64, nvrgfx-kernelvm-bridge] } }
+          - { os: windows, platform: "x86_64", compiler: clang, preset: clang, config: "Debug", flags: "unit-test,coverage", required_devices: "d3d11,d3d12,vulkan,cpu,cuda,wgpu", runs-on: { labels: [Windows, X64, nvrgfx-kernelvm-bridge] } }
+          - { os: windows, platform: "x86_64", compiler: msvc, preset: default, config: "Release", flags: "unit-test", required_devices: "d3d11,d3d12,vulkan,cpu,cuda,wgpu", runs-on: { labels: [Windows, X64, nvrgfx-kernelvm-bridge] } }
+          - { os: linux, platform: "x86_64", compiler: clang, preset: clang, config: "Debug", flags: "unit-test,coverage", required_devices: "vulkan,cuda,wgpu", runs-on: { labels: [Linux, X64, nvrgfx-kernelvm-bridge] } }
+          - { os: linux, platform: "x86_64", compiler: clang, preset: clang, config: "Release", flags: "unit-test", required_devices: "vulkan,cuda,wgpu", runs-on: { labels: [Linux, X64, nvrgfx-kernelvm-bridge] } }
           # Builds running on GitHub hosted runners (build + tests)
-          - { os: macos, platform: "aarch64", compiler: clang, preset: default, config: "Debug", flags: "unit-test,coverage", runs-on: macos-latest }
-          - { os: macos, platform: "aarch64", compiler: clang, preset: default, config: "Release", flags: "unit-test", runs-on: macos-latest }
+          - { os: macos, platform: "aarch64", compiler: clang, preset: default, config: "Debug", flags: "unit-test,coverage", required_devices: "metal,cpu,wgpu", runs-on: macos-latest }
+          - { os: macos, platform: "aarch64", compiler: clang, preset: default, config: "Release", flags: "unit-test", required_devices: "metal,cpu,wgpu", runs-on: macos-latest }
           # Builds running on GitHub hosted runners (build + tests on WARP)
-          - { os: windows, platform: "x86_64", compiler: clang, preset: clang, config: "Release", flags: "unit-test", runs-on: windows-latest }
-          - { os: windows, platform: "x86_64", compiler: msvc, preset: default, config: "Debug", flags: "unit-test", runs-on: windows-latest }
-          - { os: windows, platform: "aarch64", compiler: msvc, preset: default, config: "Release", flags: "unit-test", runs-on: windows-11-arm }
+          - { os: windows, platform: "x86_64", compiler: clang, preset: clang, config: "Release", flags: "unit-test", required_devices: "d3d11,d3d12,cpu", runs-on: windows-latest }
+          - { os: windows, platform: "x86_64", compiler: msvc, preset: default, config: "Debug", flags: "unit-test", required_devices: "d3d11,d3d12,cpu", runs-on: windows-latest }
+          - { os: windows, platform: "aarch64", compiler: msvc, preset: default, config: "Release", flags: "unit-test", required_devices: "d3d11,d3d12", runs-on: windows-11-arm }
           # Raytracing tests are flakey on aarch64/Debug builds, so tests are currently disabled
           - { os: windows, platform: "aarch64", compiler: msvc, preset: default, config: "Debug", flags: "", runs-on: windows-11-arm }
           # Builds running on GitHub hosted runners (build only)
@@ -97,17 +97,17 @@ jobs:
 
       - name: Unit Tests
         if: contains(matrix.flags, 'unit-test')
-        run: ./slang-rhi-tests -check-devices
+        run: ./slang-rhi-tests -check-devices -require-devices=${{ matrix.required_devices }}
         working-directory: build/${{matrix.config}}
 
       - name: Unit Tests (OptiX 8.0)
-        if: contains(matrix.flags, 'unit-test')
-        run: ./slang-rhi-tests -tc="ray-tracing*.cuda" -check-devices -optix-version=80000
+        if: contains(matrix.flags, 'unit-test') && contains(matrix.required_devices, 'cuda')
+        run: ./slang-rhi-tests -tc="ray-tracing*.cuda" -check-devices -require-devices=cuda -optix-version=80000
         working-directory: build/${{matrix.config}}
 
       - name: Unit Tests (OptiX 8.1)
-        if: contains(matrix.flags, 'unit-test')
-        run: ./slang-rhi-tests -tc="ray-tracing*.cuda" -check-devices -optix-version=80100
+        if: contains(matrix.flags, 'unit-test') && contains(matrix.required_devices, 'cuda')
+        run: ./slang-rhi-tests -tc="ray-tracing*.cuda" -check-devices -require-devices=cuda -optix-version=80100
         working-directory: build/${{matrix.config}}
 
       - name: Coverage Report

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,7 +97,7 @@ jobs:
 
       - name: Unit Tests
         if: contains(matrix.flags, 'unit-test')
-        run: ./slang-rhi-tests -check-devices -require-devices=${{ matrix.required_devices }}
+        run: ./slang-rhi-tests -check-devices "-require-devices=${{ matrix.required_devices }}"
         working-directory: build/${{matrix.config}}
 
       - name: Unit Tests (OptiX 8.0)

--- a/tests/doctest-reporter.h
+++ b/tests/doctest-reporter.h
@@ -45,6 +45,7 @@ struct CustomReporter : public IReporter
             stream << "                                       <device> can be d3d11, d3d12, vulkan, metal, cpu, cuda, wgpu\n";
             stream << "                                       to select a specific adapter, the adapter index can be appended after a colon (i.e. d3d12:1)\n";
             stream << "                                       use * to select all available devices\n";
+            stream << " -require-devices=<device>[,...]       fail unless all specified device types are available\n";
             stream << " -d3d12-shader-model=<major.minor>     require and cap D3D12 tests to a shader model, e.g. 6.8\n";
             stream << " -d3d12-disable-nvapi                  disable the NVAPI shader extension for native D3D12 testing\n";
             stream << " -optix-version=<version>              select a specific OptiX version to use, e.g. 80100 for version 8.1\n";

--- a/tests/main.cpp
+++ b/tests/main.cpp
@@ -28,6 +28,33 @@ std::string getCurrentTestCaseName()
     return doctest::detail::g_cs->currentTest->m_name;
 }
 
+bool checkRequiredDevices()
+{
+    bool allAvailable = true;
+    for (DeviceType deviceType : kDeviceTypes)
+    {
+        if (!options().deviceRequired[size_t(deviceType)])
+            continue;
+
+        DeviceAvailabilityResult result = checkDeviceTypeAvailable(deviceType);
+        if (result.available)
+            continue;
+
+        allAvailable = false;
+        std::fprintf(
+            stderr,
+            "Required device '%s' is not available: %s\n",
+            deviceTypeToString(deviceType),
+            result.error.c_str()
+        );
+        if (!result.debugCallbackOutput.empty())
+            std::fprintf(stderr, "Debug callback output: %s\n", result.debugCallbackOutput.c_str());
+        if (!result.diagnostics.empty())
+            std::fprintf(stderr, "Slang diagnostics: %s\n", result.diagnostics.c_str());
+    }
+    return allAvailable;
+}
+
 } // namespace rhi::testing
 
 int main(int argc, const char** argv)
@@ -86,6 +113,29 @@ int main(int argc, const char** argv)
                         }
                         break;
                     }
+                }
+            }
+        }
+
+        strings.clear();
+        if (doctest::parseCommaSepArgs(argc, argv, "require-devices=", strings))
+        {
+            for (const auto& str : strings)
+            {
+                bool matched = false;
+                for (rhi::DeviceType deviceType : rhi::testing::kDeviceTypes)
+                {
+                    if (str == rhi::testing::deviceTypeToString(deviceType))
+                    {
+                        options.deviceRequired[size_t(deviceType)] = true;
+                        matched = true;
+                        break;
+                    }
+                }
+                if (!matched)
+                {
+                    std::fprintf(stderr, "Invalid required device type '%s'.\n", str.c_str());
+                    return 1;
                 }
             }
         }
@@ -151,7 +201,8 @@ int main(int argc, const char** argv)
         // Report successful tests
         // context.setOption("success", true);
 
-        result = context.run();
+        if (context.shouldExit() || rhi::testing::options().listDevices || rhi::testing::checkRequiredDevices())
+            result = context.run();
 
         bool noSilentSkips = rhi::testing::checkNoSilentGpuSkips();
         if (result == 0 && !noSilentSkips)

--- a/tests/testing.h
+++ b/tests/testing.h
@@ -28,6 +28,7 @@ struct Options
     bool printMemoryReport = false;
     std::string memoryReportFile;
     std::array<bool, kDeviceTypeCount + 1> deviceSelected;
+    std::array<bool, kDeviceTypeCount + 1> deviceRequired;
     std::array<int, kDeviceTypeCount + 1> deviceAdapterIndex;
     uint32_t d3d12ShaderModel = 0;
     bool d3d12DisableNVAPI = false;
@@ -36,6 +37,7 @@ struct Options
     Options()
     {
         deviceSelected.fill(true);
+        deviceRequired.fill(false);
         deviceAdapterIndex.fill(-1);
     }
 };
@@ -405,6 +407,16 @@ static constexpr DeviceType kPlatformDeviceTypes[] = {
     rhi::DeviceType::CUDA,
     rhi::DeviceType::WGPU,
 #endif
+};
+
+static constexpr DeviceType kDeviceTypes[] = {
+    rhi::DeviceType::D3D11,
+    rhi::DeviceType::D3D12,
+    rhi::DeviceType::Vulkan,
+    rhi::DeviceType::Metal,
+    rhi::DeviceType::CPU,
+    rhi::DeviceType::CUDA,
+    rhi::DeviceType::WGPU,
 };
 
 inline bool isPlatformDeviceType(DeviceType deviceType)


### PR DESCRIPTION
Add -require-devices to validate requested backends before running tests and return failure when any are unavailable. Preserve help and device-list query behavior, and report clear availability diagnostics.

Declare required_devices for every CI unit-test matrix entry and pass it to the test runner. Gate OptiX checks on CUDA and require CUDA explicitly so missing devices cannot produce green jobs through silently skipped tests.