### PR TITLE
Add sanitizers

### DIFF
--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -1,0 +1,64 @@
+name: sanitizers
+
+on:
+  schedule:
+    - cron: "0 3 * * *"
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - { os: windows, platform: "x86_64", preset: clang, config: "Debug", required_devices: "d3d11,d3d12,vulkan,cpu,cuda,wgpu", runs-on: { labels: [Windows, X64, nvrgfx-kernelvm-bridge] } }
+          - { os: linux, platform: "x86_64", preset: clang, config: "Debug", required_devices: "vulkan,cuda,wgpu", runs-on: { labels: [Linux, X64, nvrgfx-kernelvm-bridge] } }
+          - { os: macos, platform: "aarch64", preset: default, config: "Debug", required_devices: "metal,cpu,wgpu", runs-on: macos-latest }
+
+    runs-on: ${{ matrix.runs-on }}
+
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          submodules: 'recursive'
+
+      - name: Setup MSVC
+        if: runner.os == 'Windows'
+        uses: step-security/msvc-dev-cmd@v1
+        with:
+          arch: amd64
+
+      - name: Setup CMake/Ninja
+        uses: lukka/get-cmake@latest
+
+      - name: Setup Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.x'
+
+      - name: Configure
+        env:
+          SLANG_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: cmake --preset ${{ matrix.preset }} -DSLANG_RHI_ENABLE_ASAN=ON -DSLANG_RHI_ENABLE_UBSAN=ON
+
+      - name: Build
+        run: cmake --build build --config ${{ matrix.config }}
+
+      - name: Setup Sanitizer Options
+        id: sanitizer_options
+        run: python tools/setup-sanitizer-env.py --config ${{ matrix.config }} --os ${{ matrix.os }}
+
+      - name: Unit Tests
+        run: ./slang-rhi-tests -check-devices "-require-devices=${{ matrix.required_devices }}"
+        working-directory: build/${{ matrix.config }}
+
+      - name: Check LeakSanitizer Reports
+        if: ${{ always() && matrix.os == 'linux' && steps.sanitizer_options.outcome == 'success' }}
+        run: python tools/filter-lsan-reports.py

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,6 +46,8 @@ option(SLANG_RHI_BUILD_TESTS "Build tests" ${SLANG_RHI_MASTER_PROJECT})
 option(SLANG_RHI_BUILD_TESTS_WITH_GLFW "Build tests that require GLFW" ${SLANG_RHI_MASTER_PROJECT})
 option(SLANG_RHI_BUILD_EXAMPLES "Build examples" ${SLANG_RHI_MASTER_PROJECT})
 option(SLANG_RHI_ENABLE_COVERAGE "Enable code coverage (clang only)" OFF)
+option(SLANG_RHI_ENABLE_ASAN "Enable AddressSanitizer (clang only)" OFF)
+option(SLANG_RHI_ENABLE_UBSAN "Enable UndefinedBehaviorSanitizer (clang only)" OFF)
 option(SLANG_RHI_INSTALL "Install library" ON)
 
 # Configure coverage flags
@@ -59,6 +61,46 @@ if(SLANG_RHI_ENABLE_COVERAGE)
         add_link_options(-fprofile-instr-generate=${SLANG_RHI_COVERAGE_PATTERN})
     else()
         message(FATAL_ERROR "Code coverage is only supported with Clang")
