### PR TITLE
Thread sanitizer

### DIFF
--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -13,7 +13,7 @@ permissions:
   contents: read
 
 jobs:
-  build:
+  asan-ubsan:
     strategy:
       fail-fast: false
       matrix:
@@ -53,7 +53,7 @@ jobs:
 
       - name: Setup Sanitizer Options
         id: sanitizer_options
-        run: python tools/setup-sanitizer-env.py --config ${{ matrix.config }} --os ${{ matrix.os }}
+        run: python tools/setup-sanitizer-env.py --config ${{ matrix.config }} --os ${{ matrix.os }} --sanitizer asan-ubsan
 
       - name: Unit Tests
         run: ./slang-rhi-tests -check-devices "-require-devices=${{ matrix.required_devices }}"
@@ -62,3 +62,61 @@ jobs:
       - name: Check LeakSanitizer Reports
         if: ${{ always() && matrix.os == 'linux' && steps.sanitizer_options.outcome == 'success' }}
         run: python tools/filter-lsan-reports.py
+
+  tsan:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # CUDA uses the GPU runner; Vulkan and WebGPU share one lavapipe process.
+          - { os: linux, preset: clang, config: "Debug", required_devices: "cuda", runs-on: { labels: [Linux, X64, nvrgfx-kernelvm-bridge] } }
+          - { os: linux, preset: clang, config: "Debug", required_devices: "vulkan,wgpu", use_lavapipe: true, runs-on: ubuntu-latest }
+          - { os: macos, preset: default, config: "Debug", required_devices: "metal,cpu,wgpu", runs-on: macos-latest }
+
+    name: tsan (${{ matrix.os }}, ${{ matrix.required_devices }})
+    runs-on: ${{ matrix.runs-on }}
+
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          submodules: 'recursive'
+
+      - name: Setup CMake/Ninja
+        uses: lukka/get-cmake@latest
+
+      # NVIDIA's uninstrumented Vulkan driver crashes inside TSAN's allocator.
+      # Lavapipe preserves instrumented Vulkan and WebGPU host-side coverage.
+      - name: Setup lavapipe
+        if: matrix.use_lavapipe
+        shell: bash
+        run: |
+          set -euo pipefail
+          sudo apt-get update
+          sudo apt-get install -y mesa-vulkan-drivers xorg-dev
+          icd_file=$(find /usr/share/vulkan/icd.d -maxdepth 1 -name 'lvp_icd*.json' -print -quit)
+          test -n "$icd_file"
+          echo "Using lavapipe ICD: $icd_file"
+          echo "VK_DRIVER_FILES=$icd_file" >> "$GITHUB_ENV"
+
+      - name: Setup Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.x'
+
+      - name: Configure
+        env:
+          SLANG_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        # TSAN checks slang-rhi host code; vendor GPU runtimes remain uninstrumented.
+        run: >
+          cmake --preset ${{ matrix.preset }} -B build-tsan
+          -DSLANG_RHI_ENABLE_TSAN=ON
+
+      - name: Build
+        run: cmake --build build-tsan --config ${{ matrix.config }}
+
+      - name: Setup Sanitizer Options
+        run: python tools/setup-sanitizer-env.py --config ${{ matrix.config }} --os ${{ matrix.os }} --sanitizer tsan --build-dir build-tsan
+
+      - name: Unit Tests
+        working-directory: build-tsan/${{ matrix.config }}
+        run: ./slang-rhi-tests -check-devices "-select-devices=${{ matrix.required_devices }}" "-require-devices=${{ matrix.required_devices }}"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,6 +48,7 @@ option(SLANG_RHI_BUILD_EXAMPLES "Build examples" ${SLANG_RHI_MASTER_PROJECT})
 option(SLANG_RHI_ENABLE_COVERAGE "Enable code coverage (clang only)" OFF)
 option(SLANG_RHI_ENABLE_ASAN "Enable AddressSanitizer (clang only)" OFF)
 option(SLANG_RHI_ENABLE_UBSAN "Enable UndefinedBehaviorSanitizer (clang only)" OFF)
