### PR TITLE
Add cache key to compilation reports

### DIFF
--- a/include/slang-rhi.h
+++ b/include/slang-rhi.h
@@ -198,6 +198,20 @@ struct CompilationReport
     /// Time point in nanoseconds.
     typedef uint64_t TimePoint;
 
+    struct CacheKeyDigest
+    {
+        /// Digest type, or None if a cache key is unavailable.
+        enum class Type : uint8_t
+        {
+            None,
+            SHA1,
+        };
+
+        Type type;
+        /// SHA-1 digest bytes, or zeroes when type is None.
+        uint8_t bytes[20];
+    };
+
     struct EntryPointReport
     {
         char name[128];
@@ -209,6 +223,8 @@ struct CompilationReport
         double compileDownstreamTime;
         bool isCached;
         size_t cacheSize;
+        /// Stable digest of the opaque persistent shader-cache key.
+        CacheKeyDigest cacheKey;
     };
 
     enum class PipelineType
@@ -226,6 +242,8 @@ struct CompilationReport
         double createTime;
         bool isCached;
         size_t cacheSize;
+        /// Stable digest of the opaque persistent pipeline-cache key.
+        CacheKeyDigest cacheKey;
     };
 
     /// Shader program label.

--- a/src/cpu/cpu-pipeline.cpp
+++ b/src/cpu/cpu-pipeline.cpp
@@ -56,7 +56,8 @@ Result DeviceImpl::createComputePipeline2(const ComputePipelineDesc& desc, IComp
             startTime,
             Timer::now(),
             false,
-            0
+            0,
+            nullptr
         );
     }
 

--- a/src/cuda/cuda-pipeline.cpp
+++ b/src/cuda/cuda-pipeline.cpp
@@ -124,7 +124,8 @@ Result DeviceImpl::createComputePipeline2(const ComputePipelineDesc& desc, IComp
             startTime,
             Timer::now(),
             false,
-            0
+            0,
+            nullptr
         );
     }
 

--- a/src/cuda/optix-api-impl.cpp
+++ b/src/cuda/optix-api-impl.cpp
@@ -987,7 +987,8 @@ public:
                 startTime,
                 Timer::now(),
                 false,
-                0
+                0,
+                nullptr
             );
         }
 

--- a/src/d3d11/d3d11-pipeline.cpp
+++ b/src/d3d11/d3d11-pipeline.cpp
@@ -180,7 +180,8 @@ Result DeviceImpl::createRenderPipeline2(const RenderPipelineDesc& desc, IRender
             startTime,
             Timer::now(),
             false,
-            0
+            0,
+            nullptr
         );
     }
 
@@ -258,7 +259,8 @@ Result DeviceImpl::createComputePipeline2(const ComputePipelineDesc& desc, IComp
             startTime,
             Timer::now(),
             false,
-            0
+            0,
+            nullptr
         );
     }
 

--- a/src/d3d12/d3d12-pipeline.cpp
+++ b/src/d3d12/d3d12-pipeline.cpp
@@ -142,11 +142,13 @@ Result createPipelineWithCache(
     Result (*createPipelineFunc)(DeviceImpl* device, PipelineDesc* desc, PipelineState** outPipeline),
     PipelineState** outPipeline,
     bool& outCached,
-    size_t& outCacheSize
+    size_t& outCacheSize,
+    ComPtr<ISlangBlob>& outCacheKey
 )
 {
     outCached = false;
     outCacheSize = 0;
+    outCacheKey = nullptr;
 
     // Early out if cache is not enabled.
     if (!device->m_persistentPipelineCache)
@@ -178,6 +180,7 @@ Result createPipelineWithCache(
             writeCache = false;
             outCached = true;
             outCacheSize = pipelineCacheData->getBufferSize();
+            outCacheKey = pipelineCacheKey;
         }
         else
         {
@@ -202,6 +205,7 @@ Result createPipelineWithCache(
             pipelineCacheData = UnownedBlob::create(cachedBlob->GetBufferPointer(), cachedBlob->GetBufferSize());
             device->m_persistentPipelineCache->writeCache(pipelineCacheKey, pipelineCacheData);
             outCacheSize = pipelineCacheData->getBufferSize();
+            outCacheKey = pipelineCacheKey;
         }
     }
 
@@ -231,6 +235,7 @@ Result DeviceImpl::createRenderPipeline2(const RenderPipelineDesc& desc, IRender
     InputLayoutImpl* inputLayout = checked_cast<InputLayoutImpl*>(desc.inputLayout);
 
     ComPtr<ID3D12PipelineState> pipelineState;
+    ComPtr<ISlangBlob> cacheKey;
     bool cached = false;
     size_t cacheSize = 0;
 
@@ -441,7 +446,8 @@ Result DeviceImpl::createRenderPipeline2(const RenderPipelineDesc& desc, IRender
             },
             pipelineState.writeRef(),
             cached,
-            cacheSize
+            cacheSize,
+            cacheKey
         );
         SLANG_RETURN_ON_FAIL(result);
     }
