### PR TITLE
Vulkan: expose cooperative matrix 2 subfeatures

### DIFF
--- a/include/slang-rhi.h
+++ b/include/slang-rhi.h
@@ -172,7 +172,13 @@ enum class DeviceType
     x(ArgumentBufferTier2,                      "argument-buffer-tier-2"                        ) \
     x(ResidencySet,                             "residency-set"                                 ) \
     /* CUDA specific features */                                                                  \
-    x(AtomicBfloat16,                           "atomic-bfloat16"                               )
+    x(AtomicBfloat16,                           "atomic-bfloat16"                               ) \
+    /* Cooperative matrix 2 sub-features (kept at the end to preserve existing feature ordinals) */ \
+    x(CooperativeMatrixReductions,              "cooperative-matrix-reductions"                 ) \
+    x(CooperativeMatrixConversions,             "cooperative-matrix-conversions"                ) \
+    x(CooperativeMatrixPerElementOperations,    "cooperative-matrix-per-element-operations"     ) \
+    x(CooperativeMatrixTensorAddressing,        "cooperative-matrix-tensor-addressing"          ) \
+    x(CooperativeMatrixBlockLoads,              "cooperative-matrix-block-loads"                )
 // clang-format on
 
 #define SLANG_RHI_FEATURE_X(e, _) e,

--- a/src/vulkan/vk-device.cpp
+++ b/src/vulkan/vk-device.cpp
@@ -1127,12 +1127,24 @@ Result DeviceImpl::initVulkanDevice(
         );
 
         auto& cooperativeMatrix2Features = extendedFeatures.cooperativeMatrix2Features;
+        const auto cooperativeMatrix2ExtensionSelection = selectCooperativeMatrix2Extensions(
+            extensionNames.count(VK_KHR_COOPERATIVE_MATRIX_EXTENSION_NAME) != 0,
+            extensionNames.count(VK_NV_COOPERATIVE_MATRIX_2_EXTENSION_NAME) != 0,
+            extendedFeatures.cooperativeMatrix1Features.cooperativeMatrix,
+            cooperativeMatrix2Features
+        );
         if (addFeatureExtension(
-                hasAnyCooperativeMatrix2Feature(cooperativeMatrix2Features),
+                cooperativeMatrix2ExtensionSelection.enableCooperativeMatrix2Extension,
                 cooperativeMatrix2Features,
                 VK_NV_COOPERATIVE_MATRIX_2_EXTENSION_NAME
             ))
         {
+            // VK_NV_cooperative_matrix2 depends on VK_KHR_cooperative_matrix. The KHR
+            // extension was already added above when its feature bit was enabled.
+            if (cooperativeMatrix2ExtensionSelection.appendCooperativeMatrixExtensionDependency)
+            {
+                deviceExtensions.push_back(VK_KHR_COOPERATIVE_MATRIX_EXTENSION_NAME);
+            }
             availableCapabilities.push_back(Capability::SPV_NV_cooperative_matrix2);
 
             if (cooperativeMatrix2Features.cooperativeMatrixWorkgroupScope)

--- a/src/vulkan/vk-device.cpp
+++ b/src/vulkan/vk-device.cpp
@@ -1126,16 +1126,22 @@ Result DeviceImpl::initVulkanDevice(
             }
         );
 
-        SIMPLE_EXTENSION_FEATURE(
-            extendedFeatures.cooperativeMatrix2Features,
-            cooperativeMatrixWorkgroupScope,
-            VK_NV_COOPERATIVE_MATRIX_2_EXTENSION_NAME,
+        auto& cooperativeMatrix2Features = extendedFeatures.cooperativeMatrix2Features;
+        if (addFeatureExtension(
+                hasAnyCooperativeMatrix2Feature(cooperativeMatrix2Features),
+                cooperativeMatrix2Features,
+                VK_NV_COOPERATIVE_MATRIX_2_EXTENSION_NAME
+            ))
+        {
+            availableCapabilities.push_back(Capability::SPV_NV_cooperative_matrix2);
+
+            if (cooperativeMatrix2Features.cooperativeMatrixWorkgroupScope)
             {
                 availableFeatures.push_back(Feature::CooperativeMatrix2);
-                availableCapabilities.push_back(Capability::SPV_NV_cooperative_matrix2);
                 availableCapabilities.push_back(Capability::spvCooperativeMatrix2NV);
             }
-        );
+            appendCooperativeMatrix2Subfeatures(cooperativeMatrix2Features, availableFeatures, availableCapabilities);
+        }
 
         SIMPLE_EXTENSION_FEATURE(
             extendedFeatures.mutableDescriptorTypeFeatures,

--- a/src/vulkan/vk-utils.cpp
+++ b/src/vulkan/vk-utils.cpp
@@ -1175,6 +1175,48 @@ CooperativeVectorMatrixLayout translateCooperativeVectorMatrixLayout(VkCooperati
     }
 }
 
