### PR TITLE
Share constant buffer pages across command buffers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1067,6 +1067,7 @@ if(SLANG_RHI_BUILD_TESTS AND NOT SLANG_RHI_BUILD_SHARED AND NOT EMSCRIPTEN)
         tests/test-caching-allocator.cpp
         tests/test-command-encoder.cpp
         tests/test-compilation-report.cpp
+        tests/test-constant-buffer-pool.cpp
         tests/test-cmd-clear-buffer.cpp
         tests/test-cmd-clear-texture.cpp
         tests/test-cmd-copy-buffer.cpp

--- a/src/command-buffer.h
+++ b/src/command-buffer.h
@@ -11,6 +11,7 @@
 #include "reference.h"
 #include "command-list.h"
 #include "device-child.h"
+#include "staging-heap.h"
 
 #include "rhi-shared-fwd.h"
 
@@ -52,6 +53,7 @@ public:
 
 public:
     QueueType m_type;
+    StagingHeap m_constantBufferHeap;
 };
 
 class RenderPassEncoder : public IRenderPassEncoder

--- a/src/d3d12/d3d12-command.cpp
+++ b/src/d3d12/d3d12-command.cpp
@@ -1919,7 +1919,8 @@ Result CommandQueueImpl::init(uint32_t queueIndex)
         CreateEventEx(nullptr, nullptr, CREATE_EVENT_INITIAL_SET | CREATE_EVENT_MANUAL_RESET, EVENT_ALL_ACCESS);
 
     StagingHeap::Config constantBufferHeapConfig;
-    constantBufferHeapConfig.pageSize = 4 * 1024 * 1024;
+    constantBufferHeapConfig.pageSize = 64 * 1024;
+    constantBufferHeapConfig.maxPageSize = 4 * 1024 * 1024;
     constantBufferHeapConfig.memoryType = MemoryType::Upload;
     constantBufferHeapConfig.usage = BufferUsage::ConstantBuffer;
     constantBufferHeapConfig.defaultState = ResourceState::ConstantBuffer;

--- a/src/d3d12/d3d12-command.cpp
+++ b/src/d3d12/d3d12-command.cpp
@@ -1917,14 +1917,28 @@ Result CommandQueueImpl::init(uint32_t queueIndex)
     );
     m_globalWaitHandle =
         CreateEventEx(nullptr, nullptr, CREATE_EVENT_INITIAL_SET | CREATE_EVENT_MANUAL_RESET, EVENT_ALL_ACCESS);
+
+    StagingHeap::Config constantBufferHeapConfig;
+    constantBufferHeapConfig.pageSize = 4 * 1024 * 1024;
+    constantBufferHeapConfig.memoryType = MemoryType::Upload;
+    constantBufferHeapConfig.usage = BufferUsage::ConstantBuffer;
+    constantBufferHeapConfig.defaultState = ResourceState::ConstantBuffer;
+    constantBufferHeapConfig.defaultAlignment = D3D12_CONSTANT_BUFFER_DATA_PLACEMENT_ALIGNMENT;
+    constantBufferHeapConfig.allocationGranularity = D3D12_CONSTANT_BUFFER_DATA_PLACEMENT_ALIGNMENT;
+    m_constantBufferHeap.initialize(device, constantBufferHeapConfig);
     return SLANG_OK;
 }
 
 void CommandQueueImpl::shutdown()
 {
     waitOnHost();
+    // A failed device wait may leave command buffers in the in-flight list. Destroy them before
+    // releasing the heap so their allocation handles cannot outlive its pages.
+    m_commandBuffersInFlight.clear();
     // Release all command buffers in order to release all resources they may hold.
     m_commandBuffersPool.clear();
+    // Release the shared constant-buffer pages while deferred deletion is still available.
+    m_constantBufferHeap.release();
     // Execute remaining deferred deletes.
     executeDeferredDeletes();
     SLANG_RHI_ASSERT(m_deferredDeleteQueue.empty());
@@ -2267,7 +2281,7 @@ Result CommandBufferImpl::init()
     };
     m_d3dCommandList->SetDescriptorHeaps(SLANG_COUNT_OF(heaps), heaps);
 
-    m_constantBufferPool.init(device);
+    m_constantBufferPool.init(&m_queue->m_constantBufferHeap);
 
     SLANG_RETURN_ON_FAIL(m_cbvSrvUavArena.init(device->m_gpuCbvSrvUavHeap, 128));
     SLANG_RETURN_ON_FAIL(m_samplerArena.init(device->m_gpuSamplerHeap, 4));

