### PR TITLE
Gate OptiX coopvec capability on SM 9.0

### DIFF
--- a/src/cuda/cuda-device.cpp
+++ b/src/cuda/cuda-device.cpp
@@ -298,7 +298,13 @@ Result DeviceImpl::initialize(const DeviceDesc& desc, BackendImpl* backend)
             if (m_ctx.optixContext->getCooperativeVectorSupport())
             {
                 addFeature(Feature::CooperativeVector);
-                addCapability(Capability::optix_coopvec);
+                // Slang's optix_coopvec capability implies _cuda_sm_9_0. Keep exposing the
+                // API feature on every device supported by OptiX, but only enable the native
+                // OptiX shader path when the device also supports the implied architecture.
+                if (hasComputeCapability(9, 0))
+                {
+                    addCapability(Capability::optix_coopvec);
+                }
             }
         }
     }

--- a/tests/test-device-features.cpp
+++ b/tests/test-device-features.cpp
@@ -63,6 +63,14 @@ GPU_TEST_CASE("cuda-device-features", CUDA)
 
     // Compute capability 9.0 features
     CHECK(device->hasFeature(Feature::AtomicBfloat16) == has_sm9_0);
+
+    // Slang's optix_coopvec capability implies _cuda_sm_9_0. OptiX can expose
+    // cooperative-vector API support on devices below that compute capability,
+    // where Slang must continue to use its generic CUDA lowering.
+    CHECK(
+        device->hasCapability(Capability::optix_coopvec) ==
+        (device->hasFeature(Feature::CooperativeVector) && has_sm9_0)
+    );
 }
 
 #if SLANG_RHI_ENABLE_METAL


### PR DESCRIPTION
Slang's optix_coopvec capability implies the _cuda_sm_9_0 target. OptiX may report cooperative-vector support on older devices, causing their shaders to be compiled for an unsupported architecture.

Keep exposing the CooperativeVector API feature whenever OptiX supports it, but advertise optix_coopvec only on SM 9.0 or newer so older devices retain the generic CUDA lowering. Add a regression assertion for the capability relationship.