+option(SLANG_RHI_ENABLE_TSAN "Enable ThreadSanitizer (clang only)" OFF)
 option(SLANG_RHI_INSTALL "Install library" ON)
 
 # Configure coverage flags
@@ -65,7 +66,11 @@ if(SLANG_RHI_ENABLE_COVERAGE)
 endif()
 
 # Configure sanitizer flags
-if(SLANG_RHI_ENABLE_ASAN OR SLANG_RHI_ENABLE_UBSAN)
+if(SLANG_RHI_ENABLE_TSAN AND (SLANG_RHI_ENABLE_ASAN OR SLANG_RHI_ENABLE_UBSAN))
+    message(FATAL_ERROR "ThreadSanitizer must run separately from AddressSanitizer and UndefinedBehaviorSanitizer")
+endif()
+
+if(SLANG_RHI_ENABLE_ASAN OR SLANG_RHI_ENABLE_UBSAN OR SLANG_RHI_ENABLE_TSAN)
     if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
         set(SLANG_RHI_SANITIZERS)
         if(SLANG_RHI_ENABLE_ASAN)
@@ -73,6 +78,9 @@ if(SLANG_RHI_ENABLE_ASAN OR SLANG_RHI_ENABLE_UBSAN)
         endif()
         if(SLANG_RHI_ENABLE_UBSAN)
             list(APPEND SLANG_RHI_SANITIZERS undefined)
+        endif()
+        if(SLANG_RHI_ENABLE_TSAN)
+            list(APPEND SLANG_RHI_SANITIZERS thread)
         endif()
         list(JOIN SLANG_RHI_SANITIZERS "," SLANG_RHI_SANITIZER_FLAGS)
 

--- a/tools/setup-sanitizer-env.py
+++ b/tools/setup-sanitizer-env.py
@@ -66,10 +66,25 @@ def main() -> int:
     parser = argparse.ArgumentParser(description="Configure sanitizer environment variables for CI.")
     parser.add_argument("--config", required=True)
     parser.add_argument("--os", required=True)
+    parser.add_argument("--sanitizer", choices=("asan-ubsan", "tsan"), default="asan-ubsan")
+    parser.add_argument("--build-dir", default="build")
     args = parser.parse_args()
 
     workspace = pathlib.Path(os.environ.get("GITHUB_WORKSPACE", os.getcwd())).resolve()
-    test_working_dir = workspace / "build" / args.config
+    test_working_dir = workspace / args.build_dir / args.config
+
+    if args.sanitizer == "tsan":
+        tsan_options = [
+            "halt_on_error=1",
+            "second_deadlock_stack=1",
+        ]
+        if args.os == "linux":
+            # Vendor GPU runtimes are not TSAN-instrumented, so their internal
+            # synchronization is invisible to the runtime and can produce false positives.
+            tsan_options.append("ignore_noninstrumented_modules=1")
+        append_github_env("TSAN_OPTIONS", ":".join(tsan_options))
+        return 0
+
     asan_suppressions = os.path.relpath(workspace / "tools" / "asan-suppressions.txt", test_working_dir)
 
     symbolizer = find_symbolizer()


### PR DESCRIPTION
Adds ThreadSanitizer support to slang-rhi and exercises it across the supported desktop environments and rendering backends.

- Adds `SLANG_RHI_ENABLE_TSAN` as a Clang-only CMake option.
- Prevents TSAN from being combined with ASAN or UBSAN.
- Extends `tools/setup-sanitizer-env.py` to configure both sanitizer families and custom build directories.
- Adds TSAN CI coverage for:
  - Linux CUDA on the self-hosted GPU runner.
  - Linux Vulkan and WebGPU together under lavapipe.
  - macOS Metal, CPU, and WebGPU.
