### PR TITLE
Fix undefined behavior

### DIFF
--- a/src/cpu/cpu-shader-object-layout.cpp
+++ b/src/cpu/cpu-shader-object-layout.cpp
@@ -8,12 +8,11 @@ ShaderObjectLayoutImpl::ShaderObjectLayoutImpl(
     slang::TypeLayoutReflection* layout
 )
 {
-    initBase(device, session, layout);
+    m_elementTypeLayout = _unwrapParameterGroups(layout, m_containerType);
+    initBase(device, session, m_elementTypeLayout);
 
     m_slotCount = 0;
     m_subObjectCount = 0;
-
-    m_elementTypeLayout = _unwrapParameterGroups(layout, m_containerType);
 
     // Compute the binding ranges that are used to store
     // the logical contents of the object in memory. These will relate

--- a/src/device.cpp
+++ b/src/device.cpp
@@ -14,16 +14,16 @@ namespace testing {
 bool gDebugDisableStateTracking = false;
 std::atomic<uint64_t> gResourceCount{0};
 
-size_t getShaderObjectLayoutCacheSize(IDevice* device)
+Device* getUnderlyingDevice(IDevice* device)
 {
-    // Unwrap the debug layer here rather than requiring callers to do it. Tests hold
-    // whatever createDevice returned, which is the wrapper whenever validation is
-    // enabled, and the cost of forgetting is uneven: checked_cast only verifies the
-    // downcast under SLANG_RHI_DEBUG, so a wrapper reaching it aborts in debug builds
-    // but silently reads a bogus pointer in release ones.
     if (auto debugDevice = dynamic_cast<debug::DebugDevice*>(device))
         device = debugDevice->baseObject.get();
-    return checked_cast<Device*>(device)->m_shaderObjectLayoutCache.size();
+    return checked_cast<Device*>(device);
+}
+
+size_t getShaderObjectLayoutCacheSize(IDevice* device)
+{
+    return getUnderlyingDevice(device)->m_shaderObjectLayoutCache.size();
 }
 } // namespace testing
 

--- a/src/device.h
+++ b/src/device.h
@@ -20,6 +20,7 @@
 namespace rhi {
 
 // Forward declarations
+class Device;
 class Heap;
 struct EntryPointCompilationStats;
 
@@ -28,6 +29,8 @@ namespace testing {
 extern bool gDebugDisableStateTracking;
 // Counter for tracking active Resource instances (for testing deferred delete)
 extern std::atomic<uint64_t> gResourceCount;
+// Returns the underlying device implementation, unwrapping the debug layer when enabled.
+Device* getUnderlyingDevice(IDevice* device);
 // Returns the number of entries in the device's shader object layout cache.
 // Accepts either a device or its debug-layer wrapper.
 size_t getShaderObjectLayoutCacheSize(IDevice* device);

--- a/src/shader-object.cpp
+++ b/src/shader-object.cpp
@@ -24,7 +24,12 @@ void ShaderObjectLayout::initBase(
     m_device = device;
     m_slangSession = session;
     m_elementTypeLayout = elementTypeLayout;
-    m_componentID = m_device->m_shaderCache.getComponentId(m_elementTypeLayout->getType());
+    auto type = m_elementTypeLayout->getType();
+    // Root layouts represent a program's global scope, which may not have a reflected type.
+    if (type)
+        m_componentID = m_device->m_shaderCache.getComponentId(type);
+    else
+        m_componentID = kInvalidComponentID;
 }
 
 // ----------------------------------------------------------------------------
@@ -647,7 +652,8 @@ Result ShaderObject::collectSpecializationArgs(ExtendedShaderObjectTypeList& arg
 Result ShaderObject::writeOrdinaryData(void* destData, Size destSize, ShaderObjectLayout* specializedLayout)
 {
     SLANG_RHI_ASSERT(m_data.size() <= destSize);
-    std::memcpy(destData, m_data.data(), m_data.size());
+    if (!m_data.empty())
+        std::memcpy(destData, m_data.data(), m_data.size());
     return SLANG_OK;
 }
 

--- a/tests/test-buffer.cpp
+++ b/tests/test-buffer.cpp
@@ -1,6 +1,5 @@
 #include "testing.h"
 
-#include "debug-layer/debug-device.h"
 #include "rhi-shared.h"
 
 #include <cstring>
@@ -9,23 +8,12 @@
 using namespace rhi;
 using namespace rhi::testing;
 
-namespace {
-
-Device* getSharedDevice(IDevice* device)
-{
-    if (auto debugDevice = dynamic_cast<debug::DebugDevice*>(device))
-        return (Device*)debugDevice->baseObject.get();
-    return (Device*)device;
-}
-
-} // namespace
-
 GPU_TEST_CASE("buffer-init-data-staging-lifetime", Vulkan)
 {
     auto queue = device->getQueue(QueueType::Graphics);
     REQUIRE_CALL(queue->waitOnHost());
 
-    StagingHeap& heap = getSharedDevice(device)->m_uploadHeap;
+    StagingHeap& heap = getUnderlyingDevice(device)->m_uploadHeap;
     CHECK_EQ(heap.getUsed(), 0);
 
     std::vector<uint32_t> data(1024);

--- a/tests/test-cmd-upload-buffer.cpp
+++ b/tests/test-cmd-upload-buffer.cpp
@@ -7,18 +7,9 @@
 #include <random>
 
 #include "rhi-shared.h"
-#include "debug-layer/debug-device.h"
 
 using namespace rhi;
 using namespace rhi::testing;
-
-Device* getSharedDevice(IDevice* device)
-{
-    if (auto debugDevice = dynamic_cast<debug::DebugDevice*>(device))
-        return (Device*)debugDevice->baseObject.get();
-    else
-        return (Device*)device;
-}
 
 struct UploadData
 {
@@ -63,7 +54,7 @@ void testUploadToBuffer(IDevice* device, Size size, Offset offset, int tests, bo
     // Ensure any previous operations have finished so we can safely check heap usage.
     device->getQueue(QueueType::Graphics)->waitOnHost();
 
-    StagingHeap& heap = getSharedDevice(device)->m_uploadHeap;
+    StagingHeap& heap = getUnderlyingDevice(device)->m_uploadHeap;
     CHECK_EQ(heap.getUsed(), 0);
 
     std::vector<UploadData> uploads(tests);

--- a/tests/test-compilation-report.cpp
+++ b/tests/test-compilation-report.cpp
@@ -6,20 +6,19 @@ using namespace rhi::testing;
 // List of retained blobs to prevent them from being released too early.
 static std::vector<ComPtr<ISlangBlob>> s_blobs;
 
+template<typename T>
+inline bool areArraysEqual(const T* a, size_t aCount, const T* b, size_t bCount)
+{
+    return aCount == bCount && (aCount == 0 || std::memcmp(a, b, aCount * sizeof(T)) == 0);
+}
+
 inline bool isEqual(const CompilationReport* a, const CompilationReport* b)
 {
-    return std::memcmp(a, b, offsetof(CompilationReport, entryPointReports)) == 0 &&
-           a->entryPointReportCount == b->entryPointReportCount && a->pipelineReportCount == b->pipelineReportCount &&
-           std::memcmp(
-               a->entryPointReports,
-               b->entryPointReports,
-               a->entryPointReportCount * sizeof(CompilationReport::EntryPointReport)
-           ) == 0 &&
-           std::memcmp(
-               a->pipelineReports,
-               b->pipelineReports,
-               a->pipelineReportCount * sizeof(CompilationReport::PipelineReport)
-           ) == 0;
+    if (std::memcmp(a, b, offsetof(CompilationReport, entryPointReports)) != 0)
+        return false;
+    if (!areArraysEqual(a->entryPointReports, a->entryPointReportCount, b->entryPointReports, b->entryPointReportCount))
+        return false;
+    return areArraysEqual(a->pipelineReports, a->pipelineReportCount, b->pipelineReports, b->pipelineReportCount);
 }
 
 inline ComPtr<IShaderProgram> createShaderProgram(IDevice* device)

--- a/tests/test-staging-heap.cpp
+++ b/tests/test-staging-heap.cpp
@@ -17,7 +17,7 @@ static const Size kPageSize = 16 * 1024 * 1024;
 GPU_TEST_CASE("staging-heap-alloc-free", ALL)
 {
     StagingHeap heap;
-    heap.initialize((Device*)device.get(), kPageSize, MemoryType::Upload);
+    heap.initialize(getUnderlyingDevice(device.get()), kPageSize, MemoryType::Upload);
 
     Size allocSize = heap.alignAllocationSize(16);
 
@@ -63,7 +63,7 @@ GPU_TEST_CASE("staging-heap-alloc-free", ALL)
 GPU_TEST_CASE("staging-heap-large-page", ALL)
 {
     StagingHeap heap;
-    heap.initialize((Device*)device.get(), kPageSize, MemoryType::Upload);
+    heap.initialize(getUnderlyingDevice(device.get()), kPageSize, MemoryType::Upload);
 
     StagingHeap::Allocation allocation;
     heap.alloc(16, {2}, &allocation);
@@ -108,7 +108,7 @@ GPU_TEST_CASE("staging-heap-large-page", ALL)
 GPU_TEST_CASE("staging-heap-realloc", ALL)
 {
     StagingHeap heap;
-    heap.initialize((Device*)device.get(), kPageSize, MemoryType::Upload);
+    heap.initialize(getUnderlyingDevice(device.get()), kPageSize, MemoryType::Upload);
 
     Size allocSize = heap.getPageSize() / 16;
 
@@ -153,7 +153,7 @@ GPU_TEST_CASE("staging-heap-realloc", ALL)
 GPU_TEST_CASE("staging-heap-handles", ALL)
 {
     StagingHeap heap;
-    heap.initialize((Device*)device.get(), kPageSize, MemoryType::Upload);
+    heap.initialize(getUnderlyingDevice(device.get()), kPageSize, MemoryType::Upload);
 
     // Make an allocation using ref counted handle within a scope.
     {
@@ -174,7 +174,7 @@ GPU_TEST_CASE("staging-heap-handles", ALL)
 GPU_TEST_CASE("staging-heap-allocation-alignment", ALL)
 {
     StagingHeap heap;
-    heap.initialize((Device*)device.get(), kPageSize, MemoryType::Upload);
+    heap.initialize(getUnderlyingDevice(device.get()), kPageSize, MemoryType::Upload);
 
     StagingHeap::Allocation first;
     REQUIRE_CALL(heap.alloc(16, {}, &first));
@@ -216,7 +216,7 @@ void thrashHeap(Device* device, StagingHeap* heap, int idx)
 
 GPU_TEST_CASE("staging-heap-mutithreading", ALL)
 {
-    Device* deviceImpl = (Device*)device.get();
+    Device* deviceImpl = getUnderlyingDevice(device.get());
 
     StagingHeap heap;
     heap.initialize(deviceImpl, kPageSize, MemoryType::Upload);
@@ -260,7 +260,7 @@ void freeAllocations(StagingHeap& heap, std::vector<StagingHeap::Allocation>& al
 
 GPU_TEST_CASE("staging-heap-threadlock-pages", ALL)
 {
-    Device* deviceImpl = (Device*)device.get();
+    Device* deviceImpl = getUnderlyingDevice(device.get());
 
     // When pages AREN'T being kept mapped, heap should allocate a new
     // page for each thread. As a result, after 3 threads have done 10
@@ -296,7 +296,7 @@ GPU_TEST_CASE("staging-heap-threadlock-pages", ALL)
 
 GPU_TEST_CASE("staging-heap-shared-pages", ALL)
 {
-    Device* deviceImpl = (Device*)device.get();
+    Device* deviceImpl = getUnderlyingDevice(device.get());
 
     // When pages ARE being kept mapped, heap should share pages
     // between threads, so 10 small allocations from 3 threads should
@@ -332,7 +332,7 @@ GPU_TEST_CASE("staging-heap-shared-pages", ALL)
 
 GPU_TEST_CASE("staging-heap-unlockpage-1", ALL)
 {
-    Device* deviceImpl = (Device*)device.get();
+    Device* deviceImpl = getUnderlyingDevice(device.get());
 
     // Verify that in none sharing mode, when this thread and another
     // one attempt to allocate, we end up with 2 pages (effectively
@@ -363,7 +363,7 @@ GPU_TEST_CASE("staging-heap-unlockpage-1", ALL)
 
 GPU_TEST_CASE("staging-heap-unlockpage-2", ALL)
 {
-    Device* deviceImpl = (Device*)device.get();
+    Device* deviceImpl = getUnderlyingDevice(device.get());
 
     // Verify that if staging-heap-unlockpage-1 is repeated, but
     // the current thread frees its allocation, the 2nd thread


### PR DESCRIPTION
This PR fixes several undefined-behavior cases involving shader objects and test utilities:

- Adds `getUnderlyingDevice()` to safely unwrap validation-layer devices before accessing the internal `Device` implementation.
- Replaces unsafe test-side `IDevice*` casts with the shared helper.
- Avoids calling `memcpy`/`memcmp` with potentially null pointers for empty data.
- Handles root shader-object layouts that legitimately have no reflected type by assigning an invalid component ID.
- Unwraps CPU parameter-group layouts before base initialization so an element type is used when available.
- Simplifies compilation-report array comparison while preserving count validation.