### PR TITLE
vk: support explicit push constant buffers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1107,6 +1107,7 @@ if(SLANG_RHI_BUILD_TESTS AND NOT SLANG_RHI_BUILD_SHARED AND NOT EMSCRIPTEN)
         tests/test-pipeline-cache.cpp
         # tests/test-precompiled-module-cache.cpp
         tests/test-precompiled-module.cpp
+        tests/test-push-constant.cpp
         tests/test-ray-tracing-clusters.cpp
         tests/test-ray-tracing-hitobject-intrinsics.cpp
         tests/test-ray-tracing-intrinsics.cpp

--- a/src/vulkan/vk-shader-object-layout.cpp
+++ b/src/vulkan/vk-shader-object-layout.cpp
@@ -336,6 +336,7 @@ void ShaderObjectLayoutImpl::Builder::addBindingRanges(slang::TypeLayoutReflecti
         case slang::BindingType::ConstantBuffer:
         case slang::BindingType::ParameterBlock:
         case slang::BindingType::ExistentialValue:
+        case slang::BindingType::PushConstant:
             subObjectIndex = m_subObjectCount;
             m_subObjectCount += count;
             break;
@@ -374,7 +375,7 @@ void ShaderObjectLayoutImpl::Builder::addBindingRanges(slang::TypeLayoutReflecti
             break;
         }
 
-        BindingRangeInfo bindingRangeInfo;
+        BindingRangeInfo bindingRangeInfo = {};
         bindingRangeInfo.bindingType = slangBindingType;
         bindingRangeInfo.count = count;
         bindingRangeInfo.slotIndex = slotIndex;
@@ -472,6 +473,11 @@ void ShaderObjectLayoutImpl::Builder::addBindingRanges(slang::TypeLayoutReflecti
             m_childDescriptorSetCount += subObjectLayout->getChildDescriptorSetCount();
             m_totalBindingCount += subObjectLayout->getTotalBindingCount();
             m_childPushConstantRangeCount += subObjectLayout->getTotalPushConstantRangeCount();
+            break;
+
+        case slang::BindingType::PushConstant:
+            m_childDescriptorSetCount += subObjectLayout->getChildDescriptorSetCount();
+            m_totalBindingCount += subObjectLayout->getTotalBindingCount();
             break;
 
         case slang::BindingType::ExistentialValue:

--- a/src/vulkan/vk-shader-object.cpp
+++ b/src/vulkan/vk-shader-object.cpp
@@ -343,46 +343,59 @@ Result BindingDataBuilder::bindAsEntryPoint(
     uint32_t entryPointIndex
 )
 {
+    if (layout->getSlangLayout()->getStage() != SLANG_STAGE_RAY_GENERATION)
+    {
+        // For non-raygen entry points, ordinary data goes into push constants.
+        return bindAsPushConstantBuffer(shaderObject, inOffset, layout);
+    }
+
+    // For raygen entry points, ordinary data is stored in the SBT instead.
+    if (shaderObject->m_data.size())
+    {
+        SLANG_RHI_ASSERT(m_bindingData->entryPointData && entryPointIndex < m_bindingData->entryPointCount);
+        BindingDataImpl::EntryPointData& epData = m_bindingData->entryPointData[entryPointIndex];
+        epData.size = shaderObject->m_data.size();
+        epData.data = m_allocator->allocate(epData.size);
+        ::memcpy(epData.data, shaderObject->m_data.data(), epData.size);
+    }
+
+    SLANG_RETURN_ON_FAIL(bindAsValue(shaderObject, inOffset, layout));
+
+    return SLANG_OK;
+}
+
+Result BindingDataBuilder::bindAsPushConstantBuffer(
+    ShaderObject* shaderObject,
+    const BindingOffset& inOffset,
+    ShaderObjectLayoutImpl* specializedLayout
+)
+{
     BindingOffset offset = inOffset;
 
     if (shaderObject->m_data.size())
     {
-        if (layout->getSlangLayout()->getStage() == SLANG_STAGE_RAY_GENERATION)
-        {
-            // For raygen entry points, ordinary data is stored in the SBT, not as push constants.
-            SLANG_RHI_ASSERT(m_bindingData->entryPointData && entryPointIndex < m_bindingData->entryPointCount);
-            BindingDataImpl::EntryPointData& epData = m_bindingData->entryPointData[entryPointIndex];
-            epData.size = shaderObject->m_data.size();
-            epData.data = m_allocator->allocate(epData.size);
-            ::memcpy(epData.data, shaderObject->m_data.data(), epData.size);
-        }
-        else
-        {
-            // For non-raygen entry points, ordinary data goes into push constants.
-            //
-            // The index of the push constant range to bind is passed down as part of the
-            // `offset`, and we increment it here so that any further recursively-contained
-            // push-constant ranges use the next index.
-            //
-            auto pushConstantRangeIndex = offset.pushConstantRange++;
+        // The offset identifies a range in the flattened pipeline layout. Increment it
+        // before recursing so any push constants nested in this object's contents use
+        // the following ranges.
+        const auto pushConstantRangeIndex = offset.pushConstantRange++;
+        SLANG_RHI_ASSERT(pushConstantRangeIndex < m_pushConstantRanges.size());
+        const auto& pushConstantRange = m_pushConstantRanges[pushConstantRangeIndex];
+        SLANG_RHI_ASSERT(pushConstantRange.size == shaderObject->m_data.size());
 
-            // Information about the push constant ranges (including offsets and stage flags)
-            // was pre-computed for the entire program and stored on the binding context.
-            //
-            const auto& pushConstantRange = m_pushConstantRanges[pushConstantRangeIndex];
-            SLANG_RHI_ASSERT(pushConstantRange.size == shaderObject->m_data.size());
-
-            uint32_t index = m_bindingData->pushConstantCount++;
-            m_bindingData->pushConstantRanges[index] = pushConstantRange;
-            m_bindingData->pushConstantData[index] = m_allocator->allocate(pushConstantRange.size);
-            ::memcpy(m_bindingData->pushConstantData[index], shaderObject->m_data.data(), pushConstantRange.size);
-        }
+        const uint32_t index = m_bindingData->pushConstantCount++;
+        SLANG_RHI_ASSERT(index < m_pushConstantRanges.size());
+        m_bindingData->pushConstantRanges[index] = pushConstantRange;
+        m_bindingData->pushConstantData[index] = m_allocator->allocate(pushConstantRange.size);
+        SLANG_RETURN_ON_FAIL(shaderObject->writeOrdinaryData(
+            m_bindingData->pushConstantData[index],
+            pushConstantRange.size,
+            specializedLayout
+        ));
     }
 
-    // Any remaining bindings in the object can be handled through the
-    // "value" case.
-    //
-    SLANG_RETURN_ON_FAIL(bindAsValue(shaderObject, offset, layout));
+    // Resources and nested parameter blocks in the push-constant element type still
+    // need their normal recursive binding treatment.
+    SLANG_RETURN_ON_FAIL(bindAsValue(shaderObject, offset, specializedLayout));
 
     return SLANG_OK;
 }
@@ -449,6 +462,7 @@ Result BindingDataBuilder::bindAsValue(
         case slang::BindingType::ConstantBuffer:
         case slang::BindingType::ParameterBlock:
         case slang::BindingType::ExistentialValue:
+        case slang::BindingType::PushConstant:
             break;
 
         case slang::BindingType::Texture:
@@ -637,6 +651,18 @@ Result BindingDataBuilder::bindAsValue(
                 //
                 ShaderObject* subObject = shaderObject->m_objects[subObjectIndex + i];
                 SLANG_RETURN_ON_FAIL(bindAsParameterBlock(subObject, objOffset, subObjectLayout));
+            }
+        }
+        break;
+
+        case slang::BindingType::PushConstant:
+        {
+            BindingOffset objOffset = rangeOffset;
+            for (uint32_t i = 0; i < count; ++i)
+            {
+                ShaderObject* subObject = shaderObject->m_objects[subObjectIndex + i];
+                SLANG_RETURN_ON_FAIL(bindAsPushConstantBuffer(subObject, objOffset, subObjectLayout));
+                objOffset += rangeStride;
             }
         }
         break;

--- a/src/vulkan/vk-shader-object.h
+++ b/src/vulkan/vk-shader-object.h
@@ -38,6 +38,13 @@ struct BindingDataBuilder
         uint32_t entryPointIndex
     );
 
+    /// Bind this object as a `PushConstantBuffer<X>`.
+    Result bindAsPushConstantBuffer(
+        ShaderObject* shaderObject,
+        const BindingOffset& inOffset,
+        ShaderObjectLayoutImpl* specializedLayout
+    );
+
     /// Bind the ordinary data buffer if needed.
     Result bindOrdinaryDataBufferIfNeeded(
         ShaderObject* shaderObject,

--- a/tests/test-push-constant.cpp
+++ b/tests/test-push-constant.cpp
@@ -1,0 +1,46 @@
+#include "testing.h"
+
+using namespace rhi;
+using namespace rhi::testing;
+
+GPU_TEST_CASE("explicit-push-constant", Vulkan)
+{
+    ComPtr<IShaderProgram> shaderProgram;
+    REQUIRE_CALL(loadProgram(device, "test-push-constant", "computeMain", shaderProgram.writeRef()));
+
+    ComputePipelineDesc pipelineDesc = {};
+    pipelineDesc.program = shaderProgram.get();
+    ComPtr<IComputePipeline> pipeline;
+    REQUIRE_CALL(device->createComputePipeline(pipelineDesc, pipeline.writeRef()));
+
+    const uint32_t initialValue = 0;
+    BufferDesc bufferDesc = {};
+    bufferDesc.size = sizeof(uint32_t);
+    bufferDesc.elementSize = sizeof(uint32_t);
+    bufferDesc.usage = BufferUsage::UnorderedAccess | BufferUsage::CopyDestination | BufferUsage::CopySource;
+    bufferDesc.defaultState = ResourceState::UnorderedAccess;
+    bufferDesc.memoryType = MemoryType::DeviceLocal;
+
+    ComPtr<IBuffer> resultBuffer;
+    REQUIRE_CALL(device->createBuffer(bufferDesc, &initialValue, resultBuffer.writeRef()));
+
+    ComPtr<IShaderObject> rootObject;
+    REQUIRE_CALL(device->createRootShaderObject(shaderProgram, rootObject.writeRef()));
+
+    const uint32_t expectedValue = 0x12345678;
+    ShaderCursor cursor(rootObject);
+    REQUIRE_CALL(cursor["pushConstants"]["value"].setData(expectedValue));
+    REQUIRE_CALL(cursor["pushConstants"]["result"].setBinding(resultBuffer));
+
+    auto queue = device->getQueue(QueueType::Graphics);
+    auto commandEncoder = queue->createCommandEncoder();
+    auto passEncoder = commandEncoder->beginComputePass();
+    passEncoder->bindPipeline(pipeline, rootObject);
+    passEncoder->dispatchCompute(1, 1, 1);
+    passEncoder->end();
+
+    queue->submit(commandEncoder->finish());
+    queue->waitOnHost();
+
+    compareComputeResult(device, resultBuffer, makeArray<uint32_t>(expectedValue));
+}

--- a/tests/test-push-constant.slang
+++ b/tests/test-push-constant.slang
@@ -1,0 +1,15 @@
+struct PushConstants
+{
+    uint value;
+    RWStructuredBuffer<uint> result;
+};
+
+[[vk::push_constant]]
+ConstantBuffer<PushConstants> pushConstants;
+
+[shader("compute")]
+[numthreads(1, 1, 1)]
+void computeMain(uint3 tid : SV_DispatchThreadID)
+{
+    pushConstants.result[0] = pushConstants.value;
+}


### PR DESCRIPTION
## Summary

Add Vulkan support for explicit global push-constant buffers declared as:

```slang
[[vk::push_constant]]
ConstantBuffer<T> pushConstants;
```

## Problem

Slang reflects this construct as `BindingType::PushConstant`, but the Vulkan shader-object path did not fully handle that binding type:

- No shader sub-object slot was allocated for it.
- Descriptor offsets remained uninitialized because push constants have no descriptor range.
- `bindAsValue()` did not upload or recursively bind the push-constant sub-object.
- Resources contained in the element type were not bound through their separately reflected descriptor bindings.

As a result, creating or binding a root shader object containing an explicit push-constant buffer could fail, and its ordinary data would not reach `vkCmdPushConstants`.

## Changes

- Treat `BindingType::PushConstant` as a shader sub-object during layout construction.
- Zero-initialize binding-range metadata for descriptor-free ranges.
- Account for descriptors and bindings contributed by the push-constant element type.
- Extract the existing entry-point push-constant upload into a shared helper.
- Upload explicit push-constant ordinary data using `writeOrdinaryData()`.
- Recursively bind resources and parameter blocks contained in the element type.
- Add a Vulkan regression test containing both ordinary push-constant data and a nested storage-buffer binding.

## Scope

This targets the supported single explicit push-constant buffer in scope for an entry point. It does not attempt to combine an explicit global block with a separate implicit entry-point push-constant block; Slang currently documents support for only one such buffer per entry point.