--- a/src/d3d12/d3d12-constant-buffer-pool.cpp
+++ b/src/d3d12/d3d12-constant-buffer-pool.cpp
@@ -19,7 +19,7 @@ Result ConstantBufferPool::allocate(size_t size, Allocation& outAllocation)
 {
     outAllocation = {};
 
-    if (size > m_heap->getPageSize())
+    if (size > m_heap->getMaxPageSize())
     {
         return SLANG_FAIL;
     }

--- a/src/d3d12/d3d12-constant-buffer-pool.cpp
+++ b/src/d3d12/d3d12-constant-buffer-pool.cpp
@@ -1,98 +1,41 @@
 #include "d3d12-constant-buffer-pool.h"
-#include "d3d12-device.h"
 #include "d3d12-buffer.h"
 
 namespace rhi::d3d12 {
 
-inline size_t alignUp(size_t value, size_t alignment)
+void ConstantBufferPool::init(StagingHeap* heap)
 {
-    return (value + alignment - 1) / alignment * alignment;
+    m_heap = heap;
 }
 
-void ConstantBufferPool::init(DeviceImpl* device)
-{
-    m_device = device;
-}
-
-void ConstantBufferPool::finish()
-{
-    for (auto& page : m_pages)
-    {
-        unmapPage(page);
-    }
-}
+void ConstantBufferPool::finish() {}
 
 void ConstantBufferPool::reset()
 {
-    m_currentPage = -1;
-    m_currentOffset = 0;
+    m_allocations.clear();
 }
 
 Result ConstantBufferPool::allocate(size_t size, Allocation& outAllocation)
 {
-    if (size > kPageSize)
+    outAllocation = {};
+
+    if (size > m_heap->getPageSize())
     {
         return SLANG_FAIL;
     }
 
-    if (m_currentPage == -1 || m_currentOffset + size > kPageSize)
-    {
-        m_currentPage += 1;
-        if (m_currentPage >= int(m_pages.size()))
-        {
-            m_pages.push_back(Page());
-            SLANG_RETURN_ON_FAIL(createPage(kPageSize, m_pages.back()));
-        }
-        SLANG_RETURN_ON_FAIL(mapPage(m_pages[m_currentPage]));
-        m_currentOffset = 0;
-    }
+    RefPtr<StagingHeap::Handle> handle;
+    SLANG_RETURN_ON_FAIL(m_heap->allocHandle(size, {}, handle.writeRef()));
 
-    const Page& page = m_pages[m_currentPage];
-    SLANG_RHI_ASSERT(page.mappedData != nullptr);
-    outAllocation.buffer = page.buffer;
-    outAllocation.offset = m_currentOffset;
-    outAllocation.mappedData = page.mappedData + m_currentOffset;
-    m_currentOffset = alignUp(m_currentOffset + size, kAlignment);
-    return SLANG_OK;
-}
+    void* mappedData = nullptr;
+    SLANG_RETURN_ON_FAIL(handle->map(&mappedData));
+    if (!mappedData)
+        return SLANG_FAIL;
 
-Result ConstantBufferPool::createPage(size_t size, Page& outPage)
-{
-    ComPtr<IBuffer> buffer;
-    BufferDesc bufferDesc;
-    bufferDesc.usage = BufferUsage::ConstantBuffer;
-    bufferDesc.defaultState = ResourceState::ConstantBuffer;
-    bufferDesc.memoryType = MemoryType::Upload;
-    bufferDesc.size = size;
-    SLANG_RETURN_ON_FAIL(m_device->createBuffer(bufferDesc, nullptr, buffer.writeRef()));
-
-    outPage.size = size;
-    outPage.buffer = checked_cast<BufferImpl*>(buffer.get());
-    // The buffer is owned by the pool.
-    outPage.buffer->breakStrongReferenceToDevice();
-    return SLANG_OK;
-}
-
-Result ConstantBufferPool::mapPage(Page& page)
-{
-    if (!page.mappedData)
-    {
-        SLANG_RETURN_ON_FAIL(m_device->mapBuffer(page.buffer, CpuAccessMode::Write, (void**)&page.mappedData));
-        if (!page.mappedData)
-        {
-            return SLANG_FAIL;
-        }
-    }
-    return SLANG_OK;
-}
-
-Result ConstantBufferPool::unmapPage(Page& page)
-{
-    if (page.mappedData)
-    {
-        SLANG_RETURN_ON_FAIL(m_device->unmapBuffer(page.buffer));
-        page.mappedData = nullptr;
-    }
+    m_allocations.push_back(handle);
+    outAllocation.buffer = checked_cast<BufferImpl*>(handle->getBuffer());
+    outAllocation.offset = handle->getOffset();
+    outAllocation.mappedData = mappedData;
     return SLANG_OK;
 }
 

--- a/src/d3d12/d3d12-constant-buffer-pool.h
+++ b/src/d3d12/d3d12-constant-buffer-pool.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "d3d12-base.h"
+#include "../staging-heap.h"
 
 #include <vector>
 
@@ -16,33 +17,15 @@ public:
         void* mappedData;
     };
 
-    void init(DeviceImpl* device);
+    void init(StagingHeap* heap);
     void finish();
     void reset();
 
     Result allocate(size_t size, Allocation& outAllocation);
 
 private:
-    static constexpr size_t kAlignment = D3D12_CONSTANT_BUFFER_DATA_PLACEMENT_ALIGNMENT;
-    static constexpr size_t kPageSize = 4 * 1024 * 1024;
-
-    struct Page
-    {
-        RefPtr<BufferImpl> buffer;
-        size_t size = 0;
-        uint8_t* mappedData = nullptr;
-    };
-
-    DeviceImpl* m_device;
-
-    std::vector<Page> m_pages;
-
-    int m_currentPage = -1;
-    size_t m_currentOffset = 0;
-
-    Result createPage(size_t size, Page& outPage);
-    Result mapPage(Page& page);
-    Result unmapPage(Page& page);
+    StagingHeap* m_heap = nullptr;
+    std::vector<RefPtr<StagingHeap::Handle>> m_allocations;
 };
 
 } // namespace rhi::d3d12