+    endif()
+endif()
+
+# Configure sanitizer flags
+if(SLANG_RHI_ENABLE_ASAN OR SLANG_RHI_ENABLE_UBSAN)
+    if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+        set(SLANG_RHI_SANITIZERS)
+        if(SLANG_RHI_ENABLE_ASAN)
+            list(APPEND SLANG_RHI_SANITIZERS address)
+        endif()
+        if(SLANG_RHI_ENABLE_UBSAN)
+            list(APPEND SLANG_RHI_SANITIZERS undefined)
+        endif()
+        list(JOIN SLANG_RHI_SANITIZERS "," SLANG_RHI_SANITIZER_FLAGS)
+
+        add_compile_options(-fsanitize=${SLANG_RHI_SANITIZER_FLAGS} -fno-omit-frame-pointer)
+        add_link_options(-fsanitize=${SLANG_RHI_SANITIZER_FLAGS})
+
+        # Make undefined behavior fail the test process instead of recovering and
+        # potentially allowing a successful exit.
+        if(SLANG_RHI_ENABLE_UBSAN)
+            add_compile_options(
+                -fno-sanitize-recover=undefined
+                -fsanitize-ignorelist=${CMAKE_CURRENT_SOURCE_DIR}/tools/ubsan-ignorelist.txt
+            )
+        endif()
+
+        # On Windows, the debug CRT conflicts with ASAN. Force the static release CRT.
+        if(SLANG_RHI_ENABLE_ASAN AND CMAKE_SYSTEM_NAME STREQUAL "Windows")
+            set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded")
+            add_compile_options(-fno-sanitize-link-runtime)
+            # The MSVC STL uses __has_feature(address_sanitizer) under Clang to
+            # activate ASAN container annotations and emits /INFERASANLIBS via a
+            # pragma in that path. Some lld-link versions reject that directive
+            # in .drectve sections. Defining __SANITIZE_ADDRESS__ selects the
+            # equivalent STL annotation path without emitting the directive.
+            add_compile_definitions(__SANITIZE_ADDRESS__)
+        endif()
+    else()
+        message(FATAL_ERROR "Sanitizers are only supported with Clang")
     endif()
 endif()
 
@@ -438,6 +480,11 @@ if(SLANG_RHI_ENABLE_D3D12)
     target_sources(slang-rhi-d3d12ma PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/external/d3d12ma/D3D12MemAlloc.cpp)
     target_include_directories(slang-rhi-d3d12ma PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/external/d3d12ma)
     target_compile_features(slang-rhi-d3d12ma PRIVATE cxx_std_20)