@@ -460,7 +466,8 @@ Result DeviceImpl::createRenderPipeline2(const RenderPipelineDesc& desc, IRender
             startTime,
             Timer::now(),
             cached,
-            cacheSize
+            cacheSize,
+            cacheKey
         );
     }
 
@@ -501,6 +508,7 @@ Result DeviceImpl::createComputePipeline2(const ComputePipelineDesc& desc, IComp
     computeDesc.CS = {program->m_shaders[0].code.data(), SIZE_T(program->m_shaders[0].code.size())};
 
     ComPtr<ID3D12PipelineState> pipelineState;
+    ComPtr<ISlangBlob> cacheKey;
     bool cached = false;
     size_t cacheSize = 0;
     Result result = createPipelineWithCache<D3D12_COMPUTE_PIPELINE_STATE_DESC, ID3D12PipelineState>(
@@ -538,7 +546,8 @@ Result DeviceImpl::createComputePipeline2(const ComputePipelineDesc& desc, IComp
         },
         pipelineState.writeRef(),
         cached,
-        cacheSize
+        cacheSize,
+        cacheKey
     );
     SLANG_RETURN_ON_FAIL(result);
 
@@ -556,7 +565,8 @@ Result DeviceImpl::createComputePipeline2(const ComputePipelineDesc& desc, IComp
             startTime,
             Timer::now(),
             cached,
-            cacheSize
+            cacheSize,
+            cacheKey
         );
     }
 
@@ -801,7 +811,8 @@ Result DeviceImpl::createRayTracingPipeline2(const RayTracingPipelineDesc& desc,
             startTime,
             Timer::now(),
             false,
-            0
+            0,
+            nullptr
         );
     }
 

--- a/src/metal/metal-pipeline.cpp
+++ b/src/metal/metal-pipeline.cpp
@@ -169,7 +169,8 @@ Result DeviceImpl::createRenderPipeline2(const RenderPipelineDesc& desc, IRender
             startTime,
             Timer::now(),
             false,
-            0
+            0,
+            nullptr
         );
     }
 
@@ -250,7 +251,8 @@ Result DeviceImpl::createComputePipeline2(const ComputePipelineDesc& desc, IComp
             startTime,
             Timer::now(),
             false,
-            0
+            0,
+            nullptr
         );
     }
 

--- a/src/shader.cpp
+++ b/src/shader.cpp
@@ -1,5 +1,6 @@
 #include "shader.h"
 
+#include "core/sha1.h"
 #include "rhi-shared.h"
 
 namespace rhi {
@@ -219,7 +220,8 @@ void ShaderProgram::reportEntryPointCompilation(Device* device, const CompiledEn
             entryPoint.stats.totalTime,
             entryPoint.stats.downstreamTime,
             entryPoint.stats.isCached,
-            entryPoint.stats.cacheSize
+            entryPoint.stats.cacheSize,
+            entryPoint.cacheKey
         );
     }
 }
