### PR TITLE
vk: include BindingType value in bindAsValue's unsupported-type assert

### DIFF
--- a/src/vulkan/vk-shader-object.cpp
+++ b/src/vulkan/vk-shader-object.cpp
@@ -9,6 +9,8 @@
 
 #include "../state-tracking.h"
 
+#include <string>
+
 namespace rhi::vk {
 
 inline void writeDescriptor(DeviceImpl* device, const VkWriteDescriptorSet& write)
@@ -572,9 +574,11 @@ Result BindingDataBuilder::bindAsValue(
             break;
 
         default:
-            SLANG_RHI_ASSERT_FAILURE("Unsupported binding type");
+        {
+            std::string message = "Unsupported binding type: " + std::to_string((int)bindingRangeInfo.bindingType);
+            SLANG_RHI_ASSERT_FAILURE(message.c_str());
             return SLANG_FAIL;
-            break;
+        }
         }
     }
 


### PR DESCRIPTION
## Motivation

CI core-dump capture in the slang repo (shader-slang/slang#11069) caught an intermittent assert in `BindingDataBuilder::bindAsValue` while binding a `ParameterBlock<ConstantBuffer<T>>` for a compute dispatch (shader-slang/slang#11147). The crash retried successfully, so the parent CI run went green — invisible without core capture.

The backtrace pointed at the `default:` arm of the binding-type switch in `bindAsValue` (`src/vulkan/vk-shader-object.cpp`), which fires when `bindingRangeInfo.bindingType` is a `slang::BindingType` not handled by any of the switch's cases. However, the release build's assert message was just the static string `"Unsupported binding type"` — the actual enum value that reached the `default:` case was never captured, and the associated core artifact has since expired. Without the value, there's no way to tell whether this is a rhi binding-type gap or a Slang reflection issue.

## Proposed solution

Include the numeric `BindingType` value in the assert message so the next occurrence is diagnosable directly from CI logs/artifacts, without needing to attach a debugger or preserve a core dump. This is the cheapest, most direct way to unblock triage — no debugger session or extra CI plumbing needed, and it doesn't require guessing at the root cause (reflection nondeterminism vs. a genuine missing case) before we even know what value shows up.

## Change summary

| File | Change |
|---|---|
| `src/vulkan/vk-shader-object.cpp` | `bindAsValue`'s `default:` case now builds `"Unsupported binding type: <N>"` (N = `(int)bindingRangeInfo.bindingType`) instead of a static string, and passes it to `SLANG_RHI_ASSERT_FAILURE`. |

## Process report

`SLANG_RHI_ASSERT_FAILURE(what)` takes a `const char*` (see `src/core/assert.h`) with no format-string support, so the message is built as a local `std::string` at the call site and passed via `.c_str()` — this matches how `handleAssert` is used elsewhere when a runtime-computed message is needed (e.g. `task-pool.cpp` passing `e.what()`).

This change is scoped to the exact call site reported in shader-slang/slang#11147 (Vulkan `bindAsValue`). The same `"Unsupported binding type"` / `"Unsupported sub-object type"` pattern exists in the equivalent D3D12, Metal, and WGPU shader-object files, and in `vk-shader-object-layout.cpp`'s `addBindingRanges`. Those weren't touched here: the issue report is specific to the Vulkan `bindAsValue` path, and widening the diagnostic to every backend's every default-case assert is a separate, larger cleanup that isn't needed to unblock this particular triage. If the value logged here turns out to indicate a broader gap (e.g. Slang reflection emitting an unexpected `BindingType` under some compile orderings, as hypothesized in the issue triage), the fix for that will be informed by what value we actually observe next time this fires — this PR only adds the missing observability, it doesn't change binding behavior.

Related to shader-slang/slang#11147 — this makes the underlying issue diagnosable; the root cause itself is still open pending a repro with the enum value visible.