+    if(SLANG_RHI_ENABLE_UBSAN AND CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+        # Windows SDK bitmask operators form out-of-range intermediate enum values.
+        # Limit the exception to the vendored allocator; slang-rhi remains fully checked.
+        target_compile_options(slang-rhi-d3d12ma PRIVATE -fno-sanitize=enum)
+    endif()
     # Force-include D3D12MA configuration header to route assertions through slang-rhi.
     target_include_directories(slang-rhi-d3d12ma PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/src)
     if(MSVC)

--- a/tools/asan-suppressions.txt
+++ b/tools/asan-suppressions.txt
@@ -1,0 +1,23 @@
+# AddressSanitizer suppressions for slang-rhi
+# These suppress known issues in third-party GPU driver libraries that are outside our control.
+# Reference: https://clang.llvm.org/docs/AddressSanitizer.html#suppressing-reports-in-external-libraries
+
+# NVIDIA CUDA driver
+interceptor_via_lib:libcuda.so
+interceptor_via_lib:libnvidia
+
+# NVIDIA Runtime Compiler
+interceptor_via_lib:libnvrtc
+
+# NVIDIA OptiX ray tracing engine
+interceptor_via_lib:libnvoptix
+
+# Vulkan loader and drivers
+interceptor_via_lib:libvulkan
+
+# OpenGL/GLX/EGL (used by some drivers)
+interceptor_via_lib:libGLX
+interceptor_via_lib:libEGL
+
+# Dawn WebGPU
+interceptor_via_lib:libdawn

--- a/tools/filter-lsan-reports.py
+++ b/tools/filter-lsan-reports.py
@@ -1,0 +1,192 @@
+#!/usr/bin/env python3
+
+import argparse
+import os
+import pathlib
+import re
+import sys
+from typing import List, Optional, Tuple
+
+
+LEAK_HEADER_RE = re.compile(r"^(Direct|Indirect) leak of .+ allocated from:$")
+FRAME_RE = re.compile(r"^\s*#(?P<index>\d+)\s+")
+PROJECT_SOURCE_DIRS = ("src/", "include/", "tests/")
+PROJECT_SYMBOL_RE = re.compile(r"\brhi::")
+
+
+def normalize_path_text(value: str) -> str:
+    return value.replace("\\", "/").lower()
+
+
+def frame_index(line: str) -> Optional[int]:
+    match = FRAME_RE.match(line)
+    return int(match.group("index")) if match else None
+
+
+def is_allocator_interceptor_frame(line: str) -> bool:
+    index = frame_index(line)
+    if index is None:
+        return False
+
+    lower = line.lower()
+    allocator_markers = (
+        "__interceptor_",
+        "asan_malloc",
+        "lsan_interceptors",
+        "sanitizer_common",
+        " in malloc ",
+        " in calloc ",
+        " in realloc ",
+        " in operator new",
+        " in operator new[]",
+    )
+
+    return any(marker in lower for marker in allocator_markers)
+
+
+def is_project_source_frame(line: str, repo_root: str) -> bool:
+    normalized = normalize_path_text(line)
+    repo = normalize_path_text(repo_root).rstrip("/") + "/"
+    repo_index = normalized.find(repo)
+    if repo_index < 0:
+        return False
+
+    relative = normalized[repo_index + len(repo) :]
+    return relative.startswith(PROJECT_SOURCE_DIRS)
+
+
+def is_project_binary_frame(line: str) -> bool:
+    normalized = normalize_path_text(line)
+    return "slang-rhi-tests+" in normalized or "slang-rhi-tests.exe+" in normalized
+
+
+def is_slang_rhi_leak(block: List[str], repo_root: str) -> bool:
+    """Attribute a leak using its first non-allocator frame.
+
+    Looking at every frame makes calls into GPU drivers appear to be project
+    leaks merely because slang-rhi initiated the external API call. The
+    allocation site is the first meaningful frame after allocator interceptors.
+    """
+    for line in block:
+        if frame_index(line) is None:
+            continue
+        if is_allocator_interceptor_frame(line):
+            continue
+        return (
+            is_project_source_frame(line, repo_root)
+            or is_project_binary_frame(line)
+            or PROJECT_SYMBOL_RE.search(line) is not None
+        )
+    return False
+
+
+def extract_leak_blocks(text: str) -> List[List[str]]:
+    lines = text.splitlines()
+    blocks: List[List[str]] = []
+    index = 0
+
+    while index < len(lines):
+        if not LEAK_HEADER_RE.match(lines[index]):
+            index += 1
+            continue
+
+        block = [lines[index]]
+        index += 1
+        while index < len(lines):
+            line = lines[index]
+            if not line.strip():
+                break
+            if LEAK_HEADER_RE.match(line):
+                index -= 1
+                break
+            if line.startswith("SUMMARY:") or line.startswith("----") or line.startswith("Suppressions used:"):
+                break
+            block.append(line)
+            index += 1
+        blocks.append(block)
+        index += 1
+
+    return blocks
+
+
+def read_log(path: pathlib.Path) -> str:
+    return path.read_text(encoding="utf-8", errors="replace")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Classify LeakSanitizer reports and surface other sanitizer failures."
+    )
+    parser.add_argument("--log-dir", type=pathlib.Path)
+    parser.add_argument("--repo-root", type=pathlib.Path)
+    args = parser.parse_args()
+
+    if args.log_dir:
+        log_dir = args.log_dir
+    elif os.environ.get("SANITIZER_LOG_DIR"):
+        log_dir = pathlib.Path(os.environ["SANITIZER_LOG_DIR"])
+    else:
+        print("No sanitizer log directory provided and SANITIZER_LOG_DIR is not set.")
+        return 1
+    repo_root_arg = args.repo_root or pathlib.Path(os.environ.get("GITHUB_WORKSPACE", os.getcwd()))
+    repo_root = str(repo_root_arg.resolve())
+    if not log_dir.exists():
+        print(f"No sanitizer log directory found: {log_dir}")
+        return 0
+
+    leak_blocks: List[Tuple[pathlib.Path, List[str]]] = []
+    project_blocks: List[Tuple[pathlib.Path, List[str]]] = []
+    unexpected_reports: List[Tuple[pathlib.Path, str]] = []
+
+    for log_path in sorted(path for path in log_dir.iterdir() if path.is_file()):
+        text = read_log(log_path)
+        if not text.strip():
+            continue
+        if "LeakSanitizer" not in text:
+            # LSAN_OPTIONS.log_path is a sanitizer-common setting, so ASAN and
+            # UBSAN diagnostics can land here too. Never silently discard them.
+            unexpected_reports.append((log_path, text))
+            continue
+        blocks = extract_leak_blocks(text)
+        if "ERROR: LeakSanitizer:" in text and not blocks:
+            # Treat format changes and truncated reports as failures. Silently
+            # accepting a report we could not classify would make this filter
+            # less strict than running LSan without post-processing.
+            unexpected_reports.append((log_path, text))
+            continue
+        for block in blocks:
+            leak_blocks.append((log_path, block))
+            if is_slang_rhi_leak(block, repo_root):
+                project_blocks.append((log_path, block))
+
+    failed = False
+
+    if unexpected_reports:
+        failed = True
+        print(f"::error::Found {len(unexpected_reports)} non-LSan sanitizer report(s).")
+        for log_path, text in unexpected_reports:
+            print(f"\n{log_path}:")
+            print(text.rstrip())
+
+    if project_blocks:
+        failed = True
+        print(
+            f"::error::LeakSanitizer found {len(project_blocks)} leak block(s) attributed to slang-rhi."
+        )
+        for log_path, block in project_blocks:
+            print(f"\n{log_path}:")
+            print("\n".join(block))
+
+    external_leak_count = len(leak_blocks) - len(project_blocks)
+    if external_leak_count:
+        print(
+            f"Ignored {external_leak_count} LeakSanitizer leak block(s) attributed to external code."
+        )
+    elif not leak_blocks:
+        print("No LeakSanitizer leak reports found.")
+
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/setup-sanitizer-env.py
+++ b/tools/setup-sanitizer-env.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+
+import argparse
+import os
+import pathlib
+import shutil
+import subprocess
+from typing import Optional
+
+
+def sanitizer_path(path: pathlib.Path) -> str:
+    return str(path).replace("\\", "/")
+
+
+def append_github_env(name: str, value: str) -> None:
+    env_file = os.environ.get("GITHUB_ENV")
+    if not env_file:
+        print(f"{name}={value}")
+        return
+    with open(env_file, "a", encoding="utf-8") as file:
+        file.write(f"{name}={value}\n")
+
+
+def find_symbolizer() -> Optional[str]:
+    clang = shutil.which("clang++")
+    if clang:
+        result = subprocess.run(
+            [clang, "--print-prog-name=llvm-symbolizer"],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        symbolizer = shutil.which(result.stdout.strip())
+        if symbolizer:
+            return symbolizer
+
+    return (
+        shutil.which("llvm-symbolizer")
+        or shutil.which("llvm-symbolizer-18")
+        or shutil.which("llvm-symbolizer-17")
+    )
+
+
+def deploy_windows_asan_runtime(test_working_dir: pathlib.Path) -> None:
+    clang = shutil.which("clang++")
+    if not clang:
+        raise RuntimeError("Could not find clang++ while locating the Windows ASAN runtime.")
+
+    runtime_name = "clang_rt.asan_dynamic-x86_64.dll"
+    result = subprocess.run(
+        [clang, f"--print-file-name={runtime_name}"],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    runtime_path = pathlib.Path(result.stdout.strip())
+    if not runtime_path.is_file():
+        raise RuntimeError(f"Could not locate the Windows ASAN runtime: {runtime_path}")
+
+    destination = test_working_dir / runtime_name
+    shutil.copy2(runtime_path, destination)
+    print(f"Copied Windows ASAN runtime to {destination}")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Configure sanitizer environment variables for CI.")
+    parser.add_argument("--config", required=True)
+    parser.add_argument("--os", required=True)
+    args = parser.parse_args()
+
+    workspace = pathlib.Path(os.environ.get("GITHUB_WORKSPACE", os.getcwd())).resolve()
+    test_working_dir = workspace / "build" / args.config
+    asan_suppressions = os.path.relpath(workspace / "tools" / "asan-suppressions.txt", test_working_dir)
+
+    symbolizer = find_symbolizer()
+    if symbolizer:
+        append_github_env("ASAN_SYMBOLIZER_PATH", symbolizer)
+
+    asan_options = [
+        "halt_on_error=1",
+        "symbolize=1",
+        "fast_unwind_on_malloc=0",
+    ]
+
+    # The Windows ASAN runtime rejects interceptor_via_lib suppressions. The
+    # suppression file only contains Unix library names, so do not pass it there.
+    if args.os != "windows":
+        asan_options.append(f"suppressions={sanitizer_path(pathlib.Path(asan_suppressions))}")
+
+    if args.os == "linux":
+        sanitizer_log_dir = test_working_dir / "sanitizer-logs"
+        sanitizer_log_dir.mkdir(parents=True, exist_ok=True)
+        xdg_runtime_dir = test_working_dir / "xdg-runtime"
+        xdg_runtime_dir.mkdir(parents=True, exist_ok=True, mode=0o700)
+        xdg_runtime_dir.chmod(0o700)
+        asan_options = [
+            "detect_leaks=1",
+            "protect_shadow_gap=0",
+            # exitcode is a sanitizer-common flag even when supplied through
+            # LSAN_OPTIONS. Keep leak-only reports non-fatal for the filter
+            # below, but make ASAN/UBSAN failures terminate with SIGABRT.
+            "abort_on_error=1",
+            *asan_options,
+        ]
+        append_github_env(
+            "LSAN_OPTIONS",
+            "exitcode=0:log_path=sanitizer-logs/lsan.log",
+        )
+        append_github_env("SANITIZER_LOG_DIR", str(sanitizer_log_dir))
+        append_github_env("XDG_RUNTIME_DIR", str(xdg_runtime_dir))
+
+    if args.os == "windows":
+        deploy_windows_asan_runtime(test_working_dir)
+
+    append_github_env("ASAN_OPTIONS", ":".join(asan_options))
+    append_github_env("UBSAN_OPTIONS", "print_stacktrace=1:halt_on_error=1")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/ubsan-ignorelist.txt
+++ b/tools/ubsan-ignorelist.txt
@@ -1,0 +1,9 @@
+# metal-cpp implements Objective-C nil messaging through C++ member calls.
+# Limit the exception to its object messaging shim; slang-rhi remains checked.
+[null]
+src:*/metal_cpp-src/Foundation/NSObject.hpp
+
+# Objective-C tagged pointers are valid message receivers but are not
+# necessarily aligned like the C++ wrapper type.
+[alignment]
+src:*/metal_cpp-src/Foundation/NSObject.hpp


### PR DESCRIPTION
Adds automated AddressSanitizer and UndefinedBehaviorSanitizer coverage for Clang builds.

- Adds `SLANG_RHI_ENABLE_ASAN` and `SLANG_RHI_ENABLE_UBSAN` CMake options.
- Adds nightly and manually triggered sanitizer jobs for Windows, Linux, and macOS.
- Configures platform-specific Windows ASan runtime handling.
- Makes UBSan failures fatal while narrowly excluding known third-party undefined behavior.
- Suppresses known ASan reports originating in external GPU libraries.
- Filters Linux LeakSanitizer output to surface leaks attributed to slang-rhi while reporting external leaks separately.