@@ -334,6 +336,17 @@ void ShaderCompilationReporter::unregisterProgram(ShaderProgram* program)
     }
 }
 
+static void setCacheKeyDigest(CompilationReport::CacheKeyDigest& dst, ISlangBlob* cacheKey)
+{
+    dst = {};
+    if (cacheKey)
+    {
+        dst.type = CompilationReport::CacheKeyDigest::Type::SHA1;
+        SHA1::Digest digest = SHA1(cacheKey->getBufferPointer(), cacheKey->getBufferSize()).getDigest();
+        std::memcpy(dst.bytes, digest.data(), digest.size());
+    }
+}
+
 void ShaderCompilationReporter::reportCompileEntryPoint(
     ShaderProgram* program,
     const char* entryPointName,
@@ -342,7 +355,8 @@ void ShaderCompilationReporter::reportCompileEntryPoint(
     double totalTime,
     double downstreamTime,
     bool isCached,
-    size_t cacheSize
+    size_t cacheSize,
+    ISlangBlob* cacheKey
 )
 {
     SLANG_RHI_ASSERT(program);
@@ -378,6 +392,7 @@ void ShaderCompilationReporter::reportCompileEntryPoint(
         entryPointReport.compileDownstreamTime = downstreamTime;
         entryPointReport.isCached = isCached;
         entryPointReport.cacheSize = cacheSize;
+        setCacheKeyDigest(entryPointReport.cacheKey, cacheKey);
     }
 }
 
@@ -387,7 +402,8 @@ void ShaderCompilationReporter::reportCreatePipeline(
     TimePoint startTime,
     TimePoint endTime,
     bool isCached,
-    size_t cacheSize
+    size_t cacheSize,
+    ISlangBlob* cacheKey
 )
 {
     SLANG_RHI_ASSERT(program);
@@ -431,6 +447,7 @@ void ShaderCompilationReporter::reportCreatePipeline(
         pipelineReport.createTime = Timer::delta(startTime, endTime);
         pipelineReport.isCached = isCached;
         pipelineReport.cacheSize = cacheSize;
+        setCacheKeyDigest(pipelineReport.cacheKey, cacheKey);
     }
 }
 

--- a/src/shader.h
+++ b/src/shader.h
@@ -166,7 +166,8 @@ public:
         double totalTime,
         double downstreamTime,
         bool isCached,
-        size_t cacheSize
+        size_t cacheSize,
+        ISlangBlob* cacheKey
     );
 
     void reportCreatePipeline(
@@ -175,7 +176,8 @@ public:
         TimePoint startTime,
         TimePoint endTime,
         bool isCached,
-        size_t cacheSize
+        size_t cacheSize,
+        ISlangBlob* cacheKey
     );
 
     Result getCompilationReport(ShaderProgram* program, ISlangBlob** outReportBlob);

