### PR TITLE
Fix shader sub-object layout creation

### DIFF
--- a/src/d3d12/d3d12-shader-object-layout.cpp
+++ b/src/d3d12/d3d12-shader-object-layout.cpp
@@ -229,12 +229,15 @@ Result ShaderObjectLayoutImpl::Builder::setElementTypeLayout(slang::TypeLayoutRe
         // know the appropraite type/layout of sub-object to allocate.
         //
         RefPtr<ShaderObjectLayoutImpl> subObjectLayout;
-        createForElementType(
-            m_device,
-            m_session,
-            slangLeafTypeLayout->getElementTypeLayout(),
-            subObjectLayout.writeRef()
-        );
+        if (slangBindingType != slang::BindingType::ExistentialValue)
+        {
+            createForElementType(
+                m_device,
+                m_session,
+                slangLeafTypeLayout->getElementTypeLayout(),
+                subObjectLayout.writeRef()
+            );
+        }
 
         SubObjectRangeInfo subObjectRange;
         subObjectRange.bindingRangeIndex = bindingRangeIndex;

--- a/src/vulkan/vk-shader-object-layout.cpp
+++ b/src/vulkan/vk-shader-object-layout.cpp
@@ -429,8 +429,13 @@ void ShaderObjectLayoutImpl::Builder::addBindingRanges(slang::TypeLayoutReflecti
         {
         default:
         {
-            auto varLayout = slangLeafTypeLayout->getElementVarLayout();
-            auto subTypeLayout = varLayout->getTypeLayout();
+            // Parameter groups expose the relative element layout through their element
+            // variable. Other containers, such as structured buffers, only expose an
+            // element type layout.
+            auto subTypeLayout = slangLeafTypeLayout->getElementTypeLayout();
+            if (auto elementVarLayout = slangLeafTypeLayout->getElementVarLayout())
+                subTypeLayout = elementVarLayout->getTypeLayout();
+            SLANG_RHI_ASSERT(subTypeLayout);
             ShaderObjectLayoutImpl::createForElementType(
                 m_device,
                 m_session,

--- a/src/wgpu/wgpu-shader-object-layout.cpp
+++ b/src/wgpu/wgpu-shader-object-layout.cpp
@@ -409,8 +409,13 @@ void ShaderObjectLayoutImpl::Builder::addBindingRanges(slang::TypeLayoutReflecti
         {
         default:
         {
-            auto varLayout = slangLeafTypeLayout->getElementVarLayout();
-            auto subTypeLayout = varLayout->getTypeLayout();
+            // Parameter groups expose the relative element layout through their element
+            // variable. Other containers, such as structured buffers, only expose an
+            // element type layout.
+            auto subTypeLayout = slangLeafTypeLayout->getElementTypeLayout();
+            if (auto elementVarLayout = slangLeafTypeLayout->getElementVarLayout())
+                subTypeLayout = elementVarLayout->getTypeLayout();
+            SLANG_RHI_ASSERT(subTypeLayout);
             ShaderObjectLayoutImpl::createForElementType(
                 m_device,
                 m_session,


### PR DESCRIPTION
## Summary

Fix undefined behavior found during UBSAN runs when constructing shader sub-object layouts.

- Skip sub-object layout creation for existential bindings on D3D12, where no concrete element layout is available.
- Handle containers without an element variable layout on Vulkan and WebGPU.
- Preserve relative element layouts for parameter groups.
- Avoid re-deriving layouts through the stored Slang session, since the reflected type may originate from another session.

## Details

`getElementVarLayout()` is available for parameter groups such as `ConstantBuffer<T>` and `ParameterBlock<T>`, but not for all containers. Structured buffers instead expose their element through `getElementTypeLayout()`.

The Vulkan and WebGPU implementations now use the element type layout as a fallback while retaining the element variable layout for parameter groups.