+bool hasAnyCooperativeMatrix2Feature(const VkPhysicalDeviceCooperativeMatrix2FeaturesNV& features)
+{
+    return features.cooperativeMatrixWorkgroupScope || features.cooperativeMatrixFlexibleDimensions ||
+           features.cooperativeMatrixReductions || features.cooperativeMatrixConversions ||
+           features.cooperativeMatrixPerElementOperations || features.cooperativeMatrixTensorAddressing ||
+           features.cooperativeMatrixBlockLoads;
+}
+
+void appendCooperativeMatrix2Subfeatures(
+    const VkPhysicalDeviceCooperativeMatrix2FeaturesNV& features,
+    std::vector<Feature>& availableFeatures,
+    std::vector<Capability>& availableCapabilities
+)
+{
+    if (features.cooperativeMatrixReductions)
+    {
+        availableFeatures.push_back(Feature::CooperativeMatrixReductions);
+        availableCapabilities.push_back(Capability::spvCooperativeMatrixReductionsNV);
+    }
+    if (features.cooperativeMatrixConversions)
+    {
+        availableFeatures.push_back(Feature::CooperativeMatrixConversions);
+        availableCapabilities.push_back(Capability::spvCooperativeMatrixConversionsNV);
+    }
+    if (features.cooperativeMatrixPerElementOperations)
+    {
+        availableFeatures.push_back(Feature::CooperativeMatrixPerElementOperations);
+        availableCapabilities.push_back(Capability::spvCooperativeMatrixPerElementOperationsNV);
+    }
+    if (features.cooperativeMatrixTensorAddressing)
+    {
+        availableFeatures.push_back(Feature::CooperativeMatrixTensorAddressing);
+        availableCapabilities.push_back(Capability::spvCooperativeMatrixTensorAddressingNV);
+        availableCapabilities.push_back(Capability::spvTensorAddressingNV);
+    }
+    if (features.cooperativeMatrixBlockLoads)
+    {
+        availableFeatures.push_back(Feature::CooperativeMatrixBlockLoads);
+        availableCapabilities.push_back(Capability::spvCooperativeMatrixBlockLoadsNV);
+    }
+}
+
 bool translateCooperativeMatrixComponentType(VkComponentTypeKHR type, CooperativeMatrixComponentType& outType)
 {
     switch (type)

--- a/src/vulkan/vk-utils.cpp
+++ b/src/vulkan/vk-utils.cpp
@@ -1183,6 +1183,22 @@ bool hasAnyCooperativeMatrix2Feature(const VkPhysicalDeviceCooperativeMatrix2Fea
            features.cooperativeMatrixBlockLoads;
 }
 
+CooperativeMatrix2ExtensionSelection selectCooperativeMatrix2Extensions(
+    bool cooperativeMatrixExtensionAvailable,
+    bool cooperativeMatrix2ExtensionAvailable,
+    bool cooperativeMatrixFeatureEnabled,
+    const VkPhysicalDeviceCooperativeMatrix2FeaturesNV& features
+)
+{
+    const bool enableCooperativeMatrix2Extension = cooperativeMatrixExtensionAvailable &&
+                                                   cooperativeMatrix2ExtensionAvailable &&
+                                                   hasAnyCooperativeMatrix2Feature(features);
+    return {
+        enableCooperativeMatrix2Extension,
+        enableCooperativeMatrix2Extension && !cooperativeMatrixFeatureEnabled,
+    };
+}
+
 void appendCooperativeMatrix2Subfeatures(
     const VkPhysicalDeviceCooperativeMatrix2FeaturesNV& features,
     std::vector<Feature>& availableFeatures,

--- a/src/vulkan/vk-utils.h
+++ b/src/vulkan/vk-utils.h
@@ -7,6 +7,8 @@
 #include "core/common.h"
 #include "core/diagnostics.h"
 
+#include <vector>
+
 namespace rhi {
 class Device;
 }
@@ -124,6 +126,13 @@ VkComponentTypeKHR translateCooperativeVectorComponentType(CooperativeVectorComp
 CooperativeVectorComponentType translateCooperativeVectorComponentType(VkComponentTypeKHR type);
 VkCooperativeVectorMatrixLayoutNV translateCooperativeVectorMatrixLayout(CooperativeVectorMatrixLayout layout);
 CooperativeVectorMatrixLayout translateCooperativeVectorMatrixLayout(VkCooperativeVectorMatrixLayoutNV layout);
+
+bool hasAnyCooperativeMatrix2Feature(const VkPhysicalDeviceCooperativeMatrix2FeaturesNV& features);
+void appendCooperativeMatrix2Subfeatures(
+    const VkPhysicalDeviceCooperativeMatrix2FeaturesNV& features,
+    std::vector<Feature>& availableFeatures,
+    std::vector<Capability>& availableCapabilities
+);
 
 bool translateCooperativeMatrixComponentType(VkComponentTypeKHR type, CooperativeMatrixComponentType& outType);
 bool translateCooperativeMatrixScope(VkScopeKHR scope, CooperativeMatrixScope& outScope);

--- a/src/vulkan/vk-utils.h
+++ b/src/vulkan/vk-utils.h
@@ -128,6 +128,17 @@ VkCooperativeVectorMatrixLayoutNV translateCooperativeVectorMatrixLayout(Coopera
 CooperativeVectorMatrixLayout translateCooperativeVectorMatrixLayout(VkCooperativeVectorMatrixLayoutNV layout);
 
 bool hasAnyCooperativeMatrix2Feature(const VkPhysicalDeviceCooperativeMatrix2FeaturesNV& features);
+struct CooperativeMatrix2ExtensionSelection
+{
+    bool enableCooperativeMatrix2Extension;
+    bool appendCooperativeMatrixExtensionDependency;
+};
+CooperativeMatrix2ExtensionSelection selectCooperativeMatrix2Extensions(
+    bool cooperativeMatrixExtensionAvailable,
+    bool cooperativeMatrix2ExtensionAvailable,
+    bool cooperativeMatrixFeatureEnabled,
+    const VkPhysicalDeviceCooperativeMatrix2FeaturesNV& features
+);
 void appendCooperativeMatrix2Subfeatures(
     const VkPhysicalDeviceCooperativeMatrix2FeaturesNV& features,
     std::vector<Feature>& availableFeatures,

--- a/tests/test-cooperative-matrix.cpp
+++ b/tests/test-cooperative-matrix.cpp
@@ -1,6 +1,13 @@
 #include "testing.h"
 #include "core/common.h"
 
+#if SLANG_RHI_ENABLE_VULKAN
+#include "vulkan/vk-utils.h"
+#endif
+
+#include <algorithm>
+#include <iterator>
+
 using namespace rhi;
 using namespace rhi::testing;
 
@@ -17,6 +24,141 @@ static CooperativeMatrixDesc makeBasicCoopMatDesc()
     desc.scope = CooperativeMatrixScope::Subgroup;
     return desc;
 }
+
+TEST_CASE("cooperative-matrix-2-feature-names")
+{
+    struct TestCase
+    {
+        Feature feature;
+        const char* name;
+    };
+    const TestCase testCases[] = {
+        {Feature::CooperativeMatrixReductions, "cooperative-matrix-reductions"},
+        {Feature::CooperativeMatrixConversions, "cooperative-matrix-conversions"},
+        {Feature::CooperativeMatrixPerElementOperations, "cooperative-matrix-per-element-operations"},
+        {Feature::CooperativeMatrixTensorAddressing, "cooperative-matrix-tensor-addressing"},
+        {Feature::CooperativeMatrixBlockLoads, "cooperative-matrix-block-loads"},
+    };
+
+    for (const auto& testCase : testCases)
+    {
+        CHECK(std::string_view(getRHI()->getFeatureName(testCase.feature)) == testCase.name);
+    }
+}
+
+#if SLANG_RHI_ENABLE_VULKAN
+TEST_CASE("cooperative-matrix-2-subfeature-projection")
+{
+    const auto featureBits = {
+        &VkPhysicalDeviceCooperativeMatrix2FeaturesNV::cooperativeMatrixWorkgroupScope,
+        &VkPhysicalDeviceCooperativeMatrix2FeaturesNV::cooperativeMatrixFlexibleDimensions,
+        &VkPhysicalDeviceCooperativeMatrix2FeaturesNV::cooperativeMatrixReductions,
+        &VkPhysicalDeviceCooperativeMatrix2FeaturesNV::cooperativeMatrixConversions,
+        &VkPhysicalDeviceCooperativeMatrix2FeaturesNV::cooperativeMatrixPerElementOperations,
+        &VkPhysicalDeviceCooperativeMatrix2FeaturesNV::cooperativeMatrixTensorAddressing,
+        &VkPhysicalDeviceCooperativeMatrix2FeaturesNV::cooperativeMatrixBlockLoads,
+    };
+    for (const auto featureBit : featureBits)
+    {
+        VkPhysicalDeviceCooperativeMatrix2FeaturesNV vulkanFeatures = {
+            VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_COOPERATIVE_MATRIX_2_FEATURES_NV
+        };
+        vulkanFeatures.*featureBit = VK_TRUE;
+        CHECK(vk::hasAnyCooperativeMatrix2Feature(vulkanFeatures));
+    }
+
+    VkPhysicalDeviceCooperativeMatrix2FeaturesNV noFeatures = {
+        VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_COOPERATIVE_MATRIX_2_FEATURES_NV
+    };
+    CHECK_FALSE(vk::hasAnyCooperativeMatrix2Feature(noFeatures));
+
+    struct TestCase
+    {
+        VkBool32 VkPhysicalDeviceCooperativeMatrix2FeaturesNV::*featureBit;
+        Feature feature;
+        Capability capabilities[2];
+        size_t capabilityCount;
+    };
+    const TestCase testCases[] = {
+        {
+            &VkPhysicalDeviceCooperativeMatrix2FeaturesNV::cooperativeMatrixReductions,
+            Feature::CooperativeMatrixReductions,
+            {Capability::spvCooperativeMatrixReductionsNV},
+            1,
+        },
+        {
+            &VkPhysicalDeviceCooperativeMatrix2FeaturesNV::cooperativeMatrixConversions,
+            Feature::CooperativeMatrixConversions,
+            {Capability::spvCooperativeMatrixConversionsNV},
+            1,
+        },
+        {
+            &VkPhysicalDeviceCooperativeMatrix2FeaturesNV::cooperativeMatrixPerElementOperations,
+            Feature::CooperativeMatrixPerElementOperations,
+            {Capability::spvCooperativeMatrixPerElementOperationsNV},
+            1,
+        },
+        {
+            &VkPhysicalDeviceCooperativeMatrix2FeaturesNV::cooperativeMatrixTensorAddressing,
+            Feature::CooperativeMatrixTensorAddressing,
+            {Capability::spvCooperativeMatrixTensorAddressingNV, Capability::spvTensorAddressingNV},
+            2,
+        },
+        {
+            &VkPhysicalDeviceCooperativeMatrix2FeaturesNV::cooperativeMatrixBlockLoads,
+            Feature::CooperativeMatrixBlockLoads,
+            {Capability::spvCooperativeMatrixBlockLoadsNV},
+            1,
+        },
+    };
+
+    for (const auto& testCase : testCases)
+    {
+        VkPhysicalDeviceCooperativeMatrix2FeaturesNV vulkanFeatures = {
+            VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_COOPERATIVE_MATRIX_2_FEATURES_NV
+        };
+        vulkanFeatures.*testCase.featureBit = VK_TRUE;
+        std::vector<Feature> features;
+        std::vector<Capability> capabilities;
+
+        vk::appendCooperativeMatrix2Subfeatures(vulkanFeatures, features, capabilities);
+
+        REQUIRE(features.size() == 1);
+        CHECK(features[0] == testCase.feature);
+        REQUIRE(capabilities.size() == testCase.capabilityCount);
+        for (size_t i = 0; i < testCase.capabilityCount; ++i)
+        {
+            CHECK(capabilities[i] == testCase.capabilities[i]);
+        }
+    }
+
+    std::vector<Feature> features;
+    std::vector<Capability> capabilities;
+    vk::appendCooperativeMatrix2Subfeatures(noFeatures, features, capabilities);
+    CHECK(features.empty());
+    CHECK(capabilities.empty());
+
+    VkPhysicalDeviceCooperativeMatrix2FeaturesNV allFeatures = {
+        VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_COOPERATIVE_MATRIX_2_FEATURES_NV
+    };
+    for (const auto featureBit : featureBits)
+    {
+        allFeatures.*featureBit = VK_TRUE;
+    }
+    CHECK(vk::hasAnyCooperativeMatrix2Feature(allFeatures));
+    vk::appendCooperativeMatrix2Subfeatures(allFeatures, features, capabilities);
+    CHECK(features.size() == std::size(testCases));
+    CHECK(capabilities.size() == std::size(testCases) + 1);
+    for (const auto& testCase : testCases)
+    {
+        CHECK(std::find(features.begin(), features.end(), testCase.feature) != features.end());
+        for (size_t i = 0; i < testCase.capabilityCount; ++i)
+        {
+            CHECK(std::find(capabilities.begin(), capabilities.end(), testCase.capabilities[i]) != capabilities.end());
+        }
+    }
+}
+#endif
 
 GPU_TEST_CASE("cooperative-matrix-invalid-desc", ALL)
 {
@@ -102,4 +244,57 @@ GPU_TEST_CASE("cooperative-matrix-query", Vulkan)
     {
         CHECK(supportedWorkgroup);
     }
+}
+
+GPU_TEST_CASE("cooperative-matrix-2-feature-capabilities", Vulkan)
+{
+    struct TestCase
+    {
+        Feature feature;
+        const char* name;
+        Capability capability;
+    };
+    const TestCase testCases[] = {
+        {
+            Feature::CooperativeMatrixReductions,
+            "cooperative-matrix-reductions",
+            Capability::spvCooperativeMatrixReductionsNV,
+        },
+        {
+            Feature::CooperativeMatrixConversions,
+            "cooperative-matrix-conversions",
+            Capability::spvCooperativeMatrixConversionsNV,
+        },
+        {
+            Feature::CooperativeMatrixPerElementOperations,
+            "cooperative-matrix-per-element-operations",
+            Capability::spvCooperativeMatrixPerElementOperationsNV,
+        },
+        {
+            Feature::CooperativeMatrixTensorAddressing,
+            "cooperative-matrix-tensor-addressing",
+            Capability::spvCooperativeMatrixTensorAddressingNV,
+        },
+        {
+            Feature::CooperativeMatrixBlockLoads,
+            "cooperative-matrix-block-loads",
+            Capability::spvCooperativeMatrixBlockLoadsNV,
+        },
+    };
+
+    for (const auto& testCase : testCases)
+    {
+        const bool supported = device->hasFeature(testCase.feature);
+        CHECK(device->hasFeature(testCase.name) == supported);
+        CHECK(device->hasCapability(testCase.capability) == supported);
+        if (supported)
+        {
+            CHECK(device->hasCapability(Capability::SPV_NV_cooperative_matrix2));
+        }
+    }
+
+    CHECK(
+        device->hasCapability(Capability::spvTensorAddressingNV) ==
+        device->hasFeature(Feature::CooperativeMatrixTensorAddressing)
+    );
 }

--- a/tests/test-cooperative-matrix.cpp
+++ b/tests/test-cooperative-matrix.cpp
@@ -7,6 +7,7 @@
 
 #include <algorithm>
 #include <iterator>
+#include <ostream>
 
 using namespace rhi;
 using namespace rhi::testing;
@@ -65,16 +66,39 @@ TEST_CASE("cooperative-matrix-2-subfeature-projection")
         };
         vulkanFeatures.*featureBit = VK_TRUE;
         CHECK(vk::hasAnyCooperativeMatrix2Feature(vulkanFeatures));
+
+        auto extensionSelection = vk::selectCooperativeMatrix2Extensions(true, true, false, vulkanFeatures);
+        CHECK(extensionSelection.enableCooperativeMatrix2Extension);
+        CHECK(extensionSelection.appendCooperativeMatrixExtensionDependency);
+
+        extensionSelection = vk::selectCooperativeMatrix2Extensions(true, true, true, vulkanFeatures);
+        CHECK(extensionSelection.enableCooperativeMatrix2Extension);
+        CHECK_FALSE(extensionSelection.appendCooperativeMatrixExtensionDependency);
+
+        extensionSelection = vk::selectCooperativeMatrix2Extensions(false, true, false, vulkanFeatures);
+        CHECK_FALSE(extensionSelection.enableCooperativeMatrix2Extension);
+        CHECK_FALSE(extensionSelection.appendCooperativeMatrixExtensionDependency);
+
+        extensionSelection = vk::selectCooperativeMatrix2Extensions(false, true, true, vulkanFeatures);
+        CHECK_FALSE(extensionSelection.enableCooperativeMatrix2Extension);
+        CHECK_FALSE(extensionSelection.appendCooperativeMatrixExtensionDependency);
+
+        extensionSelection = vk::selectCooperativeMatrix2Extensions(true, false, false, vulkanFeatures);
+        CHECK_FALSE(extensionSelection.enableCooperativeMatrix2Extension);
+        CHECK_FALSE(extensionSelection.appendCooperativeMatrixExtensionDependency);
     }
 
     VkPhysicalDeviceCooperativeMatrix2FeaturesNV noFeatures = {
         VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_COOPERATIVE_MATRIX_2_FEATURES_NV
     };
     CHECK_FALSE(vk::hasAnyCooperativeMatrix2Feature(noFeatures));
+    const auto extensionSelection = vk::selectCooperativeMatrix2Extensions(true, true, false, noFeatures);
+    CHECK_FALSE(extensionSelection.enableCooperativeMatrix2Extension);
+    CHECK_FALSE(extensionSelection.appendCooperativeMatrixExtensionDependency);
 
     struct TestCase
     {
-        VkBool32 VkPhysicalDeviceCooperativeMatrix2FeaturesNV::*featureBit;
+        VkBool32 VkPhysicalDeviceCooperativeMatrix2FeaturesNV::* featureBit;
         Feature feature;
         Capability capabilities[2];
         size_t capabilityCount;


### PR DESCRIPTION
## Summary

- expose the five independently reported `VK_NV_cooperative_matrix2` operation features through `rhi::Feature`
- advertise the matching Slang capability atoms, including both tensor-addressing capabilities
- enable and chain `VkPhysicalDeviceCooperativeMatrix2FeaturesNV` once when any of its seven feature bits is supported
- enable the mandatory `VK_KHR_cooperative_matrix` device-extension dependency alongside `VK_NV_cooperative_matrix2`
- preserve the existing `cooperative-matrix-2` feature as the workgroup-scope signal
- add deterministic extension-selection, synthetic-bit, and Vulkan device feature/capability tests

The granular feature names let Slang's cooperative-matrix runtime tests gate the exact operation they use instead of treating the extension as one all-or-nothing feature.

Closes #850.
Tracks shader-slang/slang#9030.

## Testing

- repository pre-commit suite, including clang-format 20.1.7
- `cmake --build build --config Release --target slang-rhi-tests slang-test --parallel 8`
- `slang-rhi-tests -tc="cooperative-matrix-2-feature-names"` — 5/5 assertions
- `slang-rhi-tests -tc="cooperative-matrix-2-subfeature-projection"` — 117/117 assertions
- `slang-rhi-tests -tc="*cooperative-matrix*" -check-devices` — 8/8 test cases, 154/154 assertions
- Slang `map-element-single.slang` and `map-element-tuple.slang` on Vulkan with SPIR-V validation — 10/10 cases passed

Tested locally on an NVIDIA RTX PRO 6000 Blackwell Workstation Edition. The Slang verification PR also ran all ten MapElement cases successfully on the SM80Plus CI runner.