--- a/src/staging-heap.cpp
+++ b/src/staging-heap.cpp
@@ -17,10 +17,13 @@ void StagingHeap::initialize(Device* device, const Config& config)
 {
     std::lock_guard<std::mutex> lock(m_mutex);
     SLANG_RHI_ASSERT(config.pageSize > 0);
+    SLANG_RHI_ASSERT(config.maxPageSize == 0 || config.maxPageSize >= config.pageSize);
     SLANG_RHI_ASSERT(config.defaultAlignment > 0);
     SLANG_RHI_ASSERT(config.allocationGranularity > 0);
     m_device = device;
     m_pageSize = config.pageSize;
+    m_maxPageSize = config.maxPageSize == 0 ? config.pageSize : config.maxPageSize;
+    m_nextPageSize = m_pageSize;
     m_memoryType = config.memoryType;
     m_usage = config.usage;
     m_defaultState = config.defaultState;
@@ -109,32 +112,31 @@ Result StagingHeap::allocInternal(
     // so record the thread id to lock pages to.
     auto thread_id = m_keepPagesMapped ? std::thread::id() : std::this_thread::get_id();
 
-    // Attempt to allocate from page if size is less than page size.
-    if (alignedSize < m_pageSize)
+    // Attempt to allocate from an existing page.
+    for (auto& page_pair : m_pages)
     {
-        for (auto& page_pair : m_pages)
+        Page* page = page_pair.second;
+        if (page->getLockedToThread() == std::thread::id() || page->getLockedToThread() == thread_id)
         {
-            Page* page = page_pair.second;
-            if (page->getLockedToThread() == std::thread::id() || page->getLockedToThread() == thread_id)
+            std::list<Node>::iterator node;
+            if (page->allocNode(alignedSize, alignment, metadata, thread_id, node))
             {
-                std::list<Node>::iterator node;
-                if (page->allocNode(alignedSize, alignment, metadata, thread_id, node))
-                {
-                    Allocation res;
-                    res.page = page;
-                    res.node = node;
-                    m_totalUsed += alignedSize;
-                    *outAllocation = res;
-                    return SLANG_OK;
-                }
+                Allocation res;
+                res.page = page;
+                res.node = node;
+                m_totalUsed += alignedSize;
+                *outAllocation = res;
+                return SLANG_OK;
             }
         }
     }
 
-    // Can't fit in existing page, so allocate from new one
-    size_t pageSize = alignedSize < m_pageSize ? m_pageSize : alignedSize;
+    // Can't fit in an existing page, so allocate a geometrically grown page.
+    const Size pageSize = getNewPageSize(alignedSize);
     Page* page;
     SLANG_RETURN_ON_FAIL(allocPage(pageSize, &page));
+    if (pageSize <= m_maxPageSize)
+        m_nextPageSize = growPageSize(pageSize);
     std::list<Node>::iterator node;
     page->allocNode(alignedSize, alignment, metadata, thread_id, node);
 
@@ -233,6 +235,38 @@ void StagingHeap::free(Allocation allocation)
         else
         {
             freePage(page);
+        }
+    }
+
+    updateNextPageSize();
+}
+
+Size StagingHeap::growPageSize(Size size) const
+{
+    if (size >= m_maxPageSize)
+        return m_maxPageSize;
+    return size > m_maxPageSize / 2 ? m_maxPageSize : size * 2;
+}
+
+Size StagingHeap::getNewPageSize(Size allocationSize) const
+{
+    Size pageSize = m_nextPageSize;
+    while (pageSize < allocationSize && pageSize < m_maxPageSize)
+        pageSize = growPageSize(pageSize);
+    return pageSize < allocationSize ? allocationSize : pageSize;
+}
+
+void StagingHeap::updateNextPageSize()
+{
+    m_nextPageSize = m_pageSize;
+    for (const auto& [_, page] : m_pages)
+    {
+        const Size pageSize = page->getCapacity();
+        if (pageSize >= m_pageSize && pageSize <= m_maxPageSize)
+        {
+            const Size nextPageSize = growPageSize(pageSize);
+            if (nextPageSize > m_nextPageSize)
+                m_nextPageSize = nextPageSize;
         }
     }
 }