--- a/src/vulkan/vk-pipeline.cpp
+++ b/src/vulkan/vk-pipeline.cpp
@@ -422,6 +422,7 @@ Result createPipelineWithCache(
     VkPipeline* outPipeline,
     bool& outCached,
     size_t& outCacheSize,
+    ComPtr<ISlangBlob>& outCacheKey,
     GetFallbackPipelineKey getFallbackPipelineKey = {}
 )
 {
@@ -429,6 +430,7 @@ Result createPipelineWithCache(
 
     outCached = false;
     outCacheSize = 0;
+    outCacheKey = nullptr;
 
     // Early out if cache is not enabled or the feature is not supported.
     if (!device->m_persistentPipelineCache || !api.m_extendedFeatures.pipelineBinaryFeatures.pipelineBinaries)
@@ -470,6 +472,7 @@ Result createPipelineWithCache(
                 writeCache = false;
                 outCached = true;
                 outCacheSize = pipelineCacheData->getBufferSize();
+                outCacheKey = pipelineCacheKey;
             }
             else
             {
@@ -529,6 +532,7 @@ Result createPipelineWithCache(
         {
             device->m_persistentPipelineCache->writeCache(pipelineCacheKey, pipelineCacheData);
             outCacheSize = pipelineCacheData->getBufferSize();
+            outCacheKey = pipelineCacheKey;
         }
         else
         {
@@ -766,6 +770,7 @@ Result DeviceImpl::createRenderPipeline2(const RenderPipelineDesc& desc, IRender
     createInfo.pDynamicState = &dynamicStateInfo;
 
     VkPipeline vkPipeline = VK_NULL_HANDLE;
+    ComPtr<ISlangBlob> cacheKey;
     bool cached = false;
     size_t cacheSize = 0;
     SLANG_RETURN_ON_FAIL(
@@ -779,7 +784,8 @@ Result DeviceImpl::createRenderPipeline2(const RenderPipelineDesc& desc, IRender
             },
             &vkPipeline,
             cached,
-            cacheSize
+            cacheSize,
+            cacheKey
         )
     );
 
@@ -794,7 +800,8 @@ Result DeviceImpl::createRenderPipeline2(const RenderPipelineDesc& desc, IRender
             startTime,
             Timer::now(),
             cached,
-            cacheSize
+            cacheSize,
+            cacheKey
         );
     }
 
@@ -840,6 +847,7 @@ Result DeviceImpl::createComputePipeline2(const ComputePipelineDesc& desc, IComp
     createInfo.layout = program->m_rootShaderObjectLayout->m_pipelineLayout;
 
     VkPipeline vkPipeline = VK_NULL_HANDLE;
+    ComPtr<ISlangBlob> cacheKey;
     bool cached = false;
     size_t cacheSize = 0;
     SLANG_RETURN_ON_FAIL(
@@ -853,7 +861,8 @@ Result DeviceImpl::createComputePipeline2(const ComputePipelineDesc& desc, IComp
             },
             &vkPipeline,
             cached,
-            cacheSize
+            cacheSize,
+            cacheKey
         )
     );
 
@@ -868,7 +877,8 @@ Result DeviceImpl::createComputePipeline2(const ComputePipelineDesc& desc, IComp
             startTime,
             Timer::now(),
             cached,
-            cacheSize
+            cacheSize,
+            cacheKey
         );
     }
 
@@ -1027,6 +1037,7 @@ Result DeviceImpl::createRayTracingPipeline2(const RayTracingPipelineDesc& desc,
     createInfo.basePipelineIndex = 0;
 
     VkPipeline vkPipeline = VK_NULL_HANDLE;
+    ComPtr<ISlangBlob> cacheKey;
     bool cached = false;
     size_t cacheSize = 0;
     SLANG_RETURN_ON_FAIL(
@@ -1048,6 +1059,7 @@ Result DeviceImpl::createRayTracingPipeline2(const RayTracingPipelineDesc& desc,
             &vkPipeline,
             cached,
             cacheSize,
+            cacheKey,
             [program, &desc](SHA1::Digest& outDigest)
             {
                 return getRayTracingPipelineFallbackKey(program, desc, outDigest);
@@ -1066,7 +1078,8 @@ Result DeviceImpl::createRayTracingPipeline2(const RayTracingPipelineDesc& desc,
             startTime,
             Timer::now(),
             cached,
-            cacheSize
+            cacheSize,
+            cacheKey
         );
     }
 

--- a/src/wgpu/wgpu-pipeline.cpp
+++ b/src/wgpu/wgpu-pipeline.cpp
@@ -137,7 +137,8 @@ Result DeviceImpl::createRenderPipeline2(const RenderPipelineDesc& desc, IRender
             startTime,
             Timer::now(),
             false,
-            0
+            0,
+            nullptr
         );
     }
 
@@ -206,7 +207,8 @@ Result DeviceImpl::createComputePipeline2(const ComputePipelineDesc& desc, IComp
             startTime,
             Timer::now(),
             false,
-            0
+            0,
+            nullptr
         );
     }
 

--- a/tests/test-compilation-report.cpp
+++ b/tests/test-compilation-report.cpp
@@ -1,4 +1,5 @@
 #include "testing.h"
+#include "shader-cache.h"
 
 using namespace rhi;
 using namespace rhi::testing;
@@ -139,6 +140,8 @@ GPU_TEST_CASE("compilation-report", ALL | DontCreateDevice)
     CHECK(report1b->createPipelineTime > 0.0);
     CHECK(report1b->entryPointReportCount == 1);
     CHECK(report1b->pipelineReportCount == 1);
+    CHECK(report1b->entryPointReports[0].cacheKey.type == CompilationReport::CacheKeyDigest::Type::None);
+    CHECK(report1b->pipelineReports[0].cacheKey.type == CompilationReport::CacheKeyDigest::Type::None);
 
     // The report should still be registered in the device.
     const CompilationReportList* reports1b = getCompilationReportList(device.get());
@@ -180,6 +183,8 @@ GPU_TEST_CASE("compilation-report", ALL | DontCreateDevice)
     CHECK(report2b->createPipelineTime > 0.0);
     CHECK(report2b->entryPointReportCount == 1);
     CHECK(report2b->pipelineReportCount == 1);
+    CHECK(report2b->entryPointReports[0].cacheKey.type == CompilationReport::CacheKeyDigest::Type::None);
+    CHECK(report2b->pipelineReports[0].cacheKey.type == report1b->pipelineReports[0].cacheKey.type);
 
     // The report should still be registered in the device.
     const CompilationReportList* reports2b = getCompilationReportList(device.get());
@@ -198,4 +203,36 @@ GPU_TEST_CASE("compilation-report", ALL | DontCreateDevice)
     CHECK(reports3->reportCount == 2);
     CHECK(isEqual(&reports3->reports[0], &report1c));
     CHECK(isEqual(&reports3->reports[1], report2b));
+}
+
+GPU_TEST_CASE("compilation-report-cache-keys", D3D12 | Vulkan | DontCreateDevice)
+{
+    ShaderCache shaderCache;
+    ShaderCache pipelineCache;
+    DeviceExtraOptions options = {};
+    options.enableCompilationReports = true;
+    options.persistentShaderCache = &shaderCache;
+    options.persistentPipelineCache = &pipelineCache;
+    device = createTestingDevice(ctx, ctx->deviceType, false, &options);
+    REQUIRE(device);
+
+    if (!device->hasFeature(Feature::PipelineCache))
+    {
+        device = nullptr;
+        return;
+    }
+
+    ComPtr<IShaderProgram> shaderProgram = createShaderProgram(device.get());
+    ComPtr<IComputePipeline> pipeline = createPipeline(device.get(), shaderProgram.get());
+    dispatchPipeline(device.get(), pipeline.get());
+
+    const CompilationReport* report = getCompilationReport(shaderProgram.get());
+    REQUIRE(report->entryPointReportCount == 1);
+    REQUIRE(report->pipelineReportCount == 1);
+    CHECK(report->entryPointReports[0].cacheKey.type == CompilationReport::CacheKeyDigest::Type::SHA1);
+    CHECK(report->pipelineReports[0].cacheKey.type == CompilationReport::CacheKeyDigest::Type::SHA1);
+
+    pipeline = nullptr;
+    shaderProgram = nullptr;
+    device = nullptr;
 }


### PR DESCRIPTION
## Summary

Add stable cache-key identifiers to shader compilation and pipeline creation reports.

- Introduce `CompilationReport::CacheKeyDigest`, containing a digest type and 20-byte SHA-1 value.
- Add cache-key digests to `EntryPointReport` and `PipelineReport`.
- Hash the exact opaque key passed to the corresponding persistent cache.
- Only provide keys when the persistent shader or pipeline cache is enabled; otherwise report `Type::None`.
- Propagate pipeline cache keys through the D3D12 and Vulkan backends.
- Add coverage for reports with and without configured caches.

## Motivation

Cache-key identifiers make it possible to correlate compilation-report events with persistent-cache entries and identify repeated shader or pipeline work. Using a compact digest avoids exposing variable-sized opaque keys and keeps the report representation efficient.
