### PR TITLE
Fix Vulkan texture copy row alignment

### DIFF
--- a/src/rhi-shared.cpp
+++ b/src/rhi-shared.cpp
@@ -128,7 +128,7 @@ Result calcSubresourceRegionLayout(
 
     size_t rowSize = math::divideRoundedUp(extent.width, formatInfo.blockWidth) * formatInfo.blockSizeInBytes;
     size_t rowCount = math::divideRoundedUp(extent.height, formatInfo.blockHeight);
-    size_t rowPitch = math::calcAligned2(rowSize, rowAlignment);
+    size_t rowPitch = math::calcAligned(rowSize, rowAlignment);
     size_t layerPitch = rowPitch * rowCount;
 
     outLayout->size = extent;

--- a/src/vulkan/vk-device.cpp
+++ b/src/vulkan/vk-device.cpp
@@ -2126,15 +2126,21 @@ Result DeviceImpl::getTextureAllocationInfo(const TextureDesc& desc_, Size* outS
 
 Result DeviceImpl::getTextureRowAlignment(Format format, Size* outAlignment)
 {
+    Size blockSize = getFormatInfo(format).blockSizeInBytes;
+    if (blockSize == 0)
+        blockSize = 1;
+
     switch (format)
     {
     case Format::D16Unorm:
     case Format::D32Float:
     case Format::D32FloatS8Uint:
-        *outAlignment = 4;
+        *outAlignment = math::calcAligned(4, blockSize);
         break;
     default:
-        *outAlignment = 1;
+        // VkBufferImageCopy expresses bufferRowLength in texels, so the byte
+        // row pitch must represent a whole number of format blocks.
+        *outAlignment = blockSize;
         break;
     }
     return SLANG_OK;

--- a/tests/test-cmd-copy-buffer-to-texture.cpp
+++ b/tests/test-cmd-copy-buffer-to-texture.cpp
@@ -3,6 +3,8 @@
 #include "texture-test.h"
 #include "resource-desc-utils.h"
 
+#include <numeric>
+
 using namespace rhi;
 using namespace rhi::testing;
 
@@ -55,8 +57,11 @@ GPU_TEST_CASE("cmd-copy-buffer-to-texture-full", D3D12 | Vulkan | Metal | WGPU |
 
             // Create some new cpu side data we're going to use for the buffer,
             // initialized with random data and a 256B row alignment.
+            Size requiredRowAlignment = 1;
+            REQUIRE_CALL(device->getTextureRowAlignment(data.desc.format, &requiredRowAlignment));
+            Size rowAlignment = std::lcm<Size>(256, requiredRowAlignment);
             TextureData textureData;
-            textureData.init(device, data.desc, TextureInitMode::Random, 123, 256);
+            textureData.init(device, data.desc, TextureInitMode::Random, 123, static_cast<int>(rowAlignment));
 
             // Create a buffer.
             uint64_t totalSize;

--- a/tests/test-cmd-copy-texture-to-buffer.cpp
+++ b/tests/test-cmd-copy-texture-to-buffer.cpp
@@ -3,6 +3,8 @@
 #include "texture-test.h"
 #include "resource-desc-utils.h"
 
+#include <numeric>
+
 using namespace rhi;
 using namespace rhi::testing;
 
@@ -139,7 +141,9 @@ GPU_TEST_CASE("cmd-copy-texture-to-buffer-rowalignment", D3D12 | Vulkan | Metal 
             // Get cpu side data.
             TextureData& data = c->getTextureData();
 
-            uint32_t customAlignment = 512;
+            Size requiredRowAlignment = 1;
+            REQUIRE_CALL(device->getTextureRowAlignment(data.desc.format, &requiredRowAlignment));
+            Size customAlignment = std::lcm<Size>(512, requiredRowAlignment);
 
             // Calculate total size needed for buffer
             // Note: need to ask texture its layout here, to get platform compatible strides
@@ -149,7 +153,7 @@ GPU_TEST_CASE("cmd-copy-texture-to-buffer-rowalignment", D3D12 | Vulkan | Metal 
                 SubresourceLayout textureLayout;
                 REQUIRE_CALL(c->getTexture()->getSubresourceLayout(subresource.mip, &textureLayout));
 
-                textureLayout.rowPitch = math::calcAligned2(textureLayout.rowPitch, customAlignment);
+                textureLayout.rowPitch = math::calcAligned(textureLayout.rowPitch, customAlignment);
                 textureLayout.slicePitch = textureLayout.rowPitch * textureLayout.rowCount;
                 textureLayout.sizeInBytes = textureLayout.slicePitch * textureLayout.size.depth;
 
@@ -177,7 +181,7 @@ GPU_TEST_CASE("cmd-copy-texture-to-buffer-rowalignment", D3D12 | Vulkan | Metal 
                     SubresourceLayout textureLayout;
                     REQUIRE_CALL(c->getTexture()->getSubresourceLayout(mip, &textureLayout));
 
-                    textureLayout.rowPitch = math::calcAligned2(textureLayout.rowPitch, customAlignment);
+                    textureLayout.rowPitch = math::calcAligned(textureLayout.rowPitch, customAlignment);
                     textureLayout.slicePitch = textureLayout.rowPitch * textureLayout.rowCount;
                     textureLayout.sizeInBytes = textureLayout.slicePitch * textureLayout.size.depth;
 
@@ -212,7 +216,7 @@ GPU_TEST_CASE("cmd-copy-texture-to-buffer-rowalignment", D3D12 | Vulkan | Metal 
                     SubresourceLayout textureLayout;
                     REQUIRE_CALL(c->getTexture()->getSubresourceLayout(mip, &textureLayout));
 
-                    textureLayout.rowPitch = math::calcAligned2(textureLayout.rowPitch, customAlignment);
+                    textureLayout.rowPitch = math::calcAligned(textureLayout.rowPitch, customAlignment);
                     textureLayout.slicePitch = textureLayout.rowPitch * textureLayout.rowCount;
                     textureLayout.sizeInBytes = textureLayout.slicePitch * textureLayout.size.depth;
 


### PR DESCRIPTION
VkBufferImageCopy expresses bufferRowLength in texels, so each byte row pitch must represent a whole number of format blocks. Lavapipe exposed this with formats whose blocks are not power-of-two sized, while the existing one-byte Vulkan alignment and calcAligned2 helper could produce invalid layouts.

Report the format block size as Vulkan's row-alignment requirement, use general integer alignment for subresource layouts, and make the copy tests combine their requested padding with the device requirement. This keeps the tests portable across hardware drivers and software Vulkan implementations.