--- a/src/staging-heap.cpp
+++ b/src/staging-heap.cpp
@@ -7,10 +7,25 @@ namespace rhi {
 
 void StagingHeap::initialize(Device* device, Size pageSize, MemoryType memoryType)
 {
+    Config config;
+    config.pageSize = pageSize;
+    config.memoryType = memoryType;
+    initialize(device, config);
+}
+
+void StagingHeap::initialize(Device* device, const Config& config)
+{
     std::lock_guard<std::mutex> lock(m_mutex);
+    SLANG_RHI_ASSERT(config.pageSize > 0);
+    SLANG_RHI_ASSERT(config.defaultAlignment > 0);
+    SLANG_RHI_ASSERT(config.allocationGranularity > 0);
     m_device = device;
-    m_pageSize = pageSize;
-    m_memoryType = memoryType;
+    m_pageSize = config.pageSize;
+    m_memoryType = config.memoryType;
+    m_usage = config.usage;
+    m_defaultState = config.defaultState;
+    m_defaultAlignment = config.defaultAlignment;
+    m_allocationGranularity = config.allocationGranularity;
 
     // Can safely keep pages mapped for all platforms other than WebGPU and Metal.
     // On WebGPU, mapped buffers cannot be used during dispatches.
@@ -36,10 +51,12 @@ void StagingHeap::releaseAllFreePages()
 void StagingHeap::release()
 {
     std::lock_guard<std::mutex> lock(m_mutex);
-    releaseAllFreePages();
     SLANG_RHI_ASSERT(m_totalUsed == 0);
+    if (m_totalUsed != 0)
+        return;
+
+    releaseAllFreePages();
     SLANG_RHI_ASSERT(m_pages.size() == 0);
-    m_pages.clear();
 }
 
 Result StagingHeap::allocHandle(size_t size, MetaData metadata, StagingHeap::Handle** outHandle)
@@ -226,27 +243,31 @@ Result StagingHeap::allocPage(size_t size, StagingHeap::Page** outPage)
 
     ComPtr<IBuffer> bufferPtr;
     BufferDesc bufferDesc;
-    bufferDesc.usage = BufferUsage::CopyDestination | BufferUsage::CopySource;
-    bufferDesc.defaultState = ResourceState::General;
+    bufferDesc.usage = m_usage;
+    bufferDesc.defaultState = m_defaultState;
     bufferDesc.memoryType = m_memoryType;
     bufferDesc.size = size;
 
     // Attempt to create buffer.
     SLANG_RETURN_ON_FAIL(m_device->createBuffer(bufferDesc, nullptr, bufferPtr.writeRef()));
 
-    // Create page and store buffer pointer.
-    StagingHeap::Page* page = new Page(m_nextPageId++, checked_cast<Buffer*>(bufferPtr.get()));
-    m_pages.insert({page->getId(), page});
-    m_totalCapacity += size;
-
-    // Break references to device as buffer is owned by heap, which is owned by device.
-    page->getBuffer()->breakStrongReferenceToDevice();
+    // Fully initialize the page before publishing it to the heap. If mapping fails, the local
+    // page and buffer are released without leaving an unusable entry in m_pages.
+    RefPtr<StagingHeap::Page> page = new Page(m_nextPageId, checked_cast<Buffer*>(bufferPtr.get()));
 
     // If always mapped, map page now
     if (m_keepPagesMapped)
         SLANG_RETURN_ON_FAIL(page->map(m_device));
 
-    *outPage = page;
+    // Break references to device as the buffer is now owned by the heap, which is device-owned
+    // either directly or through a command queue.
+    page->getBuffer()->breakStrongReferenceToDevice();
+
+    m_nextPageId++;
+    m_pageAllocationCount++;
+    m_totalCapacity += size;
+    m_pages.insert({page->getId(), page});
+    *outPage = page.get();
     return SLANG_OK;
 }
 

--- a/src/staging-heap.h
+++ b/src/staging-heap.h
@@ -19,7 +19,10 @@ class StagingHeap : public RefObject
 public:
     struct Config
     {
+        // Initial and minimum retained page size.
         Size pageSize = 16 * 1024 * 1024;
+        // Maximum geometrically grown page size. Zero disables growth.
+        Size maxPageSize = 0;
         MemoryType memoryType = MemoryType::Upload;
         BufferUsage usage = BufferUsage::CopyDestination | BufferUsage::CopySource;
         ResourceState defaultState = ResourceState::General;
@@ -216,8 +219,11 @@ public:
     // Get the granularity used to round allocation sizes.
     Size getAllocationGranularity() const { return m_allocationGranularity; }
 
-    // Get default page size.
+    // Get initial and minimum retained page size.
     Size getPageSize() const { return m_pageSize; }
+
+    // Get maximum geometrically grown page size.
+    Size getMaxPageSize() const { return m_maxPageSize; }
 
     // Round a size up to the heap's allocation granularity.
     Size alignAllocationSize(Size value)
@@ -242,6 +248,8 @@ private:
     Size m_defaultAlignment = 1024;
     Size m_allocationGranularity = 1024;
     Size m_pageSize = 16 * 1024 * 1024;
+    Size m_maxPageSize = 16 * 1024 * 1024;
+    Size m_nextPageSize = 16 * 1024 * 1024;
     uint64_t m_pageAllocationCount = 0;
     bool m_keepPagesMapped = true;
     std::unordered_map<int, RefPtr<Page>> m_pages;
@@ -255,6 +263,12 @@ private:
     Result allocInternal(size_t size, Size alignment, MetaData metadata, Allocation* outAllocation);
 
     Result allocPage(size_t size, StagingHeap::Page** outPage);
+
+    Size growPageSize(Size size) const;
+
+    Size getNewPageSize(Size allocationSize) const;
+
+    void updateNextPageSize();
 
     void freePage(StagingHeap::Page* page);
 

--- a/src/staging-heap.h
+++ b/src/staging-heap.h
@@ -17,6 +17,16 @@ namespace rhi {
 class StagingHeap : public RefObject
 {
 public:
+    struct Config
+    {
+        Size pageSize = 16 * 1024 * 1024;
+        MemoryType memoryType = MemoryType::Upload;
+        BufferUsage usage = BufferUsage::CopyDestination | BufferUsage::CopySource;
+        ResourceState defaultState = ResourceState::General;
+        Size defaultAlignment = 1024;
+        Size allocationGranularity = 1024;
+    };
+
     // Arbitrary meta data that sits within heap node to store extra info about allocation.
     struct MetaData
     {
@@ -132,6 +142,9 @@ public:
     // Initialize with device pointer.
     void initialize(Device* device, Size pageSize, MemoryType memoryType);
 
+    // Initialize with device pointer and explicit page buffer properties.
+    void initialize(Device* device, const Config& config);
+
     // Attempt to cleanup and check no allocations remain
     void release();
 
@@ -190,6 +203,13 @@ public:
         return m_totalUsed;
     }
 
+    // Get the total number of physical pages allocated over the heap's lifetime.
+    uint64_t getPageAllocationCount() const
+    {
+        std::lock_guard<std::mutex> lock(m_mutex);
+        return m_pageAllocationCount;
+    }
+
     // Get the default offset alignment of heap allocations.
     Size getDefaultAlignment() const { return m_defaultAlignment; }
 
@@ -222,9 +242,12 @@ private:
     Size m_defaultAlignment = 1024;
     Size m_allocationGranularity = 1024;
     Size m_pageSize = 16 * 1024 * 1024;
+    uint64_t m_pageAllocationCount = 0;
     bool m_keepPagesMapped = true;
     std::unordered_map<int, RefPtr<Page>> m_pages;
-    MemoryType m_memoryType;
+    MemoryType m_memoryType = MemoryType::Upload;
+    BufferUsage m_usage = BufferUsage::CopyDestination | BufferUsage::CopySource;
+    ResourceState m_defaultState = ResourceState::General;
     mutable std::mutex m_mutex;
 
     Result allocHandleInternal(size_t size, Size alignment, MetaData metadata, Handle** outHandle);

--- a/src/vulkan/vk-command.cpp
+++ b/src/vulkan/vk-command.cpp
@@ -1864,6 +1864,17 @@ void CommandQueueImpl::init(VkQueue queue, uint32_t queueFamilyIndex)
     m_queue = queue;
     m_queueFamilyIndex = queueFamilyIndex;
 
+    DeviceImpl* device = getDevice<DeviceImpl>();
+    const Size constantBufferAlignment = m_api.m_deviceProperties.limits.minUniformBufferOffsetAlignment;
+    StagingHeap::Config constantBufferHeapConfig;
+    constantBufferHeapConfig.pageSize = 4 * 1024 * 1024;
+    constantBufferHeapConfig.memoryType = MemoryType::Upload;
+    constantBufferHeapConfig.usage = BufferUsage::ConstantBuffer;
+    constantBufferHeapConfig.defaultState = ResourceState::ConstantBuffer;
+    constantBufferHeapConfig.defaultAlignment = constantBufferAlignment;
+    constantBufferHeapConfig.allocationGranularity = constantBufferAlignment;
+    m_constantBufferHeap.initialize(device, constantBufferHeapConfig);
+
     {
         VkSemaphoreTypeCreateInfo timelineCreateInfo = {VK_STRUCTURE_TYPE_SEMAPHORE_TYPE_CREATE_INFO};
         timelineCreateInfo.semaphoreType = VK_SEMAPHORE_TYPE_TIMELINE;
@@ -1876,8 +1887,13 @@ void CommandQueueImpl::init(VkQueue queue, uint32_t queueFamilyIndex)
 void CommandQueueImpl::shutdown()
 {
     waitOnHost();
+    // A failed device wait may leave command buffers in the in-flight list. Destroy them before
+    // releasing the heap so their allocation handles cannot outlive its pages.
+    m_commandBuffersInFlight.clear();
     // Release all command buffers in order to release all resources they may hold.
     m_commandBuffersPool.clear();
+    // Release the shared constant-buffer pages while deferred deletion is still available.
+    m_constantBufferHeap.release();
     // Execute remaining deferred deletes.
     executeDeferredDeletes();
     SLANG_RHI_ASSERT(m_deferredDeleteQueue.empty());
@@ -2242,7 +2258,7 @@ CommandBufferImpl::~CommandBufferImpl()
 Result CommandBufferImpl::init()
 {
     DeviceImpl* device = getDevice<DeviceImpl>();
-    m_constantBufferPool.init(device);
+    m_constantBufferPool.init(&m_queue->m_constantBufferHeap);
     m_descriptorSetAllocator.init(&device->m_api);
 
     VkCommandPoolCreateInfo createInfo = {VK_STRUCTURE_TYPE_COMMAND_POOL_CREATE_INFO};

--- a/src/vulkan/vk-command.cpp
+++ b/src/vulkan/vk-command.cpp
@@ -1867,7 +1867,8 @@ void CommandQueueImpl::init(VkQueue queue, uint32_t queueFamilyIndex)
     DeviceImpl* device = getDevice<DeviceImpl>();
     const Size constantBufferAlignment = m_api.m_deviceProperties.limits.minUniformBufferOffsetAlignment;
     StagingHeap::Config constantBufferHeapConfig;
-    constantBufferHeapConfig.pageSize = 4 * 1024 * 1024;
+    constantBufferHeapConfig.pageSize = 64 * 1024;
+    constantBufferHeapConfig.maxPageSize = 4 * 1024 * 1024;
     constantBufferHeapConfig.memoryType = MemoryType::Upload;
     constantBufferHeapConfig.usage = BufferUsage::ConstantBuffer;
     constantBufferHeapConfig.defaultState = ResourceState::ConstantBuffer;

--- a/src/vulkan/vk-constant-buffer-pool.cpp
+++ b/src/vulkan/vk-constant-buffer-pool.cpp
@@ -19,7 +19,7 @@ Result ConstantBufferPool::allocate(size_t size, Allocation& outAllocation)
 {
     outAllocation = {};
 
-    if (size > m_heap->getPageSize())
+    if (size > m_heap->getMaxPageSize())
     {
         return SLANG_FAIL;
     }

--- a/src/vulkan/vk-constant-buffer-pool.cpp
+++ b/src/vulkan/vk-constant-buffer-pool.cpp
@@ -1,99 +1,41 @@
 #include "vk-constant-buffer-pool.h"
-#include "vk-device.h"
 #include "vk-buffer.h"
 
 namespace rhi::vk {
 
-inline size_t alignUp(size_t value, size_t alignment)
+void ConstantBufferPool::init(StagingHeap* heap)
 {
-    return (value + alignment - 1) / alignment * alignment;
+    m_heap = heap;
 }
 
-void ConstantBufferPool::init(DeviceImpl* device)
-{
-    m_device = device;
-    m_alignment = device->m_api.m_deviceProperties.limits.minUniformBufferOffsetAlignment;
-}
-
-void ConstantBufferPool::finish()
-{
-    for (auto& page : m_pages)
-    {
-        unmapPage(page);
-    }
-}
+void ConstantBufferPool::finish() {}
 
 void ConstantBufferPool::reset()
 {
-    m_currentPage = -1;
-    m_currentOffset = 0;
+    m_allocations.clear();
 }
 
 Result ConstantBufferPool::allocate(size_t size, Allocation& outAllocation)
 {
-    if (size > kPageSize)
+    outAllocation = {};
+
+    if (size > m_heap->getPageSize())
     {
         return SLANG_FAIL;
     }
 
-    if (m_currentPage == -1 || m_currentOffset + size > kPageSize)
-    {
-        m_currentPage += 1;
-        if (m_currentPage >= int(m_pages.size()))
-        {
-            m_pages.push_back(Page());
-            SLANG_RETURN_ON_FAIL(createPage(kPageSize, m_pages.back()));
-        }
-        SLANG_RETURN_ON_FAIL(mapPage(m_pages[m_currentPage]));
-        m_currentOffset = 0;
-    }
+    RefPtr<StagingHeap::Handle> handle;
+    SLANG_RETURN_ON_FAIL(m_heap->allocHandle(size, {}, handle.writeRef()));
 
-    const Page& page = m_pages[m_currentPage];
-    SLANG_RHI_ASSERT(page.mappedData != nullptr);
-    outAllocation.buffer = page.buffer;
-    outAllocation.offset = m_currentOffset;
-    outAllocation.mappedData = page.mappedData + m_currentOffset;
-    m_currentOffset = alignUp(m_currentOffset + size, m_alignment);
-    return SLANG_OK;
-}
+    void* mappedData = nullptr;
+    SLANG_RETURN_ON_FAIL(handle->map(&mappedData));
+    if (!mappedData)
+        return SLANG_FAIL;
 
-Result ConstantBufferPool::createPage(size_t size, Page& outPage)
-{
-    ComPtr<IBuffer> buffer;
-    BufferDesc bufferDesc;
-    bufferDesc.usage = BufferUsage::ConstantBuffer;
-    bufferDesc.defaultState = ResourceState::ConstantBuffer;
-    bufferDesc.memoryType = MemoryType::Upload;
-    bufferDesc.size = size;
-    SLANG_RETURN_ON_FAIL(m_device->createBuffer(bufferDesc, nullptr, buffer.writeRef()));
-
-    outPage.size = size;
-    outPage.buffer = checked_cast<BufferImpl*>(buffer.get());
-    // The buffer is owned by the pool.
-    outPage.buffer->breakStrongReferenceToDevice();
-    return SLANG_OK;
-}
-
-Result ConstantBufferPool::mapPage(Page& page)
-{
-    if (!page.mappedData)
-    {
-        SLANG_RETURN_ON_FAIL(m_device->mapBuffer(page.buffer, CpuAccessMode::Write, (void**)&page.mappedData));
-        if (!page.mappedData)
-        {
-            return SLANG_FAIL;
-        }
-    }
-    return SLANG_OK;
-}
-
-Result ConstantBufferPool::unmapPage(Page& page)
-{
-    if (page.mappedData)
-    {
-        SLANG_RETURN_ON_FAIL(m_device->unmapBuffer(page.buffer));
-        page.mappedData = nullptr;
-    }
+    m_allocations.push_back(handle);
+    outAllocation.buffer = checked_cast<BufferImpl*>(handle->getBuffer());
+    outAllocation.offset = handle->getOffset();
+    outAllocation.mappedData = mappedData;
     return SLANG_OK;
 }
 

--- a/src/vulkan/vk-constant-buffer-pool.h
+++ b/src/vulkan/vk-constant-buffer-pool.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "vk-base.h"
+#include "../staging-heap.h"
 
 #include <vector>
 
@@ -16,33 +17,15 @@ public:
         void* mappedData;
     };
 
-    void init(DeviceImpl* device);
+    void init(StagingHeap* heap);
     void finish();
     void reset();
 
     Result allocate(size_t size, Allocation& outAllocation);
 
 private:
-    static constexpr size_t kPageSize = 4 * 1024 * 1024;
-
-    struct Page
-    {
-        RefPtr<BufferImpl> buffer;
-        size_t size = 0;
-        uint8_t* mappedData = nullptr;
-    };
-
-    DeviceImpl* m_device;
-    uint32_t m_alignment;
-
-    std::vector<Page> m_pages;
-
-    int m_currentPage = -1;
-    size_t m_currentOffset = 0;
-
-    Result createPage(size_t size, Page& outPage);
-    Result mapPage(Page& page);
-    Result unmapPage(Page& page);
+    StagingHeap* m_heap = nullptr;
+    std::vector<RefPtr<StagingHeap::Handle>> m_allocations;
 };
 
 } // namespace rhi::vk

--- a/tests/test-constant-buffer-pool.cpp
+++ b/tests/test-constant-buffer-pool.cpp
@@ -1,0 +1,157 @@
+#include "testing.h"
+
+#include "../src/command-buffer.h"
+#include "../src/device.h"
+
+#include <vector>
+
+using namespace rhi;
+using namespace rhi::testing;
+
+GPU_TEST_CASE("constant-buffer-pool-shared-pages", D3D12 | Vulkan | DontCacheDevice)
+{
+    static constexpr uint32_t kSubmissionCount = 64;
+    static constexpr uint32_t kWaveCount = 2;
+    static constexpr uint32_t kValueCount = kSubmissionCount * kWaveCount;
+
+    ComPtr<IShaderProgram> shaderProgram;
+    REQUIRE_CALL(loadComputeProgramFromSource(
+        device,
+        R"(
+            uniform RWStructuredBuffer<uint> output;
+            uniform uint index;
+            uniform uint value;
+
+            [shader("compute")]
+            [numthreads(1, 1, 1)]
+            void computeMain()
+            {
+                output[index] = value;
+            }
+        )",
+        shaderProgram.writeRef()
+    ));
+
+    ComputePipelineDesc pipelineDesc = {};
+    pipelineDesc.program = shaderProgram;
+    ComPtr<IComputePipeline> pipeline;
+    REQUIRE_CALL(device->createComputePipeline(pipelineDesc, pipeline.writeRef()));
+
+    std::vector<uint32_t> initialData(kValueCount, 0);
+    BufferDesc bufferDesc = {};
+    bufferDesc.size = initialData.size() * sizeof(uint32_t);
+    bufferDesc.elementSize = sizeof(uint32_t);
+    bufferDesc.usage =
+        BufferUsage::UnorderedAccess | BufferUsage::CopyDestination | BufferUsage::CopySource;
+    bufferDesc.defaultState = ResourceState::UnorderedAccess;
+    bufferDesc.memoryType = MemoryType::DeviceLocal;
+
+    ComPtr<IBuffer> output;
+    REQUIRE_CALL(device->createBuffer(bufferDesc, initialData.data(), output.writeRef()));
+
+    // Use the public queue for the workload so the debug layer remains active.
+    ComPtr<ICommandQueue> queue;
+    REQUIRE_CALL(device->getQueue(QueueType::Graphics, queue.writeRef()));
+
+    // Reach through the debug layer only to inspect the internal heap statistics.
+    ComPtr<ICommandQueue> innerQueue;
+    REQUIRE_CALL(getUnderlyingDevice(device)->getQueue(QueueType::Graphics, innerQueue.writeRef()));
+    StagingHeap& heap = checked_cast<CommandQueue*>(innerQueue.get())->m_constantBufferHeap;
+
+    FenceDesc fenceDesc = {};
+    ComPtr<IFence> submissionGate;
+    REQUIRE_CALL(device->createFence(fenceDesc, submissionGate.writeRef()));
+
+    CHECK_EQ(heap.getNumPages(), 0);
+    CHECK_EQ(heap.getCapacity(), 0);
+    CHECK_EQ(heap.getUsed(), 0);
+    CHECK_EQ(heap.getPageAllocationCount(), 0);
+
+    uint64_t firstWavePageAllocationCount = 0;
+
+    for (uint32_t wave = 0; wave < kWaveCount; ++wave)
+    {
+        std::vector<ComPtr<ICommandBuffer>> commandBuffers;
+        commandBuffers.reserve(kSubmissionCount);
+
+        // Record the complete wave before submitting anything. This guarantees that all
+        // constant-buffer allocations are live together, independent of GPU execution speed.
+        for (uint32_t i = 0; i < kSubmissionCount; ++i)
+        {
+            const uint32_t index = wave * kSubmissionCount + i;
+            const uint32_t value = index + 1;
+
+            ComPtr<ICommandEncoder> commandEncoder = queue->createCommandEncoder();
+            REQUIRE(commandEncoder);
+
+            IComputePassEncoder* passEncoder = commandEncoder->beginComputePass();
+            REQUIRE(passEncoder);
+
+            IShaderObject* rootObject = passEncoder->bindPipeline(pipeline);
+            REQUIRE(rootObject);
+
+            ShaderCursor cursor(rootObject);
+            REQUIRE_CALL(cursor["output"].setBinding(output));
+            REQUIRE_CALL(cursor["index"].setData(index));
+            REQUIRE_CALL(cursor["value"].setData(value));
+
+            passEncoder->dispatchCompute(1, 1, 1);
+            passEncoder->end();
+
+            ComPtr<ICommandBuffer> commandBuffer = commandEncoder->finish();
+            REQUIRE(commandBuffer);
+            commandBuffers.push_back(commandBuffer);
+        }
+
+        // Tiny allocations from every command buffer should share one physical page.
+        CHECK_EQ(heap.getNumPages(), 1);
+        CHECK_EQ(heap.getCapacity(), heap.getPageSize());
+        CHECK_GT(heap.getUsed(), 0);
+
+        const uint64_t pageAllocationCount = heap.getPageAllocationCount();
+        if (wave == 0)
+        {
+            CHECK_EQ(pageAllocationCount, 1);
+            firstWavePageAllocationCount = pageAllocationCount;
+        }
+        else
+        {
+            // The empty page retained after the first wave must be reused.
+            CHECK_EQ(pageAllocationCount, firstWavePageAllocationCount);
+        }
+
+        // Hold the queue's tracking signal behind an unsignaled fence. This makes the
+        // fence-scoped allocation lifetime deterministic even when the GPU finishes quickly.
+        const uint64_t submissionGateValue = wave + 1;
+        for (size_t i = 0; i < commandBuffers.size(); ++i)
+        {
+            ICommandBuffer* commandBuffer = commandBuffers[i].get();
+            IFence* waitFence = submissionGate.get();
+            SubmitDesc submitDesc = {};
+            submitDesc.commandBuffers = &commandBuffer;
+            submitDesc.commandBufferCount = 1;
+            submitDesc.waitFences = &waitFence;
+            submitDesc.waitFenceValues = &submissionGateValue;
+            submitDesc.waitFenceCount = 1;
+            REQUIRE_CALL(queue->submit(submitDesc));
+        }
+
+        // Every submitted command buffer must still own its range until the fence can retire it.
+        CHECK_GT(heap.getUsed(), 0);
+        REQUIRE_CALL(submissionGate->setCurrentValue(submissionGateValue));
+
+        REQUIRE_CALL(queue->waitOnHost());
+        commandBuffers.clear();
+
+        // Retirement returns every range while keeping one warm physical page.
+        CHECK_EQ(heap.getUsed(), 0);
+        CHECK_EQ(heap.getNumPages(), 1);
+        CHECK_EQ(heap.getCapacity(), heap.getPageSize());
+        CHECK_EQ(heap.getPageAllocationCount(), firstWavePageAllocationCount);
+    }
+
+    std::vector<uint32_t> expected(kValueCount);
+    for (uint32_t i = 0; i < kValueCount; ++i)
+        expected[i] = i + 1;
+    compareComputeResult(device, output, std::span<uint32_t>(expected));
+}

--- a/tests/test-constant-buffer-pool.cpp
+++ b/tests/test-constant-buffer-pool.cpp
@@ -3,6 +3,7 @@
 #include "../src/command-buffer.h"
 #include "../src/device.h"
 
+#include <array>
 #include <vector>
 
 using namespace rhi;
@@ -21,12 +22,13 @@ GPU_TEST_CASE("constant-buffer-pool-shared-pages", D3D12 | Vulkan | DontCacheDev
             uniform RWStructuredBuffer<uint> output;
             uniform uint index;
             uniform uint value;
+            uniform uint4 padding[64];
 
             [shader("compute")]
             [numthreads(1, 1, 1)]
             void computeMain()
             {
-                output[index] = value;
+                output[index] = value + padding[0].x;
             }
         )",
         shaderProgram.writeRef()
@@ -41,8 +43,7 @@ GPU_TEST_CASE("constant-buffer-pool-shared-pages", D3D12 | Vulkan | DontCacheDev
     BufferDesc bufferDesc = {};
     bufferDesc.size = initialData.size() * sizeof(uint32_t);
     bufferDesc.elementSize = sizeof(uint32_t);
-    bufferDesc.usage =
-        BufferUsage::UnorderedAccess | BufferUsage::CopyDestination | BufferUsage::CopySource;
+    bufferDesc.usage = BufferUsage::UnorderedAccess | BufferUsage::CopyDestination | BufferUsage::CopySource;
     bufferDesc.defaultState = ResourceState::UnorderedAccess;
     bufferDesc.memoryType = MemoryType::DeviceLocal;
 
@@ -66,8 +67,11 @@ GPU_TEST_CASE("constant-buffer-pool-shared-pages", D3D12 | Vulkan | DontCacheDev
     CHECK_EQ(heap.getCapacity(), 0);
     CHECK_EQ(heap.getUsed(), 0);
     CHECK_EQ(heap.getPageAllocationCount(), 0);
+    CHECK_EQ(heap.getPageSize(), 64 * 1024);
+    CHECK_EQ(heap.getMaxPageSize(), 4 * 1024 * 1024);
 
     uint64_t firstWavePageAllocationCount = 0;
+    const std::array<uint32_t, 256> padding = {};
 
     for (uint32_t wave = 0; wave < kWaveCount; ++wave)
     {
@@ -94,6 +98,7 @@ GPU_TEST_CASE("constant-buffer-pool-shared-pages", D3D12 | Vulkan | DontCacheDev
             REQUIRE_CALL(cursor["output"].setBinding(output));
             REQUIRE_CALL(cursor["index"].setData(index));
             REQUIRE_CALL(cursor["value"].setData(value));
+            REQUIRE_CALL(cursor["padding"].setData(padding.data(), padding.size() * sizeof(uint32_t)));
 
             passEncoder->dispatchCompute(1, 1, 1);
             passEncoder->end();
@@ -103,21 +108,21 @@ GPU_TEST_CASE("constant-buffer-pool-shared-pages", D3D12 | Vulkan | DontCacheDev
             commandBuffers.push_back(commandBuffer);
         }
 
-        // Tiny allocations from every command buffer should share one physical page.
-        CHECK_EQ(heap.getNumPages(), 1);
-        CHECK_EQ(heap.getCapacity(), heap.getPageSize());
-        CHECK_GT(heap.getUsed(), 0);
+        // The shared heap should grow from 64 KiB to 128 KiB for this wave.
+        CHECK_EQ(heap.getNumPages(), 2);
+        CHECK_EQ(heap.getCapacity(), heap.getPageSize() * 3);
+        CHECK_GT(heap.getUsed(), heap.getPageSize());
 
         const uint64_t pageAllocationCount = heap.getPageAllocationCount();
         if (wave == 0)
         {
-            CHECK_EQ(pageAllocationCount, 1);
+            CHECK_EQ(pageAllocationCount, 2);
             firstWavePageAllocationCount = pageAllocationCount;
         }
         else
         {
-            // The empty page retained after the first wave must be reused.
-            CHECK_EQ(pageAllocationCount, firstWavePageAllocationCount);
+            // The initial page is reused and one 128 KiB page is regrown for the new wave.
+            CHECK_EQ(pageAllocationCount, firstWavePageAllocationCount + 1);
         }
 
         // Hold the queue's tracking signal behind an unsignaled fence. This makes the
@@ -143,11 +148,11 @@ GPU_TEST_CASE("constant-buffer-pool-shared-pages", D3D12 | Vulkan | DontCacheDev
         REQUIRE_CALL(queue->waitOnHost());
         commandBuffers.clear();
 
-        // Retirement returns every range while keeping one warm physical page.
+        // Retirement trims the grown page and keeps one warm 64 KiB page.
         CHECK_EQ(heap.getUsed(), 0);
         CHECK_EQ(heap.getNumPages(), 1);
         CHECK_EQ(heap.getCapacity(), heap.getPageSize());
-        CHECK_EQ(heap.getPageAllocationCount(), firstWavePageAllocationCount);
+        CHECK_EQ(heap.getPageAllocationCount(), pageAllocationCount);
     }
 
     std::vector<uint32_t> expected(kValueCount);

--- a/tests/test-staging-heap.cpp
+++ b/tests/test-staging-heap.cpp
@@ -105,6 +105,72 @@ GPU_TEST_CASE("staging-heap-large-page", ALL)
     heap.release();
 }
 
+GPU_TEST_CASE("staging-heap-growing-pages", ALL)
+{
+    static constexpr Size kInitialPageSize = 64 * 1024;
+    static constexpr Size kMaxPageSize = 256 * 1024;
+
+    StagingHeap::Config config;
+    config.pageSize = kInitialPageSize;
+    config.maxPageSize = kMaxPageSize;
+
+    StagingHeap heap;
+    heap.initialize(getUnderlyingDevice(device.get()), config);
+
+    CHECK_EQ(heap.getPageSize(), kInitialPageSize);
+    CHECK_EQ(heap.getMaxPageSize(), kMaxPageSize);
+
+    StagingHeap::Allocation initialPageAllocation;
+    REQUIRE_CALL(heap.alloc(kInitialPageSize, {}, &initialPageAllocation));
+    CHECK_EQ(initialPageAllocation.getPage()->getCapacity(), kInitialPageSize);
+    const int initialPageId = initialPageAllocation.getPageId();
+
+    StagingHeap::Allocation grownPageAllocation;
+    REQUIRE_CALL(heap.alloc(kInitialPageSize * 2, {}, &grownPageAllocation));
+    CHECK_EQ(grownPageAllocation.getPage()->getCapacity(), kInitialPageSize * 2);
+
+    StagingHeap::Allocation maxPageAllocation;
+    REQUIRE_CALL(heap.alloc(kMaxPageSize, {}, &maxPageAllocation));
+    CHECK_EQ(maxPageAllocation.getPage()->getCapacity(), kMaxPageSize);
+    heap.checkConsistency();
+
+    CHECK_EQ(heap.getNumPages(), 3);
+    CHECK_EQ(heap.getCapacity(), kInitialPageSize + kInitialPageSize * 2 + kMaxPageSize);
+    CHECK_EQ(heap.getPageAllocationCount(), 3);
+
+    // Dropping the grown pages lowers the next growth tier immediately, even while
+    // the initial page is still in use.
+    heap.free(grownPageAllocation);
+    heap.free(maxPageAllocation);
+    heap.checkConsistency();
+
+    CHECK_EQ(heap.getUsed(), kInitialPageSize);
+    CHECK_EQ(heap.getNumPages(), 1);
+    CHECK_EQ(heap.getCapacity(), kInitialPageSize);
+
+    StagingHeap::Allocation regrownPageAllocation;
+    REQUIRE_CALL(heap.alloc(kInitialPageSize * 2, {}, &regrownPageAllocation));
+    CHECK_EQ(regrownPageAllocation.getPage()->getCapacity(), kInitialPageSize * 2);
+    CHECK_EQ(heap.getPageAllocationCount(), 4);
+    heap.checkConsistency();
+
+    heap.free(regrownPageAllocation);
+    heap.free(initialPageAllocation);
+    heap.checkConsistency();
+
+    // The heap returns to one initial-size page when idle.
+    CHECK_EQ(heap.getUsed(), 0);
+    CHECK_EQ(heap.getNumPages(), 1);
+    CHECK_EQ(heap.getCapacity(), kInitialPageSize);
+
+    StagingHeap::Allocation reusedInitialPageAllocation;
+    REQUIRE_CALL(heap.alloc(kInitialPageSize, {}, &reusedInitialPageAllocation));
+    CHECK_EQ(reusedInitialPageAllocation.getPage()->getId(), initialPageId);
+    CHECK_EQ(heap.getPageAllocationCount(), 4);
+    heap.free(reusedInitialPageAllocation);
+    heap.release();
+}
+
 GPU_TEST_CASE("staging-heap-realloc", ALL)
 {
     StagingHeap heap;


### PR DESCRIPTION
## Summary

- Replace the private 4 MiB D3D12/Vulkan constant-buffer page in every command buffer with a queue-owned shared `StagingHeap`.
- Start shared constant-buffer pages at 64 KiB and grow geometrically up to 4 MiB only when recorded uniform-data demand requires it.
- Keep suballocation handles on each command buffer until its submission fence retires, so ranges cannot be reused while the GPU may still read them.
- Release empty grown pages immediately and retain at most one warm 64 KiB page for reuse.
- Add native allocator and D3D12/Vulkan regressions covering page growth, trimming, fence-scoped lifetime, page reuse, and GPU result validation.

## Validation

- GCC Debug library/test build on Linux.
- Focused Vulkan regressions: 2 test cases and 1,343 assertions passed.
- All Vulkan staging-heap tests: 11 test cases and 113 assertions passed.
- Broader Vulkan suite with environment-dependent `surface-*` tests excluded: 864 test cases and 75,138,985 assertions passed.
- MSVC Debug `slang-rhi-tests` build on Windows 10 / D3D12 (`192.168.0.96`).
- D3D12 page-growth test: 26 assertions passed.
- D3D12 fence/retirement integration test: 1,318 assertions passed.
- `pre-commit run --all-files` passed.

Fixes #844
