### PR TITLE
Add opacity micromap support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1112,6 +1112,7 @@ if(SLANG_RHI_BUILD_TESTS AND NOT SLANG_RHI_BUILD_SHARED AND NOT EMSCRIPTEN)
         tests/test-ray-tracing-hitobject-intrinsics.cpp
         tests/test-ray-tracing-intrinsics.cpp
         tests/test-ray-tracing-lss.cpp
+        tests/test-opacity-micromap.cpp
         tests/test-ray-tracing-raygen-entrypoint.cpp
         tests/test-ray-tracing-reorder.cpp
         tests/test-ray-tracing-shader-table-multi-pipeline.cpp

--- a/docs/api.md
+++ b/docs/api.md
@@ -37,8 +37,10 @@
 | `readBuffer`                       | yes     | yes  | yes   | yes   | yes    | yes     | yes  |
 | `createQueryPool`                  | yes     | yes  | yes   | yes   | yes    | yes     | yes  |
 | `getAccelerationStructureSizes`    | :x:     | yes  | :x:   | yes   | yes    | yes     | :x:  |
+| `getMicromapSizes`                 | :x:     | yes  | :x:   | yes   | yes    | :x:     | :x:  |
 | `getClusterOperationSizes`         | :x:     | yes  | :x:   | yes   | yes    | :x:     | :x:  |
 | `createAccelerationStructure`      | :x:     | yes  | :x:   | yes   | yes    | yes     | :x:  |
+| `createMicromap`                   | :x:     | yes  | :x:   | yes   | yes    | :x:     | :x:  |
 | `createFence`                      | yes     | yes  | :x:   | yes   | yes    | yes     | yes  |
 | `waitForFences`                    | yes     | yes  | :x:   | yes   | yes    | yes     | yes  |
 | `createHeap`                       | :x:     | yes  | :x:   | yes   | yes    | :x:     | :x:  |
@@ -182,6 +184,7 @@
 | `clearTextureDepthStencil`             | :x: | :x:  | yes   | yes   | yes    | yes   | :x:  |
 | `resolveQuery`                         | yes | :x:  | :x:   | yes   | yes    | yes   | :x:  |
 | `buildAccelerationStructure`           | :x: | yes  | :x:   | yes   | yes    | yes   | :x:  |
+| `buildMicromap`                        | :x: | yes  | :x:   | yes   | yes    | :x:   | :x:  |
 | `copyAccelerationStructure`            | :x: | yes  | :x:   | yes   | yes    | yes   | :x:  |
 | `queryAccelerationStructureProperties` | :x: | :x:  | :x:   | yes   | yes    | :x:   | :x:  |
 | `executeClusterOperation`              | :x: | yes  | :x:   | yes   | yes    | :x:   | :x:  |

--- a/include/slang-rhi-device.h
+++ b/include/slang-rhi-device.h
@@ -199,6 +199,23 @@ struct AABB
 };
 
 // ----------------------------------------------------------------------------
+// Micromaps
+// ----------------------------------------------------------------------------
+
+/// GPU-side descriptor for one opacity micromap. This layout is portable across the
+/// supported native APIs.
+struct MicromapTriangleDesc
+{
+    uint32_t dataOffset;
+    uint16_t subdivisionLevel;
+    uint16_t format;
+};
+
+#ifdef __cplusplus
+static_assert(sizeof(MicromapTriangleDesc) == 8, "MicromapTriangleDesc must match the native API layout");
+#endif
+
+// ----------------------------------------------------------------------------
 // Cluster operations
 // ----------------------------------------------------------------------------
 

--- a/include/slang-rhi.h
+++ b/include/slang-rhi.h
@@ -69,6 +69,8 @@ enum class StructType
     TextureViewDesc,
     SamplerDesc,
     AccelerationStructureDesc,
+    MicromapDesc,
+    AccelerationStructureOpacityMicromapDesc,
     FenceDesc,
     RenderPipelineDesc,
     ComputePipelineDesc,
@@ -127,6 +129,7 @@ enum class DeviceType
     x(ShaderExecutionReordering,                "shader-execution-reordering"                   ) \
     x(RayTracingMotionBlur,                     "ray-tracing-motion-blur"                       ) \
     x(RayTracingValidation,                     "ray-tracing-validation"                        ) \
+    x(OpacityMicromap,                          "opacity-micromap"                              ) \
     x(ClusterAccelerationStructure,             "cluster-acceleration-structure"                ) \
     /* Other features */                                                                          \
     x(TimestampQuery,                           "timestamp-query"                               ) \
@@ -291,7 +294,8 @@ enum class LinkingStyle
 
 struct ShaderProgramDesc
 {
-    StructType type = StructType::ShaderProgramDesc;
+    static constexpr StructType kStructType = StructType::ShaderProgramDesc;
+    StructType type = kStructType;
     const void* next = nullptr;
 
     // TODO: Tess doesn't like this but doesn't know what to do about it
@@ -553,6 +557,9 @@ enum class ResourceState
     AccelerationStructureRead,
     AccelerationStructureWrite,
     AccelerationStructureBuildInput,
+    MicromapBuildInput,
+    MicromapRead,
+    MicromapWrite,
 };
 
 /// Describes how memory for the resource should be allocated for CPU access.
@@ -594,6 +601,7 @@ enum class NativeHandleType
     VkSampler = 0x0003000a,
     VkPipeline = 0x0003000b,
     VkSemaphore = 0x0003000c,
+    VkMicromapEXT = 0x0003000d,
 
     MTLDevice = 0x00040001,
     MTLCommandQueue = 0x00040002,
