### PR TITLE
Fix: handle PushConstant binding ranges in bindAsValue

### DIFF
--- a/src/vulkan/vk-shader-object.cpp
+++ b/src/vulkan/vk-shader-object.cpp
@@ -449,6 +449,7 @@ Result BindingDataBuilder::bindAsValue(
         case slang::BindingType::ConstantBuffer:
         case slang::BindingType::ParameterBlock:
         case slang::BindingType::ExistentialValue:
+        case slang::BindingType::PushConstant:
             break;
 
         case slang::BindingType::Texture:
@@ -656,7 +657,9 @@ Result BindingDataBuilder::bindAsValue(
             break;
         case slang::BindingType::RawBuffer:
         case slang::BindingType::MutableRawBuffer:
-            // No action needed for sub-objects bound though a `StructuredBuffer`.
+        case slang::BindingType::PushConstant:
+            // No action needed for sub-objects bound though a `StructuredBuffer`
+            // or a push constant.
             break;
         default:
             SLANG_RHI_ASSERT_FAILURE("Unsupported sub-object type");


### PR DESCRIPTION
`bindAsValue` iterates over every binding range of a shader object, and its two switches have no case for `SlangBindingType::PushConstant`. Any shader with a `[vk::push_constant]` parameter therefore falls through to the default branch and trips `SLANG_RHI_ASSERT_FAILURE`, both in the descriptor write loop and in the sub-object loop.

Push constant data is carried in the shader object's uniform data and written via vkCmdPushConstants, so no descriptor work is needed here, the same as ConstantBuffer and ParameterBlock.