@@ -694,7 +702,8 @@ struct VertexStreamDesc
 
 struct InputLayoutDesc
 {
-    StructType structType = StructType::InputLayoutDesc;
+    static constexpr StructType kStructType = StructType::InputLayoutDesc;
+    StructType structType = kStructType;
     const void* next = nullptr;
 
     const InputElementDesc* inputElements = nullptr;
@@ -749,14 +758,17 @@ enum class BufferUsage
     CopyDestination = (1 << 7),
     AccelerationStructure = (1 << 8),
     AccelerationStructureBuildInput = (1 << 9),
-    ShaderTable = (1 << 10),
-    Shared = (1 << 11),
+    MicromapBuildInput = (1 << 10),
+    MicromapStorage = (1 << 11),
+    ShaderTable = (1 << 12),
+    Shared = (1 << 13),
 };
 SLANG_RHI_ENUM_CLASS_OPERATORS(BufferUsage);
 
 struct BufferDesc
 {
-    StructType structType = StructType::BufferDesc;
+    static constexpr StructType kStructType = StructType::BufferDesc;
+    StructType structType = kStructType;
     const void* next = nullptr;
 
     /// Total size in bytes.
@@ -1024,7 +1036,8 @@ static const SubresourceRange kAllSubresources = {0, kAllLayers, 0, kAllMips};
 
 struct TextureDesc
 {
-    StructType structType = StructType::TextureDesc;
+    static constexpr StructType kStructType = StructType::TextureDesc;
+    StructType structType = kStructType;
     const void* next = nullptr;
 
     TextureType type = TextureType::Texture2D;
@@ -1073,7 +1086,8 @@ struct TextureDesc
 
 struct TextureViewDesc
 {
-    StructType structType = StructType::TextureViewDesc;
+    static constexpr StructType kStructType = StructType::TextureViewDesc;
+    StructType structType = kStructType;
     const void* next = nullptr;
 
     Format format = Format::Undefined;
@@ -1189,7 +1203,8 @@ enum class TextureReductionOp
 
 struct SamplerDesc
 {
-    StructType structType = StructType::SamplerDesc;
+    static constexpr StructType kStructType = StructType::SamplerDesc;
+    StructType structType = kStructType;
     const void* next = nullptr;
 
     TextureFilteringMode minFilter = TextureFilteringMode::Linear;
@@ -1265,7 +1280,9 @@ enum class AccelerationStructureInstanceFlags : uint32_t
     TriangleFacingCullDisable = (1 << 0),
     TriangleFrontCounterClockwise = (1 << 1),
     ForceOpaque = (1 << 2),
-    NoOpaque = (1 << 3)
+    NoOpaque = (1 << 3),
+    ForceOpacityMicromap2State = (1 << 4),
+    DisableOpacityMicromaps = (1 << 5),
 };
 SLANG_RHI_ENUM_CLASS_OPERATORS(AccelerationStructureInstanceFlags);
 
@@ -1336,6 +1353,9 @@ struct AccelerationStructureBuildInputTriangles
     BufferOffsetPair preTransformBuffer;
 
     AccelerationStructureGeometryFlags flags;
+
+    /// Optional chain of typed geometry extensions.
+    const void* next = nullptr;
 };
 
 struct AccelerationStructureBuildInputProceduralPrimitives
@@ -1432,7 +1452,9 @@ enum class AccelerationStructureBuildFlags
     PreferFastTrace = (1 << 2),
     PreferFastBuild = (1 << 3),
     MinimizeMemory = (1 << 4),
-    CreateMotion = (1 << 5)
+    CreateMotion = (1 << 5),
+    AllowOpacityMicromapUpdate = (1 << 6),
+    AllowDisableOpacityMicromaps = (1 << 7),
 };
 SLANG_RHI_ENUM_CLASS_OPERATORS(AccelerationStructureBuildFlags);
 
@@ -1479,7 +1501,8 @@ enum class AccelerationStructureKind
 
 struct AccelerationStructureDesc
 {
-    StructType structType = StructType::AccelerationStructureDesc;
+    static constexpr StructType kStructType = StructType::AccelerationStructureDesc;
+    StructType structType = kStructType;
     const void* next = nullptr;
 
     AccelerationStructureKind kind = AccelerationStructureKind::Unknown;
@@ -1500,6 +1523,117 @@ public:
     virtual SLANG_NO_THROW AccelerationStructureHandle SLANG_MCALL getHandle() = 0;
     virtual SLANG_NO_THROW DeviceAddress SLANG_MCALL getDeviceAddress() = 0;
     virtual SLANG_NO_THROW Result SLANG_MCALL getDescriptorHandle(DescriptorHandle* outHandle) = 0;
+};
+
+// Micromaps
+
+enum class MicromapType
+{
+    Opacity,
+};
+
+enum class OpacityMicromapFormat : uint32_t
+{
+    TwoState = 1,
+    FourState = 2,
+};
+
+enum class OpacityMicromapSpecialIndex : int32_t
+{
+    FullyTransparent = -1,
+    FullyOpaque = -2,
+    FullyUnknownTransparent = -3,
+    FullyUnknownOpaque = -4,
+};
+
+/// Host-side count for one subdivision-level/format combination.
+struct MicromapUsageCount
+{
+    uint32_t count;
+    uint32_t subdivisionLevel;
+    uint32_t format;
+};
+
+enum class MicromapIndexingMode
+{
+    Linear,
+    Indexed,
+};
+
+enum class MicromapIndexFormat
+{
+    None,
+    Uint16,
+    Uint32,
+};
+
+struct AccelerationStructureMicromapLink
+{
+    /// The referenced micromap must remain alive while an acceleration structure built
+    /// with this link may be used.
+    class IMicromap* micromap = nullptr;
+    MicromapIndexingMode indexingMode = MicromapIndexingMode::Linear;
+    BufferOffsetPair indexBuffer;
+    MicromapIndexFormat indexFormat = MicromapIndexFormat::None;
+    uint32_t indexStride = 0;
+    uint32_t baseMicromapIndex = 0;
+
+    const MicromapUsageCount* usageCounts = nullptr;
+    uint32_t usageCount = 0;
+};
+
+struct AccelerationStructureOpacityMicromapDesc
+{
+    static constexpr StructType kStructType = StructType::AccelerationStructureOpacityMicromapDesc;
+    StructType structType = kStructType;
+    const void* next = nullptr;
+    AccelerationStructureMicromapLink link;
+};
+
+enum class MicromapBuildFlags : uint32_t
+{
+    None = 0,
+    PreferFastTrace = (1 << 0),
+    PreferFastBuild = (1 << 1),
+    AllowCompaction = (1 << 2),
+};
+SLANG_RHI_ENUM_CLASS_OPERATORS(MicromapBuildFlags);
+
+struct MicromapBuildDesc
+{
+    MicromapType type = MicromapType::Opacity;
+    MicromapBuildFlags flags = MicromapBuildFlags::None;
+    BufferOffsetPair dataBuffer;
+    BufferOffsetPair descriptorBuffer;
+    uint32_t descriptorStride = sizeof(MicromapTriangleDesc);
+    const MicromapUsageCount* histogram = nullptr;
+    uint32_t histogramCount = 0;
+};
+
+struct MicromapSizes
+{
+    uint64_t micromapSize = 0;
+    uint64_t scratchSize = 0;
+};
+
+struct MicromapDesc
+{
+    static constexpr StructType kStructType = StructType::MicromapDesc;
+    StructType structType = kStructType;
+    const void* next = nullptr;
+    MicromapType type = MicromapType::Opacity;
+    uint64_t size = 0;
+    MicromapBuildFlags flags = MicromapBuildFlags::None;
+    const char* label = nullptr;
+};
+
+class IMicromap : public IResource
+{
+    SLANG_COM_INTERFACE(0xbda4e8ec, 0xf62c, 0x4ef6, {0xb0, 0x9f, 0x9e, 0x84, 0x5b, 0x1b, 0xf7, 0xe4});
+
+public:
+    virtual SLANG_NO_THROW const MicromapDesc& SLANG_MCALL getDesc() = 0;
+    virtual SLANG_NO_THROW DeviceAddress SLANG_MCALL getDeviceAddress() = 0;
 };
 
 // Cluster Acceleration Structure API
@@ -1646,7 +1780,8 @@ struct ClusterOperationSizes
 
 struct FenceDesc
 {
-    StructType structType = StructType::FenceDesc;
+    static constexpr StructType kStructType = StructType::FenceDesc;
+    StructType structType = kStructType;
     const void* next = nullptr;
 
     uint64_t initialValue = 0;
@@ -1976,7 +2111,8 @@ enum class PipelineCompilationPolicy
 
 struct RenderPipelineDesc
 {
-    StructType structType = StructType::RenderPipelineDesc;
+    static constexpr StructType kStructType = StructType::RenderPipelineDesc;
+    StructType structType = kStructType;
     const void* next = nullptr;
 
     IShaderProgram* program = nullptr;
@@ -1996,7 +2132,8 @@ struct RenderPipelineDesc
 
 struct ComputePipelineDesc
 {
-    StructType structType = StructType::ComputePipelineDesc;
+    static constexpr StructType kStructType = StructType::ComputePipelineDesc;
+    StructType structType = kStructType;
     const void* next = nullptr;
 
     IShaderProgram* program = nullptr;
@@ -2017,6 +2154,7 @@ enum class RayTracingPipelineFlags
     EnableLinearSweptSpheres = (1 << 3),
     EnableClusters = (1 << 4),
     EnableMotion = (1 << 5),
+    EnableOpacityMicromaps = (1 << 6),
 };
 SLANG_RHI_ENUM_CLASS_OPERATORS(RayTracingPipelineFlags);
 
@@ -2030,7 +2168,8 @@ struct HitGroupDesc
 
 struct RayTracingPipelineDesc
 {
-    StructType structType = StructType::RayTracingPipelineDesc;
+    static constexpr StructType kStructType = StructType::RayTracingPipelineDesc;
+    StructType structType = kStructType;
     const void* next = nullptr;
 
     IShaderProgram* program = nullptr;
@@ -2060,7 +2199,8 @@ struct ShaderRecordOverwrite
 
 struct ShaderTableDesc
 {
-    StructType structType = StructType::ShaderTableDesc;
+    static constexpr StructType kStructType = StructType::ShaderTableDesc;
+    StructType structType = kStructType;
     const void* next = nullptr;
 
     uint32_t rayGenShaderCount = 0;
@@ -2281,7 +2421,8 @@ enum class QueryResultState
 
 struct QueryPoolDesc
 {
-    StructType structType = StructType::QueryPoolDesc;
+    static constexpr StructType kStructType = StructType::QueryPoolDesc;
+    StructType structType = kStructType;
     const void* next = nullptr;
 
     QueryType type = QueryType::Timestamp;
@@ -2483,7 +2624,8 @@ struct MarkerColor
 
 struct CommandBufferDesc
 {
-    StructType structType = StructType::CommandBufferDesc;
+    static constexpr StructType kStructType = StructType::CommandBufferDesc;
+    StructType structType = kStructType;
     const void* next = nullptr;
 
     /// The name of the command buffer for debugging purposes.
@@ -2575,7 +2717,8 @@ public:
 
 struct CommandEncoderDesc
 {
-    StructType structType = StructType::CommandEncoderDesc;
+    static constexpr StructType kStructType = StructType::CommandEncoderDesc;
+    StructType structType = kStructType;
     const void* next = nullptr;
 
     /// The name of the command encoder for debugging purposes.
@@ -2736,6 +2879,12 @@ public:
         BufferOffsetPair scratchBuffer,
         uint32_t propertyQueryCount,
         const AccelerationStructureQueryDesc* queryDescs
+    ) = 0;
+
+    virtual SLANG_NO_THROW void SLANG_MCALL buildMicromap(
+        const MicromapBuildDesc& desc,
+        IMicromap* dst,
+        BufferOffsetPair scratchBuffer
     ) = 0;
 
     virtual SLANG_NO_THROW void SLANG_MCALL copyAccelerationStructure(
@@ -3010,7 +3159,8 @@ struct HeapCachingConfig
 
 struct HeapDesc
 {
-    StructType structType = StructType::HeapDesc;
+    static constexpr StructType kStructType = StructType::HeapDesc;
+    StructType structType = kStructType;
 
     /// Type of memory heap should reside in.
     MemoryType memoryType = MemoryType::DeviceLocal;
@@ -3310,7 +3460,8 @@ enum class PipelineCompilationMode
 
 struct DeviceDesc
 {
-    StructType structType = StructType::DeviceDesc;
+    static constexpr StructType kStructType = StructType::DeviceDesc;
+    StructType structType = kStructType;
     const void* next = nullptr;
 
     // The underlying API/Platform of the device.
@@ -3735,6 +3886,11 @@ public:
         AccelerationStructureSizes* outSizes
     ) = 0;
 
+    virtual SLANG_NO_THROW Result SLANG_MCALL getMicromapSizes(
+        const MicromapBuildDesc& desc,
+        MicromapSizes* outSizes
+    ) = 0;
+
     virtual SLANG_NO_THROW Result SLANG_MCALL getClusterOperationSizes(
         const ClusterOperationParams& params,
         ClusterOperationSizes* outSizes
@@ -3744,6 +3900,8 @@ public:
         const AccelerationStructureDesc& desc,
         IAccelerationStructure** outAccelerationStructure
     ) = 0;
+
+    virtual SLANG_NO_THROW Result SLANG_MCALL createMicromap(const MicromapDesc& desc, IMicromap** outMicromap) = 0;
 
     virtual SLANG_NO_THROW Result SLANG_MCALL createFence(const FenceDesc& desc, IFence** outFence) = 0;
 
@@ -4079,7 +4237,8 @@ public:
 // Extended descs.
 struct D3D12ExperimentalFeaturesDesc
 {
-    StructType structType = StructType::D3D12ExperimentalFeaturesDesc;
+    static constexpr StructType kStructType = StructType::D3D12ExperimentalFeaturesDesc;
+    StructType structType = kStructType;
     const void* next = nullptr;
 
     uint32_t featureCount = 0;
@@ -4090,7 +4249,8 @@ struct D3D12ExperimentalFeaturesDesc
 
 struct D3D12DeviceExtendedDesc
 {
-    StructType structType = StructType::D3D12DeviceExtendedDesc;
+    static constexpr StructType kStructType = StructType::D3D12DeviceExtendedDesc;
+    StructType structType = kStructType;
     const void* next = nullptr;
 
     const char* rootParameterShaderAttributeName = nullptr;
@@ -4102,7 +4262,8 @@ struct D3D12DeviceExtendedDesc
 
 struct VulkanDeviceExtendedDesc
 {
-    StructType structType = StructType::VulkanDeviceExtendedDesc;
+    static constexpr StructType kStructType = StructType::VulkanDeviceExtendedDesc;
+    StructType structType = kStructType;
     const void* next = nullptr;
 
     bool enableDebugPrintf = false;

--- a/src/command-buffer.cpp
+++ b/src/command-buffer.cpp
@@ -808,6 +808,15 @@ void CommandEncoder::buildAccelerationStructure(
     m_commandList->write(std::move(cmd));
 }
 
+void CommandEncoder::buildMicromap(const MicromapBuildDesc& desc, IMicromap* dst, BufferOffsetPair scratchBuffer)
+{
+    commands::BuildMicromap cmd;
+    cmd.desc = desc;
+    cmd.dst = dst;
+    cmd.scratchBuffer = scratchBuffer;
+    m_commandList->write(std::move(cmd));
+}
+
 void CommandEncoder::copyAccelerationStructure(
     IAccelerationStructure* dst,
     IAccelerationStructure* src,

--- a/src/command-buffer.h
+++ b/src/command-buffer.h
@@ -341,6 +341,12 @@ public:
         const AccelerationStructureQueryDesc* queryDescs
     ) override;
 
+    virtual SLANG_NO_THROW void SLANG_MCALL buildMicromap(
+        const MicromapBuildDesc& desc,
+        IMicromap* dst,
+        BufferOffsetPair scratchBuffer
+    ) override;
+
     virtual SLANG_NO_THROW void SLANG_MCALL copyAccelerationStructure(
         IAccelerationStructure* dst,
         IAccelerationStructure* src,

--- a/src/command-list.cpp
+++ b/src/command-list.cpp
@@ -201,36 +201,56 @@ void CommandList::write(commands::BuildAccelerationStructure&& cmd)
     {
         cmd.desc.inputs = (AccelerationStructureBuildInput*)
             writeData(cmd.desc.inputs, cmd.desc.inputCount * sizeof(AccelerationStructureBuildInput));
+        AccelerationStructureBuildInput* inputs = const_cast<AccelerationStructureBuildInput*>(cmd.desc.inputs);
         for (uint32_t i = 0; i < cmd.desc.inputCount; ++i)
         {
-            switch (cmd.desc.inputs[i].type)
+            switch (inputs[i].type)
             {
             case AccelerationStructureBuildInputType::Instances:
             {
-                const AccelerationStructureBuildInputInstances& instances = cmd.desc.inputs[i].instances;
+                const AccelerationStructureBuildInputInstances& instances = inputs[i].instances;
                 retainResource<Buffer>(instances.instanceBuffer.buffer);
                 break;
             }
             case AccelerationStructureBuildInputType::Triangles:
             {
-                const AccelerationStructureBuildInputTriangles& triangles = cmd.desc.inputs[i].triangles;
+                AccelerationStructureBuildInputTriangles& triangles = inputs[i].triangles;
                 for (uint32_t j = 0; j < triangles.vertexBufferCount; ++j)
                     retainResource<Buffer>(triangles.vertexBuffers[j].buffer);
                 retainResource<Buffer>(triangles.indexBuffer.buffer);
                 retainResource<Buffer>(triangles.preTransformBuffer.buffer);
+                if (const auto* sourceOpacityDesc =
+                        findStructInChain<AccelerationStructureOpacityMicromapDesc>(triangles.next))
+                {
+                    auto* opacityDesc = (AccelerationStructureOpacityMicromapDesc*)
+                        writeData(sourceOpacityDesc, sizeof(AccelerationStructureOpacityMicromapDesc));
+                    triangles.next = opacityDesc;
+                    // Extension chains are copied explicitly as support is added. Do not retain
+                    // a pointer into caller-owned memory for an unrecognized nested extension.
+                    opacityDesc->next = nullptr;
+                    retainResource<Micromap>(opacityDesc->link.micromap);
+                    retainResource<Buffer>(opacityDesc->link.indexBuffer.buffer);
+                    if (opacityDesc->link.usageCounts && opacityDesc->link.usageCount > 0)
+                    {
+                        opacityDesc->link.usageCounts = (MicromapUsageCount*)writeData(
+                            opacityDesc->link.usageCounts,
+                            opacityDesc->link.usageCount * sizeof(MicromapUsageCount)
+                        );
+                    }
+                }
                 break;
             }
             case AccelerationStructureBuildInputType::ProceduralPrimitives:
             {
                 const AccelerationStructureBuildInputProceduralPrimitives& proceduralPrimitives =
-                    cmd.desc.inputs[i].proceduralPrimitives;
+                    inputs[i].proceduralPrimitives;
                 for (uint32_t j = 0; j < proceduralPrimitives.aabbBufferCount; ++j)
                     retainResource<Buffer>(proceduralPrimitives.aabbBuffers[j].buffer);
                 break;
             }
             case AccelerationStructureBuildInputType::Spheres:
             {
-                const AccelerationStructureBuildInputSpheres& spheres = cmd.desc.inputs[i].spheres;
+                const AccelerationStructureBuildInputSpheres& spheres = inputs[i].spheres;
                 for (uint32_t j = 0; j < spheres.vertexBufferCount; ++j)
                 {
                     retainResource<Buffer>(spheres.vertexPositionBuffers[j].buffer);
@@ -241,7 +261,7 @@ void CommandList::write(commands::BuildAccelerationStructure&& cmd)
             }
             case AccelerationStructureBuildInputType::LinearSweptSpheres:
             {
-                const AccelerationStructureBuildInputLinearSweptSpheres lss = cmd.desc.inputs[i].linearSweptSpheres;
+                const AccelerationStructureBuildInputLinearSweptSpheres lss = inputs[i].linearSweptSpheres;
                 for (uint32_t j = 0; j < lss.vertexBufferCount; ++j)
                 {
                     retainResource<Buffer>(lss.vertexPositionBuffers[j].buffer);
@@ -265,6 +285,20 @@ void CommandList::write(commands::BuildAccelerationStructure&& cmd)
             retainResource<QueryPool>(cmd.queryDescs[i].queryPool);
             trackQueryWrite(cmd.queryDescs[i].queryPool, uint32_t(cmd.queryDescs[i].firstQueryIndex), 1);
         }
+    }
+    writeCommand(std::move(cmd));
+}
+
+void CommandList::write(commands::BuildMicromap&& cmd)
+{
+    retainResource<Buffer>(cmd.desc.dataBuffer.buffer);
+    retainResource<Buffer>(cmd.desc.descriptorBuffer.buffer);
+    retainResource<Micromap>(cmd.dst);
+    retainResource<Buffer>(cmd.scratchBuffer.buffer);
+    if (cmd.desc.histogram && cmd.desc.histogramCount > 0)
+    {
+        cmd.desc.histogram =
+            (MicromapUsageCount*)writeData(cmd.desc.histogram, cmd.desc.histogramCount * sizeof(MicromapUsageCount));
     }
     writeCommand(std::move(cmd));
 }

--- a/src/command-list.h
+++ b/src/command-list.h
@@ -39,6 +39,7 @@
     x(SetRayTracingState) \
     x(DispatchRays) \
     x(BuildAccelerationStructure) \
+    x(BuildMicromap) \
     x(CopyAccelerationStructure) \
     x(QueryAccelerationStructureProperties) \
     x(ExecuteClusterOperation) \
@@ -260,6 +261,13 @@ struct BuildAccelerationStructure
     const AccelerationStructureQueryDesc* queryDescs;
 };
 
+struct BuildMicromap
+{
+    MicromapBuildDesc desc;
+    IMicromap* dst;
+    BufferOffsetPair scratchBuffer;
+};
+
 struct CopyAccelerationStructure
 {
     IAccelerationStructure* dst;
@@ -441,6 +449,7 @@ public:
     void write(commands::SetRayTracingState&& cmd);
     void write(commands::DispatchRays&& cmd);
     void write(commands::BuildAccelerationStructure&& cmd);
+    void write(commands::BuildMicromap&& cmd);
     void write(commands::CopyAccelerationStructure&& cmd);
     void write(commands::QueryAccelerationStructureProperties&& cmd);
     void write(commands::ExecuteClusterOperation&& cmd);

--- a/src/cpu/cpu-command.cpp
+++ b/src/cpu/cpu-command.cpp
@@ -53,6 +53,7 @@ public:
     void cmdSetRayTracingState(const commands::SetRayTracingState& cmd);
     void cmdDispatchRays(const commands::DispatchRays& cmd);
     void cmdBuildAccelerationStructure(const commands::BuildAccelerationStructure& cmd);
+    void cmdBuildMicromap(const commands::BuildMicromap& cmd);
     void cmdCopyAccelerationStructure(const commands::CopyAccelerationStructure& cmd);
     void cmdQueryAccelerationStructureProperties(const commands::QueryAccelerationStructureProperties& cmd);
     void cmdExecuteClusterOperation(const commands::ExecuteClusterOperation& cmd);
@@ -260,6 +261,12 @@ void CommandExecutor::cmdBuildAccelerationStructure(const commands::BuildAcceler
 {
     SLANG_UNUSED(cmd);
     NOT_SUPPORTED(ICommandEncoder, buildAccelerationStructure);
+}
+
+void CommandExecutor::cmdBuildMicromap(const commands::BuildMicromap& cmd)
+{
+    SLANG_UNUSED(cmd);
+    NOT_SUPPORTED(ICommandEncoder, buildMicromap);
 }
 
 void CommandExecutor::cmdCopyAccelerationStructure(const commands::CopyAccelerationStructure& cmd)

--- a/src/cuda/cuda-acceleration-structure.cpp
+++ b/src/cuda/cuda-acceleration-structure.cpp
@@ -43,4 +43,32 @@ Result AccelerationStructureImpl::getDescriptorHandle(DescriptorHandle* outHandl
     return SLANG_OK;
 }
 
+MicromapImpl::MicromapImpl(Device* device, const MicromapDesc& desc)
+    : Micromap(device, desc)
+{
+}
+
+MicromapImpl::~MicromapImpl()
+{
+    if (m_buffer)
+        SLANG_CUDA_ASSERT_ON_FAIL(cuMemFree(m_buffer));
+}
+
+void MicromapImpl::deleteThis()
+{
+    getDevice<DeviceImpl>()->deferDelete(this);
+}
+
+Result MicromapImpl::getNativeHandle(NativeHandle* outHandle)
+{
+    outHandle->type = NativeHandleType::CUdeviceptr;
+    outHandle->value = m_buffer;
+    return SLANG_OK;
+}
+
+DeviceAddress MicromapImpl::getDeviceAddress()
+{
+    return m_buffer;
+}
+
 } // namespace rhi::cuda

--- a/src/cuda/cuda-acceleration-structure.h
+++ b/src/cuda/cuda-acceleration-structure.h
@@ -28,4 +28,22 @@ public:
     optix::OptixTraversableHandle m_handle;
 };
 
+class MicromapImpl : public Micromap
+{
+public:
+    MicromapImpl(Device* device, const MicromapDesc& desc);
+    ~MicromapImpl();
+
+    virtual void deleteThis() override;
+
+    // IResource implementation
+    virtual SLANG_NO_THROW Result SLANG_MCALL getNativeHandle(NativeHandle* outHandle) override;
+
+    // IMicromap implementation
+    virtual SLANG_NO_THROW DeviceAddress SLANG_MCALL getDeviceAddress() override;
+
+public:
+    CUdeviceptr m_buffer = 0;
+};
+
 } // namespace rhi::cuda

--- a/src/cuda/cuda-base.h
+++ b/src/cuda/cuda-base.h
@@ -33,6 +33,7 @@ class CommandBufferImpl;
 class CommandEncoderImpl;
 class CommandQueueImpl;
 class AccelerationStructureImpl;
+class MicromapImpl;
 class ShaderTableImpl;
 class HeapImpl;
 struct BindingDataImpl;

--- a/src/cuda/cuda-command.cpp
+++ b/src/cuda/cuda-command.cpp
@@ -270,6 +270,7 @@ public:
     void cmdSetRayTracingState(const commands::SetRayTracingState& cmd);
     void cmdDispatchRays(const commands::DispatchRays& cmd);
     void cmdBuildAccelerationStructure(const commands::BuildAccelerationStructure& cmd);
+    void cmdBuildMicromap(const commands::BuildMicromap& cmd);
     void cmdCopyAccelerationStructure(const commands::CopyAccelerationStructure& cmd);
     void cmdQueryAccelerationStructureProperties(const commands::QueryAccelerationStructureProperties& cmd);
     void cmdExecuteClusterOperation(const commands::ExecuteClusterOperation& cmd);
@@ -778,6 +779,14 @@ void CommandExecutor::cmdBuildAccelerationStructure(const commands::BuildAcceler
         cmd.propertyQueryCount,
         cmd.queryDescs
     );
+}
+
+void CommandExecutor::cmdBuildMicromap(const commands::BuildMicromap& cmd)
+{
+    if (!m_device->m_ctx.optixContext)
+        return;
+    m_device->m_ctx.optixContext
+        ->buildMicromap(m_stream, cmd.desc, checked_cast<MicromapImpl*>(cmd.dst), cmd.scratchBuffer);
 }
 
 void CommandExecutor::cmdCopyAccelerationStructure(const commands::CopyAccelerationStructure& cmd)

--- a/src/cuda/cuda-device.cpp
+++ b/src/cuda/cuda-device.cpp
@@ -281,6 +281,7 @@ Result DeviceImpl::initialize(const DeviceDesc& desc, BackendImpl* backend)
     {
         addFeature(Feature::AccelerationStructure);
         addFeature(Feature::RayTracing);
+        addFeature(Feature::OpacityMicromap);
         uint32_t optixVersion = m_ctx.optixContext->getOptixVersion();
         m_info.optixVersion = optixVersion;
         if (optixVersion >= 80100)
@@ -554,6 +555,13 @@ Result DeviceImpl::getAccelerationStructureSizes(
     return m_ctx.optixContext->getAccelerationStructureSizes(desc, outSizes);
 }
 
+Result DeviceImpl::getMicromapSizes(const MicromapBuildDesc& desc, MicromapSizes* outSizes)
+{
+    if (!m_ctx.optixContext)
+        return SLANG_E_NOT_AVAILABLE;
+    return m_ctx.optixContext->getMicromapSizes(desc, outSizes);
+}
+
 Result DeviceImpl::getClusterOperationSizes(const ClusterOperationParams& params, ClusterOperationSizes* outSizes)
 {
     if (!m_ctx.optixContext)
@@ -577,6 +585,16 @@ Result DeviceImpl::createAccelerationStructure(
     SLANG_CUDA_RETURN_ON_FAIL_REPORT(cuMemAlloc(&result->m_propertyBuffer, 8), this);
     result->m_handle = 0;
     returnComPtr(outAccelerationStructure, result);
+    return SLANG_OK;
+}
+
+Result DeviceImpl::createMicromap(const MicromapDesc& desc, IMicromap** outMicromap)
+{
+    if (!m_ctx.optixContext)
+        return SLANG_E_NOT_AVAILABLE;
+    RefPtr<MicromapImpl> result = new MicromapImpl(this, desc);
+    SLANG_CUDA_RETURN_ON_FAIL_REPORT(cuMemAlloc(&result->m_buffer, desc.size), this);
+    returnComPtr(outMicromap, result);
     return SLANG_OK;
 }
 

--- a/src/cuda/cuda-device.h
+++ b/src/cuda/cuda-device.h
@@ -167,6 +167,11 @@ public:
         AccelerationStructureSizes* outSizes
     ) override;
 
+    virtual SLANG_NO_THROW Result SLANG_MCALL getMicromapSizes(
+        const MicromapBuildDesc& desc,
+        MicromapSizes* outSizes
+    ) override;
+
     virtual SLANG_NO_THROW Result SLANG_MCALL getClusterOperationSizes(
         const ClusterOperationParams& params,
         ClusterOperationSizes* outSizes
@@ -175,6 +180,11 @@ public:
     virtual SLANG_NO_THROW Result SLANG_MCALL createAccelerationStructure(
         const AccelerationStructureDesc& desc,
         IAccelerationStructure** outAccelerationStructure
+    ) override;
+
+    virtual SLANG_NO_THROW Result SLANG_MCALL createMicromap(
+        const MicromapDesc& desc,
+        IMicromap** outMicromap
     ) override;
 
     virtual SLANG_NO_THROW Result SLANG_MCALL getCooperativeVectorProperties(

--- a/src/cuda/optix-api-impl.cpp
+++ b/src/cuda/optix-api-impl.cpp
@@ -1348,7 +1348,8 @@ public:
         BufferOffsetPair scratchBuffer
     ) override
     {
-        if (desc.type != MicromapType::Opacity || !desc.histogram)
+        if (desc.type != MicromapType::Opacity || !desc.dataBuffer || !desc.descriptorBuffer || !desc.histogram ||
+            desc.histogramCount == 0 || is_set(desc.flags, MicromapBuildFlags::AllowCompaction))
             return;
         std::vector<OptixOpacityMicromapHistogramEntry> histogram(desc.histogramCount);
         for (uint32_t i = 0; i < desc.histogramCount; ++i)

--- a/src/cuda/optix-api-impl.cpp
+++ b/src/cuda/optix-api-impl.cpp
@@ -354,7 +354,7 @@ Result AccelerationStructureBuildDescConverter::convert(
                     usageCounts[j].subdivisionLevel = ommDesc->link.usageCounts[j].subdivisionLevel;
                     usageCounts[j].format = (OptixOpacityMicromapFormat)ommDesc->link.usageCounts[j].format;
                 }
-                OptixOpacityMicromap& omm = buildInput.triangleArray.opacityMicromap;
+                OptixBuildInputOpacityMicromap& omm = buildInput.triangleArray.opacityMicromap;
                 omm.indexingMode = ommDesc->link.indexingMode == MicromapIndexingMode::Indexed
                                        ? OPTIX_OPACITY_MICROMAP_ARRAY_INDEXING_MODE_INDEXED
                                        : OPTIX_OPACITY_MICROMAP_ARRAY_INDEXING_MODE_LINEAR;

--- a/src/cuda/optix-api-impl.cpp
+++ b/src/cuda/optix-api-impl.cpp
@@ -231,6 +231,7 @@ public:
     stable_vector<unsigned int> flagList;
     std::vector<OptixBuildInput> buildInputs;
     OptixAccelBuildOptions buildOptions;
+    std::vector<std::vector<OptixOpacityMicromapUsageCount>> opacityMicromapUsageCounts;
 
     Result convert(const AccelerationStructureBuildDesc& buildDesc, IDebugCallback* debugCallback);
 
@@ -302,6 +303,7 @@ Result AccelerationStructureBuildDescConverter::convert(
     }
     case AccelerationStructureBuildInputType::Triangles:
     {
+        opacityMicromapUsageCounts.resize(buildDesc.inputCount);
         for (uint32_t i = 0; i < buildDesc.inputCount; ++i)
         {
             const AccelerationStructureBuildInputTriangles& triangles = buildDesc.inputs[i].triangles;
@@ -340,6 +342,40 @@ Result AccelerationStructureBuildDescConverter::convert(
                 triangles.preTransformBuffer ? triangles.preTransformBuffer.getDeviceAddress() : 0;
             buildInput.triangleArray.transformFormat =
                 triangles.preTransformBuffer ? OPTIX_TRANSFORM_FORMAT_MATRIX_FLOAT12 : OPTIX_TRANSFORM_FORMAT_NONE;
+            if (const auto* ommDesc = findStructInChain<AccelerationStructureOpacityMicromapDesc>(triangles.next))
+            {
+                if (!ommDesc->link.micromap || (ommDesc->link.usageCount > 0 && !ommDesc->link.usageCounts))
+                    return SLANG_E_INVALID_ARG;
+                std::vector<OptixOpacityMicromapUsageCount>& usageCounts = opacityMicromapUsageCounts[i];
+                usageCounts.resize(ommDesc->link.usageCount);
+                for (uint32_t j = 0; j < ommDesc->link.usageCount; ++j)
+                {
+                    usageCounts[j].count = ommDesc->link.usageCounts[j].count;
+                    usageCounts[j].subdivisionLevel = ommDesc->link.usageCounts[j].subdivisionLevel;
+                    usageCounts[j].format = (OptixOpacityMicromapFormat)ommDesc->link.usageCounts[j].format;
+                }
+                OptixOpacityMicromap& omm = buildInput.triangleArray.opacityMicromap;
+                omm.indexingMode = ommDesc->link.indexingMode == MicromapIndexingMode::Indexed
+                                       ? OPTIX_OPACITY_MICROMAP_ARRAY_INDEXING_MODE_INDEXED
+                                       : OPTIX_OPACITY_MICROMAP_ARRAY_INDEXING_MODE_LINEAR;
+                omm.opacityMicromapArray = ommDesc->link.micromap->getDeviceAddress();
+                if (ommDesc->link.indexingMode == MicromapIndexingMode::Indexed)
+                {
+                    if (!ommDesc->link.indexBuffer)
+                        return SLANG_E_INVALID_ARG;
+                    omm.indexBuffer = ommDesc->link.indexBuffer.getDeviceAddress();
+                    if (ommDesc->link.indexFormat == MicromapIndexFormat::Uint16)
+                        omm.indexSizeInBytes = 2;
+                    else if (ommDesc->link.indexFormat == MicromapIndexFormat::Uint32)
+                        omm.indexSizeInBytes = 4;
+                    else
+                        return SLANG_E_INVALID_ARG;
+                    omm.indexStrideInBytes = ommDesc->link.indexStride;
+                }
+                omm.indexOffset = ommDesc->link.baseMicromapIndex;
+                omm.numMicromapUsageCounts = (uint32_t)usageCounts.size();
+                omm.micromapUsageCounts = usageCounts.data();
+            }
         }
         break;
     }
@@ -488,6 +524,14 @@ unsigned int AccelerationStructureBuildDescConverter::translateBuildFlags(Accele
     if (is_set(flags, AccelerationStructureBuildFlags::PreferFastTrace))
     {
         result |= OPTIX_BUILD_FLAG_PREFER_FAST_TRACE;
+    }
+    if (is_set(flags, AccelerationStructureBuildFlags::AllowOpacityMicromapUpdate))
+    {
+        result |= OPTIX_BUILD_FLAG_ALLOW_OPACITY_MICROMAP_UPDATE;
+    }
+    if (is_set(flags, AccelerationStructureBuildFlags::AllowDisableOpacityMicromaps))
+    {
+        result |= OPTIX_BUILD_FLAG_ALLOW_DISABLE_OPACITY_MICROMAPS;
     }
     return result;
 }
@@ -706,7 +750,8 @@ public:
             is_set(desc.flags, RayTracingPipelineFlags::EnableClusters) ? 1 : 0;
 #endif
 
-        optixPipelineCompileOptions.allowOpacityMicromaps = 0;
+        optixPipelineCompileOptions.allowOpacityMicromaps =
+            is_set(desc.flags, RayTracingPipelineFlags::EnableOpacityMicromaps) ? 1 : 0;
 
         OptixModuleCompileOptions optixModuleCompileOptions = {};
         optixModuleCompileOptions.maxRegisterCount = 0; // no limit
@@ -1191,6 +1236,39 @@ public:
         return SLANG_OK;
     }
 
+    virtual Result getMicromapSizes(const MicromapBuildDesc& desc, MicromapSizes* outSizes) override
+    {
+        if (desc.type != MicromapType::Opacity || !desc.dataBuffer || !desc.descriptorBuffer || !desc.histogram ||
+            desc.histogramCount == 0 || is_set(desc.flags, MicromapBuildFlags::AllowCompaction))
+            return SLANG_E_INVALID_ARG;
+        std::vector<OptixOpacityMicromapHistogramEntry> histogram(desc.histogramCount);
+        for (uint32_t i = 0; i < desc.histogramCount; ++i)
+        {
+            histogram[i].count = desc.histogram[i].count;
+            histogram[i].subdivisionLevel = desc.histogram[i].subdivisionLevel;
+            histogram[i].format = (OptixOpacityMicromapFormat)desc.histogram[i].format;
+        }
+        OptixOpacityMicromapArrayBuildInput input = {};
+        input.flags = 0;
+        if (is_set(desc.flags, MicromapBuildFlags::PreferFastTrace))
+            input.flags |= OPTIX_OPACITY_MICROMAP_FLAG_PREFER_FAST_TRACE;
+        if (is_set(desc.flags, MicromapBuildFlags::PreferFastBuild))
+            input.flags |= OPTIX_OPACITY_MICROMAP_FLAG_PREFER_FAST_BUILD;
+        input.inputBuffer = desc.dataBuffer.getDeviceAddress();
+        input.perMicromapDescBuffer = desc.descriptorBuffer.getDeviceAddress();
+        input.perMicromapDescStrideInBytes = desc.descriptorStride;
+        input.numMicromapHistogramEntries = desc.histogramCount;
+        input.micromapHistogramEntries = histogram.data();
+        OptixMicromapBufferSizes sizes = {};
+        SLANG_OPTIX_RETURN_ON_FAIL_REPORT(
+            optixOpacityMicromapArrayComputeMemoryUsage(m_deviceContext, &input, &sizes),
+            m_device
+        );
+        outSizes->micromapSize = sizes.outputSizeInBytes;
+        outSizes->scratchSize = sizes.tempSizeInBytes;
+        return SLANG_OK;
+    }
+
     virtual Result getClusterOperationSizes(
         const ClusterOperationParams& params,
         ClusterOperationSizes* outSizes
@@ -1261,6 +1339,41 @@ public:
             emittedProperties.empty() ? nullptr : emittedProperties.data(),
             emittedProperties.size()
         ));
+    }
+
+    virtual void buildMicromap(
+        CUstream stream,
+        const MicromapBuildDesc& desc,
+        MicromapImpl* dst,
+        BufferOffsetPair scratchBuffer
+    ) override
+    {
+        if (desc.type != MicromapType::Opacity || !desc.histogram)
+            return;
+        std::vector<OptixOpacityMicromapHistogramEntry> histogram(desc.histogramCount);
+        for (uint32_t i = 0; i < desc.histogramCount; ++i)
+        {
+            histogram[i].count = desc.histogram[i].count;
+            histogram[i].subdivisionLevel = desc.histogram[i].subdivisionLevel;
+            histogram[i].format = (OptixOpacityMicromapFormat)desc.histogram[i].format;
+        }
+        OptixOpacityMicromapArrayBuildInput input = {};
+        input.flags = 0;
+        if (is_set(desc.flags, MicromapBuildFlags::PreferFastTrace))
+            input.flags |= OPTIX_OPACITY_MICROMAP_FLAG_PREFER_FAST_TRACE;
+        if (is_set(desc.flags, MicromapBuildFlags::PreferFastBuild))
+            input.flags |= OPTIX_OPACITY_MICROMAP_FLAG_PREFER_FAST_BUILD;
+        input.inputBuffer = desc.dataBuffer.getDeviceAddress();
+        input.perMicromapDescBuffer = desc.descriptorBuffer.getDeviceAddress();
+        input.perMicromapDescStrideInBytes = desc.descriptorStride;
+        input.numMicromapHistogramEntries = desc.histogramCount;
+        input.micromapHistogramEntries = histogram.data();
+        OptixMicromapBuffers buffers = {};
+        buffers.output = dst->m_buffer;
+        buffers.outputSizeInBytes = dst->m_desc.size;
+        buffers.temp = scratchBuffer.getDeviceAddress();
+        buffers.tempSizeInBytes = checked_cast<BufferImpl*>(scratchBuffer.buffer)->m_desc.size - scratchBuffer.offset;
+        SLANG_OPTIX_ASSERT_ON_FAIL(optixOpacityMicromapArrayBuild(m_deviceContext, stream, &input, &buffers));
     }
 
     virtual void copyAccelerationStructure(

--- a/src/cuda/optix-api.h
+++ b/src/cuda/optix-api.h
@@ -18,6 +18,7 @@ class ShaderCompilationReporter;
 namespace rhi::cuda {
 class DeviceImpl;
 class AccelerationStructureImpl;
+class MicromapImpl;
 class RayTracingPipelineImpl;
 struct BindingDataImpl;
 class ShaderTableImpl;
@@ -74,6 +75,8 @@ public:
         AccelerationStructureSizes* outSizes
     ) = 0;
 
+    virtual Result getMicromapSizes(const MicromapBuildDesc& desc, MicromapSizes* outSizes) = 0;
+
     /// Get the sizes required for building a cluster acceleration structure or BLAS-from-CLAS.
     virtual Result getClusterOperationSizes(const ClusterOperationParams& params, ClusterOperationSizes* outSizes) = 0;
 
@@ -86,6 +89,13 @@ public:
         BufferOffsetPair scratchBuffer,
         uint32_t propertyQueryCount,
         const AccelerationStructureQueryDesc* queryDescs
+    ) = 0;
+
+    virtual void buildMicromap(
+        CUstream stream,
+        const MicromapBuildDesc& desc,
+        MicromapImpl* dst,
+        BufferOffsetPair scratchBuffer
     ) = 0;
 
     /// Copy an acceleration structure.

--- a/src/d3d11/d3d11-command.cpp
+++ b/src/d3d11/d3d11-command.cpp
@@ -85,6 +85,7 @@ public:
     void cmdSetRayTracingState(const commands::SetRayTracingState& cmd);
     void cmdDispatchRays(const commands::DispatchRays& cmd);
     void cmdBuildAccelerationStructure(const commands::BuildAccelerationStructure& cmd);
+    void cmdBuildMicromap(const commands::BuildMicromap& cmd);
     void cmdCopyAccelerationStructure(const commands::CopyAccelerationStructure& cmd);
     void cmdQueryAccelerationStructureProperties(const commands::QueryAccelerationStructureProperties& cmd);
     void cmdExecuteClusterOperation(const commands::ExecuteClusterOperation& cmd);
@@ -831,6 +832,12 @@ void CommandExecutor::cmdBuildAccelerationStructure(const commands::BuildAcceler
 {
     SLANG_UNUSED(cmd);
     NOT_SUPPORTED(ICommandEncoder, buildAccelerationStructure);
+}
+
+void CommandExecutor::cmdBuildMicromap(const commands::BuildMicromap& cmd)
+{
+    SLANG_UNUSED(cmd);
+    NOT_SUPPORTED(ICommandEncoder, buildMicromap);
 }
 
 void CommandExecutor::cmdCopyAccelerationStructure(const commands::CopyAccelerationStructure& cmd)

--- a/src/d3d12/d3d12-acceleration-structure.cpp
+++ b/src/d3d12/d3d12-acceleration-structure.cpp
@@ -73,6 +73,29 @@ Result AccelerationStructureImpl::getDescriptorHandle(DescriptorHandle* outHandl
     return SLANG_OK;
 }
 
+MicromapImpl::MicromapImpl(Device* device, const MicromapDesc& desc)
+    : Micromap(device, desc)
+{
+}
+
+void MicromapImpl::deleteThis()
+{
+    m_buffer.setNull();
+    getDevice<DeviceImpl>()->deferDelete(this);
+}
+
+Result MicromapImpl::getNativeHandle(NativeHandle* outHandle)
+{
+    outHandle->type = NativeHandleType::D3D12DeviceAddress;
+    outHandle->value = getDeviceAddress();
+    return SLANG_OK;
+}
+
+DeviceAddress MicromapImpl::getDeviceAddress()
+{
+    return m_buffer->getDeviceAddress();
+}
+
 Result AccelerationStructureBuildDescConverter::convert(
     const AccelerationStructureBuildDesc& buildDesc,
     IDebugCallback* callback
@@ -129,6 +152,9 @@ Result AccelerationStructureBuildDescConverter::convert(
     case AccelerationStructureBuildInputType::Triangles:
     {
         geomDescs.resize(buildDesc.inputCount);
+        triangleDescs.resize(buildDesc.inputCount);
+        ommLinkages.resize(buildDesc.inputCount);
+        ommTriangleDescs.resize(buildDesc.inputCount);
         for (uint32_t i = 0; i < buildDesc.inputCount; ++i)
         {
             const AccelerationStructureBuildInputTriangles& triangles = buildDesc.inputs[i].triangles;
@@ -139,24 +165,65 @@ Result AccelerationStructureBuildDescConverter::convert(
             D3D12_RAYTRACING_GEOMETRY_DESC& geomDesc = geomDescs[i];
             geomDesc.Type = D3D12_RAYTRACING_GEOMETRY_TYPE_TRIANGLES;
             geomDesc.Flags = translateGeometryFlags(triangles.flags);
-            geomDesc.Triangles.VertexBuffer.StartAddress = triangles.vertexBuffers[0].getDeviceAddress();
-            geomDesc.Triangles.VertexBuffer.StrideInBytes = triangles.vertexStride;
-            geomDesc.Triangles.VertexCount = triangles.vertexCount;
-            geomDesc.Triangles.VertexFormat = getVertexFormat(triangles.vertexFormat);
+            D3D12_RAYTRACING_GEOMETRY_TRIANGLES_DESC& triangleDesc = triangleDescs[i];
+            triangleDesc.VertexBuffer.StartAddress = triangles.vertexBuffers[0].getDeviceAddress();
+            triangleDesc.VertexBuffer.StrideInBytes = triangles.vertexStride;
+            triangleDesc.VertexCount = triangles.vertexCount;
+            triangleDesc.VertexFormat = getVertexFormat(triangles.vertexFormat);
             if (triangles.indexBuffer)
             {
-                geomDesc.Triangles.IndexBuffer = triangles.indexBuffer.getDeviceAddress();
-                geomDesc.Triangles.IndexCount = triangles.indexCount;
-                geomDesc.Triangles.IndexFormat = getIndexFormat(triangles.indexFormat);
+                triangleDesc.IndexBuffer = triangles.indexBuffer.getDeviceAddress();
+                triangleDesc.IndexCount = triangles.indexCount;
+                triangleDesc.IndexFormat = getIndexFormat(triangles.indexFormat);
             }
             else
             {
-                geomDesc.Triangles.IndexBuffer = 0;
-                geomDesc.Triangles.IndexCount = 0;
-                geomDesc.Triangles.IndexFormat = DXGI_FORMAT_UNKNOWN;
+                triangleDesc.IndexBuffer = 0;
+                triangleDesc.IndexCount = 0;
+                triangleDesc.IndexFormat = DXGI_FORMAT_UNKNOWN;
             }
-            geomDesc.Triangles.Transform3x4 =
+            triangleDesc.Transform3x4 =
                 triangles.preTransformBuffer ? triangles.preTransformBuffer.getDeviceAddress() : 0;
+
+            if (const auto* ommDesc = findStructInChain<AccelerationStructureOpacityMicromapDesc>(triangles.next))
+            {
+                if (!ommDesc->link.micromap)
+                    return SLANG_E_INVALID_ARG;
+                D3D12_RAYTRACING_GEOMETRY_OMM_LINKAGE_DESC& linkage = ommLinkages[i];
+                linkage.OpacityMicromapArray = ommDesc->link.micromap->getDeviceAddress();
+                linkage.OpacityMicromapBaseLocation = ommDesc->link.baseMicromapIndex;
+                if (ommDesc->link.indexingMode == MicromapIndexingMode::Indexed)
+                {
+                    if (!ommDesc->link.indexBuffer)
+                        return SLANG_E_INVALID_ARG;
+                    linkage.OpacityMicromapIndexBuffer.StartAddress = ommDesc->link.indexBuffer.getDeviceAddress();
+                    linkage.OpacityMicromapIndexBuffer.StrideInBytes = ommDesc->link.indexStride;
+                    switch (ommDesc->link.indexFormat)
+                    {
+                    case MicromapIndexFormat::Uint16:
+                        linkage.OpacityMicromapIndexFormat = DXGI_FORMAT_R16_UINT;
+                        break;
+                    case MicromapIndexFormat::Uint32:
+                        linkage.OpacityMicromapIndexFormat = DXGI_FORMAT_R32_UINT;
+                        break;
+                    default:
+                        return SLANG_E_INVALID_ARG;
+                    }
+                }
+                else
+                {
+                    linkage.OpacityMicromapIndexFormat = DXGI_FORMAT_UNKNOWN;
+                }
+                D3D12_RAYTRACING_GEOMETRY_OMM_TRIANGLES_DESC& ommTriangles = ommTriangleDescs[i];
+                ommTriangles.pTriangles = &triangleDesc;
+                ommTriangles.pOmmLinkage = &linkage;
+                geomDesc.Type = D3D12_RAYTRACING_GEOMETRY_TYPE_OMM_TRIANGLES;
+                geomDesc.OmmTriangles = ommTriangles;
+            }
+            else
+            {
+                geomDesc.Triangles = triangleDesc;
+            }
         }
         desc.Type = D3D12_RAYTRACING_ACCELERATION_STRUCTURE_TYPE_BOTTOM_LEVEL;
         desc.NumDescs = geomDescs.size();
@@ -195,6 +262,38 @@ Result AccelerationStructureBuildDescConverter::convert(
         return SLANG_E_INVALID_ARG;
     }
 
+    return SLANG_OK;
+}
+
+Result MicromapBuildDescConverter::convert(const MicromapBuildDesc& buildDesc)
+{
+    if (buildDesc.type != MicromapType::Opacity || !buildDesc.dataBuffer || !buildDesc.descriptorBuffer ||
+        !buildDesc.histogram || buildDesc.histogramCount == 0)
+        return SLANG_E_INVALID_ARG;
+
+    histogram.resize(buildDesc.histogramCount);
+    for (uint32_t i = 0; i < buildDesc.histogramCount; ++i)
+    {
+        histogram[i].Count = buildDesc.histogram[i].count;
+        histogram[i].SubdivisionLevel = buildDesc.histogram[i].subdivisionLevel;
+        histogram[i].Format = (D3D12_RAYTRACING_OPACITY_MICROMAP_FORMAT)buildDesc.histogram[i].format;
+    }
+    arrayDesc.NumOmmHistogramEntries = buildDesc.histogramCount;
+    arrayDesc.pOmmHistogram = histogram.data();
+    arrayDesc.InputBuffer = buildDesc.dataBuffer.getDeviceAddress();
+    arrayDesc.PerOmmDescs.StartAddress = buildDesc.descriptorBuffer.getDeviceAddress();
+    arrayDesc.PerOmmDescs.StrideInBytes = buildDesc.descriptorStride;
+    desc.Type = D3D12_RAYTRACING_ACCELERATION_STRUCTURE_TYPE_OPACITY_MICROMAP_ARRAY;
+    desc.Flags = D3D12_RAYTRACING_ACCELERATION_STRUCTURE_BUILD_FLAG_NONE;
+    if (is_set(buildDesc.flags, MicromapBuildFlags::PreferFastTrace))
+        desc.Flags |= D3D12_RAYTRACING_ACCELERATION_STRUCTURE_BUILD_FLAG_PREFER_FAST_TRACE;
+    if (is_set(buildDesc.flags, MicromapBuildFlags::PreferFastBuild))
+        desc.Flags |= D3D12_RAYTRACING_ACCELERATION_STRUCTURE_BUILD_FLAG_PREFER_FAST_BUILD;
+    if (is_set(buildDesc.flags, MicromapBuildFlags::AllowCompaction))
+        desc.Flags |= D3D12_RAYTRACING_ACCELERATION_STRUCTURE_BUILD_FLAG_ALLOW_COMPACTION;
+    desc.NumDescs = 1;
+    desc.DescsLayout = D3D12_ELEMENTS_LAYOUT_ARRAY;
+    desc.pOpacityMicromapArrayDesc = &arrayDesc;
     return SLANG_OK;
 }
 

--- a/src/d3d12/d3d12-acceleration-structure.h
+++ b/src/d3d12/d3d12-acceleration-structure.h
@@ -4,6 +4,15 @@
 
 namespace rhi::d3d12 {
 
+inline bool usesOpacityMicromaps(const AccelerationStructureBuildDesc& desc)
+{
+    for (uint32_t i = 0; i < desc.inputCount; ++i)
+        if (desc.inputs[i].type == AccelerationStructureBuildInputType::Triangles &&
+            findStructInChain<AccelerationStructureOpacityMicromapDesc>(desc.inputs[i].triangles.next))
+            return true;
+    return false;
+}
+
 class AccelerationStructureImpl : public AccelerationStructure
 {
 public:
@@ -26,15 +35,43 @@ public:
     DescriptorHandle m_descriptorHandle;
 };
 
+class MicromapImpl : public Micromap
+{
+public:
+    MicromapImpl(Device* device, const MicromapDesc& desc);
+
+    virtual void deleteThis() override;
+
+    // IResource implementation
+    virtual SLANG_NO_THROW Result SLANG_MCALL getNativeHandle(NativeHandle* outHandle) override;
+
+    // IMicromap implementation
+    virtual SLANG_NO_THROW DeviceAddress SLANG_MCALL getDeviceAddress() override;
+
+public:
+    RefPtr<BufferImpl> m_buffer;
+};
+
 struct AccelerationStructureBuildDescConverter
 {
     D3D12_BUILD_RAYTRACING_ACCELERATION_STRUCTURE_INPUTS desc = {};
     std::vector<D3D12_RAYTRACING_GEOMETRY_DESC> geomDescs;
+    std::vector<D3D12_RAYTRACING_GEOMETRY_TRIANGLES_DESC> triangleDescs;
+    std::vector<D3D12_RAYTRACING_GEOMETRY_OMM_LINKAGE_DESC> ommLinkages;
+    std::vector<D3D12_RAYTRACING_GEOMETRY_OMM_TRIANGLES_DESC> ommTriangleDescs;
     Result convert(const AccelerationStructureBuildDesc& buildDesc, IDebugCallback* callback);
 
 private:
     D3D12_RAYTRACING_ACCELERATION_STRUCTURE_BUILD_FLAGS translateBuildFlags(AccelerationStructureBuildFlags flags);
     D3D12_RAYTRACING_GEOMETRY_FLAGS translateGeometryFlags(AccelerationStructureGeometryFlags flags);
+};
+
+struct MicromapBuildDescConverter
+{
+    D3D12_BUILD_RAYTRACING_ACCELERATION_STRUCTURE_INPUTS desc = {};
+    D3D12_RAYTRACING_OPACITY_MICROMAP_ARRAY_DESC arrayDesc = {};
+    std::vector<D3D12_RAYTRACING_OPACITY_MICROMAP_HISTOGRAM_ENTRY> histogram;
+    Result convert(const MicromapBuildDesc& buildDesc);
 };
 
 #if SLANG_RHI_ENABLE_NVAPI

--- a/src/d3d12/d3d12-base.h
+++ b/src/d3d12/d3d12-base.h
@@ -30,6 +30,7 @@ class RenderPipelineImpl;
 class ComputePipelineImpl;
 class RayTracingPipelineImpl;
 class AccelerationStructureImpl;
+class MicromapImpl;
 class SamplerImpl;
 class ShaderObjectImpl;
 class RootShaderObjectImpl;

--- a/src/d3d12/d3d12-command.cpp
+++ b/src/d3d12/d3d12-command.cpp
@@ -1423,6 +1423,7 @@ void CommandRecorder::cmdBuildMicromap(const commands::BuildMicromap& cmd)
     MicromapBuildDescConverter converter;
     if (SLANG_FAILED(converter.convert(cmd.desc)))
         return;
+    commitBarriers();
     D3D12_BUILD_RAYTRACING_ACCELERATION_STRUCTURE_DESC buildDesc = {};
     buildDesc.DestAccelerationStructureData = dst->getDeviceAddress();
     buildDesc.ScratchAccelerationStructureData = cmd.scratchBuffer.getDeviceAddress();
@@ -1796,8 +1797,12 @@ void CommandRecorder::commitBarriers()
         }
         else if ((bufferBarrier.stateBefore == ResourceState::AccelerationStructureWrite &&
                   bufferBarrier.stateAfter == ResourceState::AccelerationStructureRead) ||
-                 (bufferBarrier.stateAfter == ResourceState::AccelerationStructureRead &&
-                  bufferBarrier.stateBefore == ResourceState::AccelerationStructureWrite) ||
+                 (bufferBarrier.stateBefore == ResourceState::AccelerationStructureRead &&
+                  bufferBarrier.stateAfter == ResourceState::AccelerationStructureWrite) ||
+                 (bufferBarrier.stateBefore == ResourceState::MicromapWrite &&
+                  bufferBarrier.stateAfter == ResourceState::MicromapRead) ||
+                 (bufferBarrier.stateBefore == ResourceState::MicromapRead &&
+                  bufferBarrier.stateAfter == ResourceState::MicromapWrite) ||
                  ((stateAfter & D3D12_RESOURCE_STATE_UNORDERED_ACCESS) != 0))
         {
             barrier.Type = D3D12_RESOURCE_BARRIER_TYPE_UAV;

--- a/src/d3d12/d3d12-command.cpp
+++ b/src/d3d12/d3d12-command.cpp
@@ -104,6 +104,7 @@ public:
     void cmdSetRayTracingState(const commands::SetRayTracingState& cmd);
     void cmdDispatchRays(const commands::DispatchRays& cmd);
     void cmdBuildAccelerationStructure(const commands::BuildAccelerationStructure& cmd);
+    void cmdBuildMicromap(const commands::BuildMicromap& cmd);
     void cmdCopyAccelerationStructure(const commands::CopyAccelerationStructure& cmd);
     void cmdQueryAccelerationStructureProperties(const commands::QueryAccelerationStructureProperties& cmd);
     void cmdExecuteClusterOperation(const commands::ExecuteClusterOperation& cmd);
@@ -1277,6 +1278,23 @@ void CommandRecorder::cmdBuildAccelerationStructure(const commands::BuildAcceler
                     ResourceState::AccelerationStructureBuildInput
                 );
             }
+            if (const auto* ommDesc = findStructInChain<AccelerationStructureOpacityMicromapDesc>(input.triangles.next))
+            {
+                if (ommDesc->link.micromap)
+                {
+                    requireBufferState(
+                        checked_cast<MicromapImpl*>(ommDesc->link.micromap)->m_buffer,
+                        ResourceState::MicromapRead
+                    );
+                }
+                if (ommDesc->link.indexBuffer)
+                {
+                    requireBufferState(
+                        checked_cast<BufferImpl*>(ommDesc->link.indexBuffer.buffer),
+                        ResourceState::AccelerationStructureBuildInput
+                    );
+                }
+            }
             break;
         case AccelerationStructureBuildInputType::ProceduralPrimitives:
             for (uint32_t i = 0; i < input.proceduralPrimitives.aabbBufferCount; ++i)
@@ -1349,7 +1367,7 @@ void CommandRecorder::cmdBuildAccelerationStructure(const commands::BuildAcceler
     commitBarriers();
 
 #if SLANG_RHI_ENABLE_NVAPI
-    if (m_device->m_nvapiEnabled)
+    if (m_device->m_nvapiEnabled && !usesOpacityMicromaps(cmd.desc))
     {
         NVAPI_D3D12_BUILD_RAYTRACING_ACCELERATION_STRUCTURE_DESC_EX desc = {};
         desc.destAccelerationStructureData = dst->getDeviceAddress();
@@ -1391,6 +1409,25 @@ void CommandRecorder::cmdBuildAccelerationStructure(const commands::BuildAcceler
     }
 
     copyAccelerationStructureQueryResults(cmd.propertyQueryCount, cmd.queryDescs, 1);
+}
+
+void CommandRecorder::cmdBuildMicromap(const commands::BuildMicromap& cmd)
+{
+    MicromapImpl* dst = checked_cast<MicromapImpl*>(cmd.dst);
+    BufferImpl* scratch = checked_cast<BufferImpl*>(cmd.scratchBuffer.buffer);
+    requireBufferState(dst->m_buffer, ResourceState::MicromapWrite);
+    requireBufferState(scratch, ResourceState::UnorderedAccess);
+    requireBufferState(checked_cast<BufferImpl*>(cmd.desc.dataBuffer.buffer), ResourceState::MicromapBuildInput);
+    requireBufferState(checked_cast<BufferImpl*>(cmd.desc.descriptorBuffer.buffer), ResourceState::MicromapBuildInput);
+
+    MicromapBuildDescConverter converter;
+    if (SLANG_FAILED(converter.convert(cmd.desc)))
+        return;
+    D3D12_BUILD_RAYTRACING_ACCELERATION_STRUCTURE_DESC buildDesc = {};
+    buildDesc.DestAccelerationStructureData = dst->getDeviceAddress();
+    buildDesc.ScratchAccelerationStructureData = cmd.scratchBuffer.getDeviceAddress();
+    buildDesc.Inputs = converter.desc;
+    m_cmdList4->BuildRaytracingAccelerationStructure(&buildDesc, 0, nullptr);
 }
 
 void CommandRecorder::cmdCopyAccelerationStructure(const commands::CopyAccelerationStructure& cmd)

--- a/src/d3d12/d3d12-device.cpp
+++ b/src/d3d12/d3d12-device.cpp
@@ -416,8 +416,8 @@ Result DeviceImpl::initialize(const DeviceDesc& desc, BackendImpl* backend)
 
     // Process chained descs
     const D3D12DeviceExtendedDesc* extendedDesc = nullptr;
-    for (const DescStructHeader* header = static_cast<const DescStructHeader*>(desc.next); header;
-         header = header->next)
+    for (const ChainedStructHeader* header = static_cast<const ChainedStructHeader*>(desc.next); header;
+         header = static_cast<const ChainedStructHeader*>(header->next))
     {
         switch (header->type)
         {
@@ -986,6 +986,10 @@ Result DeviceImpl::initialize(const DeviceDesc& desc, BackendImpl* backend)
             if (options.RaytracingTier >= D3D12_RAYTRACING_TIER_1_1)
             {
                 addFeature(Feature::RayQuery);
+            }
+            if (options.RaytracingTier >= D3D12_RAYTRACING_TIER_1_2)
+            {
+                addFeature(Feature::OpacityMicromap);
             }
         }
     }
@@ -2042,7 +2046,7 @@ Result DeviceImpl::getAccelerationStructureSizes(
     D3D12_RAYTRACING_ACCELERATION_STRUCTURE_PREBUILD_INFO prebuildInfo = {};
 
 #if SLANG_RHI_ENABLE_NVAPI
-    if (m_nvapiEnabled)
+    if (m_nvapiEnabled && !usesOpacityMicromaps(desc))
     {
         AccelerationStructureBuildDescConverterNVAPI converter;
         SLANG_RETURN_ON_FAIL(converter.convert(desc, m_debugCallback));
@@ -2068,6 +2072,19 @@ Result DeviceImpl::getAccelerationStructureSizes(
     outSizes->scratchSize = prebuildInfo.ScratchDataSizeInBytes;
     outSizes->updateScratchSize = prebuildInfo.UpdateScratchDataSizeInBytes;
 
+    return SLANG_OK;
+}
+
+Result DeviceImpl::getMicromapSizes(const MicromapBuildDesc& desc, MicromapSizes* outSizes)
+{
+    if (!hasFeature(Feature::OpacityMicromap) || !m_device5)
+        return SLANG_E_NOT_AVAILABLE;
+    MicromapBuildDescConverter converter;
+    SLANG_RETURN_ON_FAIL(converter.convert(desc));
+    D3D12_RAYTRACING_ACCELERATION_STRUCTURE_PREBUILD_INFO info = {};
+    m_device5->GetRaytracingAccelerationStructurePrebuildInfo(&converter.desc, &info);
+    outSizes->micromapSize = info.ResultDataMaxSizeInBytes;
+    outSizes->scratchSize = info.ScratchDataSizeInBytes;
     return SLANG_OK;
 }
 
@@ -2120,6 +2137,21 @@ Result DeviceImpl::createAccelerationStructure(
     srvDesc.RaytracingAccelerationStructure.Location = result->m_buffer->getDeviceAddress();
     m_device->CreateShaderResourceView(nullptr, &srvDesc, result->m_descriptor.cpuHandle);
     returnComPtr(outAccelerationStructure, result);
+    return SLANG_OK;
+}
+
+Result DeviceImpl::createMicromap(const MicromapDesc& desc, IMicromap** outMicromap)
+{
+    if (!hasFeature(Feature::OpacityMicromap))
+        return SLANG_E_NOT_AVAILABLE;
+    RefPtr<MicromapImpl> result = new MicromapImpl(this, desc);
+    BufferDesc bufferDesc = {};
+    bufferDesc.size = desc.size;
+    bufferDesc.memoryType = MemoryType::DeviceLocal;
+    bufferDesc.usage = BufferUsage::AccelerationStructure | BufferUsage::MicromapStorage;
+    bufferDesc.defaultState = ResourceState::MicromapRead;
+    SLANG_RETURN_ON_FAIL(createBuffer(bufferDesc, nullptr, (IBuffer**)result->m_buffer.writeRef()));
+    returnComPtr(outMicromap, result);
     return SLANG_OK;
 }
 

--- a/src/d3d12/d3d12-device.h
+++ b/src/d3d12/d3d12-device.h
@@ -207,6 +207,11 @@ public:
         AccelerationStructureSizes* outSizes
     ) override;
 
+    virtual SLANG_NO_THROW Result SLANG_MCALL getMicromapSizes(
+        const MicromapBuildDesc& desc,
+        MicromapSizes* outSizes
+    ) override;
+
     virtual SLANG_NO_THROW Result SLANG_MCALL getClusterOperationSizes(
         const ClusterOperationParams& params,
         ClusterOperationSizes* outSizes
@@ -215,6 +220,11 @@ public:
     virtual SLANG_NO_THROW Result SLANG_MCALL createAccelerationStructure(
         const AccelerationStructureDesc& desc,
         IAccelerationStructure** outAccelerationStructure
+    ) override;
+
+    virtual SLANG_NO_THROW Result SLANG_MCALL createMicromap(
+        const MicromapDesc& desc,
+        IMicromap** outMicromap
     ) override;
 
     virtual SLANG_NO_THROW Result SLANG_MCALL getCooperativeVectorProperties(

--- a/src/d3d12/d3d12-pipeline.cpp
+++ b/src/d3d12/d3d12-pipeline.cpp
@@ -623,6 +623,8 @@ Result DeviceImpl::createRayTracingPipeline2(const RayTracingPipelineDesc& desc,
         pipelineConfig.Flags |= D3D12_RAYTRACING_PIPELINE_FLAG_SKIP_TRIANGLES;
     if (is_set(desc.flags, RayTracingPipelineFlags::SkipProcedurals))
         pipelineConfig.Flags |= D3D12_RAYTRACING_PIPELINE_FLAG_SKIP_PROCEDURAL_PRIMITIVES;
+    if (is_set(desc.flags, RayTracingPipelineFlags::EnableOpacityMicromaps))
+        pipelineConfig.Flags |= D3D12_RAYTRACING_PIPELINE_FLAG_ALLOW_OPACITY_MICROMAPS;
 
     D3D12_STATE_SUBOBJECT pipelineConfigSubobject = {};
     pipelineConfigSubobject.Type = D3D12_STATE_SUBOBJECT_TYPE_RAYTRACING_PIPELINE_CONFIG1;

--- a/src/d3d12/d3d12-utils.cpp
+++ b/src/d3d12/d3d12-utils.cpp
@@ -349,6 +349,11 @@ D3D12_RESOURCE_STATES translateResourceState(ResourceState state)
         return D3D12_RESOURCE_STATE_RAYTRACING_ACCELERATION_STRUCTURE;
     case ResourceState::AccelerationStructureBuildInput:
         return D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE;
+    case ResourceState::MicromapBuildInput:
+        return D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE;
+    case ResourceState::MicromapRead:
+    case ResourceState::MicromapWrite:
+        return D3D12_RESOURCE_STATE_RAYTRACING_ACCELERATION_STRUCTURE;
     }
     return D3D12_RESOURCE_STATE_COMMON;
 }

--- a/src/debug-layer/debug-command-encoder.cpp
+++ b/src/debug-layer/debug-command-encoder.cpp
@@ -1589,6 +1589,24 @@ void DebugCommandEncoder::buildAccelerationStructure(
     baseObject->buildAccelerationStructure(desc, dst, src, scratchBuffer, propertyQueryCount, innerQueryDescs.data());
 }
 
+void DebugCommandEncoder::buildMicromap(const MicromapBuildDesc& desc, IMicromap* dst, BufferOffsetPair scratchBuffer)
+{
+    SLANG_RHI_DEBUG_API(ICommandEncoder, buildMicromap);
+    requireOpen();
+    requireNoPass();
+    if (!dst || !scratchBuffer.buffer)
+    {
+        RHI_VALIDATION_ERROR("Micromap destination and scratch buffer must be provided.");
+        return;
+    }
+    if (!desc.dataBuffer.buffer || !desc.descriptorBuffer.buffer || !desc.histogram || desc.histogramCount == 0)
+    {
+        RHI_VALIDATION_ERROR("Micromap build data, descriptors, and histogram must be provided.");
+        return;
+    }
+    baseObject->buildMicromap(desc, dst, scratchBuffer);
+}
+
 void DebugCommandEncoder::copyAccelerationStructure(
     IAccelerationStructure* dst,
     IAccelerationStructure* src,

--- a/src/debug-layer/debug-command-encoder.h
+++ b/src/debug-layer/debug-command-encoder.h
@@ -248,6 +248,12 @@ public:
         const AccelerationStructureQueryDesc* queryDescs
     ) override;
 
+    virtual SLANG_NO_THROW void SLANG_MCALL buildMicromap(
+        const MicromapBuildDesc& desc,
+        IMicromap* dst,
+        BufferOffsetPair scratchBuffer
+    ) override;
+
     virtual SLANG_NO_THROW void SLANG_MCALL copyAccelerationStructure(
         IAccelerationStructure* dst,
         IAccelerationStructure* src,

--- a/src/debug-layer/debug-device.cpp
+++ b/src/debug-layer/debug-device.cpp
@@ -741,6 +741,27 @@ Result DebugDevice::getClusterOperationSizes(const ClusterOperationParams& param
     return baseObject->getClusterOperationSizes(params, outSizes);
 }
 
+Result DebugDevice::getMicromapSizes(const MicromapBuildDesc& desc, MicromapSizes* outSizes)
+{
+    SLANG_RHI_DEBUG_API(IDevice, getMicromapSizes);
+    if (!outSizes)
+    {
+        RHI_VALIDATION_ERROR("'outSizes' must not be null.");
+        return SLANG_E_INVALID_ARG;
+    }
+    if (!desc.dataBuffer.buffer || !desc.descriptorBuffer.buffer || !desc.histogram || desc.histogramCount == 0)
+    {
+        RHI_VALIDATION_ERROR("Micromap build data, descriptors, and histogram must be provided.");
+        return SLANG_E_INVALID_ARG;
+    }
+    if (desc.descriptorStride < sizeof(MicromapTriangleDesc))
+    {
+        RHI_VALIDATION_ERROR("Micromap descriptor stride is too small.");
+        return SLANG_E_INVALID_ARG;
+    }
+    return baseObject->getMicromapSizes(desc, outSizes);
+}
+
 Result DebugDevice::createAccelerationStructure(
     const AccelerationStructureDesc& desc,
     IAccelerationStructure** outAccelerationStructure
@@ -792,6 +813,22 @@ Result DebugDevice::createAccelerationStructure(
     }
 
     return baseObject->createAccelerationStructure(patchedDesc, outAccelerationStructure);
+}
+
+Result DebugDevice::createMicromap(const MicromapDesc& desc, IMicromap** outMicromap)
+{
+    SLANG_RHI_DEBUG_API(IDevice, createMicromap);
+    if (!outMicromap)
+    {
+        RHI_VALIDATION_ERROR("'outMicromap' must not be null.");
+        return SLANG_E_INVALID_ARG;
+    }
+    if (desc.size == 0)
+    {
+        RHI_VALIDATION_ERROR("Micromap size must be greater than zero.");
+        return SLANG_E_INVALID_ARG;
+    }
+    return baseObject->createMicromap(desc, outMicromap);
 }
 
 Result DebugDevice::createSurface(WindowHandle windowHandle, ISurface** outSurface)

--- a/src/debug-layer/debug-device.h
+++ b/src/debug-layer/debug-device.h
@@ -80,6 +80,10 @@ public:
         const AccelerationStructureBuildDesc& desc,
         AccelerationStructureSizes* outSizes
     ) override;
+    virtual SLANG_NO_THROW Result SLANG_MCALL getMicromapSizes(
+        const MicromapBuildDesc& desc,
+        MicromapSizes* outSizes
+    ) override;
     virtual SLANG_NO_THROW Result SLANG_MCALL getClusterOperationSizes(
         const ClusterOperationParams& params,
         ClusterOperationSizes* outSizes
@@ -87,6 +91,10 @@ public:
     virtual SLANG_NO_THROW Result SLANG_MCALL createAccelerationStructure(
         const AccelerationStructureDesc& desc,
         IAccelerationStructure** outAccelerationStructure
+    ) override;
+    virtual SLANG_NO_THROW Result SLANG_MCALL createMicromap(
+        const MicromapDesc& desc,
+        IMicromap** outMicromap
     ) override;
     virtual SLANG_NO_THROW Result SLANG_MCALL createSurface(WindowHandle windowHandle, ISurface** outSurface) override;
     virtual SLANG_NO_THROW Result SLANG_MCALL createInputLayout(

--- a/src/debug-layer/debug-helper-functions.cpp
+++ b/src/debug-layer/debug-helper-functions.cpp
@@ -301,6 +301,71 @@ Result validateAccelerationStructureBuildDesc(DebugContext* ctx, const Accelerat
                     valid = false;
                 }
             }
+            if (triangles.next)
+            {
+                for (auto* header = static_cast<const ChainedStructHeader*>(triangles.next); header;
+                     header = static_cast<const ChainedStructHeader*>(header->next))
+                {
+                    if (header->type != AccelerationStructureOpacityMicromapDesc::kStructType)
+                    {
+                        RHI_VALIDATION_ERROR_FORMAT(
+                            "AccelerationStructureBuildDesc::inputs[%d].triangles.next has an unsupported structure "
+                            "type.",
+                            i
+                        );
+                        valid = false;
+                    }
+                }
+
+                if (const auto* ommDesc = findStructInChain<AccelerationStructureOpacityMicromapDesc>(triangles.next))
+                {
+                    const auto& link = ommDesc->link;
+                    if (!link.micromap || !link.usageCounts || link.usageCount == 0)
+                    {
+                        RHI_VALIDATION_ERROR_FORMAT(
+                            "AccelerationStructureBuildDesc::inputs[%d] opacity micromap and usage counts must be "
+                            "provided.",
+                            i
+                        );
+                        valid = false;
+                    }
+                    if (link.indexingMode == MicromapIndexingMode::Indexed)
+                    {
+                        if (!link.indexBuffer || link.indexFormat == MicromapIndexFormat::None)
+                        {
+                            RHI_VALIDATION_ERROR_FORMAT(
+                                "AccelerationStructureBuildDesc::inputs[%d] indexed opacity micromaps require an index "
+                                "buffer and format.",
+                                i
+                            );
+                            valid = false;
+                        }
+                    }
+                    else if (link.indexBuffer || link.indexFormat != MicromapIndexFormat::None)
+                    {
+                        RHI_VALIDATION_ERROR_FORMAT(
+                            "AccelerationStructureBuildDesc::inputs[%d] linear opacity micromaps must not specify an "
+                            "index buffer or format.",
+                            i
+                        );
+                        valid = false;
+                    }
+                    for (uint32_t j = 0; link.usageCounts && j < link.usageCount; ++j)
+                    {
+                        if (link.usageCounts[j].subdivisionLevel > 12 ||
+                            (link.usageCounts[j].format != uint32_t(OpacityMicromapFormat::TwoState) &&
+                             link.usageCounts[j].format != uint32_t(OpacityMicromapFormat::FourState)))
+                        {
+                            RHI_VALIDATION_ERROR_FORMAT(
+                                "AccelerationStructureBuildDesc::inputs[%d] contains an invalid opacity micromap usage "
+                                "count.",
+                                i
+                            );
+                            valid = false;
+                        }
+                    }
+                }
+            }
             break;
         }
         case AccelerationStructureBuildInputType::ProceduralPrimitives:

--- a/src/debug-layer/debug-helper-functions.h
+++ b/src/debug-layer/debug-helper-functions.h
@@ -212,7 +212,7 @@ inline bool isValidTextureAspect(TextureAspect value)
 
 inline bool isValidResourceState(ResourceState value)
 {
-    return isValidEnum<ResourceState, ResourceState::AccelerationStructureBuildInput>(value);
+    return isValidEnum<ResourceState, ResourceState::MicromapWrite>(value);
 }
 
 inline bool isValidLoadOp(LoadOp value)
@@ -283,7 +283,8 @@ inline bool isValidBufferUsage(BufferUsage value)
         BufferUsage::VertexBuffer | BufferUsage::IndexBuffer | BufferUsage::ConstantBuffer |
         BufferUsage::ShaderResource | BufferUsage::UnorderedAccess | BufferUsage::IndirectArgument |
         BufferUsage::CopySource | BufferUsage::CopyDestination | BufferUsage::AccelerationStructure |
-        BufferUsage::AccelerationStructureBuildInput | BufferUsage::ShaderTable | BufferUsage::Shared;
+        BufferUsage::AccelerationStructureBuildInput | BufferUsage::MicromapBuildInput | BufferUsage::MicromapStorage |
+        BufferUsage::ShaderTable | BufferUsage::Shared;
     return isValidFlags(value, allValidBits);
 }
 
@@ -307,7 +308,9 @@ inline bool isValidAccelerationStructureBuildFlags(AccelerationStructureBuildFla
     const AccelerationStructureBuildFlags allValidBits =
         AccelerationStructureBuildFlags::AllowUpdate | AccelerationStructureBuildFlags::AllowCompaction |
         AccelerationStructureBuildFlags::PreferFastTrace | AccelerationStructureBuildFlags::PreferFastBuild |
-        AccelerationStructureBuildFlags::MinimizeMemory | AccelerationStructureBuildFlags::CreateMotion;
+        AccelerationStructureBuildFlags::MinimizeMemory | AccelerationStructureBuildFlags::CreateMotion |
+        AccelerationStructureBuildFlags::AllowOpacityMicromapUpdate |
+        AccelerationStructureBuildFlags::AllowDisableOpacityMicromaps;
     return isValidFlags(value, allValidBits);
 }
 

--- a/src/device.cpp
+++ b/src/device.cpp
@@ -848,6 +848,13 @@ Result Device::getAccelerationStructureSizes(
     return SLANG_E_NOT_AVAILABLE;
 }
 
+Result Device::getMicromapSizes(const MicromapBuildDesc& desc, MicromapSizes* outSizes)
+{
+    SLANG_UNUSED(desc);
+    SLANG_UNUSED(outSizes);
+    return SLANG_E_NOT_AVAILABLE;
+}
+
 Result Device::getClusterOperationSizes(const ClusterOperationParams& params, ClusterOperationSizes* outSizes)
 {
     SLANG_UNUSED(params);
@@ -862,6 +869,13 @@ Result Device::createAccelerationStructure(
 {
     SLANG_UNUSED(desc);
     SLANG_UNUSED(outAccelerationStructure);
+    return SLANG_E_NOT_AVAILABLE;
+}
+
+Result Device::createMicromap(const MicromapDesc& desc, IMicromap** outMicromap)
+{
+    SLANG_UNUSED(desc);
+    SLANG_UNUSED(outMicromap);
     return SLANG_E_NOT_AVAILABLE;
 }
 

--- a/src/device.h
+++ b/src/device.h
@@ -259,6 +259,11 @@ public:
         AccelerationStructureSizes* outSizes
     ) override;
 
+    virtual SLANG_NO_THROW Result SLANG_MCALL getMicromapSizes(
+        const MicromapBuildDesc& desc,
+        MicromapSizes* outSizes
+    ) override;
+
     // Provides a default implementation that returns SLANG_E_NOT_AVAILABLE for platforms
     // without cluster acceleration support.
     virtual SLANG_NO_THROW Result SLANG_MCALL getClusterOperationSizes(
@@ -271,6 +276,11 @@ public:
     virtual SLANG_NO_THROW Result SLANG_MCALL createAccelerationStructure(
         const AccelerationStructureDesc& desc,
         IAccelerationStructure** outAccelerationStructure
+    ) override;
+
+    virtual SLANG_NO_THROW Result SLANG_MCALL createMicromap(
+        const MicromapDesc& desc,
+        IMicromap** outMicromap
     ) override;
 
     // Provides a default implementation that returns SLANG_E_NOT_AVAILABLE for platforms

--- a/src/enum-strings.cpp
+++ b/src/enum-strings.cpp
@@ -137,6 +137,10 @@ const char* enumToString(BufferUsage value)
         return S_BufferUsage_AccelerationStructure;
     case BufferUsage::AccelerationStructureBuildInput:
         return S_BufferUsage_AccelerationStructureBuildInput;
+    case BufferUsage::MicromapBuildInput:
+        return S_BufferUsage_MicromapBuildInput;
+    case BufferUsage::MicromapStorage:
+        return S_BufferUsage_MicromapStorage;
     case BufferUsage::ShaderTable:
         return S_BufferUsage_ShaderTable;
     case BufferUsage::Shared:
@@ -271,6 +275,12 @@ const char* enumToString(ResourceState value)
         return S_ResourceState_AccelerationStructureWrite;
     case ResourceState::AccelerationStructureBuildInput:
         return S_ResourceState_AccelerationStructureBuildInput;
+    case ResourceState::MicromapBuildInput:
+        return S_ResourceState_MicromapBuildInput;
+    case ResourceState::MicromapRead:
+        return S_ResourceState_MicromapRead;
+    case ResourceState::MicromapWrite:
+        return S_ResourceState_MicromapWrite;
     }
     return S_INVALID;
 }

--- a/src/metal/metal-command.cpp
+++ b/src/metal/metal-command.cpp
@@ -127,6 +127,7 @@ public:
     void cmdSetRayTracingState(const commands::SetRayTracingState& cmd);
     void cmdDispatchRays(const commands::DispatchRays& cmd);
     void cmdBuildAccelerationStructure(const commands::BuildAccelerationStructure& cmd);
+    void cmdBuildMicromap(const commands::BuildMicromap& cmd);
     void cmdCopyAccelerationStructure(const commands::CopyAccelerationStructure& cmd);
     void cmdQueryAccelerationStructureProperties(const commands::QueryAccelerationStructureProperties& cmd);
     void cmdExecuteClusterOperation(const commands::ExecuteClusterOperation& cmd);
@@ -919,6 +920,12 @@ void CommandRecorder::cmdBuildAccelerationStructure(const commands::BuildAcceler
     }
 
     // TODO handle queryDescs
+}
+
+void CommandRecorder::cmdBuildMicromap(const commands::BuildMicromap& cmd)
+{
+    SLANG_UNUSED(cmd);
+    NOT_SUPPORTED(ICommandEncoder, buildMicromap);
 }
 
 void CommandRecorder::cmdCopyAccelerationStructure(const commands::CopyAccelerationStructure& cmd)

--- a/src/rhi-shared-fwd.h
+++ b/src/rhi-shared-fwd.h
@@ -6,6 +6,7 @@ namespace rhi {
 
 class DeviceChild;
 class AccelerationStructure;
+class Micromap;
 class Buffer;
 class Resource;
 class Texture;

--- a/src/rhi-shared.cpp
+++ b/src/rhi-shared.cpp
@@ -315,6 +315,24 @@ Result AccelerationStructure::getDescriptorHandle(DescriptorHandle* outHandle)
 }
 
 // ----------------------------------------------------------------------------
+// Micromap
+// ----------------------------------------------------------------------------
+
+IMicromap* Micromap::getInterface(const Guid& guid)
+{
+    if (guid == ISlangUnknown::getTypeGuid() || guid == IResource::getTypeGuid() || guid == IMicromap::getTypeGuid())
+        return static_cast<IMicromap*>(this);
+    return nullptr;
+}
+
+Micromap::Micromap(Device* device, const MicromapDesc& desc)
+    : Resource(device)
+    , m_desc(desc)
+{
+    m_descHolder.holdString(m_desc.label);
+}
+
+// ----------------------------------------------------------------------------
 // InputLayout
 // ----------------------------------------------------------------------------
 

--- a/src/rhi-shared.h
+++ b/src/rhi-shared.h
@@ -33,12 +33,25 @@ class Device;
 class CommandEncoder;
 class CommandList;
 
-/// Common header for Desc struct types.
-struct DescStructHeader
+/// Common prefix for structures linked through a `next` chain.
+struct ChainedStructHeader
 {
     StructType type;
-    DescStructHeader* next;
+    const void* next;
 };
+
+/// Finds the first structure of type `T` in a `next` chain, or returns null.
+template<typename T>
+const T* findStructInChain(const void* chain)
+{
+    for (auto* header = static_cast<const ChainedStructHeader*>(chain); header;
+         header = static_cast<const ChainedStructHeader*>(header->next))
+    {
+        if (header->type == T::kStructType)
+            return reinterpret_cast<const T*>(header);
+    }
+    return nullptr;
+}
 
 class Fence : public IFence, public DeviceChild
 {
@@ -232,6 +245,23 @@ public:
 
 public:
     AccelerationStructureDesc m_desc;
+    StructHolder m_descHolder;
+};
+
+class Micromap : public IMicromap, public Resource
+{
+public:
+    SLANG_COM_OBJECT_IUNKNOWN_ALL
+    IMicromap* getInterface(const Guid& guid);
+
+public:
+    Micromap(Device* device, const MicromapDesc& desc);
+
+    // IMicromap interface
+    virtual SLANG_NO_THROW const MicromapDesc& SLANG_MCALL getDesc() override { return m_desc; }
+
+public:
+    MicromapDesc m_desc;
     StructHolder m_descHolder;
 };
 

--- a/src/strings.h
+++ b/src/strings.h
@@ -52,6 +52,8 @@
 #define S_BufferUsage_CopyDestination "CopyDestination"
 #define S_BufferUsage_AccelerationStructure "AccelerationStructure"
 #define S_BufferUsage_AccelerationStructureBuildInput "AccelerationStructureBuildInput"
+#define S_BufferUsage_MicromapBuildInput "MicromapBuildInput"
+#define S_BufferUsage_MicromapStorage "MicromapStorage"
 #define S_BufferUsage_ShaderTable "ShaderTable"
 #define S_BufferUsage_Shared "Shared"
 
@@ -106,6 +108,9 @@
 #define S_ResourceState_AccelerationStructureRead "AccelerationStructureRead"
 #define S_ResourceState_AccelerationStructureWrite "AccelerationStructureWrite"
 #define S_ResourceState_AccelerationStructureBuildInput "AccelerationStructureBuildInput"
+#define S_ResourceState_MicromapBuildInput "MicromapBuildInput"
+#define S_ResourceState_MicromapRead "MicromapRead"
+#define S_ResourceState_MicromapWrite "MicromapWrite"
 
 // TextureFilteringMode
 #define S_TextureFilteringMode_Point "Point"

--- a/src/vulkan/vk-acceleration-structure.cpp
+++ b/src/vulkan/vk-acceleration-structure.cpp
@@ -97,6 +97,36 @@ Result AccelerationStructureImpl::getDescriptorHandle(DescriptorHandle* outHandl
     return SLANG_OK;
 }
 
+MicromapImpl::MicromapImpl(Device* device, const MicromapDesc& desc)
+    : Micromap(device, desc)
+{
+}
+
+MicromapImpl::~MicromapImpl()
+{
+    DeviceImpl* device = getDevice<DeviceImpl>();
+    if (m_vkHandle)
+        device->m_api.vkDestroyMicromapEXT(device->m_device, m_vkHandle, nullptr);
+}
+
+void MicromapImpl::deleteThis()
+{
+    m_buffer.setNull();
+    getDevice<DeviceImpl>()->deferDelete(this);
+}
+
+Result MicromapImpl::getNativeHandle(NativeHandle* outHandle)
+{
+    outHandle->type = NativeHandleType::VkMicromapEXT;
+    outHandle->value = (uint64_t)m_vkHandle;
+    return SLANG_OK;
+}
+
+DeviceAddress MicromapImpl::getDeviceAddress()
+{
+    return m_buffer ? m_buffer->getDeviceAddress() : 0;
+}
+
 Result AccelerationStructureBuildDescConverter::convert(
     const AccelerationStructureBuildDesc& buildDesc,
     IDebugCallback* debugCallback
@@ -168,6 +198,8 @@ Result AccelerationStructureBuildDescConverter::convert(
         {
             motionTrianglesDatas.resize(buildDesc.inputCount);
         }
+        opacityMicromapDatas.resize(buildDesc.inputCount);
+        opacityMicromapUsageCounts.resize(buildDesc.inputCount);
 
         for (uint32_t i = 0; i < buildDesc.inputCount; ++i)
         {
@@ -212,6 +244,45 @@ Result AccelerationStructureBuildDescConverter::convert(
                 motionData.vertexData.deviceAddress = triangles.vertexBuffers[1].getDeviceAddress();
 
                 geometry.geometry.triangles.pNext = &motionData;
+            }
+
+            if (const auto* ommDesc = findStructInChain<AccelerationStructureOpacityMicromapDesc>(triangles.next))
+            {
+                if (!ommDesc->link.micromap || (ommDesc->link.usageCount > 0 && !ommDesc->link.usageCounts))
+                    return SLANG_E_INVALID_ARG;
+                std::vector<VkMicromapUsageEXT>& usageCounts = opacityMicromapUsageCounts[i];
+                usageCounts.resize(ommDesc->link.usageCount);
+                for (uint32_t j = 0; j < ommDesc->link.usageCount; ++j)
+                {
+                    usageCounts[j].count = ommDesc->link.usageCounts[j].count;
+                    usageCounts[j].subdivisionLevel = ommDesc->link.usageCounts[j].subdivisionLevel;
+                    usageCounts[j].format = ommDesc->link.usageCounts[j].format;
+                }
+                VkAccelerationStructureTrianglesOpacityMicromapEXT& ommData = opacityMicromapDatas[i];
+                ommData.sType = VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_TRIANGLES_OPACITY_MICROMAP_EXT;
+                ommData.pNext = const_cast<void*>(geometry.geometry.triangles.pNext);
+                if (ommDesc->link.indexingMode == MicromapIndexingMode::Indexed)
+                {
+                    if (!ommDesc->link.indexBuffer)
+                        return SLANG_E_INVALID_ARG;
+                    if (ommDesc->link.indexFormat == MicromapIndexFormat::Uint16)
+                        ommData.indexType = VK_INDEX_TYPE_UINT16;
+                    else if (ommDesc->link.indexFormat == MicromapIndexFormat::Uint32)
+                        ommData.indexType = VK_INDEX_TYPE_UINT32;
+                    else
+                        return SLANG_E_INVALID_ARG;
+                    ommData.indexBuffer.deviceAddress = ommDesc->link.indexBuffer.getDeviceAddress();
+                    ommData.indexStride = ommDesc->link.indexStride;
+                }
+                else
+                {
+                    ommData.indexType = VK_INDEX_TYPE_NONE_KHR;
+                }
+                ommData.baseTriangle = ommDesc->link.baseMicromapIndex;
+                ommData.usageCountsCount = (uint32_t)usageCounts.size();
+                ommData.pUsageCounts = usageCounts.data();
+                ommData.micromap = checked_cast<MicromapImpl*>(ommDesc->link.micromap)->m_vkHandle;
+                geometry.geometry.triangles.pNext = &ommData;
             }
 
             primitiveCounts[i] = max(triangles.vertexCount, triangles.indexCount) / 3;
@@ -364,6 +435,29 @@ Result AccelerationStructureBuildDescConverter::convert(
     return SLANG_OK;
 }
 
+Result MicromapBuildDescConverter::convert(const MicromapBuildDesc& desc)
+{
+    if (desc.type != MicromapType::Opacity || !desc.dataBuffer || !desc.descriptorBuffer || !desc.histogram ||
+        desc.histogramCount == 0)
+        return SLANG_E_INVALID_ARG;
+    usageCounts.resize(desc.histogramCount);
+    for (uint32_t i = 0; i < desc.histogramCount; ++i)
+    {
+        usageCounts[i].count = desc.histogram[i].count;
+        usageCounts[i].subdivisionLevel = desc.histogram[i].subdivisionLevel;
+        usageCounts[i].format = desc.histogram[i].format;
+    }
+    buildInfo.type = VK_MICROMAP_TYPE_OPACITY_MICROMAP_EXT;
+    buildInfo.flags = (VkBuildMicromapFlagsEXT)desc.flags;
+    buildInfo.mode = VK_BUILD_MICROMAP_MODE_BUILD_EXT;
+    buildInfo.usageCountsCount = (uint32_t)usageCounts.size();
+    buildInfo.pUsageCounts = usageCounts.data();
+    buildInfo.data.deviceAddress = desc.dataBuffer.getDeviceAddress();
+    buildInfo.triangleArray.deviceAddress = desc.descriptorBuffer.getDeviceAddress();
+    buildInfo.triangleArrayStride = desc.descriptorStride;
+    return SLANG_OK;
+}
+
 VkBuildAccelerationStructureFlagsKHR AccelerationStructureBuildDescConverter::translateBuildFlags(
     AccelerationStructureBuildFlags flags
 )
@@ -392,6 +486,14 @@ VkBuildAccelerationStructureFlagsKHR AccelerationStructureBuildDescConverter::tr
     if (is_set(flags, AccelerationStructureBuildFlags::CreateMotion))
     {
         result |= VK_BUILD_ACCELERATION_STRUCTURE_MOTION_BIT_NV;
+    }
+    if (is_set(flags, AccelerationStructureBuildFlags::AllowOpacityMicromapUpdate))
+    {
+        result |= VK_BUILD_ACCELERATION_STRUCTURE_ALLOW_OPACITY_MICROMAP_UPDATE_BIT_EXT;
+    }
+    if (is_set(flags, AccelerationStructureBuildFlags::AllowDisableOpacityMicromaps))
+    {
+        result |= VK_BUILD_ACCELERATION_STRUCTURE_ALLOW_DISABLE_OPACITY_MICROMAPS_BIT_EXT;
     }
     return result;
 }

--- a/src/vulkan/vk-acceleration-structure.h
+++ b/src/vulkan/vk-acceleration-structure.h
@@ -29,6 +29,25 @@ public:
     DescriptorHandle m_descriptorHandle;
 };
 
+class MicromapImpl : public Micromap
+{
+public:
+    MicromapImpl(Device* device, const MicromapDesc& desc);
+    ~MicromapImpl();
+
+    virtual void deleteThis() override;
+
+    // IResource implementation
+    virtual SLANG_NO_THROW Result SLANG_MCALL getNativeHandle(NativeHandle* outHandle) override;
+
+    // IMicromap implementation
+    virtual SLANG_NO_THROW DeviceAddress SLANG_MCALL getDeviceAddress() override;
+
+public:
+    VkMicromapEXT m_vkHandle = VK_NULL_HANDLE;
+    RefPtr<BufferImpl> m_buffer;
+};
+
 struct AccelerationStructureBuildDescConverter
 {
 public:
@@ -44,11 +63,20 @@ private:
     std::vector<VkAccelerationStructureGeometrySpheresDataNV> spheresDatas;
     std::vector<VkAccelerationStructureGeometryLinearSweptSpheresDataNV> linearSweptSpheresDatas;
     std::vector<VkAccelerationStructureGeometryMotionTrianglesDataNV> motionTrianglesDatas;
+    std::vector<VkAccelerationStructureTrianglesOpacityMicromapEXT> opacityMicromapDatas;
+    std::vector<std::vector<VkMicromapUsageEXT>> opacityMicromapUsageCounts;
 
     VkBuildAccelerationStructureFlagsKHR translateBuildFlags(AccelerationStructureBuildFlags flags);
     VkGeometryFlagsKHR translateGeometryFlags(AccelerationStructureGeometryFlags flags);
     VkRayTracingLssIndexingModeNV translateIndexingMode(LinearSweptSpheresIndexingMode mode);
     VkRayTracingLssPrimitiveEndCapsModeNV translateEndCapsMode(LinearSweptSpheresEndCapsMode mode);
+};
+
+struct MicromapBuildDescConverter
+{
+    VkMicromapBuildInfoEXT buildInfo = {VK_STRUCTURE_TYPE_MICROMAP_BUILD_INFO_EXT};
+    std::vector<VkMicromapUsageEXT> usageCounts;
+    Result convert(const MicromapBuildDesc& desc);
 };
 
 VkBuildAccelerationStructureFlagsKHR translateClusterOperationFlags(ClusterOperationFlags flags);

--- a/src/vulkan/vk-api.h
+++ b/src/vulkan/vk-api.h
@@ -267,6 +267,10 @@ protected:
     x(vkDestroyAccelerationStructureKHR) \
     x(vkGetAccelerationStructureBuildSizesKHR) \
     x(vkGetAccelerationStructureDeviceAddressKHR) \
+    x(vkCreateMicromapEXT) \
+    x(vkDestroyMicromapEXT) \
+    x(vkCmdBuildMicromapsEXT) \
+    x(vkGetMicromapBuildSizesEXT) \
     x(vkCmdBuildClusterAccelerationStructureIndirectNV) \
     x(vkGetClusterAccelerationStructureBuildSizesNV) \
     x(vkGetSemaphoreCounterValue) \
@@ -346,6 +350,10 @@ struct VulkanExtendedFeatures
     // Acceleration structure features
     VkPhysicalDeviceAccelerationStructureFeaturesKHR accelerationStructureFeatures = {
         VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_ACCELERATION_STRUCTURE_FEATURES_KHR
+    };
+
+    VkPhysicalDeviceOpacityMicromapFeaturesEXT opacityMicromapFeatures = {
+        VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_OPACITY_MICROMAP_FEATURES_EXT
     };
 
     // Ray tracing pipeline features

--- a/src/vulkan/vk-base.h
+++ b/src/vulkan/vk-base.h
@@ -21,6 +21,7 @@ class TextureImpl;
 class TextureViewImpl;
 class SamplerImpl;
 class AccelerationStructureImpl;
+class MicromapImpl;
 class RenderPipelineImpl;
 class ComputePipelineImpl;
 class RayTracingPipelineImpl;

--- a/src/vulkan/vk-command.cpp
+++ b/src/vulkan/vk-command.cpp
@@ -104,6 +104,7 @@ public:
     void cmdSetRayTracingState(const commands::SetRayTracingState& cmd);
     void cmdDispatchRays(const commands::DispatchRays& cmd);
     void cmdBuildAccelerationStructure(const commands::BuildAccelerationStructure& cmd);
+    void cmdBuildMicromap(const commands::BuildMicromap& cmd);
     void cmdCopyAccelerationStructure(const commands::CopyAccelerationStructure& cmd);
     void cmdQueryAccelerationStructureProperties(const commands::QueryAccelerationStructureProperties& cmd);
     void cmdExecuteClusterOperation(const commands::ExecuteClusterOperation& cmd);
@@ -1271,6 +1272,19 @@ void CommandRecorder::cmdBuildAccelerationStructure(const commands::BuildAcceler
                     ResourceState::AccelerationStructureBuildInput
                 );
             }
+            if (const auto* ommDesc = findStructInChain<AccelerationStructureOpacityMicromapDesc>(input.triangles.next))
+            {
+                if (ommDesc->link.micromap)
+                    requireBufferState(
+                        checked_cast<MicromapImpl*>(ommDesc->link.micromap)->m_buffer,
+                        ResourceState::MicromapRead
+                    );
+                if (ommDesc->link.indexBuffer)
+                    requireBufferState(
+                        checked_cast<BufferImpl*>(ommDesc->link.indexBuffer.buffer),
+                        ResourceState::AccelerationStructureBuildInput
+                    );
+            }
             break;
         case AccelerationStructureBuildInputType::ProceduralPrimitives:
             for (uint32_t i = 0; i < input.proceduralPrimitives.aabbBufferCount; ++i)
@@ -1359,6 +1373,23 @@ void CommandRecorder::cmdBuildAccelerationStructure(const commands::BuildAcceler
     {
         queryAccelerationStructureProperties(1, &cmd.dst, cmd.propertyQueryCount, cmd.queryDescs);
     }
+}
+
+void CommandRecorder::cmdBuildMicromap(const commands::BuildMicromap& cmd)
+{
+    if (!m_device->m_api.vkCmdBuildMicromapsEXT)
+        return;
+    MicromapImpl* dst = checked_cast<MicromapImpl*>(cmd.dst);
+    requireBufferState(dst->m_buffer, ResourceState::MicromapWrite);
+    requireBufferState(checked_cast<BufferImpl*>(cmd.scratchBuffer.buffer), ResourceState::UnorderedAccess);
+    requireBufferState(checked_cast<BufferImpl*>(cmd.desc.dataBuffer.buffer), ResourceState::MicromapBuildInput);
+    requireBufferState(checked_cast<BufferImpl*>(cmd.desc.descriptorBuffer.buffer), ResourceState::MicromapBuildInput);
+    MicromapBuildDescConverter converter;
+    if (SLANG_FAILED(converter.convert(cmd.desc)))
+        return;
+    converter.buildInfo.dstMicromap = dst->m_vkHandle;
+    converter.buildInfo.scratchData.deviceAddress = cmd.scratchBuffer.getDeviceAddress();
+    m_device->m_api.vkCmdBuildMicromapsEXT(m_cmdBuffer, 1, &converter.buildInfo);
 }
 
 void CommandRecorder::cmdCopyAccelerationStructure(const commands::CopyAccelerationStructure& cmd)

--- a/src/vulkan/vk-command.cpp
+++ b/src/vulkan/vk-command.cpp
@@ -1387,6 +1387,7 @@ void CommandRecorder::cmdBuildMicromap(const commands::BuildMicromap& cmd)
     MicromapBuildDescConverter converter;
     if (SLANG_FAILED(converter.convert(cmd.desc)))
         return;
+    commitBarriers();
     converter.buildInfo.dstMicromap = dst->m_vkHandle;
     converter.buildInfo.scratchData.deviceAddress = cmd.scratchBuffer.getDeviceAddress();
     m_device->m_api.vkCmdBuildMicromapsEXT(m_cmdBuffer, 1, &converter.buildInfo);

--- a/src/vulkan/vk-device.cpp
+++ b/src/vulkan/vk-device.cpp
@@ -891,12 +891,21 @@ Result DeviceImpl::initVulkanDevice(
             deviceExtensions.push_back(VK_KHR_DEFERRED_HOST_OPERATIONS_EXTENSION_NAME);
             availableFeatures.push_back(Feature::AccelerationStructure);
 
-            SIMPLE_EXTENSION_FEATURE(
-                extendedFeatures.opacityMicromapFeatures,
-                micromap,
-                VK_EXT_OPACITY_MICROMAP_EXTENSION_NAME,
-                { availableFeatures.push_back(Feature::OpacityMicromap); }
-            );
+            const bool hasSynchronization2 = VK_MAKE_VERSION(majorVersion, minorVersion, 0) >= VK_API_VERSION_1_3 ||
+                                             extensionNames.count(VK_KHR_SYNCHRONIZATION_2_EXTENSION_NAME);
+            if (hasSynchronization2)
+            {
+                SIMPLE_EXTENSION_FEATURE(
+                    extendedFeatures.opacityMicromapFeatures,
+                    micromap,
+                    VK_EXT_OPACITY_MICROMAP_EXTENSION_NAME,
+                    {
+                        if (VK_MAKE_VERSION(majorVersion, minorVersion, 0) < VK_API_VERSION_1_3)
+                            deviceExtensions.push_back(VK_KHR_SYNCHRONIZATION_2_EXTENSION_NAME);
+                        availableFeatures.push_back(Feature::OpacityMicromap);
+                    }
+                );
+            }
 
             // These both depend on VK_KHR_acceleration_structure
 

--- a/src/vulkan/vk-device.cpp
+++ b/src/vulkan/vk-device.cpp
@@ -642,6 +642,7 @@ Result DeviceImpl::initVulkanDevice(
         EXTEND_DESC_CHAIN(deviceFeatures2, extendedFeatures.rayTracingMotionBlurFeatures);
         EXTEND_DESC_CHAIN(deviceFeatures2, extendedFeatures.rayTracingInvocationReorderFeatures);
         EXTEND_DESC_CHAIN(deviceFeatures2, extendedFeatures.accelerationStructureFeatures);
+        EXTEND_DESC_CHAIN(deviceFeatures2, extendedFeatures.opacityMicromapFeatures);
         EXTEND_DESC_CHAIN(deviceFeatures2, extendedFeatures.variablePointersFeatures);
         EXTEND_DESC_CHAIN(deviceFeatures2, extendedFeatures.computeShaderDerivativesFeatures);
         EXTEND_DESC_CHAIN(deviceFeatures2, extendedFeatures.extendedDynamicStateFeatures);
@@ -889,6 +890,13 @@ Result DeviceImpl::initVulkanDevice(
             deviceExtensions.push_back(VK_KHR_ACCELERATION_STRUCTURE_EXTENSION_NAME);
             deviceExtensions.push_back(VK_KHR_DEFERRED_HOST_OPERATIONS_EXTENSION_NAME);
             availableFeatures.push_back(Feature::AccelerationStructure);
+
+            SIMPLE_EXTENSION_FEATURE(
+                extendedFeatures.opacityMicromapFeatures,
+                micromap,
+                VK_EXT_OPACITY_MICROMAP_EXTENSION_NAME,
+                { availableFeatures.push_back(Feature::OpacityMicromap); }
+            );
 
             // These both depend on VK_KHR_acceleration_structure
 
@@ -1515,8 +1523,8 @@ Result DeviceImpl::initialize(const DeviceDesc& desc, BackendImpl* backend)
 
     // Process chained descs
     const VulkanDeviceExtendedDesc* extendedDesc = nullptr;
-    for (const DescStructHeader* header = static_cast<const DescStructHeader*>(desc.next); header;
-         header = header->next)
+    for (const ChainedStructHeader* header = static_cast<const ChainedStructHeader*>(desc.next); header;
+         header = static_cast<const ChainedStructHeader*>(header->next))
     {
         switch (header->type)
         {
@@ -1971,6 +1979,24 @@ Result DeviceImpl::getAccelerationStructureSizes(
     return SLANG_OK;
 }
 
+Result DeviceImpl::getMicromapSizes(const MicromapBuildDesc& desc, MicromapSizes* outSizes)
+{
+    if (!m_api.vkGetMicromapBuildSizesEXT)
+        return SLANG_E_NOT_AVAILABLE;
+    MicromapBuildDescConverter converter;
+    SLANG_RETURN_ON_FAIL(converter.convert(desc));
+    VkMicromapBuildSizesInfoEXT info = {VK_STRUCTURE_TYPE_MICROMAP_BUILD_SIZES_INFO_EXT};
+    m_api.vkGetMicromapBuildSizesEXT(
+        m_device,
+        VK_ACCELERATION_STRUCTURE_BUILD_TYPE_DEVICE_KHR,
+        &converter.buildInfo,
+        &info
+    );
+    outSizes->micromapSize = info.micromapSize;
+    outSizes->scratchSize = info.buildScratchSize;
+    return SLANG_OK;
+}
+
 Result DeviceImpl::getClusterOperationSizes(const ClusterOperationParams& params, ClusterOperationSizes* outSizes)
 {
     if (!m_api.vkGetClusterAccelerationStructureBuildSizesNV)
@@ -2038,6 +2064,26 @@ Result DeviceImpl::createAccelerationStructure(
         this
     );
     returnComPtr(outAccelerationStructure, result);
+    return SLANG_OK;
+}
+
+Result DeviceImpl::createMicromap(const MicromapDesc& desc, IMicromap** outMicromap)
+{
+    if (!m_api.vkCreateMicromapEXT)
+        return SLANG_E_NOT_AVAILABLE;
+    RefPtr<MicromapImpl> result = new MicromapImpl(this, desc);
+    BufferDesc bufferDesc = {};
+    bufferDesc.size = desc.size;
+    bufferDesc.memoryType = MemoryType::DeviceLocal;
+    bufferDesc.usage = BufferUsage::MicromapStorage;
+    bufferDesc.defaultState = ResourceState::MicromapRead;
+    SLANG_RETURN_ON_FAIL(createBuffer(bufferDesc, nullptr, (IBuffer**)result->m_buffer.writeRef()));
+    VkMicromapCreateInfoEXT createInfo = {VK_STRUCTURE_TYPE_MICROMAP_CREATE_INFO_EXT};
+    createInfo.buffer = result->m_buffer->m_buffer.m_buffer;
+    createInfo.size = desc.size;
+    createInfo.type = VK_MICROMAP_TYPE_OPACITY_MICROMAP_EXT;
+    SLANG_VK_RETURN_ON_FAIL(m_api.vkCreateMicromapEXT(m_device, &createInfo, nullptr, &result->m_vkHandle));
+    returnComPtr(outMicromap, result);
     return SLANG_OK;
 }
 

--- a/src/vulkan/vk-device.h
+++ b/src/vulkan/vk-device.h
@@ -141,6 +141,11 @@ public:
         AccelerationStructureSizes* outSizes
     ) override;
 
+    virtual SLANG_NO_THROW Result SLANG_MCALL getMicromapSizes(
+        const MicromapBuildDesc& desc,
+        MicromapSizes* outSizes
+    ) override;
+
     virtual SLANG_NO_THROW Result SLANG_MCALL getClusterOperationSizes(
         const ClusterOperationParams& params,
         ClusterOperationSizes* outSizes
@@ -149,6 +154,11 @@ public:
     virtual SLANG_NO_THROW Result SLANG_MCALL createAccelerationStructure(
         const AccelerationStructureDesc& desc,
         IAccelerationStructure** outAccelerationStructure
+    ) override;
+
+    virtual SLANG_NO_THROW Result SLANG_MCALL createMicromap(
+        const MicromapDesc& desc,
+        IMicromap** outMicromap
     ) override;
 
     virtual SLANG_NO_THROW Result SLANG_MCALL getTextureAllocationInfo(

--- a/src/vulkan/vk-utils.cpp
+++ b/src/vulkan/vk-utils.cpp
@@ -309,6 +309,8 @@ VkPipelineCreateFlags translateRayTracingPipelineFlags(RayTracingPipelineFlags f
         vkFlags |= VK_PIPELINE_CREATE_RAY_TRACING_SKIP_TRIANGLES_BIT_KHR;
     if (is_set(flags, RayTracingPipelineFlags::SkipProcedurals))
         vkFlags |= VK_PIPELINE_CREATE_RAY_TRACING_SKIP_AABBS_BIT_KHR;
+    if (is_set(flags, RayTracingPipelineFlags::EnableOpacityMicromaps))
+        vkFlags |= VK_PIPELINE_CREATE_RAY_TRACING_OPACITY_MICROMAP_BIT_EXT;
 
     return vkFlags;
 }
@@ -324,9 +326,6 @@ VkPipelineCreateFlags2 translateRayTracingPipelineFlags2(RayTracingPipelineFlags
         vkFlags |= VK_PIPELINE_CREATE_2_RAY_TRACING_ALLOW_SPHERES_AND_LINEAR_SWEPT_SPHERES_BIT_NV;
     if (is_set(flags, RayTracingPipelineFlags::EnableMotion))
         vkFlags |= VK_PIPELINE_CREATE_RAY_TRACING_ALLOW_MOTION_BIT_NV;
-    if (is_set(flags, RayTracingPipelineFlags::EnableOpacityMicromaps))
-        vkFlags |= VK_PIPELINE_CREATE_2_RAY_TRACING_OPACITY_MICROMAP_BIT_EXT;
-
     return vkFlags;
 }
 

--- a/src/vulkan/vk-utils.cpp
+++ b/src/vulkan/vk-utils.cpp
@@ -324,6 +324,8 @@ VkPipelineCreateFlags2 translateRayTracingPipelineFlags2(RayTracingPipelineFlags
         vkFlags |= VK_PIPELINE_CREATE_2_RAY_TRACING_ALLOW_SPHERES_AND_LINEAR_SWEPT_SPHERES_BIT_NV;
     if (is_set(flags, RayTracingPipelineFlags::EnableMotion))
         vkFlags |= VK_PIPELINE_CREATE_RAY_TRACING_ALLOW_MOTION_BIT_NV;
+    if (is_set(flags, RayTracingPipelineFlags::EnableOpacityMicromaps))
+        vkFlags |= VK_PIPELINE_CREATE_2_RAY_TRACING_OPACITY_MICROMAP_BIT_EXT;
 
     return vkFlags;
 }
@@ -399,6 +401,11 @@ VkAccessFlagBits calcAccessFlags(ResourceState state)
         return VK_ACCESS_ACCELERATION_STRUCTURE_WRITE_BIT_KHR;
     case ResourceState::AccelerationStructureBuildInput:
         return VK_ACCESS_SHADER_READ_BIT;
+    case ResourceState::MicromapBuildInput:
+    case ResourceState::MicromapRead:
+        return VK_ACCESS_MEMORY_READ_BIT;
+    case ResourceState::MicromapWrite:
+        return VK_ACCESS_MEMORY_WRITE_BIT;
     case ResourceState::General:
         return VkAccessFlagBits(VK_ACCESS_MEMORY_READ_BIT | VK_ACCESS_MEMORY_WRITE_BIT);
     default:
@@ -451,6 +458,10 @@ VkPipelineStageFlags calcPipelineStageFlags(
         return VK_PIPELINE_STAGE_ACCELERATION_STRUCTURE_BUILD_BIT_KHR;
     case ResourceState::AccelerationStructureBuildInput:
         return VK_PIPELINE_STAGE_ACCELERATION_STRUCTURE_BUILD_BIT_KHR;
+    case ResourceState::MicromapBuildInput:
+    case ResourceState::MicromapRead:
+    case ResourceState::MicromapWrite:
+        return VK_PIPELINE_STAGE_ALL_COMMANDS_BIT;
     default:
         SLANG_RHI_ASSERT_FAILURE("Unsupported");
         return VkPipelineStageFlagBits(0);
@@ -490,6 +501,10 @@ VkBufferUsageFlagBits _calcBufferUsageFlags(BufferUsage usage)
         flags |= VK_BUFFER_USAGE_ACCELERATION_STRUCTURE_STORAGE_BIT_KHR;
     if (is_set(usage, BufferUsage::AccelerationStructureBuildInput))
         flags |= VK_BUFFER_USAGE_ACCELERATION_STRUCTURE_BUILD_INPUT_READ_ONLY_BIT_KHR;
+    if (is_set(usage, BufferUsage::MicromapBuildInput))
+        flags |= VK_BUFFER_USAGE_MICROMAP_BUILD_INPUT_READ_ONLY_BIT_EXT;
+    if (is_set(usage, BufferUsage::MicromapStorage))
+        flags |= VK_BUFFER_USAGE_MICROMAP_STORAGE_BIT_EXT;
     if (is_set(usage, BufferUsage::ShaderTable))
         flags |= VK_BUFFER_USAGE_SHADER_BINDING_TABLE_BIT_KHR;
     return VkBufferUsageFlagBits(flags);

--- a/src/wgpu/wgpu-command.cpp
+++ b/src/wgpu/wgpu-command.cpp
@@ -78,6 +78,7 @@ public:
     void cmdSetRayTracingState(const commands::SetRayTracingState& cmd);
     void cmdDispatchRays(const commands::DispatchRays& cmd);
     void cmdBuildAccelerationStructure(const commands::BuildAccelerationStructure& cmd);
+    void cmdBuildMicromap(const commands::BuildMicromap& cmd);
     void cmdCopyAccelerationStructure(const commands::CopyAccelerationStructure& cmd);
     void cmdQueryAccelerationStructureProperties(const commands::QueryAccelerationStructureProperties& cmd);
     void cmdExecuteClusterOperation(const commands::ExecuteClusterOperation& cmd);
@@ -752,6 +753,12 @@ void CommandRecorder::cmdBuildAccelerationStructure(const commands::BuildAcceler
 {
     SLANG_UNUSED(cmd);
     NOT_SUPPORTED(ICommandEncoder, buildAccelerationStructure);
+}
+
+void CommandRecorder::cmdBuildMicromap(const commands::BuildMicromap& cmd)
+{
+    SLANG_UNUSED(cmd);
+    NOT_SUPPORTED(ICommandEncoder, buildMicromap);
 }
 
 void CommandRecorder::cmdCopyAccelerationStructure(const commands::CopyAccelerationStructure& cmd)

--- a/tests/test-opacity-micromap.cpp
+++ b/tests/test-opacity-micromap.cpp
@@ -1,0 +1,287 @@
+#include "testing.h"
+#include "rhi-shared.h"
+#include "test-ray-tracing-common.h"
+
+using namespace rhi;
+using namespace rhi::testing;
+
+TEST_CASE("find-struct-in-chain")
+{
+    D3D12DeviceExtendedDesc first = {};
+    VulkanDeviceExtendedDesc second = {};
+    first.next = &second;
+
+    CHECK(findStructInChain<D3D12DeviceExtendedDesc>(&first) == &first);
+    CHECK(findStructInChain<VulkanDeviceExtendedDesc>(&first) == &second);
+    CHECK(findStructInChain<D3D12ExperimentalFeaturesDesc>(&first) == nullptr);
+    CHECK(findStructInChain<D3D12DeviceExtendedDesc>(nullptr) == nullptr);
+}
+
+GPU_TEST_CASE("opacity-micromap-build", D3D12 | Vulkan | CUDA)
+{
+    if (!device->hasFeature(Feature::OpacityMicromap))
+        SKIP("Opacity micromaps are not supported");
+
+    std::array<uint8_t, 256> opacityData = {};
+    opacityData[0] = 1; // One opaque level-zero microtriangle.
+    BufferDesc inputDesc = {};
+    inputDesc.size = opacityData.size();
+    inputDesc.usage = BufferUsage::MicromapBuildInput;
+    inputDesc.defaultState = ResourceState::MicromapBuildInput;
+    ComPtr<IBuffer> inputBuffer = device->createBuffer(inputDesc, opacityData.data());
+    REQUIRE(inputBuffer);
+
+    std::array<MicromapTriangleDesc, 32> triangleDescs = {};
+    triangleDescs[0].dataOffset = 0;
+    triangleDescs[0].subdivisionLevel = 0;
+    triangleDescs[0].format = uint16_t(OpacityMicromapFormat::TwoState);
+    BufferDesc triangleDescBufferDesc = inputDesc;
+    triangleDescBufferDesc.size = sizeof(triangleDescs);
+    ComPtr<IBuffer> triangleDescBuffer = device->createBuffer(triangleDescBufferDesc, triangleDescs.data());
+    REQUIRE(triangleDescBuffer);
+
+    MicromapUsageCount usageCount = {1, 0, uint32_t(OpacityMicromapFormat::TwoState)};
+    MicromapBuildDesc buildDesc = {};
+    buildDesc.dataBuffer = inputBuffer;
+    buildDesc.descriptorBuffer = triangleDescBuffer;
+    buildDesc.histogram = &usageCount;
+    buildDesc.histogramCount = 1;
+
+    MicromapSizes sizes = {};
+    REQUIRE_CALL(device->getMicromapSizes(buildDesc, &sizes));
+    REQUIRE(sizes.micromapSize > 0);
+    REQUIRE(sizes.scratchSize > 0);
+
+    MicromapDesc micromapDesc = {};
+    micromapDesc.size = sizes.micromapSize;
+    ComPtr<IMicromap> micromap;
+    REQUIRE_CALL(device->createMicromap(micromapDesc, micromap.writeRef()));
+
+    BufferDesc scratchDesc = {};
+    scratchDesc.size = sizes.scratchSize;
+    scratchDesc.usage = BufferUsage::UnorderedAccess;
+    scratchDesc.defaultState = ResourceState::UnorderedAccess;
+    ComPtr<IBuffer> scratchBuffer = device->createBuffer(scratchDesc);
+    REQUIRE(scratchBuffer);
+
+    auto queue = device->getQueue(QueueType::Graphics);
+    auto encoder = queue->createCommandEncoder();
+    encoder->buildMicromap(buildDesc, micromap, scratchBuffer);
+    queue->submit(encoder->finish());
+    queue->waitOnHost();
+
+    struct Vertex
+    {
+        float position[3];
+    };
+    Vertex vertices[] = {{{0.f, 0.f, 0.f}}, {{1.f, 0.f, 0.f}}, {{0.f, 1.f, 0.f}}};
+    BufferDesc vertexDesc = {};
+    vertexDesc.size = sizeof(vertices);
+    vertexDesc.usage = BufferUsage::AccelerationStructureBuildInput;
+    vertexDesc.defaultState = ResourceState::AccelerationStructureBuildInput;
+    ComPtr<IBuffer> vertexBuffer = device->createBuffer(vertexDesc, vertices);
+
+    AccelerationStructureOpacityMicromapDesc ommAttachment = {};
+    ommAttachment.link.micromap = micromap;
+    ommAttachment.link.usageCounts = &usageCount;
+    ommAttachment.link.usageCount = 1;
+
+    AccelerationStructureBuildInput buildInput = {};
+    buildInput.type = AccelerationStructureBuildInputType::Triangles;
+    buildInput.triangles.vertexBuffers[0] = vertexBuffer;
+    buildInput.triangles.vertexBufferCount = 1;
+    buildInput.triangles.vertexFormat = Format::RGB32Float;
+    buildInput.triangles.vertexCount = 3;
+    buildInput.triangles.vertexStride = sizeof(Vertex);
+    buildInput.triangles.flags = AccelerationStructureGeometryFlags::None;
+    buildInput.triangles.next = &ommAttachment;
+    AccelerationStructureBuildDesc blasBuildDesc = {};
+    blasBuildDesc.inputs = &buildInput;
+    blasBuildDesc.inputCount = 1;
+
+    AccelerationStructureSizes blasSizes = {};
+    REQUIRE_CALL(device->getAccelerationStructureSizes(blasBuildDesc, &blasSizes));
+    AccelerationStructureDesc blasDesc = {};
+    blasDesc.kind = AccelerationStructureKind::BottomLevel;
+    blasDesc.size = blasSizes.accelerationStructureSize;
+    ComPtr<IAccelerationStructure> blas;
+    REQUIRE_CALL(device->createAccelerationStructure(blasDesc, blas.writeRef()));
+    scratchDesc.size = blasSizes.scratchSize;
+    scratchBuffer = device->createBuffer(scratchDesc);
+
+    encoder = queue->createCommandEncoder();
+    encoder->buildAccelerationStructure(blasBuildDesc, blas, nullptr, scratchBuffer, 0, nullptr);
+    queue->submit(encoder->finish());
+    queue->waitOnHost();
+
+    uint16_t micromapIndex = 0;
+    BufferDesc indexDesc = {};
+    indexDesc.size = sizeof(micromapIndex);
+    indexDesc.usage = BufferUsage::AccelerationStructureBuildInput;
+    indexDesc.defaultState = ResourceState::AccelerationStructureBuildInput;
+    ComPtr<IBuffer> micromapIndexBuffer = device->createBuffer(indexDesc, &micromapIndex);
+    ommAttachment.link.indexingMode = MicromapIndexingMode::Indexed;
+    ommAttachment.link.indexBuffer = micromapIndexBuffer;
+    ommAttachment.link.indexFormat = MicromapIndexFormat::Uint16;
+    ommAttachment.link.indexStride = sizeof(uint16_t);
+
+    REQUIRE_CALL(device->getAccelerationStructureSizes(blasBuildDesc, &blasSizes));
+    blasDesc.size = blasSizes.accelerationStructureSize;
+    blas.setNull();
+    REQUIRE_CALL(device->createAccelerationStructure(blasDesc, blas.writeRef()));
+    scratchDesc.size = blasSizes.scratchSize;
+    scratchBuffer = device->createBuffer(scratchDesc);
+    encoder = queue->createCommandEncoder();
+    encoder->buildAccelerationStructure(blasBuildDesc, blas, nullptr, scratchBuffer, 0, nullptr);
+    queue->submit(encoder->finish());
+    queue->waitOnHost();
+}
+
+GPU_TEST_CASE("opacity-micromap-trace", D3D12 | Vulkan | CUDA)
+{
+    if (!device->hasFeature(Feature::OpacityMicromap))
+        SKIP("Opacity micromaps are not supported");
+
+    auto queue = device->getQueue(QueueType::Graphics);
+
+    // Two level-zero OMMs followed by a level-one OMM whose four microtriangles
+    // alternate between transparent and opaque.
+    std::array<uint8_t, 256> opacityData = {};
+    opacityData[1] = 1;
+    opacityData[2] = 0b1010;
+    BufferDesc inputDesc = {};
+    inputDesc.size = opacityData.size();
+    inputDesc.usage = BufferUsage::MicromapBuildInput;
+    inputDesc.defaultState = ResourceState::MicromapBuildInput;
+    ComPtr<IBuffer> inputBuffer = device->createBuffer(inputDesc, opacityData.data());
+    REQUIRE(inputBuffer);
+
+    std::array<MicromapTriangleDesc, 32> triangleDescs = {};
+    triangleDescs[0] = {0, 0, uint16_t(OpacityMicromapFormat::TwoState)};
+    triangleDescs[1] = {1, 0, uint16_t(OpacityMicromapFormat::TwoState)};
+    triangleDescs[2] = {2, 1, uint16_t(OpacityMicromapFormat::TwoState)};
+    BufferDesc triangleDescBufferDesc = inputDesc;
+    triangleDescBufferDesc.size = sizeof(triangleDescs);
+    ComPtr<IBuffer> triangleDescBuffer = device->createBuffer(triangleDescBufferDesc, triangleDescs.data());
+    REQUIRE(triangleDescBuffer);
+
+    MicromapUsageCount usageCounts[] = {
+        {2, 0, uint32_t(OpacityMicromapFormat::TwoState)},
+        {1, 1, uint32_t(OpacityMicromapFormat::TwoState)},
+    };
+    MicromapBuildDesc micromapBuildDesc = {};
+    micromapBuildDesc.dataBuffer = inputBuffer;
+    micromapBuildDesc.descriptorBuffer = triangleDescBuffer;
+    micromapBuildDesc.histogram = usageCounts;
+    micromapBuildDesc.histogramCount = SLANG_COUNT_OF(usageCounts);
+
+    MicromapSizes micromapSizes = {};
+    REQUIRE_CALL(device->getMicromapSizes(micromapBuildDesc, &micromapSizes));
+    MicromapDesc micromapDesc = {};
+    micromapDesc.size = micromapSizes.micromapSize;
+    ComPtr<IMicromap> micromap;
+    REQUIRE_CALL(device->createMicromap(micromapDesc, micromap.writeRef()));
+
+    BufferDesc scratchDesc = {};
+    scratchDesc.size = micromapSizes.scratchSize;
+    scratchDesc.usage = BufferUsage::UnorderedAccess;
+    scratchDesc.defaultState = ResourceState::UnorderedAccess;
+    ComPtr<IBuffer> scratchBuffer = device->createBuffer(scratchDesc);
+    REQUIRE(scratchBuffer);
+
+    auto encoder = queue->createCommandEncoder();
+    encoder->buildMicromap(micromapBuildDesc, micromap, scratchBuffer);
+    REQUIRE_CALL(queue->submit(encoder->finish()));
+    REQUIRE_CALL(queue->waitOnHost());
+
+    Vertex vertices[] = {
+        {{-0.9f, -0.5f, 1.f}},
+        {{-0.1f, -0.5f, 1.f}},
+        {{-0.5f, 0.5f, 1.f}},
+        {{0.1f, -0.5f, 1.f}},
+        {{0.9f, -0.5f, 1.f}},
+        {{0.5f, 0.5f, 1.f}},
+        {{1.f, -0.5f, 1.f}},
+        {{2.f, -0.5f, 1.f}},
+        {{1.5f, 0.5f, 1.f}},
+    };
+    BufferDesc vertexDesc = {};
+    vertexDesc.size = sizeof(vertices);
+    vertexDesc.usage = BufferUsage::AccelerationStructureBuildInput;
+    vertexDesc.defaultState = ResourceState::AccelerationStructureBuildInput;
+    ComPtr<IBuffer> vertexBuffer = device->createBuffer(vertexDesc, vertices);
+    REQUIRE(vertexBuffer);
+
+    AccelerationStructureOpacityMicromapDesc ommAttachment = {};
+    ommAttachment.link.micromap = micromap;
+    ommAttachment.link.usageCounts = usageCounts;
+    ommAttachment.link.usageCount = SLANG_COUNT_OF(usageCounts);
+
+    AccelerationStructureBuildInput buildInput = {};
+    buildInput.type = AccelerationStructureBuildInputType::Triangles;
+    buildInput.triangles.vertexBuffers[0] = vertexBuffer;
+    buildInput.triangles.vertexBufferCount = 1;
+    buildInput.triangles.vertexFormat = Format::RGB32Float;
+    buildInput.triangles.vertexCount = SLANG_COUNT_OF(vertices);
+    buildInput.triangles.vertexStride = sizeof(Vertex);
+    buildInput.triangles.flags = AccelerationStructureGeometryFlags::None;
+    buildInput.triangles.next = &ommAttachment;
+
+    AccelerationStructureBuildDesc blasBuildDesc = {};
+    blasBuildDesc.inputs = &buildInput;
+    blasBuildDesc.inputCount = 1;
+    AccelerationStructureSizes blasSizes = {};
+    REQUIRE_CALL(device->getAccelerationStructureSizes(blasBuildDesc, &blasSizes));
+
+    AccelerationStructureDesc blasDesc = {};
+    blasDesc.kind = AccelerationStructureKind::BottomLevel;
+    blasDesc.size = blasSizes.accelerationStructureSize;
+    ComPtr<IAccelerationStructure> blas;
+    REQUIRE_CALL(device->createAccelerationStructure(blasDesc, blas.writeRef()));
+    scratchDesc.size = blasSizes.scratchSize;
+    scratchBuffer = device->createBuffer(scratchDesc);
+    REQUIRE(scratchBuffer);
+
+    encoder = queue->createCommandEncoder();
+    encoder->buildAccelerationStructure(blasBuildDesc, blas, nullptr, scratchBuffer, 0, nullptr);
+    REQUIRE_CALL(queue->submit(encoder->finish()));
+    REQUIRE_CALL(queue->waitOnHost());
+
+    TLAS tlas(device, queue, blas);
+    RayTracingTestPipeline pipeline(
+        device,
+        "test-opacity-micromap",
+        {"rayGen"},
+        {{"closestHit", nullptr, nullptr}},
+        {"miss"},
+        RayTracingPipelineFlags::EnableOpacityMicromaps
+    );
+
+    BufferDesc resultDesc = {};
+    resultDesc.size = 6 * sizeof(uint32_t);
+    resultDesc.elementSize = sizeof(uint32_t);
+    resultDesc.usage = BufferUsage::UnorderedAccess | BufferUsage::CopySource;
+    resultDesc.defaultState = ResourceState::UnorderedAccess;
+    ComPtr<IBuffer> resultBuffer = device->createBuffer(resultDesc);
+    REQUIRE(resultBuffer);
+
+    encoder = queue->createCommandEncoder();
+    auto passEncoder = encoder->beginRayTracingPass();
+    auto rootObject = passEncoder->bindPipeline(pipeline.raytracingPipeline, pipeline.shaderTable);
+    ShaderCursor(rootObject)["resultBuffer"].setBinding(resultBuffer);
+    ShaderCursor(rootObject)["sceneBVH"].setBinding(tlas.tlas);
+    passEncoder->dispatchRays(0, 6, 1, 1);
+    passEncoder->end();
+    REQUIRE_CALL(queue->submit(encoder->finish()));
+    REQUIRE_CALL(queue->waitOnHost());
+
+    ComPtr<ISlangBlob> resultBlob;
+    REQUIRE_CALL(device->readBuffer(resultBuffer, 0, resultDesc.size, resultBlob.writeRef()));
+    const auto* results = static_cast<const uint32_t*>(resultBlob->getBufferPointer());
+    CHECK(results[0] == 1); // Transparent OMM: miss.
+    CHECK(results[1] == 2); // Opaque OMM: closest hit.
+    CHECK(results[2] == 1); // Partial OMM microtriangle 0: transparent.
+    CHECK(results[3] == 2); // Partial OMM microtriangle 1: opaque.
+    CHECK(results[4] == 1); // Partial OMM microtriangle 2: transparent.
+    CHECK(results[5] == 2); // Partial OMM microtriangle 3: opaque.
+}

--- a/tests/test-opacity-micromap.cpp
+++ b/tests/test-opacity-micromap.cpp
@@ -65,10 +65,12 @@ GPU_TEST_CASE("opacity-micromap-build", D3D12 | Vulkan | CUDA)
     REQUIRE(scratchBuffer);
 
     auto queue = device->getQueue(QueueType::Graphics);
+    REQUIRE(queue);
     auto encoder = queue->createCommandEncoder();
+    REQUIRE(encoder);
     encoder->buildMicromap(buildDesc, micromap, scratchBuffer);
-    queue->submit(encoder->finish());
-    queue->waitOnHost();
+    REQUIRE_CALL(queue->submit(encoder->finish()));
+    REQUIRE_CALL(queue->waitOnHost());
 
     struct Vertex
     {
@@ -80,6 +82,7 @@ GPU_TEST_CASE("opacity-micromap-build", D3D12 | Vulkan | CUDA)
     vertexDesc.usage = BufferUsage::AccelerationStructureBuildInput;
     vertexDesc.defaultState = ResourceState::AccelerationStructureBuildInput;
     ComPtr<IBuffer> vertexBuffer = device->createBuffer(vertexDesc, vertices);
+    REQUIRE(vertexBuffer);
 
     AccelerationStructureOpacityMicromapDesc ommAttachment = {};
     ommAttachment.link.micromap = micromap;
@@ -108,11 +111,13 @@ GPU_TEST_CASE("opacity-micromap-build", D3D12 | Vulkan | CUDA)
     REQUIRE_CALL(device->createAccelerationStructure(blasDesc, blas.writeRef()));
     scratchDesc.size = blasSizes.scratchSize;
     scratchBuffer = device->createBuffer(scratchDesc);
+    REQUIRE(scratchBuffer);
 
     encoder = queue->createCommandEncoder();
+    REQUIRE(encoder);
     encoder->buildAccelerationStructure(blasBuildDesc, blas, nullptr, scratchBuffer, 0, nullptr);
-    queue->submit(encoder->finish());
-    queue->waitOnHost();
+    REQUIRE_CALL(queue->submit(encoder->finish()));
+    REQUIRE_CALL(queue->waitOnHost());
 
     uint16_t micromapIndex = 0;
     BufferDesc indexDesc = {};
@@ -120,6 +125,7 @@ GPU_TEST_CASE("opacity-micromap-build", D3D12 | Vulkan | CUDA)
     indexDesc.usage = BufferUsage::AccelerationStructureBuildInput;
     indexDesc.defaultState = ResourceState::AccelerationStructureBuildInput;
     ComPtr<IBuffer> micromapIndexBuffer = device->createBuffer(indexDesc, &micromapIndex);
+    REQUIRE(micromapIndexBuffer);
     ommAttachment.link.indexingMode = MicromapIndexingMode::Indexed;
     ommAttachment.link.indexBuffer = micromapIndexBuffer;
     ommAttachment.link.indexFormat = MicromapIndexFormat::Uint16;
@@ -131,10 +137,12 @@ GPU_TEST_CASE("opacity-micromap-build", D3D12 | Vulkan | CUDA)
     REQUIRE_CALL(device->createAccelerationStructure(blasDesc, blas.writeRef()));
     scratchDesc.size = blasSizes.scratchSize;
     scratchBuffer = device->createBuffer(scratchDesc);
+    REQUIRE(scratchBuffer);
     encoder = queue->createCommandEncoder();
+    REQUIRE(encoder);
     encoder->buildAccelerationStructure(blasBuildDesc, blas, nullptr, scratchBuffer, 0, nullptr);
-    queue->submit(encoder->finish());
-    queue->waitOnHost();
+    REQUIRE_CALL(queue->submit(encoder->finish()));
+    REQUIRE_CALL(queue->waitOnHost());
 }
 
 GPU_TEST_CASE("opacity-micromap-trace", D3D12 | Vulkan | CUDA)
@@ -186,13 +194,8 @@ GPU_TEST_CASE("opacity-micromap-trace", D3D12 | Vulkan | CUDA)
     scratchDesc.size = micromapSizes.scratchSize;
     scratchDesc.usage = BufferUsage::UnorderedAccess;
     scratchDesc.defaultState = ResourceState::UnorderedAccess;
-    ComPtr<IBuffer> scratchBuffer = device->createBuffer(scratchDesc);
-    REQUIRE(scratchBuffer);
-
-    auto encoder = queue->createCommandEncoder();
-    encoder->buildMicromap(micromapBuildDesc, micromap, scratchBuffer);
-    REQUIRE_CALL(queue->submit(encoder->finish()));
-    REQUIRE_CALL(queue->waitOnHost());
+    ComPtr<IBuffer> micromapScratchBuffer = device->createBuffer(scratchDesc);
+    REQUIRE(micromapScratchBuffer);
 
     Vertex vertices[] = {
         {{-0.9f, -0.5f, 1.f}},
@@ -239,11 +242,21 @@ GPU_TEST_CASE("opacity-micromap-trace", D3D12 | Vulkan | CUDA)
     ComPtr<IAccelerationStructure> blas;
     REQUIRE_CALL(device->createAccelerationStructure(blasDesc, blas.writeRef()));
     scratchDesc.size = blasSizes.scratchSize;
-    scratchBuffer = device->createBuffer(scratchDesc);
-    REQUIRE(scratchBuffer);
+    ComPtr<IBuffer> blasScratchBuffer = device->createBuffer(scratchDesc);
+    REQUIRE(blasScratchBuffer);
 
-    encoder = queue->createCommandEncoder();
-    encoder->buildAccelerationStructure(blasBuildDesc, blas, nullptr, scratchBuffer, 0, nullptr);
+    auto encoder = queue->createCommandEncoder();
+    REQUIRE(encoder);
+    encoder->buildMicromap(micromapBuildDesc, micromap, micromapScratchBuffer);
+    // OptiX guarantees ordering through stream submission rather than explicit resource barriers.
+    if (device->getDeviceType() == DeviceType::CUDA)
+    {
+        REQUIRE_CALL(queue->submit(encoder->finish()));
+        REQUIRE_CALL(queue->waitOnHost());
+        encoder = queue->createCommandEncoder();
+        REQUIRE(encoder);
+    }
+    encoder->buildAccelerationStructure(blasBuildDesc, blas, nullptr, blasScratchBuffer, 0, nullptr);
     REQUIRE_CALL(queue->submit(encoder->finish()));
     REQUIRE_CALL(queue->waitOnHost());
 

--- a/tests/test-opacity-micromap.slang
+++ b/tests/test-opacity-micromap.slang
@@ -1,0 +1,46 @@
+[raypayload]
+struct Payload
+{
+    uint result : read(caller) : write(caller, closesthit, miss);
+};
+
+uniform RWStructuredBuffer<uint> resultBuffer;
+uniform RaytracingAccelerationStructure sceneBVH;
+
+[shader("raygeneration")]
+void rayGen()
+{
+    uint rayIndex = DispatchRaysIndex().x;
+
+    static const float2 origins[] =
+    {
+        float2(-0.5, 0.0), // Fully transparent triangle.
+        float2(0.5, 0.0),  // Fully opaque triangle.
+        float2(1.25, -1.0 / 3.0), // Partial triangle: microtriangle 0.
+        float2(1.5, -1.0 / 6.0),  // Partial triangle: microtriangle 1.
+        float2(1.75, -1.0 / 3.0), // Partial triangle: microtriangle 2.
+        float2(1.5, 1.0 / 6.0),   // Partial triangle: microtriangle 3.
+    };
+
+    RayDesc ray;
+    ray.Origin = float3(origins[rayIndex], 0.0);
+    ray.Direction = float3(0.0, 0.0, 1.0);
+    ray.TMin = 0.001;
+    ray.TMax = 100.0;
+
+    Payload payload = {0};
+    TraceRay(sceneBVH, RAY_FLAG_NONE, 0xff, 0, 0, 0, ray, payload);
+    resultBuffer[rayIndex] = payload.result;
+}
+
+[shader("miss")]
+void miss(inout Payload payload)
+{
+    payload.result = 1;
+}
+
+[shader("closesthit")]
+void closestHit(inout Payload payload, BuiltInTriangleIntersectionAttributes attributes)
+{
+    payload.result = 2;
+}


### PR DESCRIPTION
## Summary

Adds opacity micromap (OMM) support to slang-rhi for D3D12, Vulkan, and CUDA/OptiX.

The API uses a generic micromap resource and build model so future micromap types, such as displacement micromaps, can be added without restructuring the interface. This PR does not implement DMM support.

## Changes

- Adds `IMicromap`, micromap creation, size queries, and command-encoder build operations.
- Adds opacity micromap formats, usage histograms, indexing modes, special indices, resource states, and buffer usages.
- Allows OMMs to be attached to triangle geometry through the acceleration-structure input extension chain.
- Supports linear and indexed triangle-to-micromap mapping.
- Adds the corresponding acceleration-structure, instance, and ray-tracing pipeline flags.
- Adds `Feature::OpacityMicromap` for capability detection.
- Places the GPU-side `MicromapTriangleDesc` in `slang-rhi-device.h` and verifies its native 8-byte layout.
- Adds `kStructType` to chainable public descriptors and a shared `findStructInChain<T>` helper.
- Adds command recording, resource-state tracking, and debug-layer validation.
- Updates the API support matrix.

## Backend support

- D3D12 using native DXR 1.2 opacity micromaps.
  - OMM acceleration-structure builds use the native D3D12 path rather than the NVAPI path.
- Vulkan using `VK_EXT_opacity_micromap`.
- CUDA using OptiX opacity micromap APIs.

Unsupported devices do not advertise the OMM feature.

## Testing

Adds two cross-backend tests:

- A build test covering micromap creation and both linear and indexed attachment to triangle geometry.
- A ray-traversal test covering:
  - Fully transparent triangles.
  - Fully opaque triangles.
  - A subdivided, partially opaque triangle with alternating transparent and opaque microtriangles.

Verified on D3D12, Vulkan, and CUDA/OptiX. Debug and Release builds and all pre-commit